### PR TITLE
Hid the Advanvced config toggle for QB2

### DIFF
--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -132,14 +132,14 @@ export default function StepperDemo() {
 
   const steps = useHardwareConfigStep
     ? [
-        { label: "Step 1", description: hardwareConfigSummary },
-        { label: "Step 2", description: "Model Selection" },
-        { label: "Final Step", description: "Deploy Model" },
-      ]
+      { label: "Step 1", description: hardwareConfigSummary },
+      { label: "Step 2", description: "Model Selection" },
+      { label: "Final Step", description: "Deploy Model" },
+    ]
     : [
-        { label: "Step 1", description: "Model Selection" },
-        { label: "Final Step", description: "Deploy Model" },
-      ];
+      { label: "Step 1", description: "Model Selection" },
+      { label: "Final Step", description: "Deploy Model" },
+    ];
 
   // Log when selectedModel changes
   useEffect(() => {
@@ -316,8 +316,8 @@ export default function StepperDemo() {
           const conflictsSummary =
             conflicts.length > 0
               ? ` Stop these first: ${conflicts
-                  .map((c: { model?: string; slot?: number }) => `${c.model ?? "Unknown"} (device ${c.slot ?? "?"})`)
-                  .join(", ")}.`
+                .map((c: { model?: string; slot?: number }) => `${c.model ?? "Unknown"} (device ${c.slot ?? "?"})`)
+                .join(", ")}.`
               : "";
           customToast.error(`Multi-chip Deployment Conflict: ${message}.${conflictsSummary}`);
 
@@ -466,8 +466,9 @@ export default function StepperDemo() {
           </div>
         )}
 
+        {/* TODO: Re-enable this when we want to support hardware configuration for multi-chip boards */}
         {/* QB2 hardware config toggle — only shown on P300Cx2 boards */}
-        {isQB2 && (
+        {/* {isQB2 && (
           <div className="flex items-center justify-between gap-2 pb-2 pt-1 border-b border-gray-800 mb-2">
             <span className="text-sm font-mono text-gray-300 select-none">
               Advanced: Configure Hardware
@@ -496,7 +497,7 @@ export default function StepperDemo() {
               />
             </button>
           </div>
-        )}
+        )} */}
 
         <button
           onClick={() => setDeployMode(null)}


### PR DESCRIPTION
Temporarily, we decided to remove the advanced config settings from the frontend on the QB2 that allows users to specify hardware allocation while deploying models.