### PR TITLE
Fix reset view connection failure: heartbeat the reset SSE stream

### DIFF
--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2439,6 +2439,7 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
     label = ", ".join(id_args) if id_args else "board"
     command = " ".join(["tt-smi", "-r", *id_args])
     line_timeout = max(90, 30 * len(device_ids))  # allow longer gaps on bigger boards
+    heartbeat = 15  # emit a keepalive at least this often while tt-smi is quiet
 
     await asyncio.to_thread(SystemResourceService.set_resetting_state)
 
@@ -2454,8 +2455,22 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
                 stdin=asyncio.subprocess.DEVNULL,
             )
             try:
+                waited = 0.0
                 while True:
-                    raw = await asyncio.wait_for(proc.stdout.readline(), timeout=line_timeout)
+                    try:
+                        raw = await asyncio.wait_for(proc.stdout.readline(), timeout=heartbeat)
+                    except asyncio.TimeoutError:
+                        # tt-smi -r is silent for long stretches while it re-inits
+                        # the boards. Emit a heartbeat so the SSE connection is never
+                        # idle long enough for a proxy/browser to drop it (which the
+                        # frontend surfaces as "Connection to stream lost."). Escalate
+                        # to a real stall only after the full line_timeout of silence.
+                        waited += heartbeat
+                        if waited >= line_timeout:
+                            raise
+                        yield ("heartbeat", None)
+                        continue
+                    waited = 0.0
                     if not raw:
                         break
                     line = ansi_re.sub("", raw.decode("utf-8", errors="replace")).strip()
@@ -2498,6 +2513,8 @@ async def _astream_reset_phase(device_ids, *, force_refresh, success_msg, partia
     async for kind, payload in _astream_tt_smi_reset(device_ids, force_refresh=force_refresh):
         if kind == "log":
             yield _sse_event({"type": "log", "step": "resetting", "message": payload})
+        elif kind == "heartbeat":
+            yield ":keepalive\n\n"  # SSE comment: ignored by EventSource, keeps the socket live
         else:
             reset_ok = payload
     yield _sse_event({


### PR DESCRIPTION
## Problem

Issue #902 ("reset view connection failure"). A board reset reported as a
connection failure in the UI, even though the reset **succeeded on the hardware**
(the diagnostics bundle shows `Device state set to RESETTING` → `Device state cache
cleared`, ~42s, then a healthy board).

## Root cause

The board/device reset streams `tt-smi -r` output to the browser over Server-Sent
Events (`ResetStreamView` → `_astream_tt_smi_reset` → `_astream_reset_phase` in
`app/backend/docker_control/views.py`). The stream only sends bytes when `tt-smi`
prints a line. During the reset, `tt-smi` is silent for long stretches (~40s) while
it re-initializes the boards, so the SSE connection sits idle.

The frontend consumes the stream with a raw `EventSource` (`consumeSSE`,
`app/frontend/src/api/modelsDeployedApis.ts`) that rejects on the **first**
`onerror` with `"Connection to stream lost."`. If any intermediary or the browser
drops the idle connection during the silent window, the user sees a connection
failure even though the reset itself completed.

## Fix

Emit an SSE keepalive comment (`:keepalive\n\n`) at least every 15s while `tt-smi`
is quiet, so the connection is never idle long enough to be dropped. SSE comment
lines are ignored by `EventSource`, so the frontend protocol is unchanged.

The stall-detection behavior is preserved: only after the full `line_timeout` of
**continuous** silence does it escalate to terminating the process. The change
applies to both the whole-board reset and the per-device reset performed after a
model stop (both go through `_astream_reset_phase`).

Minimal, backend-only — one file, two functions:
- `_astream_tt_smi_reset`: wait for output in short (15s) intervals, emit a
  `heartbeat` on each quiet interval, accumulate toward the existing `line_timeout`
  stall threshold.
- `_astream_reset_phase`: translate `heartbeat` into an SSE comment line.

## Verification

- Verified on Tenstorrent hardware: a real board reset driven by a real (Chromium)
  browser EventSource streams `tt-smi -r` output and resolves successfully.
- Confirmed the full SSE path (Django `StreamingHttpResponse` → uvicorn → nginx/Vite
  proxy → browser EventSource) tolerates long silent windows.
- Unit-validated the new loop with a fake `tt-smi`: keepalives interleave during
  silent stretches, real output still streams, the stream completes, and the stall
  timeout path is preserved.

This is a defensive hardening: it keeps the reset SSE connection continuously active
so an idle drop cannot turn a successful reset into a "Connection to stream lost."
in the reset view.