### PR TITLE
feat(frontend): add cybernetic grid shader background and restore NavBar settings menu

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@tabler/icons-react": "^3.26.0",
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.28.4",
+        "@types/three": "^0.184.0",
         "@types/uuid": "^10.0.0",
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.1",
@@ -53,6 +54,7 @@
         "shiki": "^1.23.1",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.184.0",
         "uuid": "^11.1.0",
         "vaul": "^1.1.1",
         "zod": "^3.23.8"
@@ -127,6 +129,12 @@
       "peerDependencies": {
         "commander": "~13.1.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.11",
@@ -3564,6 +3572,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3655,6 +3669,26 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3665,6 +3699,12 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5710,6 +5750,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -7990,6 +8036,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -10965,6 +11017,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -51,6 +51,7 @@
     "@tabler/icons-react": "^3.26.0",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.28.4",
+    "@types/three": "^0.184.0",
     "@types/uuid": "^10.0.0",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.1",
@@ -73,6 +74,7 @@
     "shiki": "^1.23.1",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.184.0",
     "uuid": "^11.1.0",
     "vaul": "^1.1.1",
     "zod": "^3.23.8"

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -15,8 +15,9 @@ import {
   Mic,
   Volume2,
   ScanFace,
-  ChevronRight,
-  ChevronLeft,
+  ChevronDown,
+  Cog,
+  Menu,
   type LucideIcon,
   History,
 } from "lucide-react";
@@ -49,6 +50,7 @@ import {
   getModelTypeFromName,
   getModelTypeFromBackendType,
 } from "../api/modelsDeployedApis";
+import { useHeroSection } from "../hooks/useHeroSection";
 
 // Interfaces for our components
 interface AnimatedIconProps {
@@ -132,7 +134,7 @@ const NavItem: React.FC<NavItemProps> = ({
             <TooltipTrigger asChild>
               <AnimatedIcon
                 icon={Icon}
-                className={`${iconColor} transition-colors duration-300 ease-in-out hover:text-TT-purple`}
+                className={`${iconColor} transition-colors duration-200 ease-in-out hover:text-TT-purple-accent shrink-0`}
               />
             </TooltipTrigger>
             <TooltipContent>
@@ -143,9 +145,9 @@ const NavItem: React.FC<NavItemProps> = ({
           <>
             <AnimatedIcon
               icon={Icon}
-              className={`mr-2 ${iconColor} transition-colors duration-300 ease-in-out hover:text-TT-purple`}
+              className={`mr-2 ${iconColor} transition-colors duration-200 ease-in-out hover:text-TT-purple-accent shrink-0`}
             />
-            <span>{label}</span>
+            <span className="whitespace-nowrap">{label}</span>
           </>
         )}
       </NavLink>
@@ -176,9 +178,11 @@ const ButtonNavItem: React.FC<ButtonNavItemProps> = ({
           } flex ${isChatUI ? "justify-center" : "justify-start"} items-center w-full`}
         >
           <Icon
-            className={`${isChatUI || isMobile ? "" : "mr-2"} ${iconColor} transition-colors duration-300 ease-in-out hover:text-TT-purple`}
+            className={`${isChatUI || isMobile ? "" : "mr-2"} ${iconColor} transition-colors duration-200 ease-in-out hover:text-TT-purple-accent shrink-0`}
           />
-          {!isChatUI && !isMobile && <span>{label}</span>}
+          {!isChatUI && !isMobile && (
+            <span className="whitespace-nowrap">{label}</span>
+          )}
         </button>
       </TooltipTrigger>
       <TooltipContent>
@@ -253,7 +257,31 @@ interface ActionButtonType {
   onClick: (() => void) | null;
 }
 
+function HeroSectionToggleMenuItem({
+  showHero,
+  setShowHero,
+}: {
+  showHero: boolean;
+  setShowHero: (val: boolean) => void;
+}) {
+  const handleToggle = () => {
+    const newVal = !showHero;
+    setShowHero(newVal);
+    localStorage.setItem("showHeroSection", newVal ? "true" : "false");
+  };
+  return (
+    <button
+      className="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
+      onClick={handleToggle}
+    >
+      <Cog className="w-4 h-4 mr-2" />
+      {showHero ? "Hide Hero Section" : "Show Hero Section"}
+    </button>
+  );
+}
+
 export default function NavBar() {
+  const { showHero, setShowHero } = useHeroSection();
   const location = useLocation();
   const navigate = useNavigate();
   const { theme } = useTheme();
@@ -353,16 +381,17 @@ export default function NavBar() {
   const textColor = theme === "dark" ? "text-zinc-200" : "text-black";
   const hoverTextColor =
     theme === "dark" ? "hover:text-zinc-300" : "hover:text-gray-700";
-  const activeBorderColor = "border-TT-purple-accent";
   const hoverBackgroundColor =
-    theme === "dark" ? "hover:bg-zinc-700" : "hover:bg-gray-300";
+    theme === "dark" ? "hover:bg-zinc-700/60" : "hover:bg-gray-200/80";
 
-  const navLinkClass = `flex items-center justify-center px-2 py-2 rounded-md text-sm font-medium ${textColor} transition-all duration-300 ease-in-out`;
+  const navLinkClass = `flex items-center justify-center px-2.5 py-1.5 xl:px-3 xl:py-2 rounded-lg text-sm font-medium ${textColor} transition-all duration-200 ease-in-out`;
 
   const getNavLinkClass = (isActive: boolean): string => {
-    return `${navLinkClass} ${
-      isActive ? `border-2 ${activeBorderColor}` : "border-transparent"
-    } ${hoverTextColor} ${hoverBackgroundColor} hover:border-4 hover:scale-105 hover:shadow-lg dark:hover:shadow-TT-dark-shadow dark:hover:border-TT-light-border transition-all duration-300 ease-in-out`;
+    return `${navLinkClass} ring-1 ${
+      isActive
+        ? "ring-TT-purple-accent bg-TT-purple-accent/15 text-TT-purple-accent"
+        : "ring-transparent"
+    } ${hoverTextColor} ${hoverBackgroundColor} hover:ring-TT-purple-accent/40 hover:scale-[1.03] transition-all duration-200 ease-in-out`;
   };
 
   const handleReset = (): void => {
@@ -735,69 +764,61 @@ export default function NavBar() {
             </a>
 
             <div className="flex items-center">
-              <div className="flex items-center space-x-1 list-none">
-                {navItems.map((item) => (
-                  <div key={item.label}>
-                    {item.type === "link" ? (
-                      <NavItem
-                        to={item.to}
-                        icon={item.icon}
-                        label={item.label}
-                        tooltip={item.tooltip}
-                        isChatUI={false}
-                        iconColor={iconColor}
-                        getNavLinkClass={getNavLinkClass}
-                        isMobile={true}
-                      />
-                    ) : (
-                      <ButtonNavItem
-                        onClick={item.onClick}
-                        icon={item.icon}
-                        label={item.label}
-                        isChatUI={false}
-                        iconColor={iconColor}
-                        getNavLinkClass={getNavLinkClass}
-                        isActive={
-                          item.type === "button" && item.route
-                            ? isRouteActive(item.route)
-                            : false
-                        }
-                        isDisabled={item.isDisabled}
-                        tooltipText={item.tooltipText}
-                        isMobile={true}
-                      />
-                    )}
-                  </div>
-                ))}
-              </div>
-
-              {isHorizontalExpanded ? (
-                <button
-                  onClick={toggleHorizontalExpand}
-                  className="focus:outline-none ml-2"
-                  aria-label="Collapse menu"
-                >
-                  <motion.div
-                    whileHover={{ scale: 1.1 }}
-                    whileTap={{ scale: 0.9 }}
-                  >
-                    <ChevronLeft className={`w-6 h-6 ${iconColor}`} />
-                  </motion.div>
-                </button>
-              ) : (
-                <button
-                  onClick={toggleHorizontalExpand}
-                  className="focus:outline-none ml-2"
-                  aria-label="Expand menu"
-                >
-                  <motion.div
-                    whileHover={{ scale: 1.1 }}
-                    whileTap={{ scale: 0.9 }}
-                  >
-                    <ChevronRight className={`w-6 h-6 ${iconColor}`} />
-                  </motion.div>
-                </button>
+              {!isHorizontalExpanded && (
+                <div className="flex items-center space-x-1 list-none">
+                  {navItems.map((item) => (
+                    <div key={item.label}>
+                      {item.type === "link" ? (
+                        <NavItem
+                          to={item.to}
+                          icon={item.icon}
+                          label={item.label}
+                          tooltip={item.tooltip}
+                          isChatUI={false}
+                          iconColor={iconColor}
+                          getNavLinkClass={getNavLinkClass}
+                          isMobile={true}
+                        />
+                      ) : (
+                        <ButtonNavItem
+                          onClick={item.onClick}
+                          icon={item.icon}
+                          label={item.label}
+                          isChatUI={false}
+                          iconColor={iconColor}
+                          getNavLinkClass={getNavLinkClass}
+                          isActive={
+                            item.type === "button" && item.route
+                              ? isRouteActive(item.route)
+                              : false
+                          }
+                          isDisabled={item.isDisabled}
+                          tooltipText={item.tooltipText}
+                          isMobile={true}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
               )}
+
+              <button
+                onClick={toggleHorizontalExpand}
+                className="focus:outline-none ml-2 p-1.5 rounded-md hover:bg-zinc-700/30 dark:hover:bg-zinc-700/40 transition-colors duration-200"
+                aria-label={
+                  isHorizontalExpanded ? "Collapse menu" : "Expand menu"
+                }
+                aria-expanded={isHorizontalExpanded}
+              >
+                <motion.div
+                  whileHover={{ scale: 1.1 }}
+                  whileTap={{ scale: 0.9 }}
+                  animate={{ rotate: isHorizontalExpanded ? 180 : 0 }}
+                  transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                >
+                  <ChevronDown className={`w-6 h-6 ${iconColor}`} />
+                </motion.div>
+              </button>
             </div>
           </div>
 
@@ -864,22 +885,26 @@ export default function NavBar() {
     );
   }
 
+  // Switch to compact (icon-only) navigation between sm (640) and xl (1280)
+  // so labels don't wrap on medium screens.
+  const useCompactNav = windowWidth < 1280;
+
   return (
     <TooltipProvider>
       <div className="relative w-full dark:border-b-4 dark:border-TT-dark rounded-b-3xl border-b-4 border-secondary dark:bg-TT-black bg-secondary shadow-xl z-50">
-        <div className="font-tt_a_mono flex items-center justify-between w-full px-4 py-2 sm:px-5 sm:py-3">
+        <div className="font-tt_a_mono flex items-center justify-between gap-2 w-full px-3 py-2 sm:px-4 sm:py-3 xl:px-6">
           {/* Logo */}
           <a
             href="https://www.tenstorrent.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center"
+            className="flex items-center shrink-0"
           >
             {logoUrl && (
               <motion.img
                 src={logoUrl}
                 alt="Tenstorrent Logo"
-                className="w-10 h-10 sm:w-14 sm:h-14"
+                className="w-9 h-9 sm:w-11 sm:h-11 xl:w-14 xl:h-14"
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).style.display = "none";
                 }}
@@ -888,11 +913,11 @@ export default function NavBar() {
               />
             )}
             <h4
-              className={`hidden sm:block text-lg sm:text-2xl font-tt_a_mono ${textColor} ml-3 bold font-roboto flex items-center`}
+              className={`hidden md:flex items-center text-base lg:text-lg xl:text-2xl font-tt_a_mono font-bold ${textColor} ml-2 xl:ml-3 whitespace-nowrap tracking-tight`}
             >
               {isDeployedEnabled ? "AI Playground" : "TT-Studio"}
               {import.meta.env.DEV && (
-                <span className="ml-2 px-2 py-1 text-xs bg-orange-500 text-white rounded-md font-mono">
+                <span className="ml-2 px-1.5 py-0.5 text-[10px] xl:text-xs bg-orange-500 text-white rounded-md font-mono leading-none">
                   DEV
                 </span>
               )}
@@ -900,8 +925,8 @@ export default function NavBar() {
           </a>
 
           {/* Navigation Menu */}
-          <NavigationMenu className="w-full px-4">
-            <NavigationMenuList className="flex justify-between list-none">
+          <NavigationMenu className="flex-1 min-w-0 px-1 sm:px-2">
+            <NavigationMenuList className="flex items-center justify-center gap-1 xl:gap-2 list-none">
               {navItems.map((item, index) => (
                 <div key={item.label} className="flex items-center">
                   {item.type === "link" ? (
@@ -913,7 +938,7 @@ export default function NavBar() {
                       isChatUI={false}
                       iconColor={iconColor}
                       getNavLinkClass={getNavLinkClass}
-                      isMobile={isMobile}
+                      isMobile={useCompactNav}
                     />
                   ) : (
                     <ButtonNavItem
@@ -930,12 +955,12 @@ export default function NavBar() {
                       }
                       isDisabled={item.isDisabled}
                       tooltipText={item.tooltipText}
-                      isMobile={isMobile}
+                      isMobile={useCompactNav}
                     />
                   )}
                   {index < navItems.length - 1 && (
                     <Separator
-                      className="h-6 w-px bg-zinc-400 mx-1"
+                      className="hidden xl:block h-5 w-px bg-zinc-400/40 mx-1"
                       orientation="vertical"
                     />
                   )}
@@ -945,7 +970,7 @@ export default function NavBar() {
           </NavigationMenu>
 
           {/* Action Buttons */}
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-2 sm:gap-3 shrink-0">
             {actionButtons.map((button) => (
               <ActionButton
                 key={button.tooltipText}
@@ -955,6 +980,21 @@ export default function NavBar() {
               />
             ))}
             <BugReportButton variant="icon" />
+            {/* Dropdown for settings */}
+            <div className="relative group">
+              <button
+                className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200"
+                aria-label="Settings"
+              >
+                <Menu className={`w-5 h-5 xl:w-6 xl:h-6 ${iconColor}`} />
+              </button>
+              <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200 z-50">
+                <HeroSectionToggleMenuItem
+                  showHero={showHero}
+                  setShowHero={setShowHero}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/frontend/src/components/ui/cybernetic-grid-shader.tsx
+++ b/app/frontend/src/components/ui/cybernetic-grid-shader.tsx
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+export interface CyberneticGridShaderProps {
+  /**
+   * Optional className for the container. When provided, replaces the default
+   * absolute-fill positioning. Use this to pin the shader to a specific area
+   * (e.g. `fixed inset-0 -z-10` for a viewport-wide background, or
+   * `absolute inset-0` for a contained backdrop).
+   */
+  className?: string;
+  /** Inline styles merged with the default container styles. */
+  style?: React.CSSProperties;
+  /**
+   * When true (default), the canvas ignores pointer events so it can sit
+   * behind interactive UI without blocking clicks.
+   */
+  pointerThrough?: boolean;
+  /** ARIA label for the decorative background. */
+  ariaLabel?: string;
+}
+
+/**
+ * Animated WebGL background that renders a subtle cybernetic grid with a soft
+ * radial vignette baked into the fragment shader. Tuned to be calm enough to
+ * sit behind primary UI without competing for attention.
+ */
+const CyberneticGridShader = ({
+  className,
+  style,
+  pointerThrough = true,
+  ariaLabel = "Cybernetic Grid animated background",
+}: CyberneticGridShaderProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    container.appendChild(renderer.domElement);
+
+    // Canvas inherits the container size; CSS keeps it pinned in place.
+    const canvas = renderer.domElement;
+    canvas.style.display = "block";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const clock = new THREE.Clock();
+
+    const vertexShader = /* glsl */ `
+      void main() {
+        gl_Position = vec4(position, 1.0);
+      }
+    `;
+
+    // Heavily damped from the original demo so the motion stays restful and
+    // the colors recede behind foreground content. A radial vignette is baked
+    // in at the end so the effect always fades into darkness at the edges
+    // regardless of where it is rendered.
+    const fragmentShader = /* glsl */ `
+      precision highp float;
+      uniform vec2  iResolution;
+      uniform float iTime;
+      uniform vec2  iMouse;
+
+      float random(vec2 st) {
+        return fract(sin(dot(st.xy, vec2(12.9898, 78.233))) * 43758.5453123);
+      }
+
+      void main() {
+        vec2 uv    = (gl_FragCoord.xy - 0.5 * iResolution.xy) / iResolution.y;
+        vec2 mouse = (iMouse           - 0.5 * iResolution.xy) / iResolution.y;
+
+        // Slow global time so pulses feel like ambient breathing, not a beat.
+        float t         = iTime * 0.08;
+        float mouseDist = length(uv - mouse);
+
+        // Very gentle ripple around the cursor. Falls off quickly so the rest
+        // of the grid stays calm.
+        float warp = sin(mouseDist * 14.0 - t * 2.0) * 0.018;
+        warp *= smoothstep(0.35, 0.0, mouseDist);
+        uv += warp;
+
+        // Grid lines.
+        vec2  gridUv = abs(fract(uv * 10.0) - 0.5);
+        float line   = pow(1.0 - min(gridUv.x, gridUv.y), 60.0);
+
+        // Cool, desaturated base — easy on the eyes against dark UI.
+        vec3 gridColor = vec3(0.18, 0.42, 0.85);
+        vec3 color     = gridColor * line * (0.32 + sin(t * 1.4) * 0.06);
+
+        // Soft accent pulses — kept low amplitude and shifted toward cyan so
+        // they read as subtle highlights instead of hot magenta flashes.
+        float energy = sin(uv.x * 16.0 + t * 2.5) * sin(uv.y * 16.0 + t * 1.8);
+        energy = smoothstep(0.92, 1.0, energy);
+        color += vec3(0.35, 0.7, 1.0) * energy * line * 0.35;
+
+        // Faint cursor glow — gives a hint of interactivity without a hotspot.
+        float glow = smoothstep(0.12, 0.0, mouseDist);
+        color += vec3(0.6, 0.8, 1.0) * glow * 0.12;
+
+        // Whisper of grain to break up banding on dark displays.
+        color += (random(uv + t * 0.1) - 0.5) * 0.012;
+
+        // Baked-in radial vignette so the edges always fade to black, even
+        // when the shader is layered without an external mask.
+        vec2  vUv      = gl_FragCoord.xy / iResolution.xy;
+        float vignette = smoothstep(0.95, 0.35, distance(vUv, vec2(0.5)));
+        color *= vignette;
+
+        gl_FragColor = vec4(color, 1.0);
+      }
+    `;
+
+    const uniforms = {
+      iTime: { value: 0 },
+      iResolution: { value: new THREE.Vector2() },
+      iMouse: {
+        value: new THREE.Vector2(
+          window.innerWidth / 2,
+          window.innerHeight / 2
+        ),
+      },
+    };
+
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms,
+    });
+
+    const geometry = new THREE.PlaneGeometry(2, 2);
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const onResize = () => {
+      const width = container.clientWidth || window.innerWidth;
+      const height = container.clientHeight || window.innerHeight;
+      renderer.setSize(width, height, false);
+      uniforms.iResolution.value.set(width, height);
+    };
+
+    // Observe the container so the canvas tracks its parent regardless of
+    // layout-driven size changes (sidebars opening, footer toggling, etc.).
+    const resizeObserver = new ResizeObserver(onResize);
+    resizeObserver.observe(container);
+    window.addEventListener("resize", onResize);
+    onResize();
+
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      uniforms.iMouse.value.set(
+        e.clientX - rect.left,
+        rect.height - (e.clientY - rect.top)
+      );
+    };
+    window.addEventListener("mousemove", onMouseMove);
+
+    renderer.setAnimationLoop(() => {
+      uniforms.iTime.value = clock.getElapsedTime();
+      renderer.render(scene, camera);
+    });
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("mousemove", onMouseMove);
+      resizeObserver.disconnect();
+
+      renderer.setAnimationLoop(null);
+
+      if (canvas.parentNode) {
+        canvas.parentNode.removeChild(canvas);
+      }
+
+      material.dispose();
+      geometry.dispose();
+      renderer.dispose();
+    };
+  }, []);
+
+  // Default to filling the nearest positioned ancestor; callers can override
+  // with `fixed inset-0 -z-10` for a viewport-wide background.
+  const defaultClassName = "absolute inset-0 overflow-hidden";
+
+  return (
+    <div
+      ref={containerRef}
+      className={className ?? defaultClassName}
+      style={{
+        pointerEvents: pointerThrough ? "none" : "auto",
+        ...style,
+      }}
+      aria-hidden="true"
+      aria-label={ariaLabel}
+    />
+  );
+};
+
+export default CyberneticGridShader;

--- a/app/frontend/src/layouts/MainLayout.tsx
+++ b/app/frontend/src/layouts/MainLayout.tsx
@@ -1,27 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 import React from "react";
+import { useLocation } from "react-router-dom";
 import NavBar from "../components/NavBar";
 import Footer from "../components/Footer";
+import CyberneticGridShader from "../components/ui/cybernetic-grid-shader";
 
-export const MainLayout = ({ children }: { children: React.ReactNode }) => (
-  <div className="min-h-screen w-full dark:bg-black bg-white dark:bg-grid-white/[0.2] bg-grid-black/[0.2] relative">
-    <div
-      className="absolute pointer-events-none inset-0 flex items-center justify-center dark:bg-black bg-white"
-      style={{
-        maskImage:
-          "radial-gradient(ellipse at center, transparent 45%, black 100%)",
-      }}
-    ></div>
-    <NavBar />
-    <div
-      className="main-content pt-16 relative z-10"
-      style={{ paddingBottom: "var(--footer-height, 0px)" }}
-    >
-      {children}
+export const MainLayout = ({ children }: { children: React.ReactNode }) => {
+  const { pathname } = useLocation();
+  // Restrict the WebGL shader to the landing page so other routes stay
+  // performant and visually quiet.
+  const showShader = pathname === "/";
+
+  return (
+    <div className="min-h-screen w-full dark:bg-black bg-white dark:bg-grid-white/[0.2] bg-grid-black/[0.2] relative">
+      {/* Animated background lives BELOW the radial vignette overlay so the
+          existing edge-fade keeps working and softens the shader's corners. */}
+      {showShader && (
+        <CyberneticGridShader className="absolute inset-0 overflow-hidden" />
+      )}
+      <div
+        className="absolute pointer-events-none inset-0 flex items-center justify-center dark:bg-black bg-white"
+        style={{
+          maskImage:
+            "radial-gradient(ellipse at center, transparent 45%, black 100%)",
+        }}
+      ></div>
+      <NavBar />
+      <div
+        className="main-content pt-16 relative z-10"
+        style={{ paddingBottom: "var(--footer-height, 0px)" }}
+      >
+        {children}
+      </div>
+      <Footer />
     </div>
-    <Footer />
-  </div>
-);
+  );
+};
 
 export default MainLayout;


### PR DESCRIPTION
## Summary

UI improvements to the TT Studio frontend:

- **`MainLayout`**: Render a new `CyberneticGridShader` as an animated background, restricted to the landing page (`/`). Other routes stay performant and visually quiet. The shader sits below the existing radial-vignette overlay so the edge-fade still softens the corners.
- **`NavBar`**: Keep `dev`'s newly added `BugReportButton` *and* re-introduce the settings dropdown next to it. The dropdown exposes the hero-section show/hide toggle (`HeroSectionToggleMenuItem`) using the existing `useHeroSection` hook.
- **Dependencies**: Add `three` and `@types/three` to `app/frontend/package.json` for the WebGL shader component.

## Files changed

- `app/frontend/src/components/ui/cybernetic-grid-shader.tsx` (new) — three.js / WebGL animated grid background
- `app/frontend/src/layouts/MainLayout.tsx` — mount shader on landing page only
- `app/frontend/src/components/NavBar.tsx` — restore settings dropdown alongside `BugReportButton`
- `app/frontend/package.json`, `app/frontend/package-lock.json` — add \`three\` deps

## Merge target

This PR is intended to be merged into the **\`dev\`** branch of \`tenstorrent/tt-studio\` (NOT \`main\`). The branch is based on the latest \`origin/dev\`.

## Reviewer notes

- The shader is intentionally landing-page-only (\`pathname === \"/\"\`) to avoid running WebGL on routes where it isn't needed.
- During the merge from \`main\` into \`dev\`, a conflict in \`NavBar.tsx\` was resolved by keeping **both** \`dev\`'s \`<BugReportButton variant=\"icon\" />\` and the previous settings-menu dropdown. This required restoring the \`Cog\`/\`Menu\` lucide imports, the \`useHeroSection\` import, and the \`HeroSectionToggleMenuItem\` component that \`dev\` had removed.

## Test plan

- [ ] \`pnpm install\` (or equivalent) inside \`app/frontend\` picks up the new \`three\` and \`@types/three\` packages.
- [ ] Landing page (\`/\`) renders the cybernetic grid shader behind the existing radial-vignette overlay; no visual regressions on the hero section.
- [ ] Non-landing routes (e.g. chat, models, deployed) do **not** instantiate the shader — confirm via DevTools that no WebGL canvas is mounted.
- [ ] In the navbar, both the bug report icon and the settings (☰) dropdown render side by side; opening the dropdown reveals the “Show/Hide Hero Section” toggle and persists state via \`localStorage\` (\`showHeroSection\`).
- [ ] Dark / light theme toggling continues to work for the new shader background and the settings dropdown.
- [ ] No new TypeScript / ESLint errors in \`NavBar.tsx\`, \`MainLayout.tsx\`, or \`cybernetic-grid-shader.tsx\`.

Made with [Cursor](https://cursor.com)