### PR TITLE
Dynamically render NavBar and ModelsDeployedTable using ModelType enum

### DIFF
--- a/app/api/docker_control/docker_utils.py
+++ b/app/api/docker_control/docker_utils.py
@@ -218,19 +218,24 @@ def get_container_status():
     containers = get_managed_containers()
     data = {}
     for con in containers:
+        # get model_impl using container's image_name
+        image_name = con.attrs.get("Config").get("Image")
+        model_impl = next(impl for impl in model_implmentations.values() if impl.image_version == image_name)
+
         data[con.id] = {
             "name": con.name,
             "status": con.status,
             "health": con.health,
             "create": con.attrs.get("Created"),
             "image_id": con.attrs.get("Image"),
-            "image_name": con.attrs.get("Config").get("Image"),
+            "image_name": image_name,
             "port_bindings": con.attrs.get("NetworkSettings").get("Ports"),
             "networks": {
                 k: {"DNSNames": v.get("DNSNames")}
                 for k, v in con.attrs.get("NetworkSettings").get("Networks").items()
             },
             "env_vars": parse_env_var_str(con.attrs.get("Config").get("Env")),
+            "model_type": model_impl.model_type.name,
         }
     return data
 

--- a/app/frontend/src/components/ModelsDeployedTable.tsx
+++ b/app/frontend/src/components/ModelsDeployedTable.tsx
@@ -139,45 +139,29 @@ export default function ModelsDeployedTable() {
     return modelName.toLowerCase().includes("llama");
   };
 
-  const getModelIcon = (modelName: string) => {
-    const modelType = getModelTypeFromName(modelName);
-    switch (modelType) {
+  const getModelIcon = (model_type: string) => {
+    switch (model_type) {
       case ModelType.ChatModel:
         return <MessageSquare className="w-4 h-4 mr-2" />
       case ModelType.ImageGeneration:
         return <Image className="w-4 h-4 mr-2" />
-      case ModelType.ObjectDetectionModel:
+      case ModelType.ObjectDetection:
         return <Eye className="w-4 h-4 mr-2" />
       default:
         return <MessageSquare className="w-4 h-4 mr-2" />
     }
   };
 
-  const getModelTypeLabel = (modelName: string) => {
-    const modelType = getModelTypeFromName(modelName);
-    switch (modelType) {
+  const getModelTypeLabel = (model_type: string) => {
+    switch (model_type) {
       case ModelType.ChatModel:
         return "ChatUI";
       case ModelType.ImageGeneration:
         return "ImageGeneration";
-      case ModelType.ObjectDetectionModel:
+      case ModelType.ObjectDetection:
         return "ObjectDetection";
       default:
         return "ChatUI"
-    }
-  };
-
-  const getModelToolTip = (modelName: string) => {
-    const modelType = getModelTypeFromName(modelName);
-    switch (modelType) {
-      case ModelType.ChatModel:
-        return "Open ChatUI for this model";
-      case ModelType.ImageGeneration:
-        return "Open ImageGeneration for this model";
-      case ModelType.ObjectDetectionModel:
-        return "Open ObjectDetection for this model";
-      default:
-        return "Open ChatUI for this model";
     }
   };
 
@@ -299,6 +283,7 @@ export default function ModelsDeployedTable() {
                                   handleModelNavigationClick(
                                     model.id,
                                     model.name,
+                                    model.model_type,
                                     navigate,
                                   )
                                 }
@@ -309,8 +294,8 @@ export default function ModelsDeployedTable() {
                                 } rounded-lg`}
                                 disabled={!model.name}
                               >
-                                {getModelIcon(model.name)}
-                                {getModelTypeLabel(model.name)}
+                                {getModelIcon(model.model_type)}
+                                {getModelTypeLabel(model.model_type)}
                                 {isLLaMAModel(model.name || "") && (
                                   <AlertCircle className="w-4 h-4 ml-2 text-yellow-600" />
                                 )}
@@ -324,7 +309,7 @@ export default function ModelsDeployedTable() {
                                 </p>
                               ) : (
                                 <p>
-                                  {getModelToolTip(model.name)}
+                                  Open {getModelTypeLabel(model.model_type)} for this model
                                 </p>
                               )}
                             </TooltipContent>

--- a/app/frontend/src/providers/ModelsContext.tsx
+++ b/app/frontend/src/providers/ModelsContext.tsx
@@ -12,6 +12,7 @@ export interface Model {
   status: string;
   health: string;
   ports: string;
+  model_type: string;
 }
 
 interface ModelsContextType {


### PR DESCRIPTION
This PR changes the way we deal with dynamically rendering the NavBar and ModelsDeployedTable by forwarding the ModelType enum to the frontend.

We now:
* display only 1 tab in the NavBar for each model (no more image-gen being greyed out when a chat model is deployed)
* can display multiple tabs in the NavBar for every deployed model
* chooses icons, tooltips, display text based off ModelType enum in both NavBar and ModelsDeployedTable (no more hardcoding)