### PR TITLE
Auto-fix root-owned PID/log files at TT Studio root

### DIFF
--- a/run.py
+++ b/run.py
@@ -111,6 +111,49 @@ SERVICE_CONTAINER_PREFIX_MAP = {
 FORCE_OVERWRITE = False
 
 
+def ensure_file_owned_by_user(file_path):
+    """Chown file_path to the current user if it exists and is owned by someone else.
+
+    A prior sudo'd run.py can leave root-owned PID/log files at the repo root,
+    which break subsequent non-root truncating opens with [Errno 13]. Falls back
+    to `sudo -n chown` (passwordless), then to printed instructions for the user.
+    """
+    if OS_NAME == "Windows":
+        return
+    try:
+        if not os.path.exists(file_path):
+            return
+        current_uid = os.getuid()
+        current_gid = os.getgid()
+        if os.stat(file_path).st_uid == current_uid:
+            return
+        print(f"{C_YELLOW}⚠️  {file_path} is owned by another user, fixing permissions...{C_RESET}")
+        try:
+            os.chown(file_path, current_uid, current_gid)
+            print(f"{C_GREEN}✅ Fixed {os.path.basename(file_path)} ownership{C_RESET}")
+            return
+        except (OSError, PermissionError):
+            pass
+        try:
+            result = subprocess.run(
+                ["sudo", "-n", "chown", f"{current_uid}:{current_gid}", file_path],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and os.stat(file_path).st_uid == current_uid:
+                print(f"{C_GREEN}✅ Fixed {os.path.basename(file_path)} ownership (via sudo){C_RESET}")
+                return
+        except Exception:
+            pass
+        print(f"{C_RED}⛔ Could not fix {file_path} permissions automatically.{C_RESET}")
+        print(f"{C_YELLOW}Please run the following in another terminal, then press Enter:{C_RESET}")
+        print(f"   {C_WHITE}sudo chown $USER:$USER {file_path}{C_RESET}")
+        if sys.stdin.isatty():
+            input("Press Enter once you've run the command above to continue...")
+    except Exception as e:
+        print(f"{C_YELLOW}Warning: ownership check failed for {file_path}: {e}{C_RESET}")
+
+
 # --- Startup Logger ---
 class StartupLogger:
     """
@@ -171,6 +214,7 @@ class StartupLogger:
             self._f.close()
 
 
+ensure_file_owned_by_user(STARTUP_LOG_FILE)
 startup_log = StartupLogger(STARTUP_LOG_FILE)
 
 
@@ -3173,8 +3217,9 @@ def start_fastapi_server(no_sudo=False, dev_mode=False):
             return False
 
     # Create PID and log files
-    
+
     for file_path in [FASTAPI_PID_FILE, FASTAPI_LOG_FILE]:
+        ensure_file_owned_by_user(file_path)
         try:
             # Create files as regular user
             with open(file_path, 'w') as f:
@@ -3424,6 +3469,7 @@ def start_docker_control_service(no_sudo=False, dev_mode=False):
 
     # Create PID and log files
     for file_path in [DOCKER_CONTROL_PID_FILE, DOCKER_CONTROL_LOG_FILE]:
+        ensure_file_owned_by_user(file_path)
         try:
             with open(file_path, 'w') as f:
                 pass


### PR DESCRIPTION
## Summary
- Fixes issue #768: when a prior `sudo python3 run.py` leaves files at the repo root owned by `root`, subsequent non-root invocations cannot truncate them and the Docker Control Service fails to start with `[Errno 13] Permission denied`
- Adds an `ensure_file_owned_by_user` helper that auto-chowns root-owned PID/log files via `sudo -n chown` (passwordless), with a non-blocking fallback when sudo or a TTY isn't available
- Extends the directory-ownership pattern from commit f9c13f07 (`fastapi_logs/`) to the five root-level service files: `startup.log`, `fastapi.pid/.log`, `docker-control-service.pid/.log`

## Root cause
The bug triggers when files at the tt-studio repo root were touched by a prior root-privileged process (a sudo'd `run.py`, or the Quietbox ISO install pathway). On subsequent non-root runs, `run.py`'s `open(path, 'w')` at lines `start_fastapi_server` and `start_docker_control_service` cannot truncate root-owned files and the services die instantly — the beta tester's screenshot shows the exact `[Errno 13]` trace.

## Test plan
End-to-end verified on the actual Quietbox beta-tester environment (`ttuser@sjc2-qb2-9b22`) and an alternate lab box (`jashansingh@yyz-lab-115`):

- [x] **Pre-fix** (revert to `origin/dev`'s `run.py`): root-own all 5 service files → `python3 run.py` produces 4/4 `Warning: Could not create ... [Errno 13] Permission denied` traces, exactly matching the beta tester's screenshot
- [x] **Post-fix** (this branch): same broken state → helper detects ownership mismatch, recovers each file via `sudo -n chown`, 0/4 errors, `open(w)` succeeds
- [x] **Restricted-sudo environment** (`yyz-lab-115`, no `chown` in sudoers): helper detects + prints `⚠️ owned by another user / ⛔ Could not fix automatically / sudo chown $USER:$USER ...` guidance for each file; `isatty()` skips the blocking `input()` in non-interactive shells
- [x] **Windows guard**: `OS_NAME == "Windows"` short-circuits the helper
- [x] **Already-owned**: `st_uid == current_uid` short-circuits as no-op (zero overhead on healthy installs)