### PR TITLE
fix: removed useless close btn

### DIFF
--- a/app/frontend/src/components/ui/dialog.tsx
+++ b/app/frontend/src/components/ui/dialog.tsx
@@ -6,7 +6,6 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
 
 import { cn } from "../../lib/utils";
 
@@ -48,10 +47,6 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-stone-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-stone-100 data-[state=open]:text-stone-500 dark:ring-offset-stone-950 dark:focus:ring-stone-300 dark:data-[state=open]:bg-stone-800 dark:data-[state=open]:text-stone-400">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));


### PR DESCRIPTION
## What does this PR do ?
This PR removes the useless 'x' ( close button ) on models-deployed page

Fixes #425 

<img width="644" height="235" alt="image" src="https://github.com/user-attachments/assets/edbc33c9-a33a-4869-ab6d-ab419505e3a1" />
