### PR TITLE
Improve workflow_logs permissions handling in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -4444,23 +4444,36 @@ def main():
         else:
             # Ensure existing directory has correct permissions (Unix/Linux only)
             if OS_NAME != "Windows":
-                try:
-                    current_stat = os.stat(workflow_logs_dir)
-                    current_uid = current_stat.st_uid
-                    current_user_uid = os.getuid()
-                    if current_uid != current_user_uid and current_uid == 0:  # Owned by root
-                        print(f"{C_YELLOW}⚠️  workflow_logs directory is owned by root, fixing permissions...{C_RESET}")
-                        os.chown(workflow_logs_dir, current_user_uid, os.getgid())
-                        print(f"{C_GREEN}✅ Fixed workflow_logs directory ownership{C_RESET}")
-                except (OSError, PermissionError, AttributeError) as e:
-                    # If we don't have permission or chown is not available, ask user to fix manually then continue
-                    print(f"{C_RED}⛔ Could not fix workflow_logs permissions: {e}{C_RESET}")
+                current_stat = os.stat(workflow_logs_dir)
+                current_uid = current_stat.st_uid
+                current_user_uid = os.getuid()
+                if current_uid != current_user_uid and current_uid == 0:  # Owned by root
+                    print(f"{C_YELLOW}⚠️  The workflow_logs directory is owned by root:{C_RESET}")
+                    print(f"   {C_WHITE}{workflow_logs_dir}{C_RESET}")
                     print()
-                    print(f"{C_YELLOW}The workflow_logs directory is owned by root. Please run the following in another terminal:{C_RESET}")
+                    print(f"{C_YELLOW}This was likely created by Docker and will prevent deployment logs from being written.{C_RESET}")
+                    print(f"{C_YELLOW}TT Studio needs to run the following command to fix it:{C_RESET}")
                     print(f"   {C_WHITE}sudo chown -R $USER:$USER {workflow_logs_dir}{C_RESET}")
                     print()
-                    input("Press Enter once you've run the command above to continue...")
+                    answer = input(f"{C_CYAN}Allow TT Studio to run this automatically? [y/N]: {C_RESET}").strip().lower()
                     print()
+                    if answer in ("y", "yes"):
+                        try:
+                            import subprocess as _sp
+                            _sp.run(
+                                ["sudo", "chown", "-R", f"{current_user_uid}:{os.getgid()}", workflow_logs_dir],
+                                check=True,
+                            )
+                            print(f"{C_GREEN}✅ Fixed workflow_logs directory ownership{C_RESET}")
+                        except Exception as e:
+                            print(f"{C_RED}⛔ sudo chown failed: {e}{C_RESET}")
+                            print(f"{C_YELLOW}Please run the command above manually and restart TT Studio.{C_RESET}")
+                            sys.exit(1)
+                    else:
+                        print(f"{C_YELLOW}Please run the following command and restart TT Studio:{C_RESET}")
+                        print(f"   {C_WHITE}sudo chown -R $USER:$USER {workflow_logs_dir}{C_RESET}")
+                        print()
+                        sys.exit(1)
 
         # Start Docker Control Service BEFORE starting Docker containers
         # This ensures the backend can connect to it when it starts


### PR DESCRIPTION
- Fixes https://tenstorrent.atlassian.net/browse/DEVSTACK-59
- Enhanced error messaging to inform users when the workflow_logs directory ownership cannot be fixed automatically.
- Added instructions for users to manually change ownership using `sudo chown -R $USER:$USER {workflow_logs_dir}`.
- Included a prompt for users to allow automatic permission fixing, improving user guidance during setup.