### PR TITLE
fix: firefox mic sample-rate mismatch on STT + voice-agent

### DIFF
--- a/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
+++ b/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
@@ -77,8 +77,6 @@ export const AudioRecorderWithVisualizer = ({
   const animationRef = useRef<number | null>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
 
-  const sampleRate = 16_000; // 16kHz sample rate
-
   function cleanupAllResources() {
     // Stop recording if in progress
     if (
@@ -150,7 +148,7 @@ export const AudioRecorderWithVisualizer = ({
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
       navigator.mediaDevices
         .getUserMedia({
-          audio: { sampleRate },
+          audio: true,
         })
         .then((stream) => {
           setIsRecording(true);
@@ -161,7 +159,7 @@ export const AudioRecorderWithVisualizer = ({
           // ============ Analyzing ============
           const AudioContext =
             window.AudioContext || (window as any).webkitAudioContext;
-          const audioCtx = new AudioContext({ sampleRate });
+          const audioCtx = new AudioContext();
           const analyser = audioCtx.createAnalyser();
           analyser.fftSize = 256;
           const source = audioCtx.createMediaStreamSource(stream);

--- a/app/frontend/src/components/voiceAgent/AudioRecorderWithVisualizer.tsx
+++ b/app/frontend/src/components/voiceAgent/AudioRecorderWithVisualizer.tsx
@@ -18,7 +18,6 @@ type Props = {
 };
 
 const LEVEL_BARS = 24;
-const SAMPLE_RATE = 16_000;
 
 const STAGE_BAR_COLORS: Record<string, string> = {
   idle: "bg-TT-purple-accent",
@@ -78,12 +77,12 @@ export const AudioRecorderWithVisualizer = ({
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
-        audio: { sampleRate: SAMPLE_RATE },
+        audio: true,
       });
       streamRef.current = stream;
 
       const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
-      const ctx = new AudioCtx({ sampleRate: SAMPLE_RATE });
+      const ctx = new AudioCtx();
       audioContextRef.current = ctx;
 
       const analyser = ctx.createAnalyser();


### PR DESCRIPTION
## Summary

- Fixes the Firefox-only `DOMException: AudioContext.createMediaStreamSource: Connecting AudioNodes from AudioContexts with different sample-rate is currently not supported.` reported in https://github.com/tenstorrent/tt-studio/pull/755#issuecomment-4443314170.
- Mirrors #556's approach (which targets `speechToText/AudioRecorderWithVisualizer.tsx`) and **extends the same fix to `voiceAgent/AudioRecorderWithVisualizer.tsx`** — that file's line 91 is the exact location in the user-reported stack trace, and it was added as part of #755's voice-agent feature so #556 doesn't cover it.

## Why this fixes it

Both files hardcoded `sampleRate: 16_000` on the `getUserMedia` constraint AND the `AudioContext` constructor. Firefox returns streams at the device's native rate (typically 48 kHz) regardless of the requested constraint. The forced-16 kHz `AudioContext` then rejects `createMediaStreamSource` because the rates don't match. Dropping the explicit `sampleRate` lets the browser pick a consistent rate for both sides.

Net diff: 4 insertions, 7 deletions across 2 files. No behavior change in Chromium.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` — same 15 pre-existing problems on these files before and after; no new lint issues introduced
- [x] Playwright-driven Firefox 150 (headless) loads `/speech-to-text` and `/voice-agent`, clicks the mic, and the recorder flow completes without `pageerror` or mic-related `console.error`
- [ ] **Manual verification on a real Firefox with a real mic** — recommended; modern Firefox 150 auto-resamples internally so the original DOMException is no longer reproducible headlessly, but the reporter's environment (older Firefox build / different audio backend) is what surfaces the bug. Click the mic on both `/voice-agent` and `/speech-to-text`, confirm the DevTools console is clean of any `createMediaStreamSource` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)