### PR TITLE
Fix TPS for base (non-instruct) models

### DIFF
--- a/app/backend/model_control/model_utils.py
+++ b/app/backend/model_control/model_utils.py
@@ -406,7 +406,9 @@ async def stream_response_from_external_api(url: str, json_data: dict):
                             )
                             if delta_reasoning:
                                 tracker.record_thinking_token()
-                            delta_content = delta.get("content", "")
+                            # chat completions: choices[0].delta.content
+                            # base/completions:  choices[0].text
+                            delta_content = delta.get("content") or choices[0].get("text") or ""
                             if delta_content:
                                 tracker.record_content_token()
                                 logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")

--- a/app/frontend/src/components/chatui/InferenceStats.tsx
+++ b/app/frontend/src/components/chatui/InferenceStats.tsx
@@ -99,7 +99,7 @@ export default function Component({
   };
 
   const userTPS =
-    typeof stats.user_tpot === "number"
+    typeof stats.user_tpot === "number" && stats.user_tpot > 0
       ? (1 / Math.max(stats.user_tpot, 0.000001)).toFixed(2)
       : "N/A";
 
@@ -488,7 +488,7 @@ export default function Component({
   // Return inline display if requested
   if (inline) {
     const tpsDisplay =
-      typeof stats.user_tpot === "number"
+      typeof stats.user_tpot === "number" && stats.user_tpot > 0
         ? (1 / Math.max(stats.user_tpot, 0.000001)).toFixed(1)
         : null;
     const ttftDisplay =


### PR DESCRIPTION
## What

Base / non-instruct models (e.g. `Llama-3.1-8B`) showed a bogus `1,000,000 t/s` and had no real throughput metrics. This PR makes TPS — and TTFT / token count — actually compute for them, end to end.

## Changes

1. **Backend (the real fix)** — `app/backend/model_control/model_utils.py`. The stream parser only recorded tokens from the chat-completions delta shape (`choices[0].delta.content`). Base models stream via `/v1/completions`, whose chunks carry `choices[0].text`, so `record_content_token()` never fired → `tpot`, `ttft`, and `tokens_decoded` were all `0`. It now also reads `choices[0].text`, so the metrics tracker records per-chunk timing for base models, symmetric with instruct models.

2. **Frontend (guard)** — `app/frontend/src/components/chatui/InferenceStats.tsx`. TPS was computed as `1 / Math.max(user_tpot, 0.000001)`, which yields exactly `1000000` when `user_tpot` is `0`. Added `&& stats.user_tpot > 0` so it falls back to `N/A` when there's genuinely no data. With the backend fix, base models now report `tpot > 0`, so the UI shows the real number — this guard just covers the rare no-data case.

## Why

`get_tpot()` returns the mean of an inter-token-latency list that's only populated for the chat-completions chunk shape; base models use a different (`/v1/completions`) shape, so the list stayed empty and TPS collapsed to a divide-by-near-zero.

## Test plan

- [ ] Base model (`Llama-3.1-8B`): chat, confirm the SSE stats have `tpot > 0`, `ttft > 0`, `tokens_decoded > 0`, and the footer shows a real TPS (not `N/A`, not `1000000`).
- [ ] Instruct model (`Llama-3.1-8B-Instruct`): unchanged.
- [ ] `cd app/frontend && npm run lint` clean for `InferenceStats.tsx`.