### PR TITLE
Added Qwen-only host-volume preload support in the inference FastAPI layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ CLAUDE.md
 docs/RAG_PRODUCTIONIZATION_PLAN.md
 docs/DOCKER_CONTROL_SERVICE_PLAN.md
 !app/backend/shared_config/models_from_inference_server.json
+!inference-api/host_volume_models.json
 
 request-venv/*
 app/.env-old

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -104,7 +104,7 @@ workflows_log_setup.setup_run_logger = _patched_setup_run_logger
 # Import from tt-inference-server
 try:
     from run import main as run_main, WorkflowType, DeviceTypes  # noqa: E402
-    from workflows.model_spec import MODEL_SPECS  # noqa: E402
+    from workflows.model_spec import MODEL_SPECS, get_runtime_model_spec  # noqa: E402
 except ImportError as e:
     raise ImportError(
         f"Failed to import from tt-inference-server: {e}\n"
@@ -209,23 +209,218 @@ _HF_DOWNLOAD_REPO_RE = re.compile(r"Downloading model from Hugging Face:\s*(?P<r
 _HOST_HF_HOME_RE = re.compile(r"HOST_HF_HOME set to\s*(?P<path>\S+)")
 _HOST_VOLUME_WEIGHTS_MISSING_RE = re.compile(r"Weights directory does not exist for\s*(?P<model>.+?)\.")
 _PREFERRED_HOST_VOLUME_PATH = Path("~/data/tt-cache")
+_HOST_VOLUME_MODELS_CONFIG_PATH = Path(__file__).with_name("host_volume_models.json")
+_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST = {"qwen3-32b"}
+_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES = {
+    "qwen3-32b": "volume_id_tt_transformers-Qwen3-32B-vqb2_launch"
+}
 
 
-def _resolve_preferred_host_volume() -> Tuple[Optional[str], str]:
-    """Resolve the preferred host-volume path for TT Inference Server.
+def _load_host_volume_model_config() -> Tuple[set[str], Dict[str, str]]:
+    try:
+        raw_config = json.loads(_HOST_VOLUME_MODELS_CONFIG_PATH.read_text())
+    except FileNotFoundError:
+        logging.getLogger(__name__).warning(
+            "Host-volume models config not found at %s; using default allowlist %s",
+            _HOST_VOLUME_MODELS_CONFIG_PATH,
+            sorted(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+        )
+        return (
+            set(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+            dict(_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES),
+        )
+    except json.JSONDecodeError as exc:
+        logging.getLogger(__name__).warning(
+            "Host-volume models config at %s is invalid JSON (%s); using default allowlist %s",
+            _HOST_VOLUME_MODELS_CONFIG_PATH,
+            exc,
+            sorted(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+        )
+        return (
+            set(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+            dict(_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES),
+        )
 
-    Defer directory creation and permission repair to tt-inference-server's
-    setup validation. That path can create the directory and attempt chmod
-    fixes, while this FastAPI pre-check only decides whether to forward the
-    user's preferred path at all.
-    """
-    candidate = _PREFERRED_HOST_VOLUME_PATH.expanduser()
+    configured_models = raw_config.get("models")
+    if not isinstance(configured_models, list):
+        logging.getLogger(__name__).warning(
+            "Host-volume models config at %s is missing a 'models' list; using default allowlist %s",
+            _HOST_VOLUME_MODELS_CONFIG_PATH,
+            sorted(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+        )
+        return (
+            set(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+            dict(_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES),
+        )
 
-    if candidate.exists() and not candidate.is_dir():
-        return None, f"{candidate} is not a directory"
+    normalized_models = {
+        str(model_name).strip().lower()
+        for model_name in configured_models
+        if str(model_name).strip()
+    }
+    if not normalized_models:
+        logging.getLogger(__name__).warning(
+            "Host-volume models config at %s did not contain any usable model names; using default allowlist %s",
+            _HOST_VOLUME_MODELS_CONFIG_PATH,
+            sorted(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+        )
+        return (
+            set(_DEFAULT_HOST_VOLUME_MODEL_ALLOWLIST),
+            dict(_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES),
+        )
 
-    resolved_candidate = candidate.resolve(strict=False)
-    return str(resolved_candidate), f"resolved preferred host-volume path {resolved_candidate}"
+    directory_overrides = dict(_DEFAULT_HOST_VOLUME_DIRECTORY_OVERRIDES)
+    raw_overrides = raw_config.get("directory_overrides", {})
+    if isinstance(raw_overrides, dict):
+        for model_name, directory_name in raw_overrides.items():
+            normalized_model_name = str(model_name).strip().lower()
+            normalized_directory_name = str(directory_name).strip()
+            if normalized_model_name and normalized_directory_name:
+                directory_overrides[normalized_model_name] = normalized_directory_name
+
+    logging.getLogger(__name__).info(
+        "Loaded host-volume model allowlist from %s: %s",
+        _HOST_VOLUME_MODELS_CONFIG_PATH,
+        sorted(normalized_models),
+    )
+    logging.getLogger(__name__).info(
+        "Loaded host-volume directory overrides from %s: %s",
+        _HOST_VOLUME_MODELS_CONFIG_PATH,
+        directory_overrides,
+    )
+    return normalized_models, directory_overrides
+
+
+_HOST_VOLUME_MODEL_ALLOWLIST, _HOST_VOLUME_DIRECTORY_OVERRIDES = (
+    _load_host_volume_model_config()
+)
+
+
+def _resolve_preferred_host_volume(
+    model_name: str, device: str, impl: Optional[str]
+) -> Tuple[Optional[str], Optional[Path], Optional[Path], Optional[Path], str]:
+    """Resolve the preferred host-volume root for preloaded Qwen data."""
+    candidate_root = _PREFERRED_HOST_VOLUME_PATH.expanduser()
+    resolved_candidate_root = candidate_root.resolve(strict=False)
+
+    try:
+        model_spec, _, _ = get_runtime_model_spec(model_name, device, impl=impl)
+    except Exception as exc:
+        return (
+            None,
+            None,
+            None,
+            None,
+            f"could not derive expected host-volume directory for {model_name} on {device}: {exc}",
+        )
+
+    normalized_model_name = (model_name or "").strip().lower()
+    directory_override = _HOST_VOLUME_DIRECTORY_OVERRIDES.get(normalized_model_name)
+    if directory_override:
+        expected_volume_dir = resolved_candidate_root / directory_override
+    else:
+        expected_volume_dir = (
+            resolved_candidate_root
+            / f"volume_id_{model_spec.impl.impl_id}-{model_spec.model_name}-v{model_spec.version}"
+        )
+    expected_weights_dir = expected_volume_dir / "weights" / model_spec.model_name
+    expected_tt_metal_cache_dir = expected_volume_dir / "tt_metal_cache"
+
+    if candidate_root.exists() and not candidate_root.is_dir():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"preferred host-volume root {resolved_candidate_root} is not a directory",
+        )
+    if not expected_volume_dir.exists():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected preloaded host-volume directory is missing: {expected_volume_dir}",
+        )
+    if not expected_volume_dir.is_dir():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected preloaded host-volume path is not a directory: {expected_volume_dir}",
+        )
+    if not expected_weights_dir.exists():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected preloaded weights directory is missing: {expected_weights_dir}",
+        )
+    if not expected_weights_dir.is_dir():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected preloaded weights path is not a directory: {expected_weights_dir}",
+        )
+    if not expected_tt_metal_cache_dir.exists():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected tt_metal_cache directory is missing: {expected_tt_metal_cache_dir}",
+        )
+    if not expected_tt_metal_cache_dir.is_dir():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected tt_metal_cache path is not a directory: {expected_tt_metal_cache_dir}",
+        )
+    if not (expected_weights_dir / "config.json").exists():
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected config.json is missing from preloaded weights directory: {expected_weights_dir}",
+        )
+    if not (
+        (expected_weights_dir / "tokenizer.json").exists()
+        or (expected_weights_dir / "tokenizer_config.json").exists()
+    ):
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected tokenizer.json or tokenizer_config.json is missing from preloaded weights directory: {expected_weights_dir}",
+        )
+    if not list(expected_weights_dir.glob("model*.safetensors")):
+        return (
+            None,
+            expected_volume_dir,
+            expected_weights_dir,
+            expected_tt_metal_cache_dir,
+            f"expected model*.safetensors files are missing from preloaded weights directory: {expected_weights_dir}",
+        )
+
+    return (
+        str(resolved_candidate_root),
+        expected_volume_dir,
+        expected_weights_dir,
+        expected_tt_metal_cache_dir,
+        f"accepted expected preloaded host-volume layout: volume_dir={expected_volume_dir}, weights_dir={expected_weights_dir}, tt_metal_cache_dir={expected_tt_metal_cache_dir}",
+    )
+
+
+def _model_uses_preferred_host_volume(model_name: str) -> bool:
+    return (model_name or "").strip().lower() in _HOST_VOLUME_MODEL_ALLOWLIST
 
 
 def _strip_cli_option(argv: list[str], option: str) -> list[str]:
@@ -1111,19 +1306,42 @@ async def run_inference(request: RunRequest):
         if request.vllm_override_args:
             base_argv.extend(["--vllm-override-args", request.vllm_override_args])
 
-        preferred_host_volume, host_volume_resolution_reason = _resolve_preferred_host_volume()
+        preferred_host_volume = None
+        expected_host_volume_dir: Optional[Path] = None
+        expected_host_weights_dir: Optional[Path] = None
+        expected_host_tt_metal_cache_dir: Optional[Path] = None
+        host_volume_resolution_reason = "model not in host-volume allowlist"
+        if _model_uses_preferred_host_volume(request.model):
+            (
+                preferred_host_volume,
+                expected_host_volume_dir,
+                expected_host_weights_dir,
+                expected_host_tt_metal_cache_dir,
+                host_volume_resolution_reason,
+            ) = _resolve_preferred_host_volume(
+                request.model, normalized_device, request.impl
+            )
         initial_argv = list(base_argv)
+        if expected_host_volume_dir is not None:
+            logger.info(
+                "Job %s: checking Qwen preloaded host-volume layout: volume_dir=%s, weights_dir=%s, tt_metal_cache_dir=%s",
+                job_id,
+                expected_host_volume_dir,
+                expected_host_weights_dir,
+                expected_host_tt_metal_cache_dir,
+            )
         if preferred_host_volume:
             initial_argv.extend(["--host-volume", preferred_host_volume])
             logger.info(
-                "Job %s: starting in host-volume mode with %s (%s)",
+                "Job %s: Qwen preloaded host-volume directory accepted: %s; using --host-volume %s (%s)",
                 job_id,
+                expected_host_volume_dir,
                 preferred_host_volume,
                 host_volume_resolution_reason,
             )
         else:
             logger.info(
-                "Job %s: preferred host-volume unavailable, using baseline startup (%s)",
+                "Job %s: using baseline startup without host-volume (%s)",
                 job_id,
                 host_volume_resolution_reason,
             )
@@ -1202,8 +1420,10 @@ async def run_inference(request: RunRequest):
                     retry_argv, retry_reason = _build_retry_argv_and_reason()
                     if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
                         logger.warning(
-                            "Job %s: host-volume attempt logged a missing weights directory warning before the retry.",
+                            "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
                             job_id,
+                            expected_host_volume_dir,
+                            expected_host_weights_dir,
                         )
                     logger.warning(
                         "Job %s: first run raised (%s), retrying once with %s",
@@ -1230,8 +1450,10 @@ async def run_inference(request: RunRequest):
                     retry_argv, retry_reason = _build_retry_argv_and_reason()
                     if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
                         logger.warning(
-                            "Job %s: host-volume attempt logged a missing weights directory warning before the retry.",
+                            "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
                             job_id,
+                            expected_host_volume_dir,
+                            expected_host_weights_dir,
                         )
                     logger.warning(
                         "Job %s: first run failed (code %s), retrying once with %s",

--- a/inference-api/host_volume_models.json
+++ b/inference-api/host_volume_models.json
@@ -1,0 +1,8 @@
+{
+  "models": [
+    "Qwen3-32B"
+  ],
+  "directory_overrides": {
+    "Qwen3-32B": "volume_id_tt_transformers-Qwen3-32B-vqb2_launch"
+  }
+}


### PR DESCRIPTION
- For Qwen3-32B, FastAPI now does a _better check_ for preloaded host-volume layout under `~/data/tt-cache` before adding --host-volume.
- If the expected Qwen weights/cache layout is present, _uses_ host-volume mode.
- If not, it _falls back_ to the existing baseline startup automatically, which is without the above flag.
- The model list that can use this flag is now configurable via `inference-api/host_volume_models.json`
- Added logging so you can see which Qwen path was checked and whether host-volume or baseline mode was used.