### PR TITLE
Surfaced error on Deployed Models page in case deployment fails unexpectedly

### DIFF
--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../api/modelsDeployedApis";
 import type {
   ColumnVisibilityMap,
+  FailedDeploymentInfo,
   HealthStatus,
   ModelRow,
 } from "../../types/models";
@@ -41,6 +42,7 @@ import ModelsTable from "./ModelsTable.tsx";
 import DeleteModelDialog from "./DeleteModelDialog.tsx";
 import LogStreamDialog from "./Logs/LogStreamDialog.tsx";
 import RegisterModelDialog from "./RegisterModelDialog.tsx";
+import WorkflowLogDialog from "../deployment/WorkflowLogDialog";
 import { useNavigate } from "react-router-dom";
 import { useTablePrefs } from "../../hooks/useTablePrefs";
 import { useDeleteStream } from "../../hooks/useDeleteStream";
@@ -178,13 +180,155 @@ export default function ModelsDeployedCard(): JSX.Element {
   const [healthMap, setHealthMap] = useState<Record<string, HealthStatus>>({});
   const [preparingBannerDismissed, setPreparingBannerDismissed] = useState(false);
 
+  // Cross-reference with deployment history so we can detect containers that
+  // died unexpectedly and surface a clear failure state on the live table.
+  // The Models page only knows /models-api/health/ which returns "unknown" for
+  // dead containers; deployment-history is authoritative about exit cause.
+  type HistoryRecord = {
+    id: number;
+    container_id: string;
+    container_name: string;
+    model_name: string;
+    device: string;
+    deployed_at: string;
+    stopped_at: string | null;
+    status: string;
+    stopped_by_user: boolean;
+    port: number | null;
+    workflow_log_path: string | null;
+  };
+  const [history, setHistory] = useState<HistoryRecord[]>([]);
+  // IDs the user has explicitly dismissed from the UI. Hide immediately so the
+  // user gets feedback even before the backend stop endpoint flips state.
+  const [dismissedFailedIds, setDismissedFailedIds] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    let cancelled = false;
+    const fetchHistory = async () => {
+      try {
+        const res = await axios.get<{ deployments: HistoryRecord[] }>(
+          "/docker-api/deployment-history/",
+        );
+        if (cancelled) return;
+        setHistory(res.data?.deployments ?? []);
+      } catch (err) {
+        console.debug("[failed-detect] history fetch error:", err);
+      }
+    };
+    fetchHistory();
+    const interval = window.setInterval(fetchHistory, 5000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshTrigger]);
+
+  // Set of container IDs currently returned by /docker-api/status/ via fetchModels.
+  const liveContainerIds = useMemo(
+    () => new Set(models.map((m: { id: string }) => m.id)),
+    [models],
+  );
+
+  // Track which container IDs we've seen alive in this session. We only want
+  // to surface a "Died Unexpectedly" state for deployments the user is
+  // currently working with — not for the entire history of failures, which
+  // would flood the table with synthetic rows.
+  const seenLiveIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const id of liveContainerIds) {
+      seenLiveIdsRef.current.add(id);
+    }
+  }, [liveContainerIds]);
+
+  const failedMap = useMemo<Record<string, FailedDeploymentInfo>>(() => {
+    const next: Record<string, FailedDeploymentInfo> = {};
+    for (const d of history) {
+      if (!d.container_id || d.container_id.startsWith("pending_")) continue;
+      if (d.stopped_by_user) continue;
+      if (dismissedFailedIds.has(d.container_id)) continue;
+      // Only flag deployments we've actually seen alive this session OR that
+      // are still in the live set (so a row that's currently visible can flip
+      // to failed). Anything we never saw is ignored — that's history.
+      const seen =
+        seenLiveIdsRef.current.has(d.container_id) ||
+        liveContainerIds.has(d.container_id);
+      if (!seen) continue;
+      const looksDead =
+        d.stopped_at !== null ||
+        d.status === "exited" ||
+        d.status === "dead" ||
+        d.status === "failed" ||
+        d.status === "stopped" ||
+        !liveContainerIds.has(d.container_id);
+      if (!looksDead) continue;
+      if (!next[d.container_id]) {
+        next[d.container_id] = {
+          deploymentId: d.id,
+          modelName: d.model_name,
+          workflowLogPath: d.workflow_log_path,
+        };
+      }
+    }
+    console.debug(
+      "[failed-detect] history:",
+      history.length,
+      "live:",
+      liveContainerIds.size,
+      "seen-this-session:",
+      seenLiveIdsRef.current.size,
+      "failed:",
+      Object.keys(next),
+    );
+    return next;
+  }, [history, liveContainerIds, dismissedFailedIds]);
+
+  // Build synthetic rows ONLY for failed containers that were alive in this
+  // session but have since disappeared from /docker-api/status/. This keeps
+  // the row visible after the container exits so the user can see the
+  // failure and click Remove. We do not surface historical failures.
+  const syntheticFailedRows = useMemo<ModelRow[]>(() => {
+    const out: ModelRow[] = [];
+    for (const d of history) {
+      const cid = d.container_id;
+      if (!cid || cid.startsWith("pending_")) continue;
+      if (!failedMap[cid]) continue;
+      if (liveContainerIds.has(cid)) continue;
+      if (!seenLiveIdsRef.current.has(cid)) continue;
+      if (out.some((r) => r.id === cid)) continue;
+      out.push({
+        id: cid,
+        name: d.model_name,
+        image: undefined,
+        status: d.status,
+        ports: d.port ? String(d.port) : undefined,
+      });
+    }
+    return out;
+  }, [history, failedMap, liveContainerIds]);
+
+  const effectiveHealthMap = useMemo<Record<string, HealthStatus>>(() => {
+    const merged: Record<string, HealthStatus> = { ...healthMap };
+    for (const id of Object.keys(failedMap)) {
+      merged[id] = "failed";
+    }
+    return merged;
+  }, [healthMap, failedMap]);
+
+  // Workflow log dialog state (used when opening logs on a failed row)
+  const [workflowDialogDeploymentId, setWorkflowDialogDeploymentId] = useState<number | null>(null);
+  const [workflowDialogModelName, setWorkflowDialogModelName] = useState<string | undefined>(undefined);
+
   // Auto-refresh model list when any model becomes unavailable/unknown
   // (container likely stopped or crashed). Uses a ref so the timer
   // isn't torn down every time healthMap changes from polling.
   const staleRefreshTimer = useRef<number | null>(null);
   const hasStaleModel = useMemo(
-    () => Object.values(healthMap).some((h) => h === "unavailable" || h === "unknown"),
-    [healthMap],
+    () =>
+      Object.entries(healthMap).some(
+        ([id, h]) =>
+          (h === "unavailable" || h === "unknown") && !failedMap[id],
+      ),
+    [healthMap, failedMap],
   );
 
   useEffect(() => {
@@ -201,7 +345,17 @@ export default function ModelsDeployedCard(): JSX.Element {
     }
   }, [hasStaleModel, showDeleteModal, loadModels, setUserStoppedModel]);
 
-  const rows: ModelRow[] = useMemo(() => models as ModelRow[], [models]);
+  const rows: ModelRow[] = useMemo(() => {
+    const baseRows = models as ModelRow[];
+    // Hide rows the user has explicitly dismissed.
+    const visibleBase = baseRows.filter((r: ModelRow) => !dismissedFailedIds.has(r.id));
+    // Append synthetic rows for failed deployments whose live container is gone.
+    const baseIds = new Set(visibleBase.map((r: ModelRow) => r.id));
+    const extras = syntheticFailedRows.filter(
+      (r: ModelRow) => !baseIds.has(r.id) && !dismissedFailedIds.has(r.id),
+    );
+    return [...visibleBase, ...extras];
+  }, [models, syntheticFailedRows, dismissedFailedIds]);
 
   const preparingModels = useMemo(() => {
     return rows.filter((r) => healthMap[r.id] === "starting");
@@ -283,8 +437,8 @@ export default function ModelsDeployedCard(): JSX.Element {
         autoCloseTimerRef.current = null;
       }
     };
-  // Only re-run when status changes, not on every render
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Only re-run when status changes, not on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deleteStream.status]);
 
   const exportVisible = useCallback(() => {
@@ -383,200 +537,244 @@ export default function ModelsDeployedCard(): JSX.Element {
 
   return (
     <>
-    <ElevatedCard accent="neutral" depth="lg" hover>
-      <CardHeader className="pb-4">
-        <div className="flex items-center justify-between gap-3">
-          {/* Left */}
-          <CardTitle className="text-xl">Models Deployed</CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowRegisterDialog(true)}
-          >
-            <Plus className="w-4 h-4 mr-1" />
-            Register Model
-          </Button>
-          {/* Center intentionally empty per redesign */}
-          <div className="flex-1" />
-          {/* Right */}
-          <ModelsToolbar
-            tableId="models-deployed"
-            visibleMap={columns}
-            onToggle={setKey}
-            onPreset={setPreset}
-            isRefreshing={isRefreshing}
-            onRefresh={refreshAllHealth}
-            density={prefs.density}
-            onDensity={setDensity}
-            autoRefreshSec={prefs.autoRefreshSec}
-            onAutoRefreshSec={setAutoRefreshSec}
-            healthRefreshSec={prefs.healthRefreshSec}
-            onHealthRefreshSec={setHealthRefreshSec}
-            onExportVisible={exportVisible}
-            onCopyAll={copyAllVisible}
-            visibleCount={Object.values(columns).filter(Boolean).length}
-            totalCount={Object.keys(columns).length}
-            onRefreshHealthNow={refreshAllHealth}
-          />
-        </div>
-      </CardHeader>
+      <ElevatedCard accent="neutral" depth="lg" hover>
+        <CardHeader className="pb-4">
+          <div className="flex items-center justify-between gap-3">
+            {/* Left */}
+            <CardTitle className="text-xl">Models Deployed</CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowRegisterDialog(true)}
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Register Model
+            </Button>
+            {/* Center intentionally empty per redesign */}
+            <div className="flex-1" />
+            {/* Right */}
+            <ModelsToolbar
+              tableId="models-deployed"
+              visibleMap={columns}
+              onToggle={setKey}
+              onPreset={setPreset}
+              isRefreshing={isRefreshing}
+              onRefresh={refreshAllHealth}
+              density={prefs.density}
+              onDensity={setDensity}
+              autoRefreshSec={prefs.autoRefreshSec}
+              onAutoRefreshSec={setAutoRefreshSec}
+              healthRefreshSec={prefs.healthRefreshSec}
+              onHealthRefreshSec={setHealthRefreshSec}
+              onExportVisible={exportVisible}
+              onCopyAll={copyAllVisible}
+              visibleCount={Object.values(columns).filter(Boolean).length}
+              totalCount={Object.keys(columns).length}
+              onRefreshHealthNow={refreshAllHealth}
+            />
+          </div>
+        </CardHeader>
 
-      {/* Voice Agent discovery banner */}
-      {showVoiceBanner && (
-        <TooltipProvider>
-          <ElevatedCard accent="blue" depth="md" className="mx-6 mb-6">
-            <CardContent className="p-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-6">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="flex items-center gap-2">
-                        <PulsatingDot label="Whisper STT" color="blue" size="md" delay={0} />
-                        <PulsatingDot label="LLM" color="green" size="md" delay={400} />
-                        <PulsatingDot label="TTS" color="purple" size="md" delay={800} />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-xs">
-                      <p className="text-sm">
-                        TT Studio automatically chains your deployed models: Whisper STT → LLM → TTS for seamless voice conversations
+        {/* Voice Agent discovery banner */}
+        {showVoiceBanner && (
+          <TooltipProvider>
+            <ElevatedCard accent="blue" depth="md" className="mx-6 mb-6">
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-6">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center gap-2">
+                          <PulsatingDot label="Whisper STT" color="blue" size="md" delay={0} />
+                          <PulsatingDot label="LLM" color="green" size="md" delay={400} />
+                          <PulsatingDot label="TTS" color="purple" size="md" delay={800} />
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="max-w-xs">
+                        <p className="text-sm">
+                          TT Studio automatically chains your deployed models: Whisper STT → LLM → TTS for seamless voice conversations
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <div>
+                      <h3 className="text-lg font-semibold text-foreground">Voice Agent Ready</h3>
+                      <p className="text-sm text-muted-foreground">
+                        3 models deployed and auto-chained
                       </p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <div>
-                    <h3 className="text-lg font-semibold text-foreground">Voice Agent Ready</h3>
-                    <p className="text-sm text-muted-foreground">
-                      3 models deployed and auto-chained
-                    </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <EnhancedButton
+                      variant="default"
+                      effect="shine"
+                      onClick={() => navigate("/voice-agent")}
+                    >
+                      Start Voice Chat
+                    </EnhancedButton>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setVoiceBannerDismissed(true)}
+                      aria-label="Dismiss"
+                    >
+                      ✕
+                    </Button>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <EnhancedButton 
-                    variant="default" 
-                    effect="shine"
-                    onClick={() => navigate("/voice-agent")}
-                  >
-                    Start Voice Chat
-                  </EnhancedButton>
-                  <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    onClick={() => setVoiceBannerDismissed(true)}
-                    aria-label="Dismiss"
-                  >
-                    ✕
-                  </Button>
-                </div>
-              </div>
-            </CardContent>
-          </ElevatedCard>
-        </TooltipProvider>
-      )}
+              </CardContent>
+            </ElevatedCard>
+          </TooltipProvider>
+        )}
 
-      {/* Model preparing banner */}
-      {!preparingBannerDismissed && preparingModels.length > 0 && (
-        <ModelPreparingBanner
-          models={preparingModels}
-          onViewLogs={(id) => setSelectedContainerId(id)}
-          onDismiss={() => setPreparingBannerDismissed(true)}
-        />
-      )}
-
-      {/* Chip slot visualization for multi-chip boards */}
-      {isMultiChipBoard && chipStatus && (
-        <div className="px-6 pb-4">
-          <ChipStatusDisplay
-            boardType={chipStatus.board_type}
-            totalSlots={chipStatus.total_slots}
-            slots={chipStatus.slots as any}
+        {/* Model preparing banner */}
+        {!preparingBannerDismissed && preparingModels.length > 0 && (
+          <ModelPreparingBanner
+            models={preparingModels}
+            onViewLogs={(id) => setSelectedContainerId(id)}
+            onDismiss={() => setPreparingBannerDismissed(true)}
           />
-        </div>
-      )}
+        )}
 
-      <div
-        className={`${selectedContainerId ? "blur-sm backdrop-blur-sm" : ""} transition-all duration-200`}
-      >
-        <CardContent className="p-0">
-          <ScrollArea className="whitespace-nowrap rounded-md">
-            <Table>
-              <ModelsTable
-                rows={rows}
-                visibleMap={columns as ColumnVisibilityMap}
-                hideDeviceId={false}
-                healthMap={healthMap}
-                onOpenLogs={(id: string) => setSelectedContainerId(id)}
-                onDelete={(id: string) => {
-                  setDeleteTargetId(id);
-                  setShowDeleteModal(true);
-                }}
-                onRedeploy={(image?: string) => image && handleRedeploy(image)}
-                onNavigateToModel={(id: string, name: string) => {
-                  const row = rows.find((r) => r.id === id);
-                  const frontendType = row?.model_type
-                    ? getModelTypeFromBackendType(row.model_type)
-                    : undefined;
-                  handleModelNavigationClick(id, name, navigate, frontendType);
-                }}
-                onOpenApi={(id: string) => {
-                  const encoded = encodeURIComponent(id);
-                  window.location.href = `/api-info/${encoded}`;
-                }}
-                refreshHealthById={refreshHealthById}
-                density={prefs.density}
-              />
-            </Table>
-            <ScrollBar
-              className="scrollbar-thumb-rounded"
-              orientation="horizontal"
+        {/* Chip slot visualization for multi-chip boards */}
+        {isMultiChipBoard && chipStatus && (
+          <div className="px-6 pb-4">
+            <ChipStatusDisplay
+              boardType={chipStatus.board_type}
+              totalSlots={chipStatus.total_slots}
+              slots={chipStatus.slots as any}
             />
-          </ScrollArea>
-        </CardContent>
+          </div>
+        )}
+
+        <div
+          className={`${selectedContainerId ? "blur-sm backdrop-blur-sm" : ""} transition-all duration-200`}
+        >
+          <CardContent className="p-0">
+            <ScrollArea className="whitespace-nowrap rounded-md">
+              <Table>
+                <ModelsTable
+                  rows={rows}
+                  visibleMap={columns as ColumnVisibilityMap}
+                  hideDeviceId={false}
+                  healthMap={effectiveHealthMap}
+                  failedMap={failedMap}
+                  onOpenLogs={(id: string) => {
+                    const failed = failedMap[id];
+                    if (failed) {
+                      setWorkflowDialogDeploymentId(failed.deploymentId);
+                      setWorkflowDialogModelName(failed.modelName);
+                    } else {
+                      setSelectedContainerId(id);
+                    }
+                  }}
+                  onDelete={(id: string) => {
+                    if (failedMap[id]) {
+                      // Quick remove for failed/died containers: hide row
+                      // immediately. The container is already dead, but we still
+                      // fire the stop endpoint in the background to clean up
+                      // any chip slot reservation and update the DB record.
+                      setDismissedFailedIds((prev: Set<string>) => {
+                        const next = new Set(prev);
+                        next.add(id);
+                        return next;
+                      });
+                      seenLiveIdsRef.current.delete(id);
+                      customToast.success("Removed failed deployment");
+                      axios
+                        .post(`/docker-api/stop/`, { container_id: id })
+                        .catch(() => {
+                          // best-effort cleanup; the row is already hidden
+                        })
+                        .finally(() => {
+                          refreshModels();
+                          window.setTimeout(() => refreshAllHealth(), 500);
+                        });
+                    } else {
+                      setDeleteTargetId(id);
+                      setShowDeleteModal(true);
+                    }
+                  }}
+                  onRedeploy={(image?: string) => image && handleRedeploy(image)}
+                  onNavigateToModel={(id: string, name: string) => {
+                    const row = rows.find((r) => r.id === id);
+                    const frontendType = row?.model_type
+                      ? getModelTypeFromBackendType(row.model_type)
+                      : undefined;
+                    handleModelNavigationClick(id, name, navigate, frontendType);
+                  }}
+                  onOpenApi={(id: string) => {
+                    const encoded = encodeURIComponent(id);
+                    window.location.href = `/api-info/${encoded}`;
+                  }}
+                  refreshHealthById={refreshHealthById}
+                  density={prefs.density}
+                />
+              </Table>
+              <ScrollBar
+                className="scrollbar-thumb-rounded"
+                orientation="horizontal"
+              />
+            </ScrollArea>
+          </CardContent>
+        </div>
+
+        <LogStreamDialog
+          open={!!selectedContainerId}
+          containerId={selectedContainerId || ""}
+          modelName={
+            models.find((m) => m.id === selectedContainerId)?.name || undefined
+          }
+          onClose={() => setSelectedContainerId(null)}
+        />
+
+        <WorkflowLogDialog
+          open={workflowDialogDeploymentId !== null}
+          deploymentId={workflowDialogDeploymentId}
+          modelName={workflowDialogModelName}
+          diedUnexpectedly={true}
+          stoppedByUser={false}
+          onClose={() => {
+            setWorkflowDialogDeploymentId(null);
+            setWorkflowDialogModelName(undefined);
+          }}
+        />
+
+        <DeleteModelDialog
+          open={showDeleteModal}
+          modelId={deleteTargetId || ""}
+          isLoading={deleteStream.status === "running"}
+          deleteStep={deleteStream.step}
+          streamStatus={deleteStream.status}
+          stepLogs={deleteStream.stepLogs}
+          errorMessage={deleteStream.errorMessage}
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCloseDeleteModal}
+        />
+
+        <RegisterModelDialog
+          open={showRegisterDialog}
+          onClose={() => setShowRegisterDialog(false)}
+          onSuccess={() => {
+            setShowRegisterDialog(false);
+            loadModels();
+          }}
+        />
+      </ElevatedCard>
+
+      {/* Hidden HealthCell container — keeps health polling alive without rendering in the table */}
+      <div style={{ position: "absolute", width: 0, height: 0, overflow: "hidden", visibility: "hidden" }}>
+        {rows.map((row) => (
+          <Fragment key={row.id}>
+            <HealthCell
+              id={row.id}
+              register={mirroredRegister}
+              onHealthChange={(id: string, h: HealthStatus) =>
+                setHealthMap((prev) => ({ ...prev, [id]: h }))
+              }
+            />
+          </Fragment>
+        ))}
       </div>
-
-      <LogStreamDialog
-        open={!!selectedContainerId}
-        containerId={selectedContainerId || ""}
-        modelName={
-          models.find((m) => m.id === selectedContainerId)?.name || undefined
-        }
-        onClose={() => setSelectedContainerId(null)}
-      />
-
-      <DeleteModelDialog
-        open={showDeleteModal}
-        modelId={deleteTargetId || ""}
-        isLoading={deleteStream.status === "running"}
-        deleteStep={deleteStream.step}
-        streamStatus={deleteStream.status}
-        stepLogs={deleteStream.stepLogs}
-        errorMessage={deleteStream.errorMessage}
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCloseDeleteModal}
-      />
-
-      <RegisterModelDialog
-        open={showRegisterDialog}
-        onClose={() => setShowRegisterDialog(false)}
-        onSuccess={() => {
-          setShowRegisterDialog(false);
-          loadModels();
-        }}
-      />
-    </ElevatedCard>
-
-    {/* Hidden HealthCell container — keeps health polling alive without rendering in the table */}
-    <div style={{ position: "absolute", width: 0, height: 0, overflow: "hidden", visibility: "hidden" }}>
-      {rows.map((row) => (
-        <Fragment key={row.id}>
-          <HealthCell
-            id={row.id}
-            register={mirroredRegister}
-            onHealthChange={(id: string, h: HealthStatus) =>
-              setHealthMap((prev) => ({ ...prev, [id]: h }))
-            }
-          />
-        </Fragment>
-      ))}
-    </div>
     </>
   );
 }

--- a/app/frontend/src/components/models/ModelsTable.tsx
+++ b/app/frontend/src/components/models/ModelsTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "../ui/table";
 import {
   Activity,
+  AlertTriangle,
   Cpu,
   Network,
   // Settings,
@@ -21,6 +22,7 @@ import {
 } from "lucide-react";
 import type {
   ColumnVisibilityMap,
+  FailedDeploymentInfo,
   ModelRow,
   HealthStatus,
 } from "../../types/models";
@@ -46,6 +48,7 @@ function HealthStatusCell({ health }: { health?: HealthStatus }) {
       case "healthy":
         return "bg-[#4CAF50] text-white";
       case "unhealthy":
+      case "failed":
         return "bg-red-500 text-white";
       default:
         return "bg-yellow-500 text-white";
@@ -57,11 +60,18 @@ function HealthStatusCell({ health }: { health?: HealthStatus }) {
       case "healthy":
         return "bg-[#A5D6A7]";
       case "unhealthy":
+      case "failed":
         return "bg-red-300";
       default:
         return "bg-yellow-300";
     }
   };
+
+  const isFailed = status === "failed";
+  const label = isFailed ? "Died Unexpectedly" : status;
+  const tooltip = isFailed
+    ? "The container exited without being stopped by the user. This may indicate an out-of-memory error, a crash, or a hardware issue. Open logs for details, or remove this entry."
+    : `Model Health: ${status}`;
 
   return (
     <TooltipProvider>
@@ -71,14 +81,18 @@ function HealthStatusCell({ health }: { health?: HealthStatus }) {
             className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap leading-none ${getBgColor()} transition-colors duration-200`}
             style={{ minHeight: 28 }}
           >
-            <div
-              className={`w-2 h-2 rounded-full mr-2 ${getDotColor()} ${status === "healthy" || status === "starting" ? "animate-pulse" : ""}`}
-            />
-            {status}
+            {isFailed ? (
+              <AlertTriangle className="w-3.5 h-3.5 mr-1.5" />
+            ) : (
+              <div
+                className={`w-2 h-2 rounded-full mr-2 ${getDotColor()} ${status === "healthy" || status === "starting" ? "animate-pulse" : ""}`}
+              />
+            )}
+            {label}
           </div>
         </TooltipTrigger>
-        <TooltipContent>
-          <p>Model Health: {status}</p>
+        <TooltipContent className="max-w-xs">
+          <p>{tooltip}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -99,6 +113,7 @@ interface Props {
   rows: ModelRow[];
   visibleMap: ColumnVisibilityMap;
   healthMap: Record<string, HealthStatus>;
+  failedMap?: Record<string, FailedDeploymentInfo>;
   onOpenLogs: (id: string) => void;
   onDelete: (id: string) => void;
   onRedeploy: (image?: string) => void;
@@ -118,6 +133,7 @@ export default function ModelsTable({
   onNavigateToModel,
   onOpenApi,
   healthMap,
+  failedMap,
   refreshHealthById,
   density = "normal",
   hideDeviceId = false,
@@ -307,10 +323,12 @@ export default function ModelsTable({
                     image={row.image}
                     model_type={row.model_type}
                     health={healthMap[row.id]}
+                    isFailed={!!failedMap?.[row.id]}
                     onDelete={onDelete}
                     onRedeploy={onRedeploy}
                     onNavigateToModel={onNavigateToModel}
                     onOpenApi={onOpenApi}
+                    onOpenLogs={onOpenLogs}
                   />
                 </TableCell>
               </TableRow>

--- a/app/frontend/src/components/models/row-cells/ManageCell.tsx
+++ b/app/frontend/src/components/models/row-cells/ManageCell.tsx
@@ -27,10 +27,12 @@ interface Props {
   image?: string;
   model_type?: string;
   health?: HealthStatus;
+  isFailed?: boolean;
   onDelete: (id: string) => void;
   onRedeploy: (image?: string) => void;
   onNavigateToModel: (id: string, name: string, navigate?: any) => void;
   onOpenApi: (id: string) => void;
+  onOpenLogs?: (id: string) => void;
 }
 
 export default React.memo(function ManageCell({
@@ -39,10 +41,12 @@ export default React.memo(function ManageCell({
   image: _image,
   model_type,
   health,
+  isFailed,
   onDelete,
   onRedeploy: _onRedeploy,
   onNavigateToModel,
   onOpenApi,
+  onOpenLogs,
 }: Props) {
   const baseBtn =
     "group/btn rounded-full border pl-4 pr-6 py-2 text-sm font-medium transition-all duration-200 inline-flex items-center gap-2 hover:ring-1 hover:ring-current min-h-[36px] leading-none";
@@ -80,6 +84,37 @@ export default React.memo(function ManageCell({
             : modelType === ModelType.TTS
               ? Volume2
               : MessageSquareText;
+
+  if (isFailed) {
+    return (
+      <div className="relative flex items-center justify-center gap-2 flex-wrap">
+        {onOpenLogs && (
+          <Button
+            variant="outline"
+            size="sm"
+            effect="expandIcon"
+            icon={ScrollText}
+            iconPlacement="left"
+            onClick={() => onOpenLogs(id)}
+            className={`${baseBtn} !border-TT-purple-accent/60 !text-TT-purple-accent/90`}
+          >
+            Logs
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          effect="expandIcon"
+          icon={Trash2}
+          iconPlacement="right"
+          onClick={() => onDelete(id)}
+          className={`${baseBtn} ${dangerBtn}`}
+        >
+          Remove
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="relative flex items-center justify-center gap-2 flex-wrap">

--- a/app/frontend/src/types/models.ts
+++ b/app/frontend/src/types/models.ts
@@ -3,7 +3,13 @@
 
 import type { HealthBadgeRef } from "../components/HealthBadge";
 
-export type HealthStatus = "healthy" | "starting" | "unavailable" | "unhealthy" | "unknown";
+export type HealthStatus = "healthy" | "starting" | "unavailable" | "unhealthy" | "unknown" | "failed";
+
+export interface FailedDeploymentInfo {
+  deploymentId: number;
+  modelName?: string;
+  workflowLogPath: string | null;
+}
 
 export interface ModelRow {
   id: string;


### PR DESCRIPTION
Models that die unexpectedly due to an inference server error are now shown on the Deployed Models page with an option to view logs or remove them from the page. Resolves issue #773. 

Logs for this issue can be found on: https://gist.github.com/rnabeelTT/66131a98d0a904132790be959d5fdce1


<img width="1920" height="705" alt="Screenshot 2026-05-13 at 5 28 36 PM" src="https://github.com/user-attachments/assets/6949bca9-1ca4-4c7b-b35b-f698e048bab0" />
