### PR TITLE
Clarify Llama 3.1 8B Instruct in P300x2 and voice pipeline text

### DIFF
--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -249,14 +249,14 @@ export default function StepperDemo() {
       const pair = pickPreferredAvailablePair(chipStatus?.slots);
       if (!pair) {
         customToast.error(
-          "Llama 3.1 8B on P300x2 needs both devices 0 and 1 free."
+          "Llama 3.1 8B Instruct on P300x2 needs both devices 0 and 1 free."
         );
         return { success: false };
       }
       resolvedDeviceId = pair.join(",");
     }
     if (shouldUseFullBoardLlamaFlow) {
-      // Simplified full-model flow runs Llama 3.1 8B as full-board p300x2.
+      // Simplified full-model flow runs Llama 3.1 8B Instruct as full-board p300x2.
       resolvedDeviceId = undefined;
     }
 

--- a/app/frontend/src/components/VoiceAgentSolutionStep.tsx
+++ b/app/frontend/src/components/VoiceAgentSolutionStep.tsx
@@ -457,7 +457,7 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
           <h2 className="text-lg font-semibold mb-1">Voice Agent Solution</h2>
           <p className="text-sm text-muted-foreground">
             {useLlamaCardPair
-              ? "Deploys the full voice pipeline: Llama 8B on devices 0,1, Whisper on device 2, SpeechT5 on device 3."
+              ? "Deploys the full voice pipeline: Llama 8B Instruct on devices 0,1, Whisper on device 2, SpeechT5 on device 3."
               : "Deploys the full voice pipeline: LLM on device 0, Whisper on device 1, SpeechT5 on device 2."}
           </p>
         </div>


### PR DESCRIPTION
The base `Llama-3.1-8B` (completions) model was removed from the model catalog, leaving only `Llama-3.1-8B-Instruct`. This updates the remaining user-facing strings that referred to a bare "Llama 3.1 8B" / "Llama 8B" so they name the Instruct variant — the only 8B model these flows can actually deploy.

## Changes
- **SelectionSteps**: P300x2 device-pair toast and the full-board flow comment now reference the Instruct variant.
- **VoiceAgentSolutionStep**: voice pipeline description now says "Llama 8B Instruct".

## Note
The chip-selection example tags in `ChipConfigStep` that previously listed the base `Llama-3.1-8B` (visible in the "Advanced: Configure Hardware" / chip-selection flow) are no longer present after the chip/device terminology refactor (#905), which replaced model-name example tags with generic descriptions. So no change is needed there — that part of the original issue is already resolved on `dev`.

## Verification
- `tsc --noEmit` passes clean.