### PR TITLE
Fix P300x2 model→chip deployment: default 8B to a 2-chip card + auto-allocate free chips

### DIFF
--- a/app/backend/docker_control/chip_allocator.py
+++ b/app/backend/docker_control/chip_allocator.py
@@ -258,6 +258,34 @@ class ChipSlotAllocator:
 
         return 0  # Multi-chip models always use device_id=0
 
+    def allocate_chip_pair(self) -> List[int]:
+        """
+        Auto-allocate a free, card-aligned 2-chip pair (one P300 card on P300x2).
+
+        Pairs are aligned to physical cards: [0, 1] or [2, 3]. Returns the first
+        pair whose both slots are free, so an 8B-class model lands on whichever
+        card is vacant without requiring the whole board.
+
+        Returns:
+            List of two contiguous slot IDs, e.g. [0, 1] or [2, 3]
+
+        Raises:
+            AllocationError: If no full 2-chip card is free
+        """
+        with self._lock:
+            occupied_slots = self._get_occupied_slots()
+
+            for base in range(0, self.total_slots, 2):
+                pair = [base, base + 1]
+                if all(slot < self.total_slots and slot not in occupied_slots for slot in pair):
+                    logger.info(f"Auto-allocated chip pair: device_ids={pair}")
+                    return pair
+
+            raise AllocationError(
+                "No free 2-chip card available. "
+                "Stop a model to free up a full card (two adjacent slots)."
+            )
+
     def _validate_manual_allocation(self, device_id: int, chips_required: int, model_name: str) -> Dict:
         """
         Validate manual chip slot selection in advanced mode.

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -89,9 +89,19 @@ except Exception:
 deployment_start_times = {}  # {job_id: timestamp} - Track when deployment started
 
 
-def _is_llama31_8b_model(model_name: str) -> bool:
-    token = (model_name or "").lower().replace("_", "").replace(" ", "")
-    return "llama-3.1-8b" in token or "llama3.18b" in token
+# 8B-class chat models (Llama-3.1-8B and similar) fit on a single P300 card
+# (2 chips). param_count is in billions; the band keeps it to ~8B-scale LLMs.
+PAIR_PARAM_MIN = 6
+PAIR_PARAM_MAX = 9
+
+
+def _is_pair_class_chat(impl) -> bool:
+    """True for ~8B chat LLMs that should default to a 2-chip card on P300x2."""
+    return (
+        impl.model_type == ModelTypes.CHAT
+        and impl.param_count is not None
+        and PAIR_PARAM_MIN <= impl.param_count <= PAIR_PARAM_MAX
+    )
 
 def _lookup_deployment_device_ids(container_id):
     """Return the list of device slot ids associated with a deployment, or []."""
@@ -332,10 +342,9 @@ class DeployView(APIView):
             chips_required = infer_chips_required(impl.device_configurations)
             board_type = detect_board_type() if impl.model_type == ModelTypes.CHAT else None
             should_force_full_board_llama = (
-                impl.model_type == ModelTypes.CHAT
-                and force_full_board_requested
+                force_full_board_requested
                 and board_type == "P300x2"
-                and _is_llama31_8b_model(impl.model_name)
+                and _is_pair_class_chat(impl)
             )
             if force_full_board_requested and not should_force_full_board_llama:
                 logger.info(
@@ -343,6 +352,17 @@ class DeployView(APIView):
                     impl.model_name,
                     board_type,
                 )
+            # Default for ~8B chat models on P300x2: auto-place on a free 2-chip
+            # card instead of the whole board. Full-board stays available via the
+            # explicit force_full_board (Advanced) path above. Explicit device_id
+            # selection (Advanced single/pair) takes precedence over auto-pairing.
+            should_use_llama_pair = (
+                board_type == "P300x2"
+                and _is_pair_class_chat(impl)
+                and not should_force_full_board_llama
+                and manual_device_id is None
+                and len(requested_device_ids) <= 1
+            )
 
             # Stop and clean up any existing starting/running deployments of this
             # model before deploying a new instance. Prevents stale records with
@@ -388,6 +408,10 @@ class DeployView(APIView):
                         )
                     device_id = 0
                     device_ids = list(range(min(4, allocator.total_slots)))
+                elif should_use_llama_pair:
+                    # Default ~8B chat path on P300x2: take one free 2-chip card.
+                    device_ids = allocator.allocate_chip_pair()
+                    device_id = device_ids[0]
                 else:
                     device_id = allocator.allocate_chip_slot(
                         impl.model_name,
@@ -433,6 +457,9 @@ class DeployView(APIView):
                 if should_force_full_board_llama:
                     # Forced full-board Llama takes over every slot on the board.
                     occupied_device_ids = list(range(allocator.total_slots))
+                elif should_use_llama_pair:
+                    # 8B-class card pair occupies exactly its two allocated slots.
+                    occupied_device_ids = device_ids
                 elif chips_required > 1:
                     # Multi-chip models occupy `chips_required` contiguous slots starting at the allocated base slot (device_id), clamped to the board size
                     occupied_device_ids = list(
@@ -481,12 +508,20 @@ class DeployView(APIView):
                         device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
                     else:
                         device = map_board_type_to_device_name(board_type)
-                    # QB2 Voice/paired-chip path: Llama-3.1-8B with --device-id 0,1
-                    # should run with --tt-device p300 (not p150).
+                    # QB2 paired-chip path: an ~8B chat model on a single P300
+                    # card ([0,1] or [2,3]) should run with --tt-device p300
+                    # (not p150). Covers both the auto-pair default and an
+                    # explicit Advanced pair selection.
+                    sorted_ids = sorted(device_ids)
+                    is_card_pair = (
+                        len(sorted_ids) == 2
+                        and sorted_ids[0] % 2 == 0
+                        and sorted_ids[1] == sorted_ids[0] + 1
+                    )
                     if (
                         board_type == "P300x2"
-                        and _is_llama31_8b_model(impl.model_name)
-                        and sorted(device_ids) == [0, 1]
+                        and _is_pair_class_chat(impl)
+                        and is_card_pair
                     ):
                         device = "p300"
                     # For P300x2 with the whole-board p300x2 device, the inference

--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -13,11 +13,7 @@ import { DeployModelStep } from "./DeployModelStep";
 import { FirstStepForm } from "./FirstStepForm";
 import { ChipConfigStep } from "./ChipConfigStep";
 import { VoiceAgentSolutionStep } from "./VoiceAgentSolutionStep";
-import {
-  isLlama31_8BModel,
-  isP300x2Board,
-  pickPreferredAvailablePair,
-} from "../utils/p300x2Placement";
+import { isP300x2Board } from "../utils/p300x2Placement";
 
 const dockerAPIURL = "/docker-api/";
 const deployUrl = `${dockerAPIURL}deploy/`;
@@ -238,37 +234,27 @@ export default function StepperDemo() {
     const weights_id = ""; // Always use default weights
 
     let resolvedDeviceId = options?.device_id;
-    const isP300x2Llama31_8B =
+    // Advanced "All chips" on P300x2 is an explicit full-board override, kept as a
+    // power-user option. The default (non-advanced) path sends neither device_id
+    // nor force_full_board, so the backend auto-allocates: a free 2-chip card for
+    // ~8B chat models, and a single free chip for everything else.
+    const useFullBoardOverride =
       isP300x2Board(chipStatus?.board_type) &&
-      isLlama31_8BModel(selectedModelName ?? selectedModel ?? "");
-    const shouldUseFullBoardLlamaFlow =
-      isP300x2Llama31_8B && !useHardwareConfigStep;
-    const shouldForceLlamaPair =
-      isP300x2Llama31_8B && !shouldUseFullBoardLlamaFlow;
-    if (shouldForceLlamaPair) {
-      const pair = pickPreferredAvailablePair(chipStatus?.slots);
-      if (!pair) {
-        customToast.error(
-          "Llama 3.1 8B on P300x2 needs both devices 0 and 1 free."
-        );
-        return { success: false };
-      }
-      resolvedDeviceId = pair.join(",");
-    }
-    if (shouldUseFullBoardLlamaFlow) {
-      // Simplified full-model flow runs Llama 3.1 8B as full-board p300x2.
+      useHardwareConfigStep &&
+      chipMode === "multi";
+    if (useFullBoardOverride) {
       resolvedDeviceId = undefined;
     }
 
     // Only include device_id when explicitly provided — omitting it lets the backend
-    // auto-allocate the best slot (required for QB2 simplified flow).
+    // auto-allocate the best slot(s) (required for the QB2 simplified flow).
     const payloadObj: Record<string, unknown> = {
       model_id,
       weights_id,
       host_port: options?.host_port ?? null,
       use_image_override: useImageOverride,
     };
-    if (shouldUseFullBoardLlamaFlow) {
+    if (useFullBoardOverride) {
       payloadObj.force_full_board = true;
     }
     if (resolvedDeviceId !== undefined) {
@@ -534,6 +520,10 @@ export default function StepperDemo() {
           <ArrowLeft className="w-3.5 h-3.5" />Back to deployment options
         </button>
         <Stepper
+          // Remount when the flow shape changes (e.g. toggling Advanced hardware
+          // config) so the stepper resets to Step 1 instead of stranding the user
+          // on a step index that no longer matches the new step list.
+          key={useHardwareConfigStep ? "hw-config" : "simplified"}
           variant="circle-alt"
           initialStep={0}
           steps={steps}


### PR DESCRIPTION
## Problem

On the **P300x2 / QB2 board** (4 chips = 2 × P300 cards, 2 chips per card), the deploy wizard behaved wrong:

1. **Llama-3.1-8B (and similar ~8B LLMs) grabbed the whole board.** The frontend sent `force_full_board=true` *by default* (Advanced OFF), so an 8B model claimed all 4 chips. The 2-chip pair path only ran when Advanced was ON — backwards from what we want.
2. **You couldn't compose deployments.** Because 8B took everything, you couldn't run e.g. Whisper (1 chip) + Llama-8B (2 chips) + another Whisper (1 chip) across the 4 chips.
3. **The Advanced toggle didn't return to Step 1.** Toggling "Advanced: Configure Hardware" ON while on Step 2 left the user on a stale step index, because toggling only swapped the `steps` array, not the Stepper's internal `activeStep`.

## Fix

The "8B-class → 2-chip card" decision now lives in the **backend** (it has `param_count`; the frontend `Model` interface does not). The frontend simply stops forcing full-board by default and lets the backend auto-allocate.

### Backend
- **`docker_control/chip_allocator.py`** — new `allocate_chip_pair()`: finds a free **card-aligned** 2-chip pair (`[0,1]` or `[2,3]`), skipping occupied slots; raises `AllocationError` (→ 409) if no full card is free.
- **`docker_control/views.py`** (`DeployView`):
  - New `_is_pair_class_chat(impl)` helper — ~8B chat models by `param_count` (band 6–9), replacing the old name-only `_is_llama31_8b_model`.
  - ~8B chat models on P300x2 now **default to a free 2-chip card** instead of the whole board.
  - **Full-board stays available** via the explicit `force_full_board` (Advanced) path.
  - Generalized the `p300` paired-device mapping to any card-aligned pair (covers `[2,3]`, not just `[0,1]`).

### Frontend
- **`components/SelectionSteps.tsx`**:
  - Default (non-Advanced) deploy path now sends **neither `device_id` nor `force_full_board`** → backend auto-allocates (2-chip card for 8B, single chip otherwise). `force_full_board` is sent only for the Advanced **"All chips"** selection. This also fixes the compose scenario: if card `[0,1]` is partly occupied, the backend places the pair on `[2,3]`.
  - Added a `key` to `<Stepper>` so it **remounts (→ Step 1)** whenever the flow shape changes — fixes the Advanced-toggle navigation bug.

## Files changed
- `app/backend/docker_control/chip_allocator.py`
- `app/backend/docker_control/views.py`
- `app/frontend/src/components/SelectionSteps.tsx`

## Note on TTS/STT
TT Studio's allocator already treats speech models (whisper/distil/speecht5) as `chips_required=1` and auto-picks a single free slot, so it does not block all 4 chips at the allocation level. If a speech container still physically consumes all chips on hardware, that's an inference-server device-mapping concern and is **out of scope** here — flagged for follow-up after on-hardware testing.

## Verification (on a P300x2 board)
1. **Advanced toggle:** advance to Step 2, toggle Advanced ON → jumps back to Step 1.
2. **8B default = 2 chips:** deploy Llama-3.1-8B (Advanced OFF) → `GET /docker-api/chip-status/` shows exactly 2 card-aligned slots occupied; deploy log shows `device="p300"`.
3. **Compose:** deploy Whisper (1 chip) → Llama-8B (auto-lands on the free card) → second Whisper (remaining chip); no false "chips occupied" 409.
4. **Full-board still works:** Advanced ON → "All chips" → Llama-8B full-board (`device="p300x2"`, all slots).
5. Frontend `tsc --noEmit` + eslint pass (0 errors).