### PR TITLE
change misleading deployment completed message

### DIFF
--- a/app/frontend/src/components/magicui/AnimatedDeployButton.tsx
+++ b/app/frontend/src/components/magicui/AnimatedDeployButton.tsx
@@ -45,7 +45,7 @@ export const AnimatedDeployButton: React.FC<AnimatedDeployButtonProps> = ({
         setIsDeployed(true);
         setIsDeploying(false);
         setIsRocketFlying(false);
-        setDisplayText(<span>Model Deployed!</span>);
+        setDisplayText(<span>Deployment Started</span>);
         safeRemoveItem(ACTIVE_DEPLOYMENT_KEY);
         stopPolling();
       } else if (progress.status === 'error' || progress.status === 'failed' || progress.status === 'timeout') {


### PR DESCRIPTION
- When a model deploment is "completed" say instead "deployment started"

[DEVSTACK-61](https://tenstorrent.atlassian.net/jira/software/c/projects/DEVSTACK/boards/3073?issueParent=224545&selectedIssue=DEVSTACK-61)