### PR TITLE
Enable --dev-mode for Qwen3-32B on p300x2

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -344,6 +344,7 @@ def run_container(impl, weights_id, device_id=0, host_port=None):
         # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
         if impl.model_name == "Qwen3-32B" and device == "p300x2":
             payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+            payload["dev_mode"] = True
 
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -355,7 +355,8 @@ class DeployView(APIView):
                 inference_device_id = None if board_type == "P300Cx2" else device_id
                 # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
                 override_tt_config = None
-                if impl.model_name == "Qwen3-32B" and device == "p300x2":
+                qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
+                if qwen32b_p300x2:
                     override_tt_config = '{"trace_region_size": 53000000}'
                 result = start_chat_deployment(
                     model_name=impl.model_name,
@@ -365,6 +366,7 @@ class DeployView(APIView):
                     timeout_seconds=30,
                     skip_system_sw_validation=True,
                     override_tt_config=override_tt_config,
+                    dev_mode=qwen32b_p300x2,
                 )
                 if result.status != "success":
                     return Response(


### PR DESCRIPTION
## Summary

Pairs `--dev-mode` with the existing `--override-tt-config '{"trace_region_size": 53000000}'` injection for Qwen3-32B on p300x2 so the deploy path uses both required runtime flags together.

## Test plan

- [x] Deploy Qwen3-32B on a p300x2 host and confirm the inference server launches with both `--override-tt-config` and `--dev-mode`