### PR TITLE
Fix: unreadable error lable in light mode

### DIFF
--- a/app/frontend/src/components/Footer.tsx
+++ b/app/frontend/src/components/Footer.tsx
@@ -156,7 +156,7 @@ const Footer: React.FC<FooterProps> = ({ className }) => {
                   ? "destructive"
                   : "default"
             }
-            className="text-xs"
+            className={`text-xs ${textColor}`}
             title={systemStatus.hardware_error || error || "Hardware status"}
           >
             {systemStatus.boardName}


### PR DESCRIPTION
## What does this PR do ?
Fixes the "Error" label text color in light mode for better readability 

Fixes #443  

<img width="377" height="38" alt="Screenshot from 2025-07-18 19-25-46" src="https://github.com/user-attachments/assets/8077ff48-cd08-4180-ba0d-91e96f513e3e" />