### PR TITLE
Enhance workflow log directory management and error handling in run.py

### DIFF
--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -335,13 +335,38 @@ def _resolve_preferred_host_volume(
             f"preferred host-volume root {resolved_candidate_root} is not a directory",
         )
     if not expected_volume_dir.exists():
-        return (
-            None,
+        # Fall back to scanning for any volume dir that matches the model name under the
+        # candidate root — handles cases where the directory was prepared with a different
+        # version/branch suffix (e.g. v0.10.1 instead of vqb2_launch).
+        fallback_volume_dir = None
+        if resolved_candidate_root.is_dir():
+            model_name_lower = model_spec.model_name.lower()
+            for candidate in sorted(resolved_candidate_root.iterdir()):
+                if not candidate.is_dir():
+                    continue
+                cname = candidate.name.lower()
+                if model_name_lower in cname and "volume_id_" in cname:
+                    candidate_weights = candidate / "weights" / model_spec.model_name
+                    candidate_cache = candidate / "tt_metal_cache"
+                    if candidate_weights.is_dir() and candidate_cache.is_dir():
+                        fallback_volume_dir = candidate
+                        break
+        if fallback_volume_dir is None:
+            return (
+                None,
+                expected_volume_dir,
+                expected_weights_dir,
+                expected_tt_metal_cache_dir,
+                f"expected preloaded host-volume directory is missing: {expected_volume_dir}",
+            )
+        logging.getLogger(__name__).warning(
+            "Expected host-volume dir %s not found; using fuzzy-matched fallback %s",
             expected_volume_dir,
-            expected_weights_dir,
-            expected_tt_metal_cache_dir,
-            f"expected preloaded host-volume directory is missing: {expected_volume_dir}",
+            fallback_volume_dir,
         )
+        expected_volume_dir = fallback_volume_dir
+        expected_weights_dir = expected_volume_dir / "weights" / model_spec.model_name
+        expected_tt_metal_cache_dir = expected_volume_dir / "tt_metal_cache"
     if not expected_volume_dir.is_dir():
         return (
             None,
@@ -1417,6 +1442,20 @@ async def run_inference(request: RunRequest):
                 except Exception as first_attempt_error:
                     # run_main() can raise directly (e.g. local setup validation errors)
                     # and bypass return-code based retry logic.
+                    #
+                    # PermissionError on the log directory means the workflow_logs dir is
+                    # root-owned (leftover from a previous sudo-based startup). Retrying
+                    # with different Docker args won't help — re-raise immediately so the
+                    # caller gets a clear error instead of a misleading retry.
+                    if isinstance(first_attempt_error, PermissionError) and "workflow_logs" in str(first_attempt_error):
+                        logger.error(
+                            "Job %s: PermissionError on workflow_logs directory — directory is likely "
+                            "root-owned from a previous sudo-based startup. Fix with: "
+                            "sudo chown -R $USER: %s/workflow_logs",
+                            job_id,
+                            script_dir,
+                        )
+                        raise
                     retry_argv, retry_reason = _build_retry_argv_and_reason()
                     if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
                         logger.warning(

--- a/run.py
+++ b/run.py
@@ -4516,6 +4516,19 @@ def main():
             print(f"\n{C_GREEN}✅ Skipping TT Inference Server FastAPI setup (AI Playground mode enabled){C_RESET}")
             print(f"{C_CYAN}   Note: AI Playground mode uses cloud models, so local FastAPI server is not needed{C_RESET}")
 
+        # Pre-create workflow_logs before docker compose up.
+        # docker-compose.yml bind-mounts this directory; if Docker creates it first, it
+        # does so as root, which blocks the FastAPI server (running as the current user)
+        # from writing logs on the first deploy. Also fix ownership if already root-owned
+        # from a previous run.
+        for _subdir in ["workflow_logs", os.path.join("workflow_logs", "run_logs")]:
+            _log_dir = os.path.join(INFERENCE_ARTIFACT_DIR, _subdir)
+            try:
+                os.makedirs(_log_dir, exist_ok=True)
+            except PermissionError:
+                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _log_dir], check=False)
+                os.makedirs(_log_dir, exist_ok=True)
+
         # Start Docker services with streaming output and comprehensive error reporting
         startup_log.step("docker_compose_up", "START")
         print(f"\n{C_CYAN}🔨 Building containers (backend, frontend, agent, chroma)...{C_RESET}")


### PR DESCRIPTION
- Pre-create the workflow_logs directory before starting Docker services to prevent permission issues caused by root ownership.
- Implement error handling for PermissionError when accessing the workflow_logs directory, providing clear instructions for users to fix ownership issues.
- Update logging to improve user guidance during setup, ensuring a smoother deployment experience.
- Fall back to scanning for any volume dir that matches the model name under the
        candidate root — handles cases where the directory was prepared with a different
        version/branch suffix (e.g. v0.10.1 instead of vqb2_launch).