### PR TITLE
Fix Deployment History showing N/A / Still running for stopped models

### DIFF
--- a/app/backend/docker_control/deployment_sync.py
+++ b/app/backend/docker_control/deployment_sync.py
@@ -84,7 +84,11 @@ def _do_sync(job_id: str, progress_data: dict) -> None:
                 )
 
         elif job_status in ("error", "failed", "cancelled", "timeout", "not_found"):
+            from django.utils import timezone
+
             dep.status = "stopped"
+            if dep.stopped_at is None:
+                dep.stopped_at = timezone.now()
             dep.save()
             logger.info(
                 f"[deployment_sync] Marked ModelDeployment for {dep.model_name} as stopped "

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -991,6 +991,8 @@ def get_canonical_deployments():
         # Stale: reconcile to stopped so the slot frees up.
         try:
             dep.status = "stopped"
+            if dep.stopped_at is None:
+                dep.stopped_at = now_utc
             dep.save()
             logger.info(
                 f"Auto-marked stale deployment {dep.container_id} "


### PR DESCRIPTION
The Deployment History page kept showing "N/A" for Stopped At and "Still running" for Duration even after a model had stopped.

The cause was that two backend paths marked a deployment as stopped without recording stopped_at: the stale-deployment reconcile in get_canonical_deployments and the failed-job handler in deployment_sync. This sets stopped_at in both places so the page shows the real stop time and duration.

This was the issue here in the form of an image:

<img width="2746" height="1224" alt="image" src="https://github.com/user-attachments/assets/c535ca41-f2ea-4e2a-bd7b-4f2493a8ea09" />
