### PR TITLE
Fix: favicon rendering

### DIFF
--- a/app/frontend/.env.default
+++ b/app/frontend/.env.default
@@ -6,6 +6,7 @@ VITE_LOGIN_PASSWORD=
 VITE_ENABLE_LOGIN= # false or true 
 VITE_ENABLE_DEPLOYED= # false or true 
 VITE_APP_TITLE= #AI Playground and or TT-Studio
+VITE_APP_LOGO=https://github.com/tenstorrent/tt-metal/raw/main/docs/source/common/images/favicon.png # used in index.html favicon
 
 
 # chatui env variables

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -5,7 +5,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="./src/assets/logo/tt_logo.svg"
+      href="%VITE_APP_LOGO%"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>%VITE_APP_TITLE%</title>


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the issue where the favicon logo wasn't showing up properly. The solution follows a similar approach to how the page title is handled, ensuring both the favicon and title load correctly.

Fixes #433 

<img width="248" height="62" alt="image" src="https://github.com/user-attachments/assets/b23dd19e-db76-42f0-bfba-f1a417b3d1c9" />
