### PR TITLE
Update deployment timeout handling and improve progress tracking

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -24,6 +24,9 @@ CONFIG_PATH = Path(backend_config.backend_cache_root).joinpath("tenstorrent", "r
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
 
+# Deployment timeout: 5 hours to allow for large model downloads
+DEPLOYMENT_TIMEOUT_SECONDS = 5 * 60 * 60  # 5 hours
+
 # Ensure the bridge network exists on startup
 def _ensure_network():
     """Ensure the tt_studio_network exists via docker-control-service"""
@@ -111,7 +114,7 @@ def run_container(impl, weights_id):
             response = requests.post(
                 api_url,
                 json=payload,
-                timeout=300  # 5 minute timeout for container startup
+                timeout=DEPLOYMENT_TIMEOUT_SECONDS  # 5 hour timeout for container startup and weight downloads
             )
 
             if response.status_code in [200, 202]:

--- a/app/frontend/src/hooks/useDeploymentProgress.ts
+++ b/app/frontend/src/hooks/useDeploymentProgress.ts
@@ -59,11 +59,13 @@ export const useDeploymentProgress = (
       console.log(`[Progress] Received progress data:`, progressData);
       setProgress(progressData);
       setError(null);
-      
-      // Stop polling if deployment is complete or failed
-      if (progressData.status === 'completed' || 
-          progressData.status === 'failed' || 
-          progressData.status === 'error') {
+
+      // Stop polling only on terminal statuses
+      // Continue polling for 'stalled', 'retrying', 'starting', 'running'
+      if (progressData.status === 'completed' ||
+          progressData.status === 'failed' ||
+          progressData.status === 'error' ||
+          progressData.status === 'timeout') {
         console.log(`[Progress] Stopping polling - final status: ${progressData.status}`);
         stopPolling();
       }
@@ -92,11 +94,13 @@ export const useDeploymentProgress = (
           console.log(`[Progress] Received SSE progress data:`, progressData);
           setProgress(progressData);
           setError(null);
-          
-          // Stop SSE if deployment is complete or failed
-          if (progressData.status === 'completed' || 
-              progressData.status === 'failed' || 
+
+          // Stop SSE only on terminal statuses
+          // Continue for 'stalled', 'retrying', 'starting', 'running'
+          if (progressData.status === 'completed' ||
+              progressData.status === 'failed' ||
               progressData.status === 'error' ||
+              progressData.status === 'timeout' ||
               progressData.status === 'cancelled') {
             console.log(`[Progress] Stopping SSE - final status: ${progressData.status}`);
             stopPolling();


### PR DESCRIPTION
- Introduced a new constant for deployment timeout set to 5 hours to accommodate large model downloads.
- Updated the `run_container` function to use the new timeout value for container startup.
- Enhanced the `DeploymentProgressView` to track elapsed time and handle timeout scenarios, providing informative messages for stalled and running statuses.
- Adjusted frontend components to continue polling for intermediate statuses while stopping on terminal statuses, including timeout.
- Improved error handling and user feedback during deployment progress.

These changes enhance the deployment process by providing better management of long-running operations and clearer communication of status to users.