### PR TITLE
Rumeza/pipelines agent

### DIFF
--- a/app/backend/api/settings.py
+++ b/app/backend/api/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "logs_control",
     "board_control",
+    "workflow_control.apps.WorkflowControlConfig",
 ]
 
 MIDDLEWARE = [
@@ -98,6 +99,14 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "api.wsgi.application"
+
+# Database – SQLite for lightweight ORM models (workflow storage, etc.)
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
 
 # local memory thread-safe default
 # the LOCATION for locmem.LocMemCache cache backend is just a name for tracking

--- a/app/backend/api/urls.py
+++ b/app/backend/api/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path("collections/", include("vector_db_control.urls")),
     path("logs/", include("logs_control.urls")),
     path("board/", include("board_control.urls")),
+    path("workflows/", include("workflow_control.urls")),
     # OpenAI-compatible audio endpoint
     path("v1/audio/speech", OpenAIAudioSpeechView.as_view()),
 ]

--- a/app/backend/workflow_control/__init__.py
+++ b/app/backend/workflow_control/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC

--- a/app/backend/workflow_control/admin.py
+++ b/app/backend/workflow_control/admin.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from django.contrib import admin
+
+from .models import Workflow, WorkflowRun
+
+admin.site.register(Workflow)
+admin.site.register(WorkflowRun)

--- a/app/backend/workflow_control/apps.py
+++ b/app/backend/workflow_control/apps.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from django.apps import AppConfig
+from shared_config.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class WorkflowControlConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "workflow_control"
+
+    def ready(self):
+        logger.info("Workflow control app is ready")
+        from django.db.models.signals import post_migrate
+        post_migrate.connect(_seed_after_migrate, sender=self)
+
+
+def _seed_after_migrate(sender, **kwargs):
+    """Seed preset workflow templates after migrations have been applied."""
+    try:
+        from .templates import seed_templates
+        seed_templates()
+    except Exception as exc:
+        logger.warning(f"Could not seed workflow templates: {exc}")

--- a/app/backend/workflow_control/executor.py
+++ b/app/backend/workflow_control/executor.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""
+DAG executor for workflow graphs.
+
+Parses the React Flow ``graph_data`` (nodes + edges), topologically sorts
+them, and runs each node's handler in dependency order while piping outputs
+between connected nodes.  All progress is yielded as SSE event dicts so the
+view can stream them to the browser.
+"""
+
+import json
+from graphlib import TopologicalSorter
+from typing import AsyncGenerator
+
+from django.utils import timezone
+
+from shared_config.logger_config import get_logger
+
+from .handlers import NODE_HANDLERS
+from .models import WorkflowRun
+
+logger = get_logger(__name__)
+
+
+def _build_adjacency(graph_data: dict):
+    """Return (node_map, predecessors) from React Flow graph_data.
+
+    ``node_map``   – {node_id: node_dict}
+    ``predecessors`` – {node_id: set(upstream_node_ids)}  for TopologicalSorter
+    ``edge_map``   – {target_node_id: [source_node_ids]}  for wiring outputs
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    node_map = {n["id"]: n for n in nodes}
+    predecessors: dict[str, set[str]] = {n["id"]: set() for n in nodes}
+    edge_map: dict[str, list[str]] = {n["id"]: [] for n in nodes}
+
+    for edge in edges:
+        src = edge["source"]
+        tgt = edge["target"]
+        if tgt in predecessors:
+            predecessors[tgt].add(src)
+        if tgt in edge_map:
+            edge_map[tgt].append(src)
+
+    return node_map, predecessors, edge_map
+
+
+def _sse_event(event_type: str, data: dict) -> str:
+    """Format a single SSE ``data:`` line."""
+    payload = {"event": event_type, **data}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+async def execute_workflow(
+    workflow_graph: dict,
+    initial_input: str,
+    run: WorkflowRun,
+) -> AsyncGenerator[str, None]:
+    """Execute the workflow DAG and yield SSE-formatted strings.
+
+    The caller (view) wraps this in a ``StreamingHttpResponse``.
+    """
+    run.status = WorkflowRun.Status.RUNNING
+    run.started_at = timezone.now()
+    await run.asave(update_fields=["status", "started_at"])
+
+    yield _sse_event("run_started", {"run_id": str(run.id)})
+
+    node_map, predecessors, edge_map = _build_adjacency(workflow_graph)
+
+    if not node_map:
+        run.status = WorkflowRun.Status.FAILED
+        run.error = "Workflow has no nodes"
+        run.completed_at = timezone.now()
+        await run.asave(update_fields=["status", "error", "completed_at"])
+        yield _sse_event("run_error", {"error": "Workflow has no nodes"})
+        return
+
+    sorter = TopologicalSorter(predecessors)
+    try:
+        order = list(sorter.static_order())
+    except Exception as exc:
+        run.status = WorkflowRun.Status.FAILED
+        run.error = f"Invalid graph: {exc}"
+        run.completed_at = timezone.now()
+        await run.asave(update_fields=["status", "error", "completed_at"])
+        yield _sse_event("run_error", {"error": str(exc)})
+        return
+
+    node_outputs: dict[str, str] = {}
+    total = len(order)
+    completed_count = 0
+
+    for node_id in order:
+        node = node_map[node_id]
+        node_type = node.get("type", "unknown")
+        config = node.get("data", {})
+
+        handler = NODE_HANDLERS.get(node_type)
+        if handler is None:
+            logger.warning(f"No handler for node type '{node_type}', skipping {node_id}")
+            node_outputs[node_id] = ""
+            completed_count += 1
+            continue
+
+        # Wire upstream outputs into this node's inputs
+        inputs: dict[str, str] = {}
+        for src_id in edge_map.get(node_id, []):
+            inputs[src_id] = node_outputs.get(src_id, "")
+
+        # Inject the user's initial input for input nodes
+        if node_type == "input":
+            inputs["__initial_input__"] = initial_input
+
+        yield _sse_event("node_started", {"node_id": node_id, "type": node_type})
+
+        node_output = ""
+        try:
+            async for evt in handler(node_id, config, inputs, str(run.id)):
+                event_type = evt.get("event", "")
+                evt_node_id = evt.get("node_id", node_id)
+                evt_data = evt.get("data", {})
+
+                if event_type == "node_done":
+                    node_output = evt_data.get("output", "")
+                elif event_type == "node_error":
+                    run.status = WorkflowRun.Status.FAILED
+                    run.error = evt_data.get("error", "Unknown error")
+                    run.completed_at = timezone.now()
+                    await run.asave(update_fields=["status", "error", "completed_at"])
+                    yield _sse_event("node_error", {
+                        "node_id": evt_node_id,
+                        "error": run.error,
+                    })
+                    yield _sse_event("run_error", {"error": run.error})
+                    return
+
+                # Forward all handler events to the client
+                yield _sse_event(event_type, {
+                    "node_id": evt_node_id,
+                    **evt_data,
+                })
+        except Exception as exc:
+            logger.error(f"Node {node_id} ({node_type}) failed: {exc}")
+            run.status = WorkflowRun.Status.FAILED
+            run.error = str(exc)
+            run.completed_at = timezone.now()
+            await run.asave(update_fields=["status", "error", "completed_at"])
+            yield _sse_event("node_error", {"node_id": node_id, "error": str(exc)})
+            yield _sse_event("run_error", {"error": str(exc)})
+            return
+
+        node_outputs[node_id] = node_output
+        completed_count += 1
+        yield _sse_event("node_completed", {
+            "node_id": node_id,
+            "progress": completed_count / total,
+        })
+
+    # Persist results
+    run.status = WorkflowRun.Status.COMPLETED
+    run.node_outputs = node_outputs
+    run.completed_at = timezone.now()
+    await run.asave(update_fields=["status", "node_outputs", "completed_at"])
+
+    yield _sse_event("run_completed", {
+        "run_id": str(run.id),
+        "node_outputs": node_outputs,
+    })

--- a/app/backend/workflow_control/handlers.py
+++ b/app/backend/workflow_control/handlers.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""
+Node handler functions for workflow execution.
+
+Each handler is an async generator that:
+  1. Receives the node's config dict and a dict of upstream inputs.
+  2. Yields SSE event dicts (type, node_id, payload) for live progress.
+  3. Returns the node's final output text via a final ``node_done`` event.
+"""
+
+import json
+import uuid
+from typing import AsyncGenerator
+
+import httpx
+from django.conf import settings
+
+from shared_config.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+# Reuse the connection-pooled httpx client from model_control when available,
+# otherwise create a lightweight one for the workflow executor.
+try:
+    from model_control.model_utils import _vllm_client, encoded_jwt
+except ImportError:
+    _vllm_client = httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=5.0, read=None, write=10.0, pool=5.0),
+        limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
+    )
+    encoded_jwt = ""
+
+
+def _sse(event_type: str, node_id: str, data: dict | str) -> dict:
+    """Build a uniform SSE event envelope."""
+    return {"event": event_type, "node_id": node_id, "data": data}
+
+
+# ---------------------------------------------------------------------------
+# Input Node
+# ---------------------------------------------------------------------------
+
+async def handle_input(
+    node_id: str, config: dict, inputs: dict, run_id: str
+) -> AsyncGenerator[dict, None]:
+    """Pass-through node that emits the user's initial input text."""
+    text = config.get("text", "") or inputs.get("__initial_input__", "")
+    yield _sse("node_done", node_id, {"output": text})
+
+
+# ---------------------------------------------------------------------------
+# Output Node
+# ---------------------------------------------------------------------------
+
+async def handle_output(
+    node_id: str, config: dict, inputs: dict, run_id: str
+) -> AsyncGenerator[dict, None]:
+    """Terminal node -- collects the first upstream input as the workflow result."""
+    upstream_values = list(inputs.values())
+    result = upstream_values[0] if upstream_values else ""
+    yield _sse("node_done", node_id, {"output": result})
+
+
+# ---------------------------------------------------------------------------
+# LLM Node
+# ---------------------------------------------------------------------------
+
+async def handle_llm(
+    node_id: str, config: dict, inputs: dict, run_id: str
+) -> AsyncGenerator[dict, None]:
+    """
+    Call a deployed chat model via the same vLLM streaming path used by
+    ``model_control.model_utils.stream_response_from_external_api``.
+    """
+    from model_control.model_utils import get_deploy_cache
+
+    deploy_id = config.get("deploy_id", "")
+    prompt_template = config.get("prompt_template", "{input}")
+    temperature = config.get("temperature", 0.7)
+    max_tokens = config.get("max_tokens", 1024)
+
+    upstream_text = " ".join(str(v) for v in inputs.values())
+    user_content = prompt_template.replace("{input}", upstream_text)
+
+    deploy_cache = get_deploy_cache()
+    entry = deploy_cache.get(deploy_id)
+    if not entry:
+        for _cid, e in deploy_cache.items():
+            if e.get("status") == "running":
+                entry = e
+                break
+    if not entry:
+        yield _sse("node_error", node_id, {"error": "No deployed LLM found"})
+        return
+
+    internal_url = entry.get("internal_url", "")
+    url = f"http://{internal_url}"
+
+    model_impl = entry.get("model_impl")
+    fallback_name = getattr(model_impl, "hf_model_id", "default") if model_impl else "default"
+    model_name = entry.get("cached_model_name", fallback_name)
+
+    payload = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": user_content}],
+        "stream": True,
+        "temperature": float(temperature),
+        "max_tokens": int(max_tokens),
+    }
+    headers = {"Authorization": f"Bearer {encoded_jwt}"}
+
+    assembled = []
+    try:
+        async with _vllm_client.stream("POST", url, json=payload, headers=headers) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_text():
+                for line in chunk.split("\n"):
+                    line = line.strip()
+                    if not line or not line.startswith("data: "):
+                        continue
+                    raw = line[len("data: "):]
+                    if raw == "[DONE]":
+                        break
+                    try:
+                        obj = json.loads(raw)
+                        delta = obj.get("choices", [{}])[0].get("delta", {})
+                        token = delta.get("content", "")
+                        if token:
+                            assembled.append(token)
+                            yield _sse("node_progress", node_id, {"token": token})
+                    except json.JSONDecodeError:
+                        continue
+    except Exception as exc:
+        logger.error(f"LLM node {node_id} error: {exc}")
+        yield _sse("node_error", node_id, {"error": str(exc)})
+        return
+
+    output = "".join(assembled)
+    yield _sse("node_done", node_id, {"output": output})
+
+
+# ---------------------------------------------------------------------------
+# RAG Query Node
+# ---------------------------------------------------------------------------
+
+async def handle_rag_query(
+    node_id: str, config: dict, inputs: dict, run_id: str
+) -> AsyncGenerator[dict, None]:
+    """Query a ChromaDB collection and return concatenated results."""
+    from vector_db_control.chroma import query_collection
+
+    collection_name = config.get("collection_name", "")
+    n_results = config.get("n_results", 5)
+    embed_model = getattr(settings, "CHROMA_DB_EMBED_MODEL", "all-MiniLM-L6-v2")
+
+    upstream_text = " ".join(str(v) for v in inputs.values())
+
+    if not collection_name:
+        yield _sse("node_error", node_id, {"error": "No collection selected"})
+        return
+
+    try:
+        results = query_collection(
+            collection_name=collection_name,
+            embedding_func_name=embed_model,
+            query_texts=[upstream_text],
+            n_results=int(n_results),
+        )
+        docs = results.get("documents", [[]])[0]
+        output = "\n\n---\n\n".join(docs) if docs else "(no results)"
+        yield _sse("node_done", node_id, {"output": output})
+    except Exception as exc:
+        logger.error(f"RAG node {node_id} error: {exc}")
+        yield _sse("node_error", node_id, {"error": str(exc)})
+
+
+# ---------------------------------------------------------------------------
+# Agent Node
+# ---------------------------------------------------------------------------
+
+async def handle_agent(
+    node_id: str, config: dict, inputs: dict, run_id: str
+) -> AsyncGenerator[dict, None]:
+    """
+    Forward to the existing ``app/agent`` FastAPI service (tt_studio_agent:8080)
+    and stream reasoning steps back through the workflow SSE channel.
+    """
+    import os
+
+    agent_host = os.environ.get("AGENT_HOST", "tt_studio_agent")
+    agent_port = os.environ.get("AGENT_PORT", "8080")
+    agent_url = f"http://{agent_host}:{agent_port}/poll_requests"
+
+    goal = config.get("goal", "")
+    upstream_text = " ".join(str(v) for v in inputs.values())
+    message = f"{goal}\n\nContext:\n{upstream_text}" if goal else upstream_text
+
+    thread_id = config.get("thread_id", str(uuid.uuid4()))
+
+    payload = {"thread_id": thread_id, "message": message}
+
+    assembled = []
+    try:
+        async with _vllm_client.stream("POST", agent_url, json=payload) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_text():
+                chunk = chunk.strip()
+                if not chunk or chunk == "[DONE]":
+                    continue
+                if chunk.startswith("[STATS]"):
+                    continue
+
+                # Forward raw reasoning text
+                assembled.append(chunk)
+                yield _sse("agent_reasoning", node_id, {"text": chunk})
+    except Exception as exc:
+        logger.error(f"Agent node {node_id} error: {exc}")
+        yield _sse("node_error", node_id, {"error": str(exc)})
+        return
+
+    output = "".join(assembled)
+    yield _sse("node_done", node_id, {"output": output})
+
+
+# ---------------------------------------------------------------------------
+# Handler registry
+# ---------------------------------------------------------------------------
+
+NODE_HANDLERS = {
+    "input": handle_input,
+    "output": handle_output,
+    "llm": handle_llm,
+    "rag_query": handle_rag_query,
+    "agent": handle_agent,
+}

--- a/app/backend/workflow_control/migrations/0001_initial.py
+++ b/app/backend/workflow_control/migrations/0001_initial.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import uuid
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="Workflow",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("description", models.TextField(blank=True, default="")),
+                (
+                    "graph_data",
+                    models.JSONField(
+                        default=dict,
+                        help_text="React Flow serialised state: {nodes: [...], edges: [...]}",
+                    ),
+                ),
+                ("is_template", models.BooleanField(default=False)),
+                (
+                    "created_at",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "ordering": ["-updated_at"],
+            },
+        ),
+        migrations.CreateModel(
+            name="WorkflowRun",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("running", "Running"),
+                            ("completed", "Completed"),
+                            ("failed", "Failed"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("initial_input", models.TextField(blank=True, default="")),
+                (
+                    "node_outputs",
+                    models.JSONField(
+                        default=dict,
+                        help_text="Map of node_id -> output value produced during execution",
+                    ),
+                ),
+                ("error", models.TextField(blank=True, null=True)),
+                ("started_at", models.DateTimeField(blank=True, null=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "workflow",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="runs",
+                        to="workflow_control.workflow",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-started_at"],
+            },
+        ),
+    ]

--- a/app/backend/workflow_control/migrations/__init__.py
+++ b/app/backend/workflow_control/migrations/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC

--- a/app/backend/workflow_control/models.py
+++ b/app/backend/workflow_control/models.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import uuid
+
+from django.db import models
+from django.utils import timezone
+
+
+class Workflow(models.Model):
+    """A user-defined workflow graph (nodes + edges from React Flow)."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    description = models.TextField(blank=True, default="")
+    graph_data = models.JSONField(
+        default=dict,
+        help_text="React Flow serialised state: {nodes: [...], edges: [...]}",
+    )
+    is_template = models.BooleanField(default=False)
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-updated_at"]
+
+    def __str__(self):
+        return self.name
+
+
+class WorkflowRun(models.Model):
+    """A single execution of a workflow."""
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        RUNNING = "running", "Running"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+        CANCELLED = "cancelled", "Cancelled"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    workflow = models.ForeignKey(
+        Workflow, on_delete=models.CASCADE, related_name="runs"
+    )
+    status = models.CharField(
+        max_length=20, choices=Status.choices, default=Status.PENDING
+    )
+    initial_input = models.TextField(blank=True, default="")
+    node_outputs = models.JSONField(
+        default=dict,
+        help_text="Map of node_id -> output value produced during execution",
+    )
+    error = models.TextField(blank=True, null=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-started_at"]
+
+    def __str__(self):
+        return f"Run {self.id} ({self.status})"

--- a/app/backend/workflow_control/serializers.py
+++ b/app/backend/workflow_control/serializers.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from rest_framework import serializers
+
+from .models import Workflow, WorkflowRun
+
+
+class WorkflowSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Workflow
+        fields = [
+            "id",
+            "name",
+            "description",
+            "graph_data",
+            "is_template",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class WorkflowRunSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WorkflowRun
+        fields = [
+            "id",
+            "workflow",
+            "status",
+            "initial_input",
+            "node_outputs",
+            "error",
+            "started_at",
+            "completed_at",
+        ]
+        read_only_fields = [
+            "id",
+            "status",
+            "node_outputs",
+            "error",
+            "started_at",
+            "completed_at",
+        ]
+
+
+class WorkflowRunInputSerializer(serializers.Serializer):
+    """Validates the POST body for /workflows/{id}/run/"""
+
+    input = serializers.CharField(required=True, help_text="Initial user input text")

--- a/app/backend/workflow_control/templates.py
+++ b/app/backend/workflow_control/templates.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+"""
+Preset workflow template definitions.
+
+Each template is a ``graph_data`` dict in React Flow format (nodes + edges).
+These are seeded as ``Workflow(is_template=True)`` rows on first startup via
+``seed_templates()``.
+"""
+
+from shared_config.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NODE_DEFAULTS = {
+    "input": {"label": "User Input", "text": ""},
+    "output": {"label": "Output"},
+    "llm": {"label": "LLM", "prompt_template": "{input}", "temperature": 0.7, "max_tokens": 1024},
+    "rag_query": {"label": "RAG Query", "collection_name": "", "n_results": 5},
+    "agent": {"label": "Agent", "goal": "", "thread_id": ""},
+}
+
+
+def _node(node_id: str, node_type: str, x: int, y: int, **data_overrides):
+    base = dict(_NODE_DEFAULTS.get(node_type, {}))
+    base.update(data_overrides)
+    return {
+        "id": node_id,
+        "type": node_type,
+        "position": {"x": x, "y": y},
+        "data": base,
+    }
+
+
+def _edge(source: str, target: str):
+    return {
+        "id": f"e-{source}-{target}",
+        "source": source,
+        "target": target,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Template definitions
+# ---------------------------------------------------------------------------
+
+RESEARCH_BRIEFING = {
+    "name": "Research Briefing",
+    "description": "Agent searches the web and RAG, then an LLM summarises the findings.",
+    "graph_data": {
+        "nodes": [
+            _node("input-1", "input", 0, 200, label="Research Topic"),
+            _node("agent-1", "agent", 300, 200, label="Research Agent", goal="Research this topic thoroughly and extract key findings."),
+            _node("llm-1", "llm", 600, 200, label="Summariser", prompt_template="Summarise the following research findings into a clear briefing:\n\n{input}"),
+            _node("output-1", "output", 900, 200, label="Briefing"),
+        ],
+        "edges": [
+            _edge("input-1", "agent-1"),
+            _edge("agent-1", "llm-1"),
+            _edge("llm-1", "output-1"),
+        ],
+    },
+}
+
+DOCUMENT_PROCESSOR = {
+    "name": "Document Processor",
+    "description": "Query a RAG collection and extract key information with an LLM.",
+    "graph_data": {
+        "nodes": [
+            _node("input-1", "input", 0, 200, label="Query"),
+            _node("rag-1", "rag_query", 300, 200, label="Document Search", n_results=5),
+            _node("llm-1", "llm", 600, 200, label="Extractor", prompt_template="Based on the following documents, extract the key information relevant to the query:\n\n{input}"),
+            _node("output-1", "output", 900, 200, label="Extracted Info"),
+        ],
+        "edges": [
+            _edge("input-1", "rag-1"),
+            _edge("rag-1", "llm-1"),
+            _edge("llm-1", "output-1"),
+        ],
+    },
+}
+
+QA_PIPELINE = {
+    "name": "Q&A Pipeline",
+    "description": "Answer questions using RAG-retrieved context and an LLM.",
+    "graph_data": {
+        "nodes": [
+            _node("input-1", "input", 0, 200, label="Question"),
+            _node("rag-1", "rag_query", 300, 200, label="Context Retrieval", n_results=5),
+            _node("llm-1", "llm", 600, 200, label="Answer Generator", prompt_template="Answer the following question using the provided context. If the context does not contain enough information, say so.\n\nContext:\n{input}"),
+            _node("output-1", "output", 900, 200, label="Answer"),
+        ],
+        "edges": [
+            _edge("input-1", "rag-1"),
+            _edge("rag-1", "llm-1"),
+            _edge("llm-1", "output-1"),
+        ],
+    },
+}
+
+ALL_TEMPLATES = [RESEARCH_BRIEFING, DOCUMENT_PROCESSOR, QA_PIPELINE]
+
+
+def seed_templates():
+    """Create template Workflow rows if they don't already exist."""
+    from .models import Workflow
+
+    for tmpl in ALL_TEMPLATES:
+        _, created = Workflow.objects.get_or_create(
+            name=tmpl["name"],
+            is_template=True,
+            defaults={
+                "description": tmpl["description"],
+                "graph_data": tmpl["graph_data"],
+            },
+        )
+        if created:
+            logger.info(f"Seeded workflow template: {tmpl['name']}")

--- a/app/backend/workflow_control/urls.py
+++ b/app/backend/workflow_control/urls.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("", views.WorkflowListCreateView.as_view(), name="workflow-list-create"),
+    path(
+        "templates/",
+        views.WorkflowTemplateListView.as_view(),
+        name="workflow-templates",
+    ),
+    path(
+        "runs/<uuid:run_id>/",
+        views.WorkflowRunDetailView.as_view(),
+        name="workflow-run-detail",
+    ),
+    path(
+        "<uuid:pk>/",
+        views.WorkflowDetailView.as_view(),
+        name="workflow-detail",
+    ),
+    path(
+        "<uuid:pk>/run/",
+        views.WorkflowRunView.as_view(),
+        name="workflow-run",
+    ),
+]

--- a/app/backend/workflow_control/views.py
+++ b/app/backend/workflow_control/views.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import json
+
+from django.http import StreamingHttpResponse, JsonResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from shared_config.logger_config import get_logger
+
+from .executor import execute_workflow
+from .models import Workflow, WorkflowRun
+from .serializers import (
+    WorkflowRunInputSerializer,
+    WorkflowRunSerializer,
+    WorkflowSerializer,
+)
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Workflow CRUD
+# ---------------------------------------------------------------------------
+
+
+class WorkflowListCreateView(APIView):
+    """GET  /workflows/          – list all workflows
+    POST /workflows/          – create a new workflow
+    """
+
+    def get(self, request):
+        workflows = Workflow.objects.filter(is_template=False)
+        serializer = WorkflowSerializer(workflows, many=True)
+        return Response(serializer.data)
+
+    def post(self, request):
+        serializer = WorkflowSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class WorkflowDetailView(APIView):
+    """GET    /workflows/{id}/   – retrieve
+    PUT    /workflows/{id}/   – full update
+    DELETE /workflows/{id}/   – delete
+    """
+
+    def _get(self, pk):
+        try:
+            return Workflow.objects.get(pk=pk)
+        except Workflow.DoesNotExist:
+            return None
+
+    def get(self, request, pk):
+        wf = self._get(pk)
+        if wf is None:
+            return Response(
+                {"error": "Workflow not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        return Response(WorkflowSerializer(wf).data)
+
+    def put(self, request, pk):
+        wf = self._get(pk)
+        if wf is None:
+            return Response(
+                {"error": "Workflow not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        serializer = WorkflowSerializer(wf, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+    def delete(self, request, pk):
+        wf = self._get(pk)
+        if wf is None:
+            return Response(
+                {"error": "Workflow not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        wf.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+
+class WorkflowTemplateListView(APIView):
+    """GET /workflows/templates/ – list preset workflow templates."""
+
+    def get(self, request):
+        templates = Workflow.objects.filter(is_template=True)
+        serializer = WorkflowSerializer(templates, many=True)
+        return Response(serializer.data)
+
+
+# ---------------------------------------------------------------------------
+# Workflow Run
+# ---------------------------------------------------------------------------
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class WorkflowRunView(View):
+    """POST /workflows/{pk}/run/ – execute a workflow, returns SSE stream."""
+
+    async def post(self, request, pk):
+        try:
+            wf = await Workflow.objects.aget(pk=pk)
+        except Workflow.DoesNotExist:
+            return JsonResponse({"error": "Workflow not found"}, status=404)
+
+        try:
+            body = json.loads(request.body)
+        except (json.JSONDecodeError, ValueError):
+            return JsonResponse({"error": "Invalid JSON body"}, status=400)
+
+        serializer = WorkflowRunInputSerializer(data=body)
+        if not serializer.is_valid():
+            return JsonResponse({"errors": serializer.errors}, status=400)
+
+        initial_input = serializer.validated_data["input"]
+
+        run = await WorkflowRun.objects.acreate(
+            workflow=wf,
+            initial_input=initial_input,
+        )
+
+        async def stream():
+            async for chunk in execute_workflow(
+                wf.graph_data, initial_input, run
+            ):
+                yield chunk
+
+        return StreamingHttpResponse(
+            streaming_content=stream(),
+            content_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run status
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRunDetailView(APIView):
+    """GET /workflows/runs/{run_id}/ – get run status & outputs."""
+
+    def get(self, request, run_id):
+        try:
+            run = WorkflowRun.objects.get(pk=run_id)
+        except WorkflowRun.DoesNotExist:
+            return Response(
+                {"error": "Run not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        return Response(WorkflowRunSerializer(run).data)

--- a/app/docker-compose.dev-mode.yml
+++ b/app/docker-compose.dev-mode.yml
@@ -13,7 +13,7 @@ services:
       # Mount fastapi_logs/ directory so the backend can read per-deployment logs
       - ${TT_STUDIO_ROOT}/fastapi_logs:${TT_STUDIO_ROOT}/fastapi_logs:ro
     command: >
-      uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --reload
+      sh -c "python manage.py migrate --noinput && uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --reload"
     environment:
       - DEBUG=True
     # Allow container to access host services (docker-control-service)

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "8000:8000"
     command: >
-      uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --workers 4 --timeout-keep-alive 1200
+      sh -c "python manage.py migrate --noinput && uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --workers 4 --timeout-keep-alive 1200"
     depends_on:
       tt_studio_chroma:
         condition: service_healthy

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -51,6 +51,7 @@
     "@tabler/icons-react": "^3.26.0",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.28.4",
+    "@xyflow/react": "^12.4.0",
     "@types/uuid": "^10.0.0",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.1",
@@ -75,7 +76,8 @@
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^11.1.0",
     "vaul": "^1.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/app/frontend/src/api/workflowApi.ts
+++ b/app/frontend/src/api/workflowApi.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import axios from "axios";
+import type { Workflow, WorkflowRun, SSEEvent } from "../types/workflow";
+
+const BASE = "/workflows-api";
+
+export async function listWorkflows(): Promise<Workflow[]> {
+  const { data } = await axios.get<Workflow[]>(`${BASE}/`);
+  return data;
+}
+
+export async function getWorkflow(id: string): Promise<Workflow> {
+  const { data } = await axios.get<Workflow>(`${BASE}/${id}/`);
+  return data;
+}
+
+export async function createWorkflow(
+  payload: Pick<Workflow, "name" | "description" | "graph_data">
+): Promise<Workflow> {
+  const { data } = await axios.post<Workflow>(`${BASE}/`, payload);
+  return data;
+}
+
+export async function updateWorkflow(
+  id: string,
+  payload: Partial<Pick<Workflow, "name" | "description" | "graph_data">>
+): Promise<Workflow> {
+  const { data } = await axios.put<Workflow>(`${BASE}/${id}/`, payload);
+  return data;
+}
+
+export async function deleteWorkflow(id: string): Promise<void> {
+  await axios.delete(`${BASE}/${id}/`);
+}
+
+export async function listTemplates(): Promise<Workflow[]> {
+  const { data } = await axios.get<Workflow[]>(`${BASE}/templates/`);
+  return data;
+}
+
+export async function getWorkflowRun(runId: string): Promise<WorkflowRun> {
+  const { data } = await axios.get<WorkflowRun>(`${BASE}/runs/${runId}/`);
+  return data;
+}
+
+/**
+ * Execute a workflow and stream SSE events back.
+ * Returns an AbortController so the caller can cancel.
+ */
+export function executeWorkflow(
+  workflowId: string,
+  input: string,
+  onEvent: (event: SSEEvent) => void,
+  onDone: () => void,
+  onError: (err: Error) => void
+): AbortController {
+  const controller = new AbortController();
+
+  fetch(`${BASE}/${workflowId}/run/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ input }),
+    signal: controller.signal,
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("No response body");
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data: ")) continue;
+          const raw = trimmed.slice(6);
+          if (raw === "[DONE]") {
+            onDone();
+            return;
+          }
+          try {
+            const parsed = JSON.parse(raw) as SSEEvent;
+            onEvent(parsed);
+          } catch {
+            // skip malformed lines
+          }
+        }
+      }
+
+      onDone();
+    })
+    .catch((err) => {
+      if (err.name !== "AbortError") {
+        onError(err);
+      }
+    });
+
+  return controller;
+}

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -19,6 +19,7 @@ import {
   ChevronLeft,
   type LucideIcon,
   History,
+  Workflow,
 } from "lucide-react";
 
 import { useLogo } from "../utils/logo";
@@ -284,10 +285,11 @@ export default function NavBar() {
     return hasLlm && hasStt && hasTts;
   }, [models]);
 
-  // Check if we're in Chat UI or Image Generation mode
+  // Check if we're in Chat UI, Image Generation, or Workflows mode
   const isChatUI = location.pathname === "/chat";
   const isImageGeneration = location.pathname === "/image-generation";
-  const shouldUseVerticalNav = isChatUI || isImageGeneration; // Always use vertical for Chat UI and Image Generation
+  const isWorkflows = location.pathname === "/workflows";
+  const shouldUseVerticalNav = isChatUI || isImageGeneration || isWorkflows;
 
   // console.log("Path:", location.pathname);
   // console.log("isChatUI:", isChatUI);
@@ -478,6 +480,13 @@ export default function NavBar() {
       icon: History,
       label: "Deployment History",
       tooltip: "View deployment history and container status",
+    },
+    {
+      type: "link",
+      to: "/workflows",
+      icon: Workflow,
+      label: "Workflows",
+      tooltip: "Build and run multi-step AI pipelines",
     },
     // Voice Agent is only shown when all three voice-stack models are deployed
     ...(isVoiceAgentReady

--- a/app/frontend/src/components/workflows/ExecutionPanel.tsx
+++ b/app/frontend/src/components/workflows/ExecutionPanel.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useState } from "react";
+import { Play, Square, RotateCcw, AlertCircle, CheckCircle2 } from "lucide-react";
+import { useWorkflowStore } from "../../store/workflowStore";
+
+export default function ExecutionPanel() {
+  const {
+    currentWorkflow,
+    isRunning,
+    runProgress,
+    runError,
+    nodeStatuses,
+    nodeOutputs,
+    agentReasoningLog,
+    nodes,
+    runWorkflow,
+    cancelRun,
+    resetExecution,
+  } = useWorkflowStore();
+
+  const [inputText, setInputText] = useState("");
+  const [showDetails, setShowDetails] = useState(false);
+
+  const completedNodes = Object.values(nodeStatuses).filter(
+    (s) => s === "completed"
+  ).length;
+  const totalNodes = nodes.length;
+  const progressPercent = Math.round(runProgress * 100);
+  const hasFinished = !isRunning && completedNodes > 0;
+
+  const handleRun = () => {
+    if (!inputText.trim()) return;
+    runWorkflow(inputText);
+  };
+
+  const handleReset = () => {
+    resetExecution();
+    setInputText("");
+    setShowDetails(false);
+  };
+
+  return (
+    <div className="border-t border-zinc-800 bg-zinc-900">
+      {/* Input + controls row */}
+      <div className="flex items-center gap-2 px-4 py-2">
+        <input
+          type="text"
+          value={inputText}
+          onChange={(e) => setInputText(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && !isRunning && handleRun()}
+          disabled={isRunning}
+          placeholder={
+            currentWorkflow
+              ? "Enter your input and press Run..."
+              : "Save your workflow first, then run it"
+          }
+          className="flex-1 px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 
+                     placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-violet-500
+                     disabled:opacity-50"
+        />
+
+        {isRunning ? (
+          <button
+            onClick={cancelRun}
+            className="flex items-center gap-1.5 px-4 py-2 bg-red-600 hover:bg-red-500 text-white 
+                       text-xs font-medium rounded transition-colors"
+          >
+            <Square className="w-3.5 h-3.5" />
+            Stop
+          </button>
+        ) : (
+          <button
+            onClick={handleRun}
+            disabled={!currentWorkflow || !inputText.trim()}
+            className="flex items-center gap-1.5 px-4 py-2 bg-violet-600 hover:bg-violet-500 text-white 
+                       text-xs font-medium rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Play className="w-3.5 h-3.5" />
+            Run
+          </button>
+        )}
+
+        {hasFinished && (
+          <button
+            onClick={handleReset}
+            title="Reset"
+            className="p-2 text-zinc-400 hover:text-zinc-200 transition-colors"
+          >
+            <RotateCcw className="w-4 h-4" />
+          </button>
+        )}
+
+        {(isRunning || hasFinished) && (
+          <button
+            onClick={() => setShowDetails(!showDetails)}
+            className="text-xs text-zinc-400 hover:text-zinc-200 transition-colors underline"
+          >
+            {showDetails ? "Hide" : "Details"}
+          </button>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      {(isRunning || hasFinished) && (
+        <div className="px-4 pb-1">
+          <div className="flex items-center gap-2 mb-1">
+            <div className="flex-1 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${
+                  runError ? "bg-red-500" : "bg-violet-500"
+                }`}
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+            <span className="text-[10px] text-zinc-500 tabular-nums w-16 text-right">
+              {completedNodes}/{totalNodes} nodes
+            </span>
+          </div>
+
+          {/* Status message */}
+          {runError && (
+            <div className="flex items-center gap-1.5 text-xs text-red-400 mb-1">
+              <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate">{runError}</span>
+            </div>
+          )}
+          {hasFinished && !runError && (
+            <div className="flex items-center gap-1.5 text-xs text-emerald-400 mb-1">
+              <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+              Workflow completed successfully
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Expandable details */}
+      {showDetails && (
+        <div className="border-t border-zinc-800 max-h-48 overflow-y-auto px-4 py-2">
+          <div className="flex flex-col gap-2">
+            {nodes.map((node) => {
+              const status = nodeStatuses[node.id] || "idle";
+              const output = nodeOutputs[node.id];
+              const reasoning = agentReasoningLog[node.id];
+              const label =
+                (node.data as Record<string, unknown>).label as string ||
+                node.type;
+
+              return (
+                <div
+                  key={node.id}
+                  className="flex flex-col gap-0.5 text-xs border-l-2 pl-2"
+                  style={{
+                    borderColor:
+                      status === "completed"
+                        ? "#10b981"
+                        : status === "running"
+                          ? "#8b5cf6"
+                          : status === "error"
+                            ? "#ef4444"
+                            : "#3f3f46",
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-zinc-300">{label}</span>
+                    <span className="text-zinc-500">({node.type})</span>
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded ${
+                        status === "completed"
+                          ? "bg-emerald-500/10 text-emerald-400"
+                          : status === "running"
+                            ? "bg-violet-500/10 text-violet-400"
+                            : status === "error"
+                              ? "bg-red-500/10 text-red-400"
+                              : "bg-zinc-800 text-zinc-500"
+                      }`}
+                    >
+                      {status}
+                    </span>
+                  </div>
+                  {output && (
+                    <p className="text-zinc-400 truncate max-w-md">
+                      {output.slice(0, 200)}
+                    </p>
+                  )}
+                  {reasoning && reasoning.length > 0 && (
+                    <p className="text-amber-300/70 font-mono truncate max-w-md">
+                      {reasoning.length} reasoning steps
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/ExecutionPanel.tsx
+++ b/app/frontend/src/components/workflows/ExecutionPanel.tsx
@@ -185,8 +185,10 @@ export default function ExecutionPanel() {
                     </p>
                   )}
                   {reasoning && reasoning.length > 0 && (
-                    <p className="text-amber-300/70 font-mono truncate max-w-md">
-                      {reasoning.length} reasoning steps
+                    <p className="text-amber-300/70 truncate max-w-md">
+                      {/Searching:/.test(reasoning.join(""))
+                        ? "Searched the web"
+                        : "Agent reasoning complete"}
                     </p>
                   )}
                 </div>

--- a/app/frontend/src/components/workflows/NodeConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/NodeConfigPanel.tsx
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useState } from "react";
+import {
+  X,
+  Trash2,
+  Settings,
+  Terminal,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  Brain,
+} from "lucide-react";
+import { useWorkflowStore } from "../../store/workflowStore";
+import InputConfigPanel from "./config/InputConfigPanel";
+import LLMConfigPanel from "./config/LLMConfigPanel";
+import RAGConfigPanel from "./config/RAGConfigPanel";
+import AgentConfigPanel from "./config/AgentConfigPanel";
+
+type Tab = "config" | "output";
+
+export default function NodeConfigPanel() {
+  const {
+    nodes,
+    selectedNodeId,
+    setSelectedNode,
+    deleteSelected,
+    nodeStatuses,
+    nodeOutputs,
+    agentReasoningLog,
+  } = useWorkflowStore();
+
+  const [activeTab, setActiveTab] = useState<Tab>("config");
+
+  const node = nodes.find((n) => n.id === selectedNodeId);
+  if (!node) return null;
+
+  const status = nodeStatuses[node.id] || "idle";
+  const output = nodeOutputs[node.id];
+  const reasoning = agentReasoningLog[node.id];
+  const hasOutput = !!output || (reasoning && reasoning.length > 0);
+
+  const renderConfig = () => {
+    switch (node.type) {
+      case "input":
+        return <InputConfigPanel nodeId={node.id} data={node.data} />;
+      case "llm":
+        return <LLMConfigPanel nodeId={node.id} data={node.data} />;
+      case "rag_query":
+        return <RAGConfigPanel nodeId={node.id} data={node.data} />;
+      case "agent":
+        return <AgentConfigPanel nodeId={node.id} data={node.data} />;
+      case "output":
+        return (
+          <p className="text-xs text-zinc-500">
+            The output node displays the final result of the workflow. No
+            configuration needed.
+          </p>
+        );
+      default:
+        return (
+          <p className="text-xs text-zinc-500">
+            No configuration available for this node type.
+          </p>
+        );
+    }
+  };
+
+  const renderOutput = () => {
+    if (status === "idle" && !hasOutput) {
+      return (
+        <p className="text-xs text-zinc-500 italic">
+          Run the workflow to see output from this node.
+        </p>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-3">
+        {/* Status badge */}
+        <div className="flex items-center gap-2">
+          {status === "running" && (
+            <Loader2 className="w-3.5 h-3.5 text-violet-400 animate-spin" />
+          )}
+          {status === "completed" && (
+            <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400" />
+          )}
+          {status === "error" && (
+            <AlertCircle className="w-3.5 h-3.5 text-red-400" />
+          )}
+          <span
+            className={`text-xs font-medium ${
+              status === "running"
+                ? "text-violet-400"
+                : status === "completed"
+                  ? "text-emerald-400"
+                  : status === "error"
+                    ? "text-red-400"
+                    : "text-zinc-500"
+            }`}
+          >
+            {status.charAt(0).toUpperCase() + status.slice(1)}
+          </span>
+        </div>
+
+        {/* Agent reasoning steps */}
+        {reasoning && reasoning.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-amber-400">
+              <Brain className="w-3.5 h-3.5" />
+              Reasoning ({reasoning.length} steps)
+            </div>
+            <div className="max-h-48 overflow-y-auto rounded border border-zinc-800 bg-zinc-950 p-2">
+              {reasoning.map((step, i) => (
+                <div key={i} className="text-xs text-amber-300/70 font-mono py-0.5 border-b border-zinc-800/50 last:border-0">
+                  <span className="text-zinc-600 mr-1.5">{i + 1}.</span>
+                  {step}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Node output */}
+        {output && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-zinc-400">Output</span>
+            <div className="overflow-y-auto rounded border border-zinc-800 bg-zinc-950 p-4">
+              <p className="text-sm text-zinc-300 whitespace-pre-wrap break-words leading-relaxed text-left">
+                {output}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full bg-zinc-900 border-l border-zinc-800 flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-200">
+            {(node.data as Record<string, unknown>).label as string ||
+              node.type}
+          </h3>
+          <p className="text-xs text-zinc-500">{node.type}</p>
+        </div>
+        <button
+          onClick={() => setSelectedNode(null)}
+          className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-zinc-800">
+        <button
+          onClick={() => setActiveTab("config")}
+          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors ${
+            activeTab === "config"
+              ? "text-violet-400 border-b-2 border-violet-500"
+              : "text-zinc-500 hover:text-zinc-300"
+          }`}
+        >
+          <Settings className="w-3.5 h-3.5" />
+          Config
+        </button>
+        <button
+          onClick={() => setActiveTab("output")}
+          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors relative ${
+            activeTab === "output"
+              ? "text-violet-400 border-b-2 border-violet-500"
+              : "text-zinc-500 hover:text-zinc-300"
+          }`}
+        >
+          <Terminal className="w-3.5 h-3.5" />
+          Output
+          {hasOutput && activeTab !== "output" && (
+            <span className="absolute top-1.5 right-3 w-1.5 h-1.5 rounded-full bg-emerald-400" />
+          )}
+        </button>
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {activeTab === "config" ? renderConfig() : renderOutput()}
+      </div>
+
+      {/* Delete button */}
+      <div className="px-4 py-3 border-t border-zinc-800">
+        <button
+          onClick={deleteSelected}
+          className="flex items-center gap-1.5 w-full justify-center px-3 py-2 text-xs text-red-400 
+                     hover:bg-red-500/10 border border-red-500/20 hover:border-red-500/40 rounded transition-colors"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+          Delete Node
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/NodeConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/NodeConfigPanel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import {
   X,
   Trash2,
@@ -10,13 +10,57 @@ import {
   Loader2,
   CheckCircle2,
   AlertCircle,
-  Brain,
+  Globe,
+  Search,
+  ChevronDown,
 } from "lucide-react";
 import { useWorkflowStore } from "../../store/workflowStore";
 import InputConfigPanel from "./config/InputConfigPanel";
 import LLMConfigPanel from "./config/LLMConfigPanel";
 import RAGConfigPanel from "./config/RAGConfigPanel";
 import AgentConfigPanel from "./config/AgentConfigPanel";
+
+interface SourceLink {
+  title: string;
+  url: string;
+}
+
+interface SearchInfo {
+  isSearch: boolean;
+  queries: string[];
+  sources: SourceLink[];
+}
+
+function parseSearchInfo(text: string): SearchInfo {
+  const queries: string[] = [];
+  const sources: SourceLink[] = [];
+  const seenUrls = new Set<string>();
+
+  const searchRegex = /Searching:\s*(.+)/g;
+  let m;
+  while ((m = searchRegex.exec(text)) !== null) {
+    const q = m[1].trim();
+    if (q) queries.push(q);
+  }
+
+  const sourceRegex = /Source:\s*\[([^\]]*)\]\(([^)]+)\)/g;
+  while ((m = sourceRegex.exec(text)) !== null) {
+    const title = m[1].trim();
+    const url = m[2].trim();
+    if (url && !seenUrls.has(url)) {
+      seenUrls.add(url);
+      sources.push({ title: title || url, url });
+    }
+  }
+
+  const hasSearchSignal = /\[searching\]/.test(text);
+
+  return {
+    isSearch: queries.length > 0 || sources.length > 0 || hasSearchSignal,
+    queries,
+    sources,
+  };
+}
 
 type Tab = "config" | "output";
 
@@ -104,22 +148,12 @@ export default function NodeConfigPanel() {
           </span>
         </div>
 
-        {/* Agent reasoning steps */}
+        {/* Agent reasoning / search activity */}
         {reasoning && reasoning.length > 0 && (
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center gap-1.5 text-xs font-medium text-amber-400">
-              <Brain className="w-3.5 h-3.5" />
-              Reasoning ({reasoning.length} steps)
-            </div>
-            <div className="max-h-48 overflow-y-auto rounded border border-zinc-800 bg-zinc-950 p-2">
-              {reasoning.map((step, i) => (
-                <div key={i} className="text-xs text-amber-300/70 font-mono py-0.5 border-b border-zinc-800/50 last:border-0">
-                  <span className="text-zinc-600 mr-1.5">{i + 1}.</span>
-                  {step}
-                </div>
-              ))}
-            </div>
-          </div>
+          <AgentReasoningDisplay
+            reasoning={reasoning}
+            isRunning={status === "running"}
+          />
         )}
 
         {/* Node output */}
@@ -201,6 +235,133 @@ export default function NodeConfigPanel() {
           Delete Node
         </button>
       </div>
+    </div>
+  );
+}
+
+function AgentReasoningDisplay({
+  reasoning,
+  isRunning,
+}: {
+  reasoning: string[];
+  isRunning: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const fullText = reasoning.join("");
+  const searchInfo = parseSearchInfo(fullText);
+
+  useEffect(() => {
+    if (scrollRef.current && isRunning) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [fullText, isRunning]);
+
+  if (searchInfo.isSearch) {
+    return (
+      <div className="flex flex-col gap-2">
+        {/* Header */}
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-2 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+        >
+          {isRunning ? (
+            <Globe className="w-3.5 h-3.5 text-blue-400 animate-spin" />
+          ) : (
+            <Globe className="w-3.5 h-3.5 text-blue-400/70" />
+          )}
+          <span className="font-medium">
+            {isRunning ? "Searching the web..." : "Searched the web"}
+          </span>
+          {searchInfo.queries.length > 0 && (
+            <span className="text-zinc-600">
+              ({searchInfo.queries.length}{" "}
+              {searchInfo.queries.length === 1 ? "query" : "queries"})
+            </span>
+          )}
+          <ChevronDown
+            className={`w-3 h-3 ml-auto transition-transform ${expanded ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {/* Search queries list */}
+        {(expanded || isRunning) && searchInfo.queries.length > 0 && (
+          <div className="rounded-md border border-zinc-800 bg-zinc-950 overflow-hidden">
+            <div className="px-3 py-2 space-y-1.5">
+              {searchInfo.queries.map((q, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-2 text-xs text-zinc-300"
+                >
+                  <Search className="w-3 h-3 flex-shrink-0 text-zinc-500" />
+                  <span>{q}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Sources */}
+        {searchInfo.sources.length > 0 && (expanded || isRunning) && (
+          <div className="rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2">
+            <p className="text-[10px] text-zinc-600 font-medium mb-1">
+              Sources
+            </p>
+            {searchInfo.sources.map((src, i) => (
+              <a
+                key={i}
+                href={src.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block text-xs text-blue-400 hover:text-blue-300 truncate py-0.5"
+              >
+                {src.title}
+              </a>
+            ))}
+          </div>
+        )}
+
+        {/* Full reasoning text (collapsed) */}
+        {expanded && (
+          <div
+            ref={scrollRef}
+            className="max-h-36 overflow-y-auto rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-400 font-mono whitespace-pre-wrap leading-relaxed"
+          >
+            {fullText}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+      >
+        {isRunning ? (
+          <Loader2 className="w-3.5 h-3.5 text-amber-400 animate-spin" />
+        ) : (
+          <CheckCircle2 className="w-3.5 h-3.5 text-amber-400/70" />
+        )}
+        <span className="font-medium">
+          {isRunning ? "Reasoning..." : "Reasoning complete"}
+        </span>
+        <ChevronDown
+          className={`w-3 h-3 ml-auto transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {(expanded || isRunning) && (
+        <div
+          ref={scrollRef}
+          className="max-h-48 overflow-y-auto rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-300 font-mono whitespace-pre-wrap leading-relaxed"
+        >
+          {fullText}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/frontend/src/components/workflows/NodePalette.tsx
+++ b/app/frontend/src/components/workflows/NodePalette.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import type React from "react";
+import {
+  MessageSquare,
+  Database,
+  Bot,
+  ArrowRightToLine,
+  ArrowLeftFromLine,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { WorkflowNodeType } from "../../types/workflow";
+
+interface PaletteItem {
+  type: WorkflowNodeType;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  color: string;
+}
+
+const PALETTE_ITEMS: PaletteItem[] = [
+  {
+    type: "input",
+    label: "Input",
+    description: "User prompt entry point",
+    icon: ArrowRightToLine,
+    color: "text-emerald-400",
+  },
+  {
+    type: "llm",
+    label: "LLM",
+    description: "Chat model inference",
+    icon: MessageSquare,
+    color: "text-violet-400",
+  },
+  {
+    type: "rag_query",
+    label: "RAG Query",
+    description: "Search document collections",
+    icon: Database,
+    color: "text-blue-400",
+  },
+  {
+    type: "agent",
+    label: "Agent",
+    description: "Autonomous reasoning with tools",
+    icon: Bot,
+    color: "text-amber-400",
+  },
+  {
+    type: "output",
+    label: "Output",
+    description: "Final result display",
+    icon: ArrowLeftFromLine,
+    color: "text-rose-400",
+  },
+];
+
+function PaletteCard({ item }: { item: PaletteItem }) {
+  const onDragStart = (event: React.DragEvent) => {
+    event.dataTransfer.setData("application/workflow-node-type", item.type);
+    event.dataTransfer.effectAllowed = "move";
+  };
+
+  const Icon = item.icon;
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      className="flex items-center gap-3 p-3 rounded-lg border border-zinc-700 bg-zinc-800/50 
+                 hover:bg-zinc-700/50 hover:border-zinc-600 cursor-grab active:cursor-grabbing 
+                 transition-colors select-none"
+    >
+      <Icon className={`w-5 h-5 ${item.color} shrink-0`} />
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-zinc-200 truncate">
+          {item.label}
+        </p>
+        <p className="text-xs text-zinc-500 truncate">{item.description}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function NodePalette() {
+  return (
+    <div className="h-full bg-zinc-900 border-r border-zinc-800 p-4 flex flex-col gap-1">
+      <h2 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-3">
+        Node Types
+      </h2>
+      <p className="text-xs text-zinc-500 mb-4">
+        Drag a node onto the canvas to add it to your workflow.
+      </p>
+      <div className="flex flex-col gap-2">
+        {PALETTE_ITEMS.map((item) => (
+          <PaletteCard key={item.type} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/WorkflowCanvas.tsx
+++ b/app/frontend/src/components/workflows/WorkflowCanvas.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useCallback, useEffect } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type NodeMouseHandler,
+  type OnDragOver,
+  type OnDrop,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import "./canvas-overrides.css";
+
+import { useWorkflowStore } from "../../store/workflowStore";
+import { nodeTypes } from "./nodes/nodeTypes";
+import type { WorkflowNodeType, WorkflowNode } from "../../types/workflow";
+
+const NODE_DEFAULTS: Record<string, Record<string, unknown>> = {
+  input: { label: "User Input", text: "" },
+  output: { label: "Output" },
+  llm: {
+    label: "LLM",
+    deploy_id: "",
+    prompt_template: "{input}",
+    temperature: 0.7,
+    max_tokens: 1024,
+  },
+  rag_query: { label: "RAG Query", collection_name: "", n_results: 5 },
+  agent: { label: "Agent", goal: "", thread_id: "" },
+};
+
+let nextId = 1;
+function generateId(type: string) {
+  return `${type}-${Date.now()}-${nextId++}`;
+}
+
+export default function WorkflowCanvas() {
+  const {
+    nodes,
+    edges,
+    onNodesChange,
+    onEdgesChange,
+    onConnect,
+    addNode,
+    setSelectedNode,
+    deleteSelected,
+    selectedNodeId,
+  } = useWorkflowStore();
+
+  const onNodeClick: NodeMouseHandler<WorkflowNode> = useCallback(
+    (_event, node) => {
+      setSelectedNode(node.id);
+    },
+    [setSelectedNode]
+  );
+
+  const onPaneClick = useCallback(() => {
+    setSelectedNode(null);
+  }, [setSelectedNode]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === "Delete" || e.key === "Backspace") && selectedNodeId) {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        e.preventDefault();
+        deleteSelected();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedNodeId, deleteSelected]);
+
+  const onDragOver: OnDragOver = useCallback((event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+  }, []);
+
+  const onDrop: OnDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      const type = event.dataTransfer.getData(
+        "application/workflow-node-type"
+      ) as WorkflowNodeType;
+      if (!type || !NODE_DEFAULTS[type]) return;
+
+      const bounds = (
+        event.target as HTMLElement
+      ).closest(".react-flow")?.getBoundingClientRect();
+      if (!bounds) return;
+
+      const position = {
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top,
+      };
+
+      const newNode: WorkflowNode = {
+        id: generateId(type),
+        type,
+        position,
+        data: { ...NODE_DEFAULTS[type] } as WorkflowNode["data"],
+      };
+
+      addNode(newNode);
+    },
+    [addNode]
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      onNodeClick={onNodeClick}
+      onPaneClick={onPaneClick}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      nodeTypes={nodeTypes}
+      colorMode="dark"
+      fitView
+      defaultEdgeOptions={{
+        animated: true,
+        style: { stroke: "#7c3aed" },
+      }}
+      proOptions={{ hideAttribution: true }}
+    >
+      <Background color="#333" gap={20} />
+      <Controls />
+      <MiniMap
+        nodeColor={() => "#7c3aed"}
+        maskColor="rgba(0, 0, 0, 0.7)"
+      />
+    </ReactFlow>
+  );
+}

--- a/app/frontend/src/components/workflows/WorkflowToolbar.tsx
+++ b/app/frontend/src/components/workflows/WorkflowToolbar.tsx
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useState } from "react";
+import { Save, FolderOpen, FilePlus, Trash2, LayoutTemplate } from "lucide-react";
+import { useWorkflowStore } from "../../store/workflowStore";
+import type { Workflow } from "../../types/workflow";
+
+export default function WorkflowToolbar() {
+  const {
+    currentWorkflow,
+    workflows,
+    templates,
+    saveWorkflow,
+    createWorkflow,
+    deleteWorkflow,
+    setCurrentWorkflow,
+    loadFromTemplate,
+  } = useWorkflowStore();
+
+  const [showList, setShowList] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [showNewDialog, setShowNewDialog] = useState(false);
+
+  const handleNew = () => {
+    setShowNewDialog(true);
+    setNewName("Untitled Workflow");
+  };
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    await createWorkflow(newName.trim());
+    setShowNewDialog(false);
+    setNewName("");
+  };
+
+  const handleSave = async () => {
+    if (!currentWorkflow) {
+      handleNew();
+      return;
+    }
+    await saveWorkflow();
+  };
+
+  const handleOpen = (wf: Workflow) => {
+    setCurrentWorkflow(wf);
+    setShowList(false);
+  };
+
+  const handleDelete = async () => {
+    if (!currentWorkflow) return;
+    await deleteWorkflow(currentWorkflow.id);
+  };
+
+  const handleLoadTemplate = (tmpl: Workflow) => {
+    loadFromTemplate(tmpl);
+    setShowTemplates(false);
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-zinc-900 border-b border-zinc-800">
+      {/* Workflow name */}
+      <span className="text-sm font-medium text-zinc-300 mr-2 truncate max-w-48">
+        {currentWorkflow?.name || "New Workflow"}
+      </span>
+
+      <div className="h-4 w-px bg-zinc-700" />
+
+      {/* Action buttons */}
+      <ToolbarButton icon={FilePlus} label="New" onClick={handleNew} />
+      <ToolbarButton icon={Save} label="Save" onClick={handleSave} />
+      <div className="relative">
+        <ToolbarButton
+          icon={FolderOpen}
+          label="Open"
+          onClick={() => {
+            setShowList(!showList);
+            setShowTemplates(false);
+          }}
+        />
+        {showList && (
+          <DropdownMenu
+            items={workflows}
+            onSelect={handleOpen}
+            onClose={() => setShowList(false)}
+            emptyLabel="No saved workflows"
+          />
+        )}
+      </div>
+      <div className="relative">
+        <ToolbarButton
+          icon={LayoutTemplate}
+          label="Templates"
+          onClick={() => {
+            setShowTemplates(!showTemplates);
+            setShowList(false);
+          }}
+        />
+        {showTemplates && (
+          <DropdownMenu
+            items={templates}
+            onSelect={handleLoadTemplate}
+            onClose={() => setShowTemplates(false)}
+            emptyLabel="No templates available"
+          />
+        )}
+      </div>
+      {currentWorkflow && (
+        <ToolbarButton icon={Trash2} label="Delete" onClick={handleDelete} />
+      )}
+
+      {/* New workflow dialog */}
+      {showNewDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="bg-zinc-900 border border-zinc-700 rounded-lg p-6 w-96">
+            <h3 className="text-sm font-semibold text-zinc-200 mb-4">
+              Create New Workflow
+            </h3>
+            <input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              autoFocus
+              className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 
+                         focus:outline-none focus:ring-1 focus:ring-violet-500 mb-4"
+              placeholder="Workflow name"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowNewDialog(false)}
+                className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreate}
+                className="px-3 py-1.5 text-xs bg-violet-600 hover:bg-violet-500 text-white rounded transition-colors"
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolbarButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={label}
+      className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 
+                 hover:bg-zinc-800 rounded transition-colors"
+    >
+      <Icon className="w-3.5 h-3.5" />
+      <span className="hidden sm:inline">{label}</span>
+    </button>
+  );
+}
+
+function DropdownMenu({
+  items,
+  onSelect,
+  onClose,
+  emptyLabel,
+}: {
+  items: Workflow[];
+  onSelect: (wf: Workflow) => void;
+  onClose: () => void;
+  emptyLabel: string;
+}) {
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="absolute top-full left-0 mt-1 w-64 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl z-50 py-1 max-h-64 overflow-y-auto">
+        {items.length === 0 ? (
+          <p className="px-3 py-2 text-xs text-zinc-500">{emptyLabel}</p>
+        ) : (
+          items.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => onSelect(item)}
+              className="w-full text-left px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors"
+            >
+              <p className="font-medium truncate">{item.name}</p>
+              {item.description && (
+                <p className="text-xs text-zinc-500 truncate">
+                  {item.description}
+                </p>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/frontend/src/components/workflows/canvas-overrides.css
+++ b/app/frontend/src/components/workflows/canvas-overrides.css
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC */
+
+/* Strip React Flow's default node chrome -- BaseNode renders its own */
+.react-flow__node {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 0 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.react-flow__node.selected {
+  box-shadow: none !important;
+  outline: none !important;
+}

--- a/app/frontend/src/components/workflows/config/AgentConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/config/AgentConfigPanel.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+interface Props {
+  nodeId: string;
+  data: Record<string, unknown>;
+}
+
+export default function AgentConfigPanel({ nodeId, data }: Props) {
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Field label="Label">
+        <input
+          type="text"
+          value={(data.label as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { label: e.target.value })}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        />
+      </Field>
+
+      <Field label="Agent Goal">
+        <textarea
+          value={(data.goal as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { goal: e.target.value })}
+          rows={4}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500 resize-y"
+          placeholder="e.g. Research this topic and extract key findings"
+        />
+        <p className="text-xs text-zinc-500 mt-1">
+          The agent will autonomously decide which tools to call to achieve this
+          goal.
+        </p>
+      </Field>
+
+      <div className="border-t border-zinc-800 pt-3">
+        <p className="text-xs text-zinc-400 font-medium mb-2">
+          Available Tools
+        </p>
+        <div className="flex flex-col gap-2">
+          <ToolToggle label="Web Search (Tavily)" checked disabled />
+          <ToolToggle label="RAG Query" checked disabled />
+          <ToolToggle label="Code Interpreter" checked={false} disabled />
+        </div>
+        <p className="text-xs text-zinc-500 mt-2">
+          Tools are managed by the agent service configuration.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-zinc-400 mb-1.5">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function ToolToggle({
+  label,
+  checked,
+  disabled,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-xs text-zinc-300">
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        readOnly
+        className="accent-amber-500"
+      />
+      {label}
+    </label>
+  );
+}

--- a/app/frontend/src/components/workflows/config/InputConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/config/InputConfigPanel.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+interface Props {
+  nodeId: string;
+  data: Record<string, unknown>;
+}
+
+export default function InputConfigPanel({ nodeId, data }: Props) {
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Field label="Label">
+        <input
+          type="text"
+          value={(data.label as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { label: e.target.value })}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 
+                     focus:outline-none focus:ring-1 focus:ring-violet-500"
+        />
+      </Field>
+      <Field label="Default Text">
+        <textarea
+          value={(data.text as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { text: e.target.value })}
+          rows={4}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 
+                     focus:outline-none focus:ring-1 focus:ring-violet-500 resize-y"
+          placeholder="Optional default input text..."
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-zinc-400 mb-1.5">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/config/LLMConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/config/LLMConfigPanel.tsx
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+interface DeployedModel {
+  id: string;
+  name: string;
+  status: string;
+}
+
+interface Props {
+  nodeId: string;
+  data: Record<string, unknown>;
+}
+
+export default function LLMConfigPanel({ nodeId, data }: Props) {
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
+  const [models, setModels] = useState<DeployedModel[]>([]);
+
+  useEffect(() => {
+    axios
+      .get("/models-api/deployed")
+      .then((res) => {
+        const entries = Object.entries(
+          (res.data as Record<string, Record<string, unknown>>) || {}
+        ).map(([id, info]) => ({
+          id,
+          name: (info.cached_model_name as string) || (info.model_name as string) || id.slice(0, 12),
+          status: (info.status as string) || "unknown",
+        }));
+        setModels(entries.filter((m) => m.status === "running"));
+      })
+      .catch(() => setModels([]));
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Field label="Label">
+        <input
+          type="text"
+          value={(data.label as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { label: e.target.value })}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        />
+      </Field>
+
+      <Field label="Deployed Model">
+        <select
+          value={(data.deploy_id as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { deploy_id: e.target.value })}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        >
+          <option value="">Auto-select first available</option>
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Prompt Template">
+        <textarea
+          value={(data.prompt_template as string) || "{input}"}
+          onChange={(e) =>
+            updateNodeData(nodeId, { prompt_template: e.target.value })
+          }
+          rows={5}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500 resize-y font-mono text-xs"
+          placeholder="Use {input} for upstream text"
+        />
+        <p className="text-xs text-zinc-500 mt-1">
+          Use <code className="text-violet-400">{"{input}"}</code> to inject
+          upstream output.
+        </p>
+      </Field>
+
+      <Field label={`Temperature: ${data.temperature ?? 0.7}`}>
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={0.1}
+          value={(data.temperature as number) ?? 0.7}
+          onChange={(e) =>
+            updateNodeData(nodeId, { temperature: parseFloat(e.target.value) })
+          }
+          className="w-full accent-violet-500"
+        />
+      </Field>
+
+      <Field label={`Max Tokens: ${data.max_tokens ?? 1024}`}>
+        <input
+          type="range"
+          min={64}
+          max={4096}
+          step={64}
+          value={(data.max_tokens as number) ?? 1024}
+          onChange={(e) =>
+            updateNodeData(nodeId, { max_tokens: parseInt(e.target.value) })
+          }
+          className="w-full accent-violet-500"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-zinc-400 mb-1.5">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/config/RAGConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/config/RAGConfigPanel.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+interface Collection {
+  name: string;
+  id: string;
+}
+
+interface Props {
+  nodeId: string;
+  data: Record<string, unknown>;
+}
+
+export default function RAGConfigPanel({ nodeId, data }: Props) {
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
+  const [collections, setCollections] = useState<Collection[]>([]);
+
+  useEffect(() => {
+    axios
+      .get("/collections-api/")
+      .then((res) => {
+        const list = Array.isArray(res.data)
+          ? res.data
+          : (res.data as Record<string, unknown>).results ?? [];
+        setCollections(list as Collection[]);
+      })
+      .catch(() => setCollections([]));
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Field label="Label">
+        <input
+          type="text"
+          value={(data.label as string) || ""}
+          onChange={(e) => updateNodeData(nodeId, { label: e.target.value })}
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        />
+      </Field>
+
+      <Field label="Collection">
+        <select
+          value={(data.collection_name as string) || ""}
+          onChange={(e) =>
+            updateNodeData(nodeId, { collection_name: e.target.value })
+          }
+          className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        >
+          <option value="">Select a collection...</option>
+          {collections.map((c) => (
+            <option key={c.id || c.name} value={c.name}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label={`Results to Retrieve: ${data.n_results ?? 5}`}>
+        <input
+          type="range"
+          min={1}
+          max={20}
+          step={1}
+          value={(data.n_results as number) ?? 5}
+          onChange={(e) =>
+            updateNodeData(nodeId, { n_results: parseInt(e.target.value) })
+          }
+          className="w-full accent-blue-500"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-zinc-400 mb-1.5">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/nodes/AgentNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/AgentNode.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import { memo } from "react";
-import { Bot } from "lucide-react";
+import { Bot, Globe, Loader2 } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
 import BaseNode from "./BaseNode";
 import { useWorkflowStore } from "../../../store/workflowStore";
@@ -12,6 +12,10 @@ function AgentNodeComponent({ id, data }: NodeProps) {
   const goal = (data.goal as string) || "";
   const reasoning = useWorkflowStore((s) => s.agentReasoningLog[id]);
   const isRunning = useWorkflowStore((s) => s.nodeStatuses[id] === "running");
+
+  const fullText = reasoning ? reasoning.join("") : "";
+  const isSearching = /\[searching\]|Searching:/.test(fullText);
+  const lastLine = fullText.split("\n").filter(Boolean).pop() || "";
 
   return (
     <BaseNode
@@ -29,10 +33,17 @@ function AgentNodeComponent({ id, data }: NodeProps) {
       {!goal && (
         <p className="text-[11px] text-zinc-600 italic">No goal set</p>
       )}
-      {isRunning && reasoning && reasoning.length > 0 && (
-        <p className="text-[11px] text-amber-300/60 mt-1 max-h-12 overflow-hidden whitespace-pre-wrap break-words leading-tight font-mono">
-          {reasoning[reasoning.length - 1]?.slice(0, 120)}
-        </p>
+      {isRunning && fullText && (
+        <div className="flex items-center gap-1.5 mt-1">
+          {isSearching ? (
+            <Globe className="w-3 h-3 text-blue-400 animate-spin flex-shrink-0" />
+          ) : (
+            <Loader2 className="w-3 h-3 text-amber-400 animate-spin flex-shrink-0" />
+          )}
+          <p className="text-[11px] text-amber-300/60 truncate leading-tight">
+            {isSearching ? "Searching..." : lastLine.slice(0, 80)}
+          </p>
+        </div>
       )}
     </BaseNode>
   );

--- a/app/frontend/src/components/workflows/nodes/AgentNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/AgentNode.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { memo } from "react";
+import { Bot } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNode from "./BaseNode";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+function AgentNodeComponent({ id, data }: NodeProps) {
+  const label = (data.label as string) || "Agent";
+  const goal = (data.goal as string) || "";
+  const reasoning = useWorkflowStore((s) => s.agentReasoningLog[id]);
+  const isRunning = useWorkflowStore((s) => s.nodeStatuses[id] === "running");
+
+  return (
+    <BaseNode
+      id={id}
+      label={label}
+      icon={<Bot className="w-4 h-4" />}
+      accent="#fbbf24"
+    >
+      {goal && (
+        <p className="text-[11px] text-zinc-500 truncate">
+          <span className="text-zinc-600">Goal:</span> {goal.slice(0, 50)}
+          {goal.length > 50 && "..."}
+        </p>
+      )}
+      {!goal && (
+        <p className="text-[11px] text-zinc-600 italic">No goal set</p>
+      )}
+      {isRunning && reasoning && reasoning.length > 0 && (
+        <p className="text-[11px] text-amber-300/60 mt-1 max-h-12 overflow-hidden whitespace-pre-wrap break-words leading-tight font-mono">
+          {reasoning[reasoning.length - 1]?.slice(0, 120)}
+        </p>
+      )}
+    </BaseNode>
+  );
+}
+
+export default memo(AgentNodeComponent);

--- a/app/frontend/src/components/workflows/nodes/BaseNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/BaseNode.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import type React from "react";
+import { Handle, Position } from "@xyflow/react";
+import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import type { NodeStatus } from "../../../types/workflow";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+interface BaseNodeProps {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  accent: string;
+  hasInput?: boolean;
+  hasOutput?: boolean;
+  children?: React.ReactNode;
+}
+
+const BORDER_BY_STATUS: Record<NodeStatus, string> = {
+  idle: "border-zinc-700/60",
+  running: "border-violet-500 ring-2 ring-violet-500/20",
+  completed: "border-emerald-500/80",
+  error: "border-red-500/80",
+};
+
+function StatusIndicator({ status }: { status: NodeStatus }) {
+  switch (status) {
+    case "running":
+      return <Loader2 className="w-3 h-3 text-violet-400 animate-spin" />;
+    case "completed":
+      return <CheckCircle2 className="w-3 h-3 text-emerald-400" />;
+    case "error":
+      return <AlertCircle className="w-3 h-3 text-red-400" />;
+    default:
+      return null;
+  }
+}
+
+export default function BaseNode({
+  id,
+  label,
+  icon,
+  accent,
+  hasInput = true,
+  hasOutput = true,
+  children,
+}: BaseNodeProps) {
+  const nodeStatus = useWorkflowStore((s) => s.nodeStatuses[id]) || "idle";
+  const isSelected = useWorkflowStore((s) => s.selectedNodeId === id);
+
+  return (
+    <div
+      className={`
+        rounded-xl border bg-zinc-900/95 backdrop-blur-sm w-[220px]
+        transition-all duration-200 relative
+        ${BORDER_BY_STATUS[nodeStatus]}
+        ${isSelected ? "ring-2 ring-violet-500/50 border-violet-500/60" : ""}
+      `}
+    >
+      {hasInput && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="!w-2.5 !h-2.5 !bg-zinc-500 !border-2 !border-zinc-400 hover:!bg-violet-400 hover:!border-violet-300 !transition-colors"
+        />
+      )}
+
+      <div className="overflow-hidden rounded-xl">
+        {/* Header with accent stripe */}
+        <div
+          className="flex items-center gap-2.5 px-3 py-2.5"
+          style={{ borderBottom: `2px solid ${accent}` }}
+        >
+          <div
+            className="flex items-center justify-center w-7 h-7 rounded-lg shrink-0"
+            style={{ backgroundColor: `${accent}15` }}
+          >
+            <span style={{ color: accent }}>{icon}</span>
+          </div>
+          <span className="text-sm font-semibold text-zinc-100 truncate flex-1">
+            {label}
+          </span>
+          <StatusIndicator status={nodeStatus} />
+        </div>
+
+        {children && (
+          <div className="px-3 py-2 text-left">{children}</div>
+        )}
+      </div>
+
+      {hasOutput && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="!w-2.5 !h-2.5 !bg-zinc-500 !border-2 !border-zinc-400 hover:!bg-violet-400 hover:!border-violet-300 !transition-colors"
+        />
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/workflows/nodes/InputNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/InputNode.tsx
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { memo } from "react";
+import { ArrowRightToLine } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNode from "./BaseNode";
+
+function InputNodeComponent({ id, data }: NodeProps) {
+  const label = (data.label as string) || "User Input";
+
+  return (
+    <BaseNode
+      id={id}
+      label={label}
+      icon={<ArrowRightToLine className="w-4 h-4" />}
+      accent="#34d399"
+      hasInput={false}
+      hasOutput={true}
+    >
+      <p className="text-[11px] text-zinc-500">Workflow entry point</p>
+    </BaseNode>
+  );
+}
+
+export default memo(InputNodeComponent);

--- a/app/frontend/src/components/workflows/nodes/LLMNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/LLMNode.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { memo } from "react";
+import { MessageSquare } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNode from "./BaseNode";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+function LLMNodeComponent({ id, data }: NodeProps) {
+  const label = (data.label as string) || "LLM";
+  const output = useWorkflowStore((s) => s.nodeOutputs[id]);
+  const isRunning = useWorkflowStore((s) => s.nodeStatuses[id] === "running");
+
+  return (
+    <BaseNode
+      id={id}
+      label={label}
+      icon={<MessageSquare className="w-4 h-4" />}
+      accent="#a78bfa"
+    >
+      <div className="flex items-center gap-3 text-[11px] text-zinc-500">
+        <span>Temp {(data.temperature as number) ?? 0.7}</span>
+        <span className="text-zinc-700">|</span>
+        <span>Max {(data.max_tokens as number) ?? 1024}</span>
+      </div>
+      {isRunning && output && (
+        <p className="text-[11px] text-zinc-400 mt-1.5 max-h-14 overflow-hidden whitespace-pre-wrap break-words leading-tight opacity-70">
+          {output.slice(-100)}
+        </p>
+      )}
+    </BaseNode>
+  );
+}
+
+export default memo(LLMNodeComponent);

--- a/app/frontend/src/components/workflows/nodes/OutputNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/OutputNode.tsx
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { memo } from "react";
+import { ArrowLeftFromLine } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNode from "./BaseNode";
+import { useWorkflowStore } from "../../../store/workflowStore";
+
+function OutputNodeComponent({ id, data }: NodeProps) {
+  const label = (data.label as string) || "Output";
+  const output = useWorkflowStore((s) => s.nodeOutputs[id]);
+
+  return (
+    <BaseNode
+      id={id}
+      label={label}
+      icon={<ArrowLeftFromLine className="w-4 h-4" />}
+      accent="#fb7185"
+      hasInput={true}
+      hasOutput={false}
+    >
+      {output ? (
+        <p className="text-[11px] text-zinc-300 line-clamp-3 whitespace-pre-wrap break-words leading-relaxed">
+          {output.slice(0, 150)}
+        </p>
+      ) : (
+        <p className="text-[11px] text-zinc-600 italic">Result will appear here</p>
+      )}
+    </BaseNode>
+  );
+}
+
+export default memo(OutputNodeComponent);

--- a/app/frontend/src/components/workflows/nodes/RAGQueryNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/RAGQueryNode.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { memo } from "react";
+import { Database } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import BaseNode from "./BaseNode";
+
+function RAGQueryNodeComponent({ id, data }: NodeProps) {
+  const label = (data.label as string) || "RAG Query";
+  const collection = (data.collection_name as string) || "not set";
+
+  return (
+    <BaseNode
+      id={id}
+      label={label}
+      icon={<Database className="w-4 h-4" />}
+      accent="#60a5fa"
+    >
+      <p className="text-[11px] text-zinc-500 truncate">
+        <span className="text-zinc-600">Collection:</span> {collection}
+      </p>
+      <p className="text-[11px] text-zinc-500">
+        <span className="text-zinc-600">Top-k:</span> {(data.n_results as number) ?? 5}
+      </p>
+    </BaseNode>
+  );
+}
+
+export default memo(RAGQueryNodeComponent);

--- a/app/frontend/src/components/workflows/nodes/nodeTypes.ts
+++ b/app/frontend/src/components/workflows/nodes/nodeTypes.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import type { NodeTypes } from "@xyflow/react";
+import InputNode from "./InputNode";
+import OutputNode from "./OutputNode";
+import LLMNode from "./LLMNode";
+import RAGQueryNode from "./RAGQueryNode";
+import AgentNode from "./AgentNode";
+
+export const nodeTypes: NodeTypes = {
+  input: InputNode,
+  output: OutputNode,
+  llm: LLMNode,
+  rag_query: RAGQueryNode,
+  agent: AgentNode,
+};

--- a/app/frontend/src/pages/WorkflowsPage.tsx
+++ b/app/frontend/src/pages/WorkflowsPage.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { useEffect } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "../components/ui/resizable";
+import { useWorkflowStore } from "../store/workflowStore";
+import WorkflowCanvas from "../components/workflows/WorkflowCanvas";
+import NodePalette from "../components/workflows/NodePalette";
+import NodeConfigPanel from "../components/workflows/NodeConfigPanel";
+import WorkflowToolbar from "../components/workflows/WorkflowToolbar";
+import ExecutionPanel from "../components/workflows/ExecutionPanel";
+import { useFooterVisibility } from "../hooks/useFooterVisibility";
+
+export default function WorkflowsPage() {
+  const { loadWorkflows, loadTemplates, selectedNodeId, nodes, loadExampleWorkflow } =
+    useWorkflowStore();
+  const { setShowFooter } = useFooterVisibility();
+
+  useEffect(() => {
+    loadWorkflows();
+    loadTemplates();
+  }, [loadWorkflows, loadTemplates]);
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      loadExampleWorkflow();
+    }
+  }, []);
+
+  useEffect(() => {
+    setShowFooter(false);
+    return () => setShowFooter(true);
+  }, [setShowFooter]);
+
+  return (
+    <ReactFlowProvider>
+      <div className="fixed top-0 bottom-0 right-0 left-16 flex flex-col z-20">
+        <WorkflowToolbar />
+        <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
+          <ResizablePanel defaultSize={15} minSize={10} maxSize={25}>
+            <NodePalette />
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={selectedNodeId ? 50 : 85} minSize={30}>
+            <div className="flex flex-col h-full">
+              <div className="flex-1 min-h-0">
+                <WorkflowCanvas />
+              </div>
+              <ExecutionPanel />
+            </div>
+          </ResizablePanel>
+          {selectedNodeId && (
+            <>
+              <ResizableHandle withHandle />
+              <ResizablePanel defaultSize={35} minSize={25} maxSize={50}>
+                <NodeConfigPanel />
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
+      </div>
+    </ReactFlowProvider>
+  );
+}

--- a/app/frontend/src/routes/route-config.tsx
+++ b/app/frontend/src/routes/route-config.tsx
@@ -56,6 +56,7 @@ import SpeechToTextPage from "../pages/SpeechToTextPage";
 import ApiInfoPage from "../pages/ApiInfoPage";
 import DeploymentHistoryPage from "../pages/DeploymentHistoryPage";
 import TTSPage from "../pages/TTSPage";
+import WorkflowsPage from "../pages/WorkflowsPage";
 
 // Define route configuration type
 export interface RouteConfig {
@@ -140,6 +141,11 @@ export const getRoutes = (): RouteConfig[] => {
     {
       path: "/tts",
       element: <TTSPage />,
+      condition: true,
+    },
+    {
+      path: "/workflows",
+      element: <WorkflowsPage />,
       condition: true,
     },
     {

--- a/app/frontend/src/store/workflowStore.ts
+++ b/app/frontend/src/store/workflowStore.ts
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import { create } from "zustand";
+import {
+  applyNodeChanges,
+  applyEdgeChanges,
+  addEdge,
+  type Connection,
+  type NodeChange,
+  type EdgeChange,
+} from "@xyflow/react";
+import type {
+  Workflow,
+  WorkflowNode,
+  WorkflowEdge,
+  NodeStatus,
+  SSEEvent,
+} from "../types/workflow";
+import {
+  listWorkflows,
+  createWorkflow,
+  updateWorkflow,
+  deleteWorkflow,
+  listTemplates,
+  executeWorkflow,
+} from "../api/workflowApi";
+
+export interface WorkflowState {
+  // Workflow list
+  workflows: Workflow[];
+  templates: Workflow[];
+  isLoading: boolean;
+
+  // Current canvas
+  currentWorkflow: Workflow | null;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+  selectedNodeId: string | null;
+
+  // Execution
+  isRunning: boolean;
+  nodeStatuses: Record<string, NodeStatus>;
+  nodeOutputs: Record<string, string>;
+  agentReasoningLog: Record<string, string[]>;
+  runProgress: number;
+  runError: string | null;
+  abortController: AbortController | null;
+
+  // Actions – CRUD
+  loadWorkflows: () => Promise<void>;
+  loadTemplates: () => Promise<void>;
+  createWorkflow: (name: string, description?: string) => Promise<Workflow>;
+  saveWorkflow: () => Promise<void>;
+  deleteWorkflow: (id: string) => Promise<void>;
+  setCurrentWorkflow: (wf: Workflow | null) => void;
+  loadFromTemplate: (template: Workflow) => void;
+
+  // Actions – canvas manipulation
+  onNodesChange: (changes: NodeChange<WorkflowNode>[]) => void;
+  onEdgesChange: (changes: EdgeChange[]) => void;
+  onConnect: (connection: Connection) => void;
+  addNode: (node: WorkflowNode) => void;
+  setSelectedNode: (id: string | null) => void;
+  updateNodeData: (nodeId: string, data: Record<string, unknown>) => void;
+  deleteSelected: () => void;
+
+  // Actions – execution
+  runWorkflow: (input: string) => void;
+  cancelRun: () => void;
+  handleSSEEvent: (event: SSEEvent) => void;
+  resetExecution: () => void;
+
+  // Actions – examples
+  loadExampleWorkflow: () => void;
+}
+
+export const useWorkflowStore = create<WorkflowState>((set, get) => ({
+  workflows: [],
+  templates: [],
+  isLoading: false,
+
+  currentWorkflow: null,
+  nodes: [],
+  edges: [],
+  selectedNodeId: null,
+
+  isRunning: false,
+  nodeStatuses: {},
+  nodeOutputs: {},
+  agentReasoningLog: {},
+  runProgress: 0,
+  runError: null,
+  abortController: null,
+
+  // -----------------------------------------------------------------------
+  // CRUD
+  // -----------------------------------------------------------------------
+
+  loadWorkflows: async () => {
+    set({ isLoading: true });
+    try {
+      const workflows = await listWorkflows();
+      set({ workflows });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  loadTemplates: async () => {
+    try {
+      const templates = await listTemplates();
+      set({ templates });
+    } catch {
+      // templates are optional
+    }
+  },
+
+  createWorkflow: async (name, description = "") => {
+    const { nodes, edges } = get();
+    const wf = await createWorkflow({
+      name,
+      description,
+      graph_data: { nodes, edges },
+    });
+    set((s) => ({
+      workflows: [wf, ...s.workflows],
+      currentWorkflow: wf,
+    }));
+    return wf;
+  },
+
+  saveWorkflow: async () => {
+    const { currentWorkflow, nodes, edges } = get();
+    if (!currentWorkflow) return;
+    const updated = await updateWorkflow(currentWorkflow.id, {
+      name: currentWorkflow.name,
+      description: currentWorkflow.description,
+      graph_data: { nodes, edges },
+    });
+    set((s) => ({
+      currentWorkflow: updated,
+      workflows: s.workflows.map((w) => (w.id === updated.id ? updated : w)),
+    }));
+  },
+
+  deleteWorkflow: async (id) => {
+    await deleteWorkflow(id);
+    set((s) => ({
+      workflows: s.workflows.filter((w) => w.id !== id),
+      currentWorkflow:
+        s.currentWorkflow?.id === id ? null : s.currentWorkflow,
+    }));
+  },
+
+  setCurrentWorkflow: (wf) => {
+    if (wf) {
+      set({
+        currentWorkflow: wf,
+        nodes: (wf.graph_data?.nodes ?? []) as WorkflowNode[],
+        edges: (wf.graph_data?.edges ?? []) as WorkflowEdge[],
+        selectedNodeId: null,
+      });
+    } else {
+      set({
+        currentWorkflow: null,
+        nodes: [],
+        edges: [],
+        selectedNodeId: null,
+      });
+    }
+    get().resetExecution();
+  },
+
+  loadFromTemplate: (template) => {
+    set({
+      currentWorkflow: null,
+      nodes: (template.graph_data?.nodes ?? []) as WorkflowNode[],
+      edges: (template.graph_data?.edges ?? []) as WorkflowEdge[],
+      selectedNodeId: null,
+    });
+    get().resetExecution();
+  },
+
+  // -----------------------------------------------------------------------
+  // Canvas
+  // -----------------------------------------------------------------------
+
+  onNodesChange: (changes) => {
+    set((s) => ({
+      nodes: applyNodeChanges(changes, s.nodes) as WorkflowNode[],
+    }));
+  },
+
+  onEdgesChange: (changes) => {
+    set((s) => ({
+      edges: applyEdgeChanges(changes, s.edges),
+    }));
+  },
+
+  onConnect: (connection) => {
+    set((s) => ({
+      edges: addEdge(connection, s.edges),
+    }));
+  },
+
+  addNode: (node) => {
+    set((s) => ({ nodes: [...s.nodes, node] }));
+  },
+
+  setSelectedNode: (id) => {
+    set({ selectedNodeId: id });
+  },
+
+  updateNodeData: (nodeId, data) => {
+    set((s) => ({
+      nodes: s.nodes.map((n) =>
+        n.id === nodeId ? { ...n, data: { ...n.data, ...data } } : n
+      ),
+    }));
+  },
+
+  deleteSelected: () => {
+    const { selectedNodeId } = get();
+    if (!selectedNodeId) return;
+    set((s) => ({
+      nodes: s.nodes.filter((n) => n.id !== selectedNodeId),
+      edges: s.edges.filter(
+        (e) => e.source !== selectedNodeId && e.target !== selectedNodeId
+      ),
+      selectedNodeId: null,
+    }));
+  },
+
+  // -----------------------------------------------------------------------
+  // Execution
+  // -----------------------------------------------------------------------
+
+  runWorkflow: (input) => {
+    const { currentWorkflow } = get();
+    if (!currentWorkflow) return;
+
+    get().resetExecution();
+    set({ isRunning: true });
+
+    const controller = executeWorkflow(
+      currentWorkflow.id,
+      input,
+      (event) => get().handleSSEEvent(event),
+      () => set({ isRunning: false }),
+      (err) => set({ isRunning: false, runError: err.message })
+    );
+
+    set({ abortController: controller });
+  },
+
+  cancelRun: () => {
+    const { abortController } = get();
+    abortController?.abort();
+    set({ isRunning: false, abortController: null });
+  },
+
+  handleSSEEvent: (event) => {
+    const nodeId = event.node_id as string | undefined;
+
+    switch (event.event) {
+      case "node_started":
+        if (nodeId) {
+          set((s) => ({
+            nodeStatuses: { ...s.nodeStatuses, [nodeId]: "running" },
+          }));
+        }
+        break;
+
+      case "node_progress":
+        if (nodeId) {
+          const token = (event as Record<string, unknown>).token as string;
+          if (token) {
+            set((s) => ({
+              nodeOutputs: {
+                ...s.nodeOutputs,
+                [nodeId]: (s.nodeOutputs[nodeId] || "") + token,
+              },
+            }));
+          }
+        }
+        break;
+
+      case "agent_reasoning":
+        if (nodeId) {
+          const text = (event as Record<string, unknown>).text as string;
+          if (text) {
+            set((s) => ({
+              agentReasoningLog: {
+                ...s.agentReasoningLog,
+                [nodeId]: [...(s.agentReasoningLog[nodeId] || []), text],
+              },
+            }));
+          }
+        }
+        break;
+
+      case "node_done":
+        if (nodeId) {
+          const output = (event as Record<string, unknown>).output as string;
+          set((s) => ({
+            nodeStatuses: { ...s.nodeStatuses, [nodeId]: "completed" },
+            nodeOutputs: { ...s.nodeOutputs, [nodeId]: output ?? "" },
+          }));
+        }
+        break;
+
+      case "node_completed":
+        if (nodeId) {
+          const progress = (event as Record<string, unknown>)
+            .progress as number;
+          set((s) => ({
+            nodeStatuses: { ...s.nodeStatuses, [nodeId]: "completed" },
+            runProgress: progress ?? s.runProgress,
+          }));
+        }
+        break;
+
+      case "node_error":
+        if (nodeId) {
+          const error = (event as Record<string, unknown>).error as string;
+          set((s) => ({
+            nodeStatuses: { ...s.nodeStatuses, [nodeId]: "error" },
+            runError: error,
+          }));
+        }
+        break;
+
+      case "run_error":
+        set({
+          isRunning: false,
+          runError: (event as Record<string, unknown>).error as string,
+        });
+        break;
+
+      case "run_completed":
+        set({ isRunning: false, runProgress: 1 });
+        break;
+    }
+  },
+
+  resetExecution: () => {
+    set({
+      isRunning: false,
+      nodeStatuses: {},
+      nodeOutputs: {},
+      agentReasoningLog: {},
+      runProgress: 0,
+      runError: null,
+      abortController: null,
+    });
+  },
+
+  loadExampleWorkflow: () => {
+    const nodes: WorkflowNode[] = [
+      {
+        id: "input-1",
+        type: "input",
+        position: { x: 50, y: 200 },
+        data: { label: "User Prompt", text: "" },
+      },
+      {
+        id: "llm-1",
+        type: "llm",
+        position: { x: 350, y: 80 },
+        data: {
+          label: "Research LLM",
+          deploy_id: "",
+          prompt_template:
+            "You are a research assistant. Given the following topic, provide a comprehensive summary with key facts:\n\n{input}",
+          temperature: 0.7,
+          max_tokens: 1024,
+        },
+      },
+      {
+        id: "rag-1",
+        type: "rag_query",
+        position: { x: 350, y: 320 },
+        data: {
+          label: "Knowledge Base",
+          collection_name: "",
+          n_results: 5,
+        },
+      },
+      {
+        id: "llm-2",
+        type: "llm",
+        position: { x: 700, y: 200 },
+        data: {
+          label: "Synthesizer",
+          deploy_id: "",
+          prompt_template:
+            "Combine the following research and retrieved knowledge into a clear, well-structured briefing:\n\nResearch: {input}\n\nProvide a final briefing with sections: Summary, Key Points, and Recommendations.",
+          temperature: 0.5,
+          max_tokens: 2048,
+        },
+      },
+      {
+        id: "output-1",
+        type: "output",
+        position: { x: 1020, y: 200 },
+        data: { label: "Research Briefing" },
+      },
+    ];
+
+    const edges: WorkflowEdge[] = [
+      {
+        id: "e-input-llm",
+        source: "input-1",
+        target: "llm-1",
+      },
+      {
+        id: "e-input-rag",
+        source: "input-1",
+        target: "rag-1",
+      },
+      {
+        id: "e-llm-synth",
+        source: "llm-1",
+        target: "llm-2",
+      },
+      {
+        id: "e-rag-synth",
+        source: "rag-1",
+        target: "llm-2",
+      },
+      {
+        id: "e-synth-output",
+        source: "llm-2",
+        target: "output-1",
+      },
+    ];
+
+    set({
+      currentWorkflow: null,
+      nodes,
+      edges,
+      selectedNodeId: null,
+    });
+    get().resetExecution();
+  },
+}));

--- a/app/frontend/src/types/workflow.ts
+++ b/app/frontend/src/types/workflow.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+import type { Node, Edge } from "@xyflow/react";
+
+export type WorkflowNodeType =
+  | "input"
+  | "output"
+  | "llm"
+  | "rag_query"
+  | "agent";
+
+export interface InputNodeData extends Record<string, unknown> {
+  label: string;
+  text: string;
+}
+
+export interface OutputNodeData extends Record<string, unknown> {
+  label: string;
+}
+
+export interface LLMNodeData extends Record<string, unknown> {
+  label: string;
+  deploy_id: string;
+  prompt_template: string;
+  temperature: number;
+  max_tokens: number;
+}
+
+export interface RAGNodeData extends Record<string, unknown> {
+  label: string;
+  collection_name: string;
+  n_results: number;
+}
+
+export interface AgentNodeData extends Record<string, unknown> {
+  label: string;
+  goal: string;
+  thread_id: string;
+}
+
+export type WorkflowNode = Node<
+  | InputNodeData
+  | OutputNodeData
+  | LLMNodeData
+  | RAGNodeData
+  | AgentNodeData,
+  WorkflowNodeType
+>;
+
+export type WorkflowEdge = Edge;
+
+export interface GraphData {
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+}
+
+export interface Workflow {
+  id: string;
+  name: string;
+  description: string;
+  graph_data: GraphData;
+  is_template: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowRun {
+  id: string;
+  workflow: string;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  initial_input: string;
+  node_outputs: Record<string, string>;
+  error: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export type NodeStatus = "idle" | "running" | "completed" | "error";
+
+export interface SSEEvent {
+  event: string;
+  node_id?: string;
+  [key: string]: unknown;
+}

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -16,6 +16,7 @@ const VITE_BACKEND_PROXY_MAPPING: { [key: string]: string } = {
   "collections-api": "collections",
   "logs-api": "logs",
   "board-api": "board",
+  "workflows-api": "workflows",
 };
 
 const proxyConfig: Record<string, string | ProxyOptions> = Object.fromEntries(


### PR DESCRIPTION
## Summary
Adds a full drag-and-drop workflow pipeline editor that lets users compose multi-step AI workflows by chaining nodes together on a visual canvas. This builds on top of the existing search agent and deployed model infrastructure.
### Backend — new `workflow_control` Django app
- **Data model**: `Workflow` (stores graph as JSON) and `WorkflowRun` (tracks execution state + per-node outputs)
- **Topological executor**: Parses the DAG, runs nodes in dependency order, streams progress via SSE
- **5 node handlers**: Input, Output, LLM (connects to any deployed model via `deploy_cache`), RAG Query (ChromaDB), and Agent (forwards to the search agent service)
- **Template system**: Seeds 3 starter workflows on first migration (Research Briefing, Document Processor, Q&A Pipeline)
- **REST API**: Full CRUD on workflows + SSE streaming execution endpoint
### Frontend — React Flow canvas + Zustand store
- **Visual canvas**: Drag-and-drop node palette, animated edge connections, minimap, zoom controls, keyboard delete
- **Per-node config panels**: LLM node picks from deployed models, RAG node picks from ChromaDB collections, Agent node sets a goal, all with live sliders/dropdowns
- **Real-time execution**: Run button streams SSE events — shows per-node status badges, live token streaming on LLM nodes, and agent reasoning activity
- **Workflow management**: Create, save, open, delete workflows; load from templates; built-in example workflow on first visit
- **Navbar integration**: New "Workflows" link in the app navigation

## Test plan
- [ ] Create a new workflow, add Input → LLM → Output nodes, connect edges, save and run with text input
- [ ] Verify LLM node dropdown shows currently deployed (running) models
- [ ] Add RAG Query node, verify collections dropdown populates from ChromaDB
- [ ] Add Agent node with a search goal, verify reasoning displays cleanly as "Searching the web" with query list (not fragmented tokens)
- [ ] Load a template workflow (Research Briefing / Document Processor / Q&A Pipeline)
- [ ] Test workflow CRUD: create, rename, save, open, delete
- [ ] Test execution controls: run, cancel mid-stream, reset
- [ ] Verify SSE streaming shows per-node progress bar and status badges
