### PR TITLE
fix: improve Generate button text visibility in dark mode

### DIFF
--- a/app/frontend/src/components/chatui/InputArea.tsx
+++ b/app/frontend/src/components/chatui/InputArea.tsx
@@ -744,9 +744,10 @@ export default function InputArea({
                     disabled={
                       isStreaming || (!textInput.trim() && files.length === 0)
                     }
-                    className={`
+                      className={`
                       bg-[#7C68FA] hover:bg-[#7C68FA]/90 active:bg-[#7C68FA]/80 text-white 
-                      dark:text-white
+                      dark:text-gray-800 border border-[#7C68FA]/50
+                      rounded-full flex items-center transition-all duration-200 touch-manipulation
                       ${isMobileView ? "px-3 py-2 text-sm" : "px-4 py-2 text-sm"} 
                       rounded-lg flex items-center gap-1 sm:gap-2 transition-all duration-200 touch-manipulation
                       ${(!textInput.trim() && files.length === 0) || isStreaming ? "opacity-70 cursor-not-allowed" : "cursor-pointer"}


### PR DESCRIPTION
## What does this PR do ?
Fixes the "Generate" button text visibility issue in dark mode by improving contrast for better readability.

Fixes #454   


<img width="966" height="115" alt="Screenshot from 2025-07-22 11-50-18" src="https://github.com/user-attachments/assets/615a8a50-90c6-426b-8b73-568efded7dab" />


<img width="976" height="110" alt="Screenshot from 2025-07-22 11-50-01" src="https://github.com/user-attachments/assets/82d9c9e1-83e0-48a0-936d-05243de47949" />