### PR TITLE
fix: handle full array of documents instead of only first entry

### DIFF
--- a/app/frontend/src/components/chatui/getRagContext.ts
+++ b/app/frontend/src/components/chatui/getRagContext.ts
@@ -73,7 +73,7 @@ export const getRagContext = async (
         if (response?.data) {
            const docs = response.data.documents;
           if (Array.isArray(docs)) {
-            const items = Array.isArray(docs[0]) ? docs[0] : docs;
+            const items = docs.flat();
             ragContext.documents = items.map((d: any) => {
 	              if (typeof d === "string") {
 	                return d;


### PR DESCRIPTION
## What does this PR do ?
Updated `getRagContext.ts` to handle full response.data.documents array instead of only the first element.
The code now normalizes nested arrays and object/string formats, ensuring **ragContext.documents** always resolves to a string array.

Example cases handled:

`documents: [ [ "a", "b" ] ]`
`documents: [ "a", "b" ]`
`documents: [ { text: "a" } ]`

This ensures no data is lost 

Fixes #380 