### PR TITLE
Enhance cache management and system resource handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,55 @@
 </p>
 
 <h1 align="center">TT-Studio</h1>
-<p align="center">An all-in-one platform with an interactive UI for deploying, managing, and interacting with TT-Metal–based models on Tenstorrent AI accelerators.</p>
+
 
 > To use TT-Studio’s deployment features, you need access to a Tenstorrent AI accelerator.<br>
 > Alternatively, you can connect just the frontend to a remote API endpoint if you do not have direct hardware access.
 
 
-TT-Studio combines [TT Inference Server's](https://github.com/tenstorrent/tt-inference-server) core packaging setup, containerization, and deployment automation with [TT-Metal's](https://github.com/tenstorrent-metal/tt-metal) model execution framework specifically optimized for Tenstorrent hardware and provides an intuitive GUI for model management and interaction. 
-
-This guide explains how to use TT-Studio in both standard and development environments.
-
-## Table of Contents
-
-1. [Prerequisites](#prerequisites)
-2. [Overview](#overview)
-3. [Quick Start](#quick-start)
-   - [One-Command Setup (Recommended)](#one-command-setup-recommended)
-   - [For General Users](#for-general-users)
-4. [Running in Development Mode](#running-in-development-mode)
-5. [Troubleshooting](#troubleshooting)
-6. [Documentation](#documentation)
-   - [Frontend Documentation](app/frontend/README.md)
-   - [Backend API Documentation](app/backend/README.md)
-   - [Running vLLM Models in TT-Studio](docs/HowToRun_vLLM_Models.md)
-   - [Running AI Agent in TT-Studio](app/agent/README.md)
+**TL;DR:** TT-Studio is an easy-to-use web interface for running AI models on Tenstorrent hardware. It handles all the technical setup automatically and gives you a simple GUI to deploy models, chat with models, and more.
 
 ---
 
+TT-Studio combines [TT Inference Server's](https://github.com/tenstorrent/tt-inference-server) core packaging setup, containerization, and deployment automation with [TT-Metal's](https://github.com/tenstorrent-metal/tt-metal) model execution framework specifically optimized for Tenstorrent hardware and provides an intuitive GUI for model management and interaction. 
+
 ## Prerequisites
 
-1. Python 3.8 or higher: Required to run the setup script. You can download Python from [python.org](https://www.python.org/downloads/).
-2. Docker: Ensure that Docker is installed on your machine. You can refer to the installation guide [here](https://docs.docker.com/engine/install/).
-3. Tenstorrent Hardware (optional): TT-Studio will automatically detect and use available Tenstorrent hardware.
+Before you start, make sure you have:
+
+1. **Python 3.8+** - [Download here](https://www.python.org/downloads/)
+2. **Docker** - [Installation guide](https://docs.docker.com/engine/install/)
+3. **Tenstorrent Hardware** (optional) - Auto-detected when available
+
+## 📚 Choose Your Path
+
+### 👤 I'm a Normal User
+> I want to use TT-Studio to run AI models
+
+**Start Here:**
+1. **[FAQ](docs/FAQ.md)** - Quick answers to common questions
+2. **[Setup Guide](docs/run-py-guide.md)** - Complete installation & configuration  
+3. **[AI Model Interface](docs/model-interface.md)** - Use TT-Studio as AI playground (Chat, Vision, Speech, Images)
+
+**Need Help?**
+- **Having issues?** → [Troubleshooting Guide](docs/troubleshooting.md)
+- **Want specific models?** → [vLLM Models Guide](docs/HowToRun_vLLM_Models.md)
+- **Need AI assistant?** → [AI Agent Setup](app/agent/README.md)
+
+### 🛠️ I'm a Developer
+> I want to contribute to TT-Studio or modify it
+
+**Start Here:**
+1. **[Contributing Guide](docs/CONTRIBUTING.md)** - How to contribute code
+2. **[Dev Setup](docs/development.md)** - Development environment setup
+3. **[Frontend Docs](app/frontend/README.md)** - React frontend development
+4. **[Backend API](app/backend/README.md)** - Django backend & API endpoints
+
+**Tools & Resources:**
+- **[Dev Tools](dev-tools/README.md)** - Development utilities
+- **[Troubleshooting](docs/troubleshooting.md)** - Fix common problems
+
+---
 
 ## Overview
 
@@ -217,31 +234,3 @@ Developers can run the app with live code reloading for easier development.
 For detailed information about using the `run.py` script, including all command-line options, authentication requirements, and advanced usage scenarios, see our [Complete `run.py` Guide](docs/run-py-guide.md).
 
 ---
-
-## Documentation
-
-- **Frontend Documentation**: [app/frontend/README.md](app/frontend/README.md)  
-  Detailed documentation about the frontend of TT Studio, including setup, development, and customization guides.
-
-- **Backend API Documentation**: [app/backend/README.md](app/backend/README.md)  
-  Information on the backend API, including available endpoints and integration details.
-
-- **Running vLLM Models in TT-Studio**: Models are automatically set up and deployed through the TT-Studio interface. No manual configuration is required.
-
-- **Running AI Agent in TT-Studio**: [app/agent/README.md](app/agent/README.md)
-  Instructions on how to run AI Agent by providing an API Key.
-
-- **Contribution Guide**: [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)  
-  If you're interested in contributing to the project, please refer to our contribution guidelines.
-
-- **Complete `run.py` Guide**: [docs/run-py-guide.md](docs/run-py-guide.md)  
-  Detailed documentation for using the `run.py` script, including all command-line options and authentication requirements.
-
-- **Troubleshooting Guide**: [docs/troubleshooting.md](docs/troubleshooting.md)  
-  Comprehensive solutions for common issues you might encounter with TT-Studio.
-
-- **Developer Tools**: [dev-tools/README.md](dev-tools/README.md)  
-  Development utilities and tools for TT-Studio, including the SPDX header tool for adding license headers to source files.
-
-- **Frequently Asked Questions (FAQ)**: [docs/FAQ.md](docs/FAQ.md)  
-  A compilation of frequently asked questions to help users quickly solve common issues.

--- a/app/backend/board_control/urls.py
+++ b/app/backend/board_control/urls.py
@@ -16,4 +16,7 @@ urlpatterns = [
     # Alert endpoints
     path("alerts/", views.HardwareAlertsView.as_view(), name="hardware-alerts"),
     path("alerts/<int:alert_id>/resolve/", views.HardwareAlertsView.as_view(), name="resolve-alert"),
+    
+    # Cache management
+    path("refresh-cache/", views.RefreshCacheView.as_view(), name="refresh-cache"),
 ] 

--- a/app/backend/board_control/views.py
+++ b/app/backend/board_control/views.py
@@ -223,3 +223,25 @@ class HardwareAlertsView(APIView):
                 {"error": "Failed to resolve alert", "details": str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             ) 
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class RefreshCacheView(APIView):
+    """Manual cache refresh endpoint for debugging and manual triggering"""
+    
+    def post(self, request, *args, **kwargs):
+        try:
+            logger.info("Manual cache refresh requested")
+            SystemResourceService.force_refresh_tt_smi_cache()
+            
+            return Response({
+                "status": "success",
+                "message": "tt-smi cache refreshed successfully"
+            }, status=status.HTTP_200_OK)
+            
+        except Exception as e:
+            logger.error(f"Error manually refreshing cache: {str(e)}")
+            return Response(
+                {"error": "Failed to refresh cache", "details": str(e)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            ) 

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -8,6 +8,7 @@ import copy
 from pathlib import Path
 
 import docker
+import requests
 from django.core.cache import caches
 
 from shared_config.device_config import DeviceConfigurations
@@ -15,6 +16,7 @@ from shared_config.logger_config import get_logger
 from shared_config.model_config import model_implmentations
 from shared_config.backend_config import backend_config
 from shared_config.model_type_config import ModelTypes
+from board_control.services import SystemResourceService
 
 
 CONFIG_PATH = "/root/.config/tenstorrent/reset_config.json"
@@ -67,7 +69,6 @@ def run_container(impl, weights_id):
             logger.info(f"API payload: {payload}")
 
             # Make POST request to TT Inference Server API
-            import requests
             api_url = "http://172.18.0.1:8001/run"
 
             response = requests.post(
@@ -634,11 +635,7 @@ def pull_image_with_progress(image_name, image_tag, progress_callback=None):
 def detect_board_type():
     """Detect board type using cached data from SystemResourceService"""
     try:
-        from board_control.services import SystemResourceService
         return SystemResourceService.get_board_type()
-    except ImportError:
-        logger.error("Could not import SystemResourceService")
-        return "unknown"
     except Exception as e:
         logger.error(f"Error detecting board type: {str(e)}")
         return "unknown"

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -32,6 +32,7 @@ from .serializers import DeploymentSerializer, StopSerializer
 from shared_config.logger_config import get_logger
 from shared_config.backend_config import backend_config
 from shared_config.device_config import DeviceConfigurations
+from board_control.services import SystemResourceService
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
@@ -84,7 +85,6 @@ class StopView(APIView):
                 else:
                     # Refresh tt-smi cache after successful stop and reset
                     try:
-                        from board_control.services import SystemResourceService
                         SystemResourceService.force_refresh_tt_smi_cache()
                     except Exception as e:
                         logger.warning(f"Failed to refresh tt-smi cache after model stop: {e}")
@@ -186,7 +186,6 @@ class DeployView(APIView):
             # Refresh tt-smi cache after successful deployment
             if response.get("status") == "success":
                 try:
-                    from board_control.services import SystemResourceService
                     SystemResourceService.force_refresh_tt_smi_cache()
                 except Exception as e:
                     logger.warning(f"Failed to refresh tt-smi cache after deployment: {e}")
@@ -209,7 +208,6 @@ class RedeployView(APIView):
             # Refresh tt-smi cache after successful redeployment
             if response.get("status") == "success":
                 try:
-                    from board_control.services import SystemResourceService
                     SystemResourceService.force_refresh_tt_smi_cache()
                 except Exception as e:
                     logger.warning(f"Failed to refresh tt-smi cache after redeployment: {e}")

--- a/app/frontend/src/components/DeployModelStep.tsx
+++ b/app/frontend/src/components/DeployModelStep.tsx
@@ -28,7 +28,7 @@ export function DeployModelStep({
 }) {
   const { nextStep } = useStepper();
   const { refreshModels } = useModels();
-  const { triggerRefresh } = useRefresh();
+  const { triggerRefresh, triggerHardwareRefresh } = useRefresh();
   const navigate = useNavigate();
   const [modelName, setModelName] = useState<string | null>(null);
   const [deployedInfo, setDeployedInfo] = useState<{
@@ -104,9 +104,12 @@ export function DeployModelStep({
 
       // Trigger a global refresh
       triggerRefresh();
+      
+      // Trigger hardware cache refresh after successful deployment
+      await triggerHardwareRefresh();
     }
     return deploySuccess;
-  }, [handleDeploy, refreshModels, triggerRefresh, isDeployDisabled]);
+  }, [handleDeploy, refreshModels, triggerRefresh, triggerHardwareRefresh, isDeployDisabled]);
 
   const onDeploymentComplete = useCallback(() => {
     setTimeout(() => {

--- a/app/frontend/src/components/Footer.tsx
+++ b/app/frontend/src/components/Footer.tsx
@@ -84,16 +84,10 @@ const Footer: React.FC<FooterProps> = ({ className }) => {
   };
 
   useEffect(() => {
-    // Initial fetch
+    // Initial fetch on mount only
     fetchSystemStatus();
 
-    // Set up polling every 2 minutes for system status only
-    const interval = setInterval(() => {
-      fetchSystemStatus();
-    }, 120000);
-
-    // Cleanup interval on unmount
-    return () => clearInterval(interval);
+    // No more timer-based polling - will refresh on model deployment events
   }, []);
 
   const textColor = theme === "dark" ? "text-zinc-300" : "text-gray-700";

--- a/app/frontend/src/components/HealthBadge.tsx
+++ b/app/frontend/src/components/HealthBadge.tsx
@@ -45,8 +45,7 @@ const HealthBadge: React.FC<HealthBadgeProps> = ({ deployId }) => {
 
   useEffect(() => {
     fetchHealth();
-    const intervalId = setInterval(fetchHealth, 120000); // 2 minutes
-    return () => clearInterval(intervalId);
+    // No more timer-based polling - health will be checked on model deployment events
   }, [deployId]);
 
   const getStatusColor = () => {
@@ -83,7 +82,7 @@ const HealthBadge: React.FC<HealthBadgeProps> = ({ deployId }) => {
           </div>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Docker Container Health: {health} (refreshed every 2 minutes)</p>
+          <p>Docker Container Health: {health} (refreshed on deployment events)</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/app/frontend/src/components/ModelsDeployedTable.tsx
+++ b/app/frontend/src/components/ModelsDeployedTable.tsx
@@ -737,7 +737,7 @@ function LogsDialog({
 
 export default function ModelsDeployedTable() {
   const navigate = useNavigate();
-  const { refreshTrigger, triggerRefresh } = useRefresh();
+  const { refreshTrigger, triggerRefresh, triggerHardwareRefresh } = useRefresh();
   const { models, setModels, refreshModels } = useModels();
   const [fadingModels, setFadingModels] = useState<string[]>([]);
   const [pulsatingModels, setPulsatingModels] = useState<string[]>([]);
@@ -807,12 +807,11 @@ export default function ModelsDeployedTable() {
     };
     if (models.length > 0) {
       fetchAllHealth();
-      const interval = setInterval(fetchAllHealth, 120000);
-      return () => {
-        isMounted = false;
-        clearInterval(interval);
-      };
+      // No more timer-based polling - health will be checked when models change
     }
+    return () => {
+      isMounted = false;
+    };
   }, [models]);
 
   // Placeholder for backend reset call
@@ -845,6 +844,7 @@ export default function ModelsDeployedTable() {
         error: "Failed to reset card.",
       });
       await refreshModels();
+      triggerHardwareRefresh(); // Trigger hardware refresh
       setShowDeleteModal(false);
       setDeleteTargetId(null);
     } catch (error) {

--- a/app/frontend/src/providers/RefreshContext.tsx
+++ b/app/frontend/src/providers/RefreshContext.tsx
@@ -1,33 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
-import { createContext, useContext, useState, ReactNode } from "react";
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import React, { createContext, useContext, useState } from "react";
 
 interface RefreshContextType {
   refreshTrigger: number;
   triggerRefresh: () => void;
+  triggerHardwareRefresh: () => Promise<void>; // New function for hardware cache refresh
 }
 
 const RefreshContext = createContext<RefreshContextType | undefined>(undefined);
 
-export const RefreshProvider = ({ children }: { children: ReactNode }) => {
+export const RefreshProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  // + 1 to trigger a refresh
   const triggerRefresh = () => {
     setRefreshTrigger((prev) => prev + 1);
   };
 
+  const triggerHardwareRefresh = async () => {
+    try {
+      console.log("Triggering hardware cache refresh...");
+      const response = await fetch("/board-api/refresh-cache/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      
+      if (response.ok) {
+        console.log("Hardware cache refreshed successfully");
+        // Also trigger regular refresh to update UI
+        triggerRefresh();
+      } else {
+        console.warn("Failed to refresh hardware cache:", response.status);
+      }
+    } catch (error) {
+      console.error("Error triggering hardware refresh:", error);
+    }
+  };
+
   return (
-    <RefreshContext.Provider value={{ refreshTrigger, triggerRefresh }}>
+    <RefreshContext.Provider value={{ refreshTrigger, triggerRefresh, triggerHardwareRefresh }}>
       {children}
     </RefreshContext.Provider>
   );
 };
 
 export const useRefresh = () => {
-  // console.log("useRefresh called");
   const context = useContext(RefreshContext);
-  if (!context) {
+  if (context === undefined) {
     throw new Error("useRefresh must be used within a RefreshProvider");
   }
   return context;


### PR DESCRIPTION
Changelog
- #413


  - Updated cache timeout for tt-smi data to 1 hour and introduced a new cache for board type data, also set to 1 hour.
  - Improved error handling by extending the timeout for caching failed tt-smi results to 2 minutes.
  - Added a new endpoint for manual cache refresh, allowing users to trigger a refresh of the tt-smi and board type caches.
  - Implemented a method to force refresh the tt-smi cache after model deployment or deletion events, ensuring up-to-date data.
  - Refactored frontend components to trigger hardware cache refresh upon successful model deployment, enhancing user experience.