### PR TITLE
Enhance deployment configuration for Qwen3-32B model on p300x2

### DIFF
--- a/app/.env.default
+++ b/app/.env.default
@@ -12,7 +12,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 #! optionally, you can specify a specific release version to be used , which is recommened for production deployments for stability. 
 # example : TT_INFERENCE_ARTIFACT_VERSION=v0.1.0 
 # TT_INFERENCE_ARTIFACT_VERSION=v0.10.0
-TT_INFERENCE_ARTIFACT_BRANCH=anirud/combined-effort-speech-whisper
+TT_INFERENCE_ARTIFACT_BRANCH=tt_qb2_launch_branch
 
 # Security Credentials (REQUIRED - keep secret in production!)
 JWT_SECRET=test-secret-456

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -341,6 +341,10 @@ def run_container(impl, weights_id, device_id=0, host_port=None):
         # Multi-chip models need this to specify which configuration to use
         payload["device_id"] = str(device_id)
 
+        # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+        if impl.model_name == "Qwen3-32B" and device == "p300x2":
+            payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:
             payload["skip_system_sw_validation"] = True

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -344,6 +344,7 @@ def run_container(impl, weights_id, device_id=0, host_port=None):
         # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
         if impl.model_name == "Qwen3-32B" and device == "p300x2":
             payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+            payload["dev_mode"] = True
 
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -31,6 +31,7 @@ def start_chat_deployment(
     timeout_seconds: int = 30,
     dev_mode: bool = False,
     skip_system_sw_validation: bool = True,
+    override_tt_config: Optional[str] = None,
 ) -> TTInferenceRunResult:
     """Start a chat model deployment via TT Inference Server (/run).
 
@@ -49,6 +50,8 @@ def start_chat_deployment(
         payload["service_port"] = str(service_port)
     if device_id is not None:
         payload["device_id"] = str(device_id)
+    if override_tt_config is not None:
+        payload["override_tt_config"] = override_tt_config
 
     try:
         r = requests.post(fastapi_run_url, json=payload, timeout=timeout_seconds)

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -353,6 +353,10 @@ class DeployView(APIView):
                 # p300x2 device itself — do not pass device_id so it is omitted from the
                 # run.py invocation entirely.
                 inference_device_id = None if board_type == "P300Cx2" else device_id
+                # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+                override_tt_config = None
+                if impl.model_name == "Qwen3-32B" and device == "p300x2":
+                    override_tt_config = '{"trace_region_size": 53000000}'
                 result = start_chat_deployment(
                     model_name=impl.model_name,
                     device=device,
@@ -360,6 +364,7 @@ class DeployView(APIView):
                     service_port=service_port,
                     timeout_seconds=30,
                     skip_system_sw_validation=True,
+                    override_tt_config=override_tt_config,
                 )
                 if result.status != "success":
                     return Response(

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -355,7 +355,8 @@ class DeployView(APIView):
                 inference_device_id = None if board_type == "P300Cx2" else device_id
                 # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
                 override_tt_config = None
-                if impl.model_name == "Qwen3-32B" and device == "p300x2":
+                qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
+                if qwen32b_p300x2:
                     override_tt_config = '{"trace_region_size": 53000000}'
                 result = start_chat_deployment(
                     model_name=impl.model_name,
@@ -365,6 +366,7 @@ class DeployView(APIView):
                     timeout_seconds=30,
                     skip_system_sw_validation=True,
                     override_tt_config=override_tt_config,
+                    dev_mode=qwen32b_p300x2,
                 )
                 if result.status != "success":
                     return Response(


### PR DESCRIPTION
- Added support for overriding the trace region size in the deployment configuration for the Qwen3-32B model when using the p300x2 device, addressing memory limitations.
- Updated the `start_chat_deployment` function to accept an optional `override_tt_config` parameter for flexible configuration management.
- Modified the `DeployView` to conditionally set the `override_tt_config` based on the model and device, improving deployment accuracy.