### PR TITLE
Release Candidate v2.5.1 (#726)

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -341,6 +341,11 @@ def run_container(impl, weights_id, device_id=0, host_port=None):
         # Multi-chip models need this to specify which configuration to use
         payload["device_id"] = str(device_id)
 
+        # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+        if impl.model_name == "Qwen3-32B" and device == "p300x2":
+            payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+            payload["dev_mode"] = True
+
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:
             payload["skip_system_sw_validation"] = True

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -31,6 +31,7 @@ def start_chat_deployment(
     timeout_seconds: int = 30,
     dev_mode: bool = False,
     skip_system_sw_validation: bool = True,
+    override_tt_config: Optional[str] = None,
 ) -> TTInferenceRunResult:
     """Start a chat model deployment via TT Inference Server (/run).
 
@@ -49,6 +50,8 @@ def start_chat_deployment(
         payload["service_port"] = str(service_port)
     if device_id is not None:
         payload["device_id"] = str(device_id)
+    if override_tt_config is not None:
+        payload["override_tt_config"] = override_tt_config
 
     try:
         r = requests.post(fastapi_run_url, json=payload, timeout=timeout_seconds)

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -353,6 +353,11 @@ class DeployView(APIView):
                 # p300x2 device itself — do not pass device_id so it is omitted from the
                 # run.py invocation entirely.
                 inference_device_id = None if board_type == "P300Cx2" else device_id
+                # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+                override_tt_config = None
+                qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
+                if qwen32b_p300x2:
+                    override_tt_config = '{"trace_region_size": 53000000}'
                 result = start_chat_deployment(
                     model_name=impl.model_name,
                     device=device,
@@ -360,6 +365,8 @@ class DeployView(APIView):
                     service_port=service_port,
                     timeout_seconds=30,
                     skip_system_sw_validation=True,
+                    override_tt_config=override_tt_config,
+                    dev_mode=qwen32b_p300x2,
                 )
                 if result.status != "success":
                     return Response(

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -335,13 +335,38 @@ def _resolve_preferred_host_volume(
             f"preferred host-volume root {resolved_candidate_root} is not a directory",
         )
     if not expected_volume_dir.exists():
-        return (
-            None,
+        # Fall back to scanning for any volume dir that matches the model name under the
+        # candidate root — handles cases where the directory was prepared with a different
+        # version/branch suffix (e.g. v0.10.1 instead of vqb2_launch).
+        fallback_volume_dir = None
+        if resolved_candidate_root.is_dir():
+            model_name_lower = model_spec.model_name.lower()
+            for candidate in sorted(resolved_candidate_root.iterdir()):
+                if not candidate.is_dir():
+                    continue
+                cname = candidate.name.lower()
+                if model_name_lower in cname and "volume_id_" in cname:
+                    candidate_weights = candidate / "weights" / model_spec.model_name
+                    candidate_cache = candidate / "tt_metal_cache"
+                    if candidate_weights.is_dir() and candidate_cache.is_dir():
+                        fallback_volume_dir = candidate
+                        break
+        if fallback_volume_dir is None:
+            return (
+                None,
+                expected_volume_dir,
+                expected_weights_dir,
+                expected_tt_metal_cache_dir,
+                f"expected preloaded host-volume directory is missing: {expected_volume_dir}",
+            )
+        logging.getLogger(__name__).warning(
+            "Expected host-volume dir %s not found; using fuzzy-matched fallback %s",
             expected_volume_dir,
-            expected_weights_dir,
-            expected_tt_metal_cache_dir,
-            f"expected preloaded host-volume directory is missing: {expected_volume_dir}",
+            fallback_volume_dir,
         )
+        expected_volume_dir = fallback_volume_dir
+        expected_weights_dir = expected_volume_dir / "weights" / model_spec.model_name
+        expected_tt_metal_cache_dir = expected_volume_dir / "tt_metal_cache"
     if not expected_volume_dir.is_dir():
         return (
             None,
@@ -1417,6 +1442,20 @@ async def run_inference(request: RunRequest):
                 except Exception as first_attempt_error:
                     # run_main() can raise directly (e.g. local setup validation errors)
                     # and bypass return-code based retry logic.
+                    #
+                    # PermissionError on the log directory means the workflow_logs dir is
+                    # root-owned (leftover from a previous sudo-based startup). Retrying
+                    # with different Docker args won't help — re-raise immediately so the
+                    # caller gets a clear error instead of a misleading retry.
+                    if isinstance(first_attempt_error, PermissionError) and "workflow_logs" in str(first_attempt_error):
+                        logger.error(
+                            "Job %s: PermissionError on workflow_logs directory — directory is likely "
+                            "root-owned from a previous sudo-based startup. Fix with: "
+                            "sudo chown -R $USER: %s/workflow_logs",
+                            job_id,
+                            script_dir,
+                        )
+                        raise
                     retry_argv, retry_reason = _build_retry_argv_and_reason()
                     if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
                         logger.warning(

--- a/run.py
+++ b/run.py
@@ -4444,23 +4444,36 @@ def main():
         else:
             # Ensure existing directory has correct permissions (Unix/Linux only)
             if OS_NAME != "Windows":
-                try:
-                    current_stat = os.stat(workflow_logs_dir)
-                    current_uid = current_stat.st_uid
-                    current_user_uid = os.getuid()
-                    if current_uid != current_user_uid and current_uid == 0:  # Owned by root
-                        print(f"{C_YELLOW}⚠️  workflow_logs directory is owned by root, fixing permissions...{C_RESET}")
-                        os.chown(workflow_logs_dir, current_user_uid, os.getgid())
-                        print(f"{C_GREEN}✅ Fixed workflow_logs directory ownership{C_RESET}")
-                except (OSError, PermissionError, AttributeError) as e:
-                    # If we don't have permission or chown is not available, ask user to fix manually then continue
-                    print(f"{C_RED}⛔ Could not fix workflow_logs permissions: {e}{C_RESET}")
+                current_stat = os.stat(workflow_logs_dir)
+                current_uid = current_stat.st_uid
+                current_user_uid = os.getuid()
+                if current_uid != current_user_uid and current_uid == 0:  # Owned by root
+                    print(f"{C_YELLOW}⚠️  The workflow_logs directory is owned by root:{C_RESET}")
+                    print(f"   {C_WHITE}{workflow_logs_dir}{C_RESET}")
                     print()
-                    print(f"{C_YELLOW}The workflow_logs directory is owned by root. Please run the following in another terminal:{C_RESET}")
+                    print(f"{C_YELLOW}This was likely created by Docker and will prevent deployment logs from being written.{C_RESET}")
+                    print(f"{C_YELLOW}TT Studio needs to run the following command to fix it:{C_RESET}")
                     print(f"   {C_WHITE}sudo chown -R $USER:$USER {workflow_logs_dir}{C_RESET}")
                     print()
-                    input("Press Enter once you've run the command above to continue...")
+                    answer = input(f"{C_CYAN}Allow TT Studio to run this automatically? [y/N]: {C_RESET}").strip().lower()
                     print()
+                    if answer in ("y", "yes"):
+                        try:
+                            import subprocess as _sp
+                            _sp.run(
+                                ["sudo", "chown", "-R", f"{current_user_uid}:{os.getgid()}", workflow_logs_dir],
+                                check=True,
+                            )
+                            print(f"{C_GREEN}✅ Fixed workflow_logs directory ownership{C_RESET}")
+                        except Exception as e:
+                            print(f"{C_RED}⛔ sudo chown failed: {e}{C_RESET}")
+                            print(f"{C_YELLOW}Please run the command above manually and restart TT Studio.{C_RESET}")
+                            sys.exit(1)
+                    else:
+                        print(f"{C_YELLOW}Please run the following command and restart TT Studio:{C_RESET}")
+                        print(f"   {C_WHITE}sudo chown -R $USER:$USER {workflow_logs_dir}{C_RESET}")
+                        print()
+                        sys.exit(1)
 
         # Start Docker Control Service BEFORE starting Docker containers
         # This ensures the backend can connect to it when it starts
@@ -4515,6 +4528,19 @@ def main():
             startup_log.step("fastapi_server", "SKIP", "AI Playground mode")
             print(f"\n{C_GREEN}✅ Skipping TT Inference Server FastAPI setup (AI Playground mode enabled){C_RESET}")
             print(f"{C_CYAN}   Note: AI Playground mode uses cloud models, so local FastAPI server is not needed{C_RESET}")
+
+        # Pre-create workflow_logs before docker compose up.
+        # docker-compose.yml bind-mounts this directory; if Docker creates it first, it
+        # does so as root, which blocks the FastAPI server (running as the current user)
+        # from writing logs on the first deploy. Also fix ownership if already root-owned
+        # from a previous run.
+        for _subdir in ["workflow_logs", os.path.join("workflow_logs", "run_logs")]:
+            _log_dir = os.path.join(INFERENCE_ARTIFACT_DIR, _subdir)
+            try:
+                os.makedirs(_log_dir, exist_ok=True)
+            except PermissionError:
+                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _log_dir], check=False)
+                os.makedirs(_log_dir, exist_ok=True)
 
         # Start Docker services with streaming output and comprehensive error reporting
         startup_log.step("docker_compose_up", "START")


### PR DESCRIPTION
* Enhance workflow log directory management and error handling in run.py (#725)

- Pre-create the workflow_logs directory before starting Docker services to prevent permission issues caused by root ownership.
- Implement error handling for PermissionError when accessing the workflow_logs directory, providing clear instructions for users to fix ownership issues.
- Update logging to improve user guidance during setup, ensuring a smoother deployment experience.

* Improve workflow_logs permissions handling in run.py (#723)

- Enhanced error messaging to inform users when the workflow_logs directory ownership cannot be fixed automatically.
- Added instructions for users to manually change ownership using `sudo chown -R $USER:$USER {workflow_logs_dir}`.
- Included a prompt for users to allow automatic permission fixing, improving user guidance during setup.

* Enhance deployment configuration for Qwen3-32B model on p300x2 (#729)

* Enhance deployment configuration for Qwen3-32B model on p300x2

- Added support for overriding the trace region size in the deployment configuration for the Qwen3-32B model when using the p300x2 device, addressing memory limitations.
- Updated the `start_chat_deployment` function to accept an optional `override_tt_config` parameter for flexible configuration management.
- Modified the `DeployView` to conditionally set the `override_tt_config` based on the model and device, improving deployment accuracy.

* change to point to qb2 launch branch

* Enable --dev-mode for Qwen3-32B on p300x2 (#730)

Pair --dev-mode with the existing trace_region_size override so the Qwen3-32B p300x2 deploy path matches the required runtime flags.


