### PR TITLE
fix container health checks

### DIFF
--- a/app/api/model_control/model_utils.py
+++ b/app/api/model_control/model_utils.py
@@ -42,6 +42,7 @@ def health_check(url, json_data, timeout=5):
         headers = {"Authorization": f"Bearer {encoded_jwt}"}
         response = requests.get(url, json=json_data, headers=headers, timeout=5)
         response.raise_for_status()
+        logger.info(f"Health check passed: {response.status_code}")
         return True, response.json() if response.content else {}
     except requests.RequestException as e:
         logger.error(f"Health check failed: {str(e)}")

--- a/app/frontend/src/components/HealthBadge.tsx
+++ b/app/frontend/src/components/HealthBadge.tsx
@@ -8,7 +8,7 @@ interface HealthBadgeProps {
   deployId: string
 }
 
-type HealthStatus = 'healthy' | 'unhealthy' | 'unknown'
+type HealthStatus = 'healthy' | 'unavailable' | 'unhealthy' | 'unknown'
 
 const HealthBadge: React.FC<HealthBadgeProps> = ({ deployId }) => {
   console.log('HealthBadge component rendered', deployId)
@@ -17,18 +17,14 @@ const HealthBadge: React.FC<HealthBadgeProps> = ({ deployId }) => {
 
   const fetchHealth = async () => {
     try {
-      const response = await fetch('/models/health/', {
+      const response = await fetch(`/models-api/health/?deploy_id=${deployId}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Deploy-Id': deployId,
-        }
       })
 
       if (response.status === 200) {
         setHealth('healthy')
       } else if (response.status === 503) {
-        setHealth('unhealthy')
+        setHealth('unavailable')
       } else {
         setHealth('unknown')
       }
@@ -41,7 +37,7 @@ const HealthBadge: React.FC<HealthBadgeProps> = ({ deployId }) => {
 
   useEffect(() => {
     fetchHealth()
-    const intervalId = setInterval(fetchHealth, 360000) // 6 minutes
+    const intervalId = setInterval(fetchHealth, 5000) // 5 seconds
     return () => clearInterval(intervalId)
   }, [deployId])
 


### PR DESCRIPTION
# change log
- fixing health status handling to use query params
- fixing frontend endpoint and usage of query params
- add unavailable status for container startup 503 default
- Front end polling health check every 5 seconds
- Improve logging and add return content explaining status and propagating errors from inference server if present