### PR TITLE
Remove Qwen3-8B from model catalog

### DIFF
--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.14.0",
     "generated_at": "2026-05-20T16:49:35.390566+00:00"
   },
-  "total_models": 57,
+  "total_models": 56,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -1030,38 +1030,6 @@
         "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 72
-    },
-    {
-      "model_name": "Qwen3-8B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "N150",
-        "N300",
-        "P300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-8B",
-      "inference_engine": "vLLM",
-      "supported_modalities": [
-        "text"
-      ],
-      "status": "FUNCTIONAL",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "shm_size": "32G",
-      "setup_type": "TT_INFERENCE_SERVER",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 8
     },
     {
       "model_name": "QwQ-32B",


### PR DESCRIPTION
Removes the Qwen3-8B entry from the model catalog so it no longer surfaces in the deploy UI. Updates `total_models` to 56.