### PR TITLE
hotfix: reuse preloaded QB2 weights under pinned release

### DIFF
--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -481,6 +481,32 @@ def _model_uses_preferred_host_volume(model_name: str) -> bool:
     return (model_name or "").strip().lower() in _HOST_VOLUME_MODEL_ALLOWLIST
 
 
+# ─── TEMP (QB2 workaround) — remove this fn + its call in the deploy path ──────
+def _stage_preloaded_version_symlink(model, device, impl, override_dir, root, job_id):
+    """Link volume_id_<impl>-<model>-v{model_spec.version} -> the preloaded
+    -vqb2_launch override dir, so `--host-volume <root>` reuse lands on the
+    preloaded data instead of re-downloading.
+
+    The version is resolved with the SAME get_runtime_model_spec(model, device,
+    impl) that run.py/setup_host use, so the symlink name matches what setup_host
+    requests for any model/impl/device (the dir version is the per-model
+    catalog-pinned model_spec.version, not the repo VERSION). Excise this fn +
+    its call when the preloaded data is re-staged under the release name.
+    """
+    if not override_dir:
+        return
+    try:
+        ms, _, _ = get_runtime_model_spec(model, device, impl=impl)
+        target = Path(root) / f"volume_id_{ms.impl.impl_id}-{ms.model_name}-v{ms.version}"
+        if target.exists() or target.is_symlink():  # never clobber; idempotent
+            return
+        os.symlink(Path(override_dir).resolve(), target)  # resolve() avoids symlink-to-symlink
+        logger.info("Job %s: linked %s -> %s", job_id, target.name, Path(override_dir).name)
+    except Exception as exc:
+        logger.warning("Job %s: could not stage preloaded host-volume symlink: %s", job_id, exc)
+# ─── end TEMP (QB2 workaround) ────────────────────────────────────────────────
+
+
 def _strip_cli_option(argv: list[str], option: str) -> list[str]:
     """Return argv without a single `--option value` pair."""
     stripped_argv: list[str] = []
@@ -1712,6 +1738,16 @@ async def run_inference(request: RunRequest):
             )
         if preferred_host_volume:
             initial_argv.extend(["--host-volume", preferred_host_volume])
+            # ─── TEMP (QB2 workaround) — remove with _stage_preloaded_version_symlink ──
+            _stage_preloaded_version_symlink(
+                request.model,
+                normalized_device,
+                request.impl,
+                expected_host_volume_dir,
+                preferred_host_volume,
+                job_id,
+            )
+            # ─── end TEMP (QB2 workaround) ────────────────────────────────────────────
             logger.info(
                 "Job %s: Qwen preloaded host-volume directory accepted: %s; using --host-volume %s (%s)",
                 job_id,

--- a/run.py
+++ b/run.py
@@ -2757,8 +2757,43 @@ def get_inference_server_version():
     env_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION") or os.getenv("TT_INFERENCE_ARTIFACT_VERSION")
     if env_version and env_version != "latest":
         return env_version
-    
+
     return None
+
+
+# ─── TEMP (QB2 workaround) — remove this block + its call in main() when done ──
+def stage_qb2_preloaded_volume_symlinks():
+    """Symlink the release-versioned host-volume dir to the QB2-preloaded one.
+
+    Fleet machines ship weights/cache preloaded at
+    ~/data/tt-cache/volume_id_<impl>-<model>-vqb2_launch/, but a pinned-release
+    tt-inference-server derives ...-v<VERSION>/ from its own VERSION file, so
+    --host-volume reuse misses the preloaded data and re-downloads. impl_id and
+    model_name are stable across the version change, so swapping only the
+    -vqb2_launch suffix for -v<VERSION> is the complete remap for all models
+    (mapping mirrors inference-api/api.py:246-249). Symlink, not copy — Qwen3-32B
+    weights are tens of GB. Excise this function + its call in main() when the
+    preloaded data is re-staged under the release name.
+    """
+    QB2_SUFFIX = "-vqb2_launch"
+    cache_root = Path(
+        os.getenv("TT_PRELOADED_HOST_VOLUME_ROOT", "~/data/tt-cache")
+    ).expanduser()
+    version = get_inference_server_version()  # None on branch artifacts
+    if not cache_root.is_dir() or not version or version == "qb2_launch":
+        return
+    for src in sorted(cache_root.glob(f"volume_id_*{QB2_SUFFIX}")):
+        if not src.is_dir():
+            continue
+        target = cache_root / (src.name[: -len(QB2_SUFFIX)] + f"-v{version}")
+        if target.exists() or target.is_symlink():  # never clobber; idempotent
+            continue
+        try:
+            os.symlink(src.resolve(), target)  # resolve() avoids symlink-to-symlink
+            print(f"{C_GREEN}✅ QB2: linked {target.name} → {src.name}{C_RESET}")
+        except OSError as exc:
+            print(f"{C_YELLOW}⚠️  QB2: could not link {target.name}: {exc}{C_RESET}")
+# ─── end TEMP (QB2 workaround) ────────────────────────────────────────────────
 
 
 def validate_artifact_structure(artifact_dir):
@@ -4953,6 +4988,10 @@ def main():
                     startup_log.summary(exit_code=1)
                     startup_log.close()
                     sys.exit(1)
+
+                # ─── TEMP (QB2 workaround) — remove with stage_qb2_... helper ──
+                stage_qb2_preloaded_volume_symlinks()
+                # ─── end TEMP (QB2 workaround) ────────────────────────────────
 
                 # Sync model catalog from artifact
                 models_json_path = os.path.join(TT_STUDIO_ROOT, "app", "backend", "shared_config", "models_from_inference_server.json")

--- a/run.py
+++ b/run.py
@@ -2757,43 +2757,8 @@ def get_inference_server_version():
     env_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION") or os.getenv("TT_INFERENCE_ARTIFACT_VERSION")
     if env_version and env_version != "latest":
         return env_version
-
+    
     return None
-
-
-# ─── TEMP (QB2 workaround) — remove this block + its call in main() when done ──
-def stage_qb2_preloaded_volume_symlinks():
-    """Symlink the release-versioned host-volume dir to the QB2-preloaded one.
-
-    Fleet machines ship weights/cache preloaded at
-    ~/data/tt-cache/volume_id_<impl>-<model>-vqb2_launch/, but a pinned-release
-    tt-inference-server derives ...-v<VERSION>/ from its own VERSION file, so
-    --host-volume reuse misses the preloaded data and re-downloads. impl_id and
-    model_name are stable across the version change, so swapping only the
-    -vqb2_launch suffix for -v<VERSION> is the complete remap for all models
-    (mapping mirrors inference-api/api.py:246-249). Symlink, not copy — Qwen3-32B
-    weights are tens of GB. Excise this function + its call in main() when the
-    preloaded data is re-staged under the release name.
-    """
-    QB2_SUFFIX = "-vqb2_launch"
-    cache_root = Path(
-        os.getenv("TT_PRELOADED_HOST_VOLUME_ROOT", "~/data/tt-cache")
-    ).expanduser()
-    version = get_inference_server_version()  # None on branch artifacts
-    if not cache_root.is_dir() or not version or version == "qb2_launch":
-        return
-    for src in sorted(cache_root.glob(f"volume_id_*{QB2_SUFFIX}")):
-        if not src.is_dir():
-            continue
-        target = cache_root / (src.name[: -len(QB2_SUFFIX)] + f"-v{version}")
-        if target.exists() or target.is_symlink():  # never clobber; idempotent
-            continue
-        try:
-            os.symlink(src.resolve(), target)  # resolve() avoids symlink-to-symlink
-            print(f"{C_GREEN}✅ QB2: linked {target.name} → {src.name}{C_RESET}")
-        except OSError as exc:
-            print(f"{C_YELLOW}⚠️  QB2: could not link {target.name}: {exc}{C_RESET}")
-# ─── end TEMP (QB2 workaround) ────────────────────────────────────────────────
 
 
 def validate_artifact_structure(artifact_dir):
@@ -4988,10 +4953,6 @@ def main():
                     startup_log.summary(exit_code=1)
                     startup_log.close()
                     sys.exit(1)
-
-                # ─── TEMP (QB2 workaround) — remove with stage_qb2_... helper ──
-                stage_qb2_preloaded_volume_symlinks()
-                # ─── end TEMP (QB2 workaround) ────────────────────────────────
 
                 # Sync model catalog from artifact
                 models_json_path = os.path.join(TT_STUDIO_ROOT, "app", "backend", "shared_config", "models_from_inference_server.json")


### PR DESCRIPTION
## What's going on

Some machines were imaged with model weights already baked on disk under a folder named for the old `qb2_launch` build. We've since pinned tt-studio to a numbered tt-inference-server release, which looks for those weights under a folder named for the *resolved model version* — so it doesn't find the preloaded copy and re-downloads tens of GB.

This creates a symlink from the version-named folder to the already-present preloaded one, so the existing weights get reused.

## Why this lives in inference-api/api.py (deploy time), not run.py

The folder version is **not** the repo `VERSION`. It's the **per-model, catalog-pinned `model_spec.version`** (e.g. Qwen3-32B → `0.14.0`, not `0.15.0`), and it varies by impl/device. A first attempt in `run.py` at startup guessed the global VERSION and produced the wrong name (`-v0.15.0`) while the deploy actually wanted `-v0.14.0`. Startup can't know the right token — it doesn't know the request's device/impl.

So the symlink is now created at **deploy time** in `api.py`, resolving the version with the *same* `get_runtime_model_spec(model, device, impl)` that `setup_host` uses. The names match by construction, for any model/impl/device. The run.py helper is reverted.

## Notes
- **Symlink, not copy** — no duplicated disk.
- **Safe / invisible when not needed:** does nothing if there's no preloaded folder, if the target already exists (never overwrites), or for models not on the host-volume allowlist (`host_volume_models.json`). Machines already upgraded past the ISO are unaffected.
- **Temporary:** `TEMP (QB2 workaround)` banner-marked helper + one call — delete to fully revert.

## Testing
Verified locally: links the version resolved from `model_spec.version` (`-v0.14.0`, not the repo VERSION), weights reachable through the link, idempotent, never clobbers a real dir, NOP without an override. End-to-end reuse to be confirmed on a QB2 machine.
