### PR TITLE
fix(chat): replace rotating chat input suggestions with single static placeholder

### DIFF
--- a/app/frontend/src/components/chatui/ChatComponent.tsx
+++ b/app/frontend/src/components/chatui/ChatComponent.tsx
@@ -1359,6 +1359,7 @@ export default function ChatComponent() {
               isMobileView={screenSize.isMobileView}
               onCreateNewConversation={createNewConversation}
               onStopInference={handleStopInference}
+              hasMessages={getCurrentThread().messages.length > 0}
             />
           </div>
         </div>

--- a/app/frontend/src/components/chatui/InputArea.tsx
+++ b/app/frontend/src/components/chatui/InputArea.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 import React from "react";
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Button } from "../ui/button";

--- a/app/frontend/src/components/chatui/InputArea.tsx
+++ b/app/frontend/src/components/chatui/InputArea.tsx
@@ -43,7 +43,6 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 import { useNavigate } from "react-router-dom";
-import { TypingAnimation } from "../ui/typing-animation";
 
 interface PdfDetectionDialogProps {
   open: boolean;
@@ -130,15 +129,8 @@ interface InputAreaProps {
   isMobileView?: boolean;
   onCreateNewConversation?: () => void;
   onStopInference?: () => void;
+  hasMessages?: boolean;
 }
-
-const EXAMPLE_PROMPTS = [
-  "How can I help you today?",
-  "What would you like to know?",
-  "Ask me anything!",
-  "I'm here to assist you.",
-  "What's on your mind?",
-];
 
 export default function InputArea({
   textInput,
@@ -152,6 +144,7 @@ export default function InputArea({
   isMobileView = false,
   onCreateNewConversation,
   onStopInference,
+  hasMessages = false,
 }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isFileUploadOpen, setIsFileUploadOpen] = useState(false);
@@ -161,6 +154,7 @@ export default function InputArea({
   const [showReplaceDialog, setShowReplaceDialog] = useState(false);
   const [pendingImageFile, setPendingImageFile] = useState<File | null>(null);
   const [isFocused, setIsFocused] = useState(false);
+  const [hasInteracted, setHasInteracted] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
   const [isTouched, setIsTouched] = useState(false);
@@ -187,6 +181,10 @@ export default function InputArea({
       textareaRef.current.focus();
     }
   }, [isStreaming]);
+
+  useEffect(() => {
+    if (!hasMessages) setHasInteracted(false);
+  }, [hasMessages]);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -570,7 +568,10 @@ export default function InputArea({
                 WebkitAppearance: "none",
               }}
               aria-label="Chat input"
-              onFocus={() => setIsFocused(true)}
+              onFocus={() => {
+                setIsFocused(true);
+                setHasInteracted(true);
+              }}
               onBlur={() => setIsFocused(false)}
               onTouchStart={() => setIsTouched(true)}
               onTouchEnd={() => {
@@ -579,14 +580,9 @@ export default function InputArea({
                 }, 300);
               }}
             />
-            {!textInput && !isFocused && (
-              <div className="absolute inset-0 pointer-events-none">
-                <TypingAnimation
-                  texts={EXAMPLE_PROMPTS}
-                  duration={50}
-                  cycleDelay={2000}
-                  className="absolute inset-0 flex items-center px-1 text-gray-600 dark:text-gray-200"
-                />
+            {!textInput && !isFocused && !hasInteracted && !hasMessages && (
+              <div className="absolute inset-0 pointer-events-none flex items-center px-1 text-gray-600 dark:text-gray-200">
+                Ask me anything…
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

The chat input had an animated `TypingAnimation` overlay that rotated through five suggestion strings (e.g. "How can I help you today?", "I'm here to assist you.", etc.). It was gated only on `!textInput && !isFocused`, so it kept reappearing every time the textarea was empty and unfocused — including after the user had already chatted, which made it feel distracting.

This PR replaces that overlay with a single static `Ask me anything…` line that:

- Hides as soon as the user focuses the textarea, and **stays hidden** for the rest of that chat thread.
- Only becomes eligible to show again when the user starts a fresh empty conversation (e.g. via "New chat"), so the very first message of any new thread still gets a friendly hint.

## Changes

- `app/frontend/src/components/chatui/InputArea.tsx`
  - Removed the `TypingAnimation` import, the `EXAMPLE_PROMPTS` array, and the rotating overlay JSX.
  - Added a `hasMessages?: boolean` prop and a local `hasInteracted` state.
  - `onFocus` now also sets `hasInteracted=true`; a small effect resets it when `hasMessages` becomes `false` (handles "New chat").
  - The overlay is replaced with one static line, gated on `!textInput && !isFocused && !hasInteracted && !hasMessages`.
- `app/frontend/src/components/chatui/ChatComponent.tsx`
  - Passes `hasMessages={getCurrentThread().messages.length > 0}` down to `InputArea`.

`ChatExamples` empty-state cards in `ChatHistory.tsx` are unchanged.

## Test plan

- [x] Fresh `/chat` load: textarea grabs focus on mount, so placeholder stays out of the way; on blur with empty input it does not return.
- [x] Type and send a message, then click outside the input: placeholder does not reappear.
- [x] Click "New chat" and defocus the input: placeholder is eligible again on the fresh empty thread.
- [x] No linter errors.

Made with [Cursor](https://cursor.com)