### PR TITLE
Improve model deletion flow

### DIFF
--- a/app/backend/docker_control/urls.py
+++ b/app/backend/docker_control/urls.py
@@ -7,6 +7,7 @@ from django.urls import path
 from . import views
 from .views import (
     StopView,
+    StopStreamView,
     ContainersView,
     StatusView,
     ChipStatusView,
@@ -36,6 +37,7 @@ urlpatterns = [
     path("deploy/logs/<str:job_id>/", views.DeploymentLogsView.as_view(), name="deployment-logs"),
     path("deploy/progress/stream/<str:job_id>/", views.DeploymentProgressStreamView.as_view(), name="deployment-progress-stream"),
     path("stop/", views.StopView.as_view()),
+    path("stop/stream/<str:container_id>/", views.StopStreamView.as_view(), name="stop-stream"),
     path("status/", views.StatusView.as_view()),
     path("chip-status/", views.ChipStatusView.as_view(), name="chip-status"),
     path("redeploy/", views.RedeployView.as_view()),

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -14,6 +14,7 @@ from django.utils.decorators import method_decorator
 import json
 import shutil
 import subprocess
+import signal
 import os
 from pathlib import Path
 
@@ -1969,6 +1970,176 @@ class WorkflowLogStreamView(View):
                 status=500,
                 content=str(e)
             )
+
+
+class StopStreamView(View):
+    """Stream model deletion progress as Server-Sent Events.
+
+    Performs stop → remove → board-reset sequentially, emitting real-time
+    log lines so the frontend dialog can mirror what the backend is doing.
+    Each ``log`` event carries a ``step`` field so the UI can slot it under
+    the correct progress row.
+
+    Uses an async generator so that yields flush immediately through
+    uvicorn's event loop instead of being batched by the sync threadpool.
+    """
+
+    @staticmethod
+    def _sse(data: dict) -> str:
+        return f"data: {json.dumps(data)}\n\n"
+
+    async def get(self, request, container_id, *args, **kwargs):
+        import asyncio
+        sse = self._sse
+        ansi_re = re.compile(r'\x1b\[[0-9;]*m|\|[0-9;]*m')
+
+        async def generate():
+            yield "retry: 1000\n\n"
+
+            truncated = container_id[:12]
+            current_step = "deleting"
+
+            # --- Step 1: mark deployment stopped in DB ---
+            yield sse({"type": "step", "step": "deleting", "message": f"Stopping model {truncated}…"})
+
+            def _mark_stopped():
+                from docker_control.models import ModelDeployment
+                from django.utils import timezone
+                deployment = ModelDeployment.objects.filter(container_id=container_id).first()
+                if deployment:
+                    deployment.stopped_by_user = True
+                    deployment.status = "stopped"
+                    deployment.stopped_at = timezone.now()
+                    deployment.save()
+                    return f"Marked deployment {truncated} as stopped in database"
+                return "No deployment record found — continuing"
+
+            try:
+                msg = await asyncio.to_thread(_mark_stopped)
+                yield sse({"type": "log", "step": current_step, "message": msg})
+            except Exception as e:
+                yield sse({"type": "log", "step": current_step, "message": f"Warning: failed to update deployment record: {e}"})
+
+            # --- Step 2: stop container ---
+            yield sse({"type": "log", "step": current_step, "message": f"Sending stop signal to container {truncated}…"})
+            docker_client = get_docker_client()
+            container_gone = False
+            try:
+                stop_result = await asyncio.to_thread(docker_client.stop_container, container_id)
+                stop_status = stop_result.get("status", "unknown")
+                yield sse({"type": "log", "step": current_step, "message": f"Stop result: {stop_status}"})
+
+                if stop_status != "success":
+                    yield sse({"type": "complete", "status": "error", "message": f"Failed to stop container: {stop_result.get('message', 'unknown error')}"})
+                    return
+            except Exception as e:
+                error_str = str(e)
+                # 404 / "Not Found" means the container is already gone — not an error
+                if "404" in error_str or "Not Found" in error_str:
+                    container_gone = True
+                    yield sse({"type": "log", "step": current_step, "message": "Container already stopped"})
+                else:
+                    yield sse({"type": "log", "step": current_step, "message": f"Error stopping container: {error_str}"})
+                    yield sse({"type": "complete", "status": "error", "message": f"Failed to stop container {truncated}"})
+                    return
+
+            # --- Step 3: remove container (best-effort, container may already be gone) ---
+            if not container_gone:
+                yield sse({"type": "log", "step": current_step, "message": f"Cleaning up container {truncated}…"})
+                try:
+                    await asyncio.to_thread(docker_client.remove_container, container_id, True)
+                    yield sse({"type": "log", "step": current_step, "message": "Container removed"})
+                except Exception:
+                    yield sse({"type": "log", "step": current_step, "message": "Container already removed"})
+
+            try:
+                await asyncio.to_thread(update_deploy_cache)
+            except Exception:
+                pass
+
+            yield sse({"type": "log", "step": current_step, "message": f"Container {truncated} stopped and removed successfully"})
+
+            # --- Step 4: board reset (stream tt-smi output line-by-line) ---
+            current_step = "resetting"
+            yield sse({"type": "step", "step": "resetting", "message": "Resetting the board…"})
+
+            await asyncio.to_thread(SystemResourceService.set_resetting_state)
+
+            MAX_ATTEMPTS = 2
+            reset_ok = False
+
+            for attempt in range(1, MAX_ATTEMPTS + 1):
+                yield sse({"type": "log", "step": current_step, "message": f"Running tt-smi -r (attempt {attempt}/{MAX_ATTEMPTS})…"})
+
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        "tt-smi", "-r",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                        stdin=asyncio.subprocess.DEVNULL,
+                    )
+
+                    try:
+                        async def _read_with_timeout():
+                            while True:
+                                raw_line = await asyncio.wait_for(
+                                    proc.stdout.readline(), timeout=90
+                                )
+                                if not raw_line:
+                                    break
+                                cleaned = ansi_re.sub("", raw_line.decode("utf-8", errors="replace")).strip()
+                                if cleaned:
+                                    yield cleaned
+
+                        async for line in _read_with_timeout():
+                            yield sse({"type": "log", "step": current_step, "message": line})
+
+                        await asyncio.wait_for(proc.wait(), timeout=10)
+
+                    except asyncio.TimeoutError:
+                        yield sse({"type": "log", "step": current_step, "message": "Timed out after 90s"})
+                        try:
+                            proc.terminate()
+                            await asyncio.sleep(2)
+                            proc.kill()
+                        except Exception:
+                            pass
+
+                    returncode = proc.returncode if proc.returncode is not None else -1
+
+                except Exception as exc:
+                    yield sse({"type": "log", "step": current_step, "message": str(exc)})
+                    returncode = -1
+
+                if returncode == 0:
+                    reset_ok = True
+                    yield sse({"type": "log", "step": current_step, "message": f"Board reset succeeded on attempt {attempt}"})
+                    break
+                else:
+                    yield sse({"type": "log", "step": current_step, "message": f"Attempt {attempt} failed (exit code {returncode})"})
+
+            await asyncio.to_thread(SystemResourceService.clear_device_state_cache)
+
+            if reset_ok:
+                try:
+                    await asyncio.to_thread(SystemResourceService.force_refresh_tt_smi_cache)
+                    yield sse({"type": "log", "step": current_step, "message": "tt-smi cache refreshed"})
+                except Exception as e:
+                    yield sse({"type": "log", "step": current_step, "message": f"Warning: tt-smi cache refresh failed: {e}"})
+
+            final_status = "success" if reset_ok else "partial"
+            final_msg = (
+                "Model deleted and board reset successfully"
+                if reset_ok
+                else "Model deleted but board reset failed"
+            )
+            yield sse({"type": "complete", "status": final_status, "message": final_msg})
+
+        response = StreamingHttpResponse(generate(), content_type="text/event-stream")
+        response["Cache-Control"] = "no-cache, no-transform"
+        response["X-Accel-Buffering"] = "no"
+        response["Content-Encoding"] = "identity"
+        return response
 
 
 class AvailableDevicesView(APIView):

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -269,6 +269,10 @@ class ChipStatusView(APIView):
         Returns JSON with board type, total slots, and per-slot occupancy info.
         """
         try:
+            # Prune deploy cache of containers that are no longer running
+            # so dead containers don't block device slots.
+            update_deploy_cache()
+
             from docker_control.chip_allocator import ChipSlotAllocator
 
             allocator = ChipSlotAllocator()

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -191,68 +191,23 @@ export const fetchModels = async (): Promise<Model[]> => {
 };
 
 export const deleteModel = async (modelId: string): Promise<StopResponse> => {
-  const truncatedModelId = modelId.substring(0, 4);
-  try {
-    const payload = JSON.stringify({ container_id: modelId });
-    console.log("Payload:", payload);
+  const payload = JSON.stringify({ container_id: modelId });
 
-    const response = await axios.post<StopResponse>(stopModelsURL, payload, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    console.log("Response: on ts from backend", response);
+  const response = await axios.post<StopResponse>(stopModelsURL, payload, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
 
-    if (
-      response.data.status !== "success" ||
-      !response.data.stop_response ||
-      response.data.stop_response.status !== "success"
-    ) {
-      customToast.error("Failed to stop the container");
-      throw new Error("Failed to stop the container");
-    } else {
-      customToast.success(
-        `Model ID: ${truncatedModelId} has been deleted successfully.`
-      );
-
-      if (
-        response.data.reset_response &&
-        response.data.reset_response.status === "success"
-      ) {
-        customToast.success(
-          `Model ID: ${truncatedModelId} has been reset successfully.`
-        );
-      } else {
-        customToast.error(`Board Reset failed.`);
-      }
-
-      console.log(
-        `Reset Output: ${response.data.reset_response?.output || "No reset output available"}`
-      );
-    }
-
-    return response.data;
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      console.error("Error stopping the container:", error.response?.data);
-      customToast.error(
-        `Failed to delete Model ID: ${truncatedModelId} - ${
-          error.response?.data.message || error.message
-        }`
-      );
-    } else if (error instanceof Error) {
-      console.error("Error stopping the container:", error.message);
-      customToast.error(
-        `Failed to delete Model ID: ${truncatedModelId} - ${error.message}`
-      );
-    } else {
-      console.error("Unknown error stopping the container", error);
-      customToast.error(
-        `Failed to delete Model ID: ${truncatedModelId} - Unknown error`
-      );
-    }
-    throw error;
+  if (
+    response.data.status !== "success" ||
+    !response.data.stop_response ||
+    response.data.stop_response.status !== "success"
+  ) {
+    throw new Error("Failed to stop the container");
   }
+
+  return response.data;
 };
 
 export const handleRedeploy = (modelName: string): void => {

--- a/app/frontend/src/components/models/DeleteModelDialog.tsx
+++ b/app/frontend/src/components/models/DeleteModelDialog.tsx
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import type { ReactNode } from "react";
-import { AlertTriangle, CheckCircle, Loader2, Trash2, RotateCcw } from "lucide-react";
+import { useEffect, useRef, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  Loader2,
+  Trash2,
+  RotateCcw,
+  XCircle,
+} from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -11,6 +18,7 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Button } from "../ui/button";
+import type { DeleteStreamStatus, StepLogs } from "../../hooks/useDeleteStream";
 
 export type DeleteStep = "deleting" | "resetting" | null;
 
@@ -19,8 +27,50 @@ interface Props {
   modelId: string;
   isLoading: boolean;
   deleteStep: DeleteStep;
+  streamStatus: DeleteStreamStatus;
+  stepLogs: StepLogs;
+  errorMessage: string | null;
   onConfirm: () => void;
   onCancel: () => void;
+}
+
+type StepState = "pending" | "active" | "done" | "error";
+
+function StepLogPanel({ logs }: { logs: string[] }) {
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logs]);
+
+  if (logs.length === 0) return null;
+
+  return (
+    <div className="mt-2 rounded-md border border-stone-700/60 bg-stone-950/80 overflow-hidden">
+      <div className="max-h-32 overflow-y-auto overflow-x-hidden px-3 py-2 font-mono text-[11px] leading-relaxed text-stone-400 scrollbar-thin scrollbar-thumb-stone-700">
+        {logs.map((line, i) => (
+          <div
+            key={i}
+            className={`py-px break-all ${
+              line.toLowerCase().includes("error") ||
+              line.toLowerCase().includes("failed")
+                ? "text-red-400"
+                : line.toLowerCase().includes("success") ||
+                    line.toLowerCase().includes("completed") ||
+                    line.toLowerCase().includes("successfully")
+                  ? "text-green-400"
+                  : line.toLowerCase().includes("warning")
+                    ? "text-yellow-400"
+                    : ""
+            }`}
+          >
+            {line}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+    </div>
+  );
 }
 
 function StepRow({
@@ -29,52 +79,70 @@ function StepRow({
   label,
   sublabel,
   state,
+  logs,
 }: {
   number: number;
   icon: ReactNode;
   label: string;
   sublabel?: string;
-  state: "pending" | "active" | "done";
+  state: StepState;
+  logs: string[];
 }) {
   return (
     <div
-      className={`flex items-start gap-3 p-3 rounded-lg border transition-all duration-300 ${
+      className={`p-3 rounded-lg border transition-all duration-300 ${
         state === "active"
           ? "bg-blue-900/30 border-blue-500/40"
           : state === "done"
             ? "bg-green-900/20 border-green-600/30"
-            : "bg-stone-800/50 border-stone-700/40"
+            : state === "error"
+              ? "bg-red-900/20 border-red-600/30"
+              : "bg-stone-800/50 border-stone-700/40"
       }`}
     >
-      <div className="w-7 h-7 flex items-center justify-center shrink-0 mt-0.5">
-        {state === "active" ? (
-          <Loader2 className="w-5 h-5 text-blue-400 animate-spin" />
-        ) : state === "done" ? (
-          <CheckCircle className="w-5 h-5 text-green-400" />
-        ) : (
-          <div className="w-6 h-6 rounded-full bg-stone-600 flex items-center justify-center text-xs font-bold text-stone-300">
-            {number}
-          </div>
-        )}
-      </div>
-      <div className="flex-1 min-w-0">
-        <div
-          className={`font-medium text-sm ${
-            state === "pending" ? "text-stone-400" : "text-white"
-          }`}
-        >
-          <span className="inline-flex items-center gap-1.5">
-            {icon}
-            {label}
-          </span>
+      <div className="flex items-start gap-3">
+        <div className="w-7 h-7 flex items-center justify-center shrink-0 mt-0.5">
+          {state === "active" ? (
+            <Loader2 className="w-5 h-5 text-blue-400 animate-spin" />
+          ) : state === "done" ? (
+            <CheckCircle className="w-5 h-5 text-green-400" />
+          ) : state === "error" ? (
+            <XCircle className="w-5 h-5 text-red-400" />
+          ) : (
+            <div className="w-6 h-6 rounded-full bg-stone-600 flex items-center justify-center text-xs font-bold text-stone-300">
+              {number}
+            </div>
+          )}
         </div>
-        {sublabel && state === "active" && (
-          <div className="text-xs text-blue-300 mt-1">{sublabel}</div>
-        )}
-        {state === "done" && (
-          <div className="text-xs text-green-400 mt-0.5">Completed</div>
-        )}
+        <div className="flex-1 min-w-0">
+          <div
+            className={`font-medium text-sm ${
+              state === "pending"
+                ? "text-stone-400"
+                : state === "error"
+                  ? "text-red-300"
+                  : "text-white"
+            }`}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {icon}
+              {label}
+            </span>
+          </div>
+          {sublabel && state === "active" && (
+            <div className="text-xs text-blue-300 mt-1">{sublabel}</div>
+          )}
+          {state === "done" && (
+            <div className="text-xs text-green-400 mt-0.5">Completed</div>
+          )}
+          {state === "error" && (
+            <div className="text-xs text-red-400 mt-0.5">Failed</div>
+          )}
+        </div>
       </div>
+
+      {/* Per-step log output */}
+      <StepLogPanel logs={logs} />
     </div>
   );
 }
@@ -84,27 +152,53 @@ export default function DeleteModelDialog({
   modelId: _modelId,
   isLoading,
   deleteStep,
+  streamStatus,
+  stepLogs,
+  errorMessage,
   onConfirm,
   onCancel,
 }: Props) {
-  const step1State =
-    deleteStep === "deleting"
-      ? "active"
-      : deleteStep === "resetting"
-        ? "done"
-        : "pending";
+  const isDone = streamStatus === "success" || streamStatus === "partial";
+  const isError = streamStatus === "error";
 
-  const step2State =
-    deleteStep === "resetting" ? "active" : "pending";
+  const step1State: StepState =
+    isError && deleteStep === "deleting"
+      ? "error"
+      : deleteStep === "deleting"
+        ? "active"
+        : deleteStep === "resetting" || isDone
+          ? "done"
+          : "pending";
+
+  const step2State: StepState =
+    isError && deleteStep === "resetting"
+      ? "error"
+      : streamStatus === "partial"
+        ? "error"
+        : deleteStep === "resetting"
+          ? "active"
+          : isDone
+            ? "done"
+            : "pending";
+
+  const canClose = !isLoading || isDone || isError;
 
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && !isLoading && onCancel()}>
-      <DialogContent className="sm:max-w-md p-6 rounded-xl shadow-2xl bg-stone-900 text-white border border-stone-700 backdrop-blur-md">
+    <Dialog open={open} onOpenChange={(v) => !v && canClose && onCancel()}>
+      <DialogContent className="sm:max-w-xl max-h-[85vh] overflow-y-auto p-6 rounded-xl shadow-2xl bg-stone-900 text-white border border-stone-700 backdrop-blur-md">
         <DialogHeader>
           <div className="flex items-center gap-3 mb-1">
-            {isLoading ? (
+            {isLoading && !isDone && !isError ? (
               <div className="w-9 h-9 rounded-full bg-blue-900/50 flex items-center justify-center">
                 <Loader2 className="h-5 w-5 text-blue-400 animate-spin" />
+              </div>
+            ) : isDone ? (
+              <div className="w-9 h-9 rounded-full bg-green-900/50 flex items-center justify-center">
+                <CheckCircle className="h-5 w-5 text-green-400" />
+              </div>
+            ) : isError ? (
+              <div className="w-9 h-9 rounded-full bg-red-900/50 flex items-center justify-center">
+                <XCircle className="h-5 w-5 text-red-400" />
               </div>
             ) : (
               <div className="w-9 h-9 rounded-full bg-yellow-900/50 flex items-center justify-center">
@@ -113,15 +207,20 @@ export default function DeleteModelDialog({
             )}
             <div>
               <DialogTitle className="text-base font-semibold text-white leading-tight">
-                {isLoading
-                  ? deleteStep === "deleting"
-                    ? "Removing model…"
-                    : "Resetting board…"
-                  : "Delete Model & Reset Card"}
+                {isDone
+                  ? "Deletion Complete"
+                  : isError
+                    ? "Deletion Failed"
+                    : isLoading
+                      ? deleteStep === "deleting"
+                        ? "Removing model…"
+                        : "Resetting board…"
+                      : "Delete Model & Reset Card"}
               </DialogTitle>
-              {isLoading && (
+              {isLoading && !isDone && !isError && (
                 <p className="text-xs text-stone-400 mt-0.5">
-                  Step {deleteStep === "deleting" ? "1" : "2"} of 2 — do not close this window
+                  Step {deleteStep === "deleting" ? "1" : "2"} of 2 — do not
+                  close this window
                 </p>
               )}
             </div>
@@ -129,27 +228,38 @@ export default function DeleteModelDialog({
         </DialogHeader>
 
         <div className="space-y-2 mt-2">
-          {/* Step 1 */}
           <StepRow
             number={1}
             icon={<Trash2 className="w-3.5 h-3.5" />}
             label="Stop & remove model container"
             sublabel="Sending stop signal to the container…"
             state={step1State}
+            logs={stepLogs.deleting}
           />
-
-          {/* Step 2 */}
           <StepRow
             number={2}
             icon={<RotateCcw className="w-3.5 h-3.5" />}
             label="Reset the board"
             sublabel="Running tt-smi -r, this may take 10–30 seconds…"
             state={step2State}
+            logs={stepLogs.resetting}
           />
         </div>
 
+        {/* Error banner */}
+        {isError && errorMessage && (
+          <div className="mt-3 flex items-start gap-2 p-3 bg-red-950/40 rounded-lg border border-red-500/25 text-red-200 text-sm">
+            <XCircle className="h-4 w-4 text-red-400 mt-0.5 shrink-0" />
+            <span>
+              {errorMessage}
+              {" — "}check the logs above for details. You may need to retry or
+              reset the board manually.
+            </span>
+          </div>
+        )}
+
         {/* Warning — only shown when idle */}
-        {!isLoading && (
+        {!isLoading && !isDone && !isError && (
           <div className="mt-4 flex items-start gap-2 p-3 bg-red-950/40 rounded-lg border border-red-500/25 text-red-200 text-sm">
             <AlertTriangle className="h-4 w-4 text-red-400 mt-0.5 shrink-0" />
             <span>
@@ -160,28 +270,39 @@ export default function DeleteModelDialog({
         )}
 
         <DialogFooter className="mt-5 flex justify-end gap-2">
-          <Button
-            variant="outline"
-            onClick={onCancel}
-            disabled={isLoading}
-            className="border-stone-600 text-stone-300 hover:bg-stone-800"
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={onConfirm}
-            disabled={isLoading}
-            className="bg-red-600 text-white hover:bg-red-700 border border-red-500/30 min-w-[130px]"
-          >
-            {isLoading ? (
-              <span className="flex items-center gap-2">
-                <Loader2 className="w-4 h-4 animate-spin" />
-                Processing…
-              </span>
-            ) : (
-              "Delete & Reset"
-            )}
-          </Button>
+          {isDone || isError ? (
+            <Button
+              onClick={onCancel}
+              className="border-stone-600 text-stone-300 hover:bg-stone-800"
+            >
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                onClick={onCancel}
+                disabled={isLoading}
+                className="border-stone-600 text-stone-300 hover:bg-stone-800"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={onConfirm}
+                disabled={isLoading}
+                className="bg-red-600 text-white hover:bg-red-700 border border-red-500/30 min-w-[130px]"
+              >
+                {isLoading ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Processing…
+                  </span>
+                ) : (
+                  "Delete & Reset"
+                )}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -48,7 +48,7 @@ import axios from "axios";
 import { ChipStatusDisplay } from "../ChipStatusDisplay";
 
 export default function ModelsDeployedCard(): JSX.Element {
-  const { models, setModels, refreshModels } = useModels();
+  const { models, setModels, refreshModels, userStoppedModel, setUserStoppedModel } = useModels();
   const { refreshTrigger, triggerRefresh, triggerHardwareRefresh } =
     useRefresh();
 
@@ -225,6 +225,10 @@ export default function ModelsDeployedCard(): JSX.Element {
 
     const finished = deleteStream.status === "success" || deleteStream.status === "partial" || deleteStream.status === "error";
     if (finished) {
+      if (deleteStream.status === "success" || deleteStream.status === "partial") {
+        localStorage.setItem("hasEverDeployed", "true");
+        setUserStoppedModel(true);
+      }
       refreshModels();
       triggerHardwareRefresh();
       window.setTimeout(() => refreshAllHealth(), 1000);
@@ -239,6 +243,8 @@ export default function ModelsDeployedCard(): JSX.Element {
   const autoCloseTimerRef = useRef<number | null>(null);
   useEffect(() => {
     if (deleteStream.status === "success" && showDeleteModal) {
+      localStorage.setItem("hasEverDeployed", "true");
+      setUserStoppedModel(true);
       autoCloseTimerRef.current = window.setTimeout(() => {
         refreshModels();
         triggerHardwareRefresh();
@@ -349,7 +355,7 @@ export default function ModelsDeployedCard(): JSX.Element {
   }
 
   if (rows.length === 0) {
-    return <NoModelsRunning />;
+    return <NoModelsRunning userStopped={userStoppedModel} />;
   }
 
   return (

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -23,7 +23,6 @@ import { useHealthRefresh } from "../../hooks/useHealthRefresh";
 import { useOpenLogsFromUrl } from "../../hooks/useOpenLogsFromUrl";
 import { useColumnPrefs } from "../../hooks/useColumnPrefs";
 import {
-  deleteModel,
   handleRedeploy,
   handleModelNavigationClick,
   fetchModels,
@@ -39,11 +38,12 @@ import type {
 } from "../../types/models";
 import ModelsToolbar from "./ModelsToolbar.tsx";
 import ModelsTable from "./ModelsTable.tsx";
-import DeleteModelDialog, { type DeleteStep } from "./DeleteModelDialog.tsx";
+import DeleteModelDialog from "./DeleteModelDialog.tsx";
 import LogStreamDialog from "./Logs/LogStreamDialog.tsx";
 import RegisterModelDialog from "./RegisterModelDialog.tsx";
 import { useNavigate } from "react-router-dom";
 import { useTablePrefs } from "../../hooks/useTablePrefs";
+import { useDeleteStream } from "../../hooks/useDeleteStream";
 import axios from "axios";
 import { ChipStatusDisplay } from "../ChipStatusDisplay";
 
@@ -169,8 +169,7 @@ export default function ModelsDeployedCard(): JSX.Element {
   // Delete state
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-  const [isProcessingDelete, setIsProcessingDelete] = useState(false);
-  const [deleteStep, setDeleteStep] = useState<DeleteStep>(null);
+  const deleteStream = useDeleteStream();
 
   useEffect(() => {
     loadModels();
@@ -216,35 +215,48 @@ export default function ModelsDeployedCard(): JSX.Element {
     loadModels();
   };
 
-  const handleConfirmDelete = useCallback(async () => {
+  const handleConfirmDelete = useCallback(() => {
     if (!deleteTargetId) return;
-    setIsProcessingDelete(true);
-    const truncatedModelId = deleteTargetId.substring(0, 4);
-    try {
-      // Step 1: stop & remove the model (backend also runs tt-smi -r internally)
-      setDeleteStep("deleting");
-      await customToast.promise(deleteModel(deleteTargetId), {
-        loading: `Stopping model ${truncatedModelId}…`,
-        success: `Model ${truncatedModelId} stopped.`,
-        error: `Failed to stop model ${truncatedModelId}.`,
-      });
+    deleteStream.start(deleteTargetId);
+  }, [deleteTargetId, deleteStream]);
 
-      // Step 2: board reset is handled by the stop API, show progress while cleanup settles
-      setDeleteStep("resetting");
-      await new Promise((resolve) => window.setTimeout(resolve, 2000));
+  const handleCloseDeleteModal = useCallback(() => {
+    if (deleteStream.status === "running") return;
 
-      await refreshModels();
+    const finished = deleteStream.status === "success" || deleteStream.status === "partial" || deleteStream.status === "error";
+    if (finished) {
+      refreshModels();
       triggerHardwareRefresh();
-      setShowDeleteModal(false);
-      setDeleteTargetId(null);
-      window.setTimeout(() => {
-        refreshAllHealth();
-      }, 1000);
-    } finally {
-      setIsProcessingDelete(false);
-      setDeleteStep(null);
+      window.setTimeout(() => refreshAllHealth(), 1000);
     }
-  }, [deleteTargetId, refreshModels, triggerHardwareRefresh, refreshAllHealth]);
+
+    setShowDeleteModal(false);
+    setDeleteTargetId(null);
+    deleteStream.reset();
+  }, [deleteStream, refreshModels, triggerHardwareRefresh, refreshAllHealth]);
+
+  // Auto-close the dialog once deletion finishes successfully
+  const autoCloseTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (deleteStream.status === "success" && showDeleteModal) {
+      autoCloseTimerRef.current = window.setTimeout(() => {
+        refreshModels();
+        triggerHardwareRefresh();
+        window.setTimeout(() => refreshAllHealth(), 1000);
+        setShowDeleteModal(false);
+        setDeleteTargetId(null);
+        deleteStream.reset();
+      }, 1500);
+    }
+    return () => {
+      if (autoCloseTimerRef.current) {
+        clearTimeout(autoCloseTimerRef.current);
+        autoCloseTimerRef.current = null;
+      }
+    };
+  // Only re-run when status changes, not on every render
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deleteStream.status]);
 
   const exportVisible = useCallback(() => {
     const visibleRows = rows.map((r) => ({
@@ -503,10 +515,13 @@ export default function ModelsDeployedCard(): JSX.Element {
       <DeleteModelDialog
         open={showDeleteModal}
         modelId={deleteTargetId || ""}
-        isLoading={isProcessingDelete}
-        deleteStep={deleteStep}
+        isLoading={deleteStream.status === "running"}
+        deleteStep={deleteStream.step}
+        streamStatus={deleteStream.status}
+        stepLogs={deleteStream.stepLogs}
+        errorMessage={deleteStream.errorMessage}
         onConfirm={handleConfirmDelete}
-        onCancel={() => !isProcessingDelete && setShowDeleteModal(false)}
+        onCancel={handleCloseDeleteModal}
       />
 
       <RegisterModelDialog

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -191,6 +191,7 @@ export default function ModelsDeployedCard(): JSX.Element {
     if (hasStaleModel && !showDeleteModal && !staleRefreshTimer.current) {
       staleRefreshTimer.current = window.setTimeout(() => {
         staleRefreshTimer.current = null;
+        setUserStoppedModel(false);
         loadModels();
       }, 5000);
     }
@@ -198,7 +199,7 @@ export default function ModelsDeployedCard(): JSX.Element {
       clearTimeout(staleRefreshTimer.current);
       staleRefreshTimer.current = null;
     }
-  }, [hasStaleModel, showDeleteModal, loadModels]);
+  }, [hasStaleModel, showDeleteModal, loadModels, setUserStoppedModel]);
 
   const rows: ModelRow[] = useMemo(() => models as ModelRow[], [models]);
 

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -178,6 +178,28 @@ export default function ModelsDeployedCard(): JSX.Element {
   const [healthMap, setHealthMap] = useState<Record<string, HealthStatus>>({});
   const [preparingBannerDismissed, setPreparingBannerDismissed] = useState(false);
 
+  // Auto-refresh model list when any model becomes unavailable/unknown
+  // (container likely stopped or crashed). Uses a ref so the timer
+  // isn't torn down every time healthMap changes from polling.
+  const staleRefreshTimer = useRef<number | null>(null);
+  const hasStaleModel = useMemo(
+    () => Object.values(healthMap).some((h) => h === "unavailable" || h === "unknown"),
+    [healthMap],
+  );
+
+  useEffect(() => {
+    if (hasStaleModel && !showDeleteModal && !staleRefreshTimer.current) {
+      staleRefreshTimer.current = window.setTimeout(() => {
+        staleRefreshTimer.current = null;
+        loadModels();
+      }, 5000);
+    }
+    if (!hasStaleModel && staleRefreshTimer.current) {
+      clearTimeout(staleRefreshTimer.current);
+      staleRefreshTimer.current = null;
+    }
+  }, [hasStaleModel, showDeleteModal, loadModels]);
+
   const rows: ModelRow[] = useMemo(() => models as ModelRow[], [models]);
 
   const preparingModels = useMemo(() => {

--- a/app/frontend/src/components/models/NoModelsRunning.tsx
+++ b/app/frontend/src/components/models/NoModelsRunning.tsx
@@ -5,13 +5,24 @@ import type { JSX } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 
-export default function NoModelsRunning(): JSX.Element {
+interface NoModelsRunningProps {
+  userStopped?: boolean;
+}
+
+export default function NoModelsRunning({ userStopped = false }: NoModelsRunningProps): JSX.Element {
   const navigate = useNavigate();
+  const hasEverDeployed = localStorage.getItem("hasEverDeployed") === "true";
+
+  const message = userStopped
+    ? "Model stopped successfully. Deploy a new model to get started."
+    : !hasEverDeployed
+      ? "Deploy a model to get started."
+      : "Your model may have stopped unexpectedly, or the board was reset. Check deployment history to see what happened and access logs.";
 
   return (
     <div className="flex flex-col items-center justify-center gap-6 py-20 px-4 max-w-md mx-auto text-center">
       {/* Terminal-style status line */}
-      <span className="font-mono text-amber-500/60 text-xs tracking-widest uppercase select-none">
+      <span className="font-mono text-TT-purple-accent/70 text-xs tracking-widest uppercase select-none">
         // STATUS: NO ACTIVE DEPLOYMENTS
       </span>
 
@@ -21,8 +32,7 @@ export default function NoModelsRunning(): JSX.Element {
           No models currently running
         </h2>
         <p className="text-stone-400 text-sm leading-relaxed">
-          Your model may have stopped unexpectedly, or the board was reset.
-          Check deployment history to see what happened and access logs.
+          {message}
         </p>
       </div>
 

--- a/app/frontend/src/contexts/ModelsContext.ts
+++ b/app/frontend/src/contexts/ModelsContext.ts
@@ -20,6 +20,8 @@ export interface ModelsContextType {
   setModels: React.Dispatch<React.SetStateAction<Model[]>>;
   refreshModels: () => Promise<void>;
   hasDeployedModels: boolean;
+  userStoppedModel: boolean;
+  setUserStoppedModel: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const ModelsContext = createContext<ModelsContextType | undefined>(

--- a/app/frontend/src/hooks/useDeleteStream.ts
+++ b/app/frontend/src/hooks/useDeleteStream.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { DeleteStep } from "../components/models/DeleteModelDialog";
+
+export type DeleteStreamStatus = "idle" | "running" | "success" | "partial" | "error";
+
+export interface StepLogs {
+  deleting: string[];
+  resetting: string[];
+}
+
+export function useDeleteStream() {
+  const [stepLogs, setStepLogs] = useState<StepLogs>({ deleting: [], resetting: [] });
+  const [step, setStep] = useState<DeleteStep>(null);
+  const [status, setStatus] = useState<DeleteStreamStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  const statusRef = useRef<DeleteStreamStatus>("idle");
+
+  const updateStatus = (next: DeleteStreamStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  };
+
+  const appendLog = (logStep: string, message: string) => {
+    const key = logStep === "resetting" ? "resetting" : "deleting";
+    setStepLogs((prev) => ({ ...prev, [key]: [...prev[key], message] }));
+  };
+
+  const cleanup = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    cleanup();
+    setStepLogs({ deleting: [], resetting: [] });
+    setStep(null);
+    updateStatus("idle");
+    setErrorMessage(null);
+  }, [cleanup]);
+
+  const start = useCallback(
+    (containerId: string) => {
+      cleanup();
+      setStepLogs({ deleting: [], resetting: [] });
+      setStep("deleting");
+      updateStatus("running");
+      setErrorMessage(null);
+
+      const endpoint = `/docker-api/stop/stream/${containerId}/`;
+
+      timeoutRef.current = window.setTimeout(() => {
+        if (statusRef.current === "running") {
+          setErrorMessage("Deletion timed out — the backend may still be processing.");
+          updateStatus("error");
+          cleanup();
+        }
+      }, 180_000);
+
+      try {
+        const es = new EventSource(endpoint, { withCredentials: true });
+        eventSourceRef.current = es;
+
+        es.onmessage = (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            switch (data.type) {
+              case "step":
+                setStep(data.step as DeleteStep);
+                break;
+              case "log":
+                appendLog(data.step ?? "deleting", data.message);
+                break;
+              case "complete":
+                updateStatus(
+                  data.status === "success"
+                    ? "success"
+                    : data.status === "partial"
+                      ? "partial"
+                      : "error",
+                );
+                if (data.status !== "success") {
+                  setErrorMessage(data.message);
+                }
+                cleanup();
+                break;
+              default:
+                if (data.message) {
+                  appendLog(data.step ?? "deleting", data.message);
+                }
+                break;
+            }
+          } catch {
+            appendLog("deleting", event.data);
+          }
+        };
+
+        es.onerror = () => {
+          if (statusRef.current === "running") {
+            setErrorMessage("Connection to deletion stream lost.");
+            updateStatus("error");
+          }
+          cleanup();
+        };
+      } catch {
+        setErrorMessage("Failed to connect to deletion stream.");
+        updateStatus("error");
+      }
+    },
+    [cleanup],
+  );
+
+  useEffect(() => {
+    return cleanup;
+  }, [cleanup]);
+
+  return { stepLogs, step, status, errorMessage, start, reset } as const;
+}

--- a/app/frontend/src/providers/ModelsContext.tsx
+++ b/app/frontend/src/providers/ModelsContext.tsx
@@ -13,6 +13,17 @@ export const ModelsProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [models, setModels] = useState<Model[]>([]);
   const [hasDeployedModels, setHasDeployedModels] = useState<boolean>(false);
+  const [userStoppedModel, setUserStoppedModelState] = useState<boolean>(
+    () => sessionStorage.getItem("userStoppedModel") === "true"
+  );
+
+  const setUserStoppedModel = useCallback((value: boolean | ((prev: boolean) => boolean)) => {
+    setUserStoppedModelState((prev) => {
+      const next = typeof value === "function" ? value(prev) : value;
+      sessionStorage.setItem("userStoppedModel", String(next));
+      return next;
+    });
+  }, []);
 
   const refreshModels = useCallback(async () => {
     try {
@@ -23,6 +34,8 @@ export const ModelsProvider: React.FC<{ children: React.ReactNode }> = ({
       ]);
 
       if (deployedModelsInfo.length > 0) {
+        setUserStoppedModel(false);
+        localStorage.setItem("hasEverDeployed", "true");
         // Merge the deployed models info with Docker container info.
         // model_type from deployed API is required for correct navbar routing (e.g. Speech Recognition -> /speech-to-text).
         const mergedModels = deployedModelsInfo.map((deployedModel) => {
@@ -65,11 +78,11 @@ export const ModelsProvider: React.FC<{ children: React.ReactNode }> = ({
         setHasDeployedModels(false);
       }
     }
-  }, []);
+  }, [setUserStoppedModel]);
 
   return (
     <ModelsContext.Provider
-      value={{ models, setModels, refreshModels, hasDeployedModels }}
+      value={{ models, setModels, refreshModels, hasDeployedModels, userStoppedModel, setUserStoppedModel }}
     >
       {children}
     </ModelsContext.Provider>


### PR DESCRIPTION
### Streaming Model Deletion with Live Logs
Replaces the synchronous model deletion flow (toast notifications + hardcoded delays) with a real-time SSE-streamed dialog that shows exactly what the backend is doing. 

### Changes
#### Backend
- New async SSE endpoint GET /docker-api/stop/stream/<container_id>/ (StopStreamView) that performs stop → remove → - board reset sequentially, streaming each step's logs in real time
- Uses asyncio.create_subprocess_exec for tt-smi so output streams line-by-line instead of all at once
- Handles 404 on stop/remove gracefully (container already gone = success, not failure)
- Strips ANSI escape codes from tt-smi output
#### Frontend
- New useDeleteStream hook that connects to the SSE endpoint and buckets logs per step (deleting / resetting)
- Redesigned DeleteModelDialog with per-step inline log panels — container logs under step 1, tt-smi output under step 2
- Auto-closes dialog 1.5s after successful completion and triggers model list + hardware refresh
- Removed all toast notifications from the deletion flow
- Cleaned up deleteModel() API function (stripped toasts; still used by reset flows)

UPDATE
- remove stale models with status "unknown" without refresh and show "Your Model may have stopped unexpectedly or the board was reset"