### PR TITLE
switch out docker bridge network name

### DIFF
--- a/app/api/README.md
+++ b/app/api/README.md
@@ -56,7 +56,7 @@ example JSON response:
             ]
         },
         "networks": {
-            "llm_studio_network": {
+            "tt_studio_network": {
                 "DNSNames": [
                     "dummy_echo_model_p8013",
                     "1d1a274a7126"

--- a/app/api/shared_config/backend_config.py
+++ b/app/api/shared_config/backend_config.py
@@ -32,7 +32,7 @@ backend_config = BackendConfig(
         "backend_volume"
     ),
     django_deploy_cache_name="deploy_cache",
-    docker_bridge_network_name="llm_studio_network",
+    docker_bridge_network_name="tt_studio_network",
     weights_dir="model_weights",
     model_container_cache_root="/home/user/cache_root",
     jwt_secret=os.environ["JWT_SECRET"],

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
     # note that `network_mode: host` does not work on mac OS
     networks:
-      - llm_studio_network
+      - tt_studio_network
     ports:
       - "8000:8000"
     # command: bash
@@ -66,7 +66,7 @@ services:
       tt_studio_backend:
         condition: service_healthy
     networks:
-      - llm_studio_network
+      - tt_studio_network
     ports:
       - "3000:3000"
     # volumes:
@@ -100,12 +100,12 @@ services:
     container_name: tt_studio_chroma
 
     networks:
-      - llm_studio_network
+      - tt_studio_network
 
 networks:
-  llm_studio_network:
+  tt_studio_network:
     # need external flag to allow for the backend to manage the docker network
     # otherwise, docker compose will create an app_* network for the backend container
     # to avoid colliding existing docker networks
     external: true
-    name: llm_studio_network
+    name: tt_studio_network

--- a/startup.sh
+++ b/startup.sh
@@ -17,7 +17,7 @@ usage() {
     echo -e "This script sets up the TT-Studio environment by performing the following steps:"
     echo -e "  1. 🧭 Detects the OS."
     echo -e "  2. 🛠️  Sets the TT_STUDIO_ROOT variable in .env based on the running directory."
-    echo -e "  3. 🌐 Checks for and creates a Docker network named 'llm_studio_network' if not present."
+    echo -e "  3. 🌐 Checks for and creates a Docker network named 'tt_studio_network' if not present."
     echo -e "  4. 🚀 Runs Docker Compose to start the TT Studio services."
     echo
     echo -e "Options:"
@@ -160,7 +160,7 @@ fi
 source "${ENV_FILE_PATH}"
 
 # Step 3: Check if the Docker network already exists
-NETWORK_NAME="llm_studio_network"
+NETWORK_NAME="tt_studio_network"
 if docker network ls | grep -qw "${NETWORK_NAME}"; then
     echo "Network '${NETWORK_NAME}' exists."
 else


### PR DESCRIPTION
### Switches out the docker bridge network name 

- #114 

Should be tested on a loudbox to essure both mock and vLLM llama model can be deployed and works 