### PR TITLE
Hide board reset button while a model is deployed

### DIFF
--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -258,7 +258,7 @@ export default function NavBar() {
   const navigate = useNavigate();
   const { theme, setTheme } = useTheme();
   const { triggerRefresh, refreshTrigger } = useRefresh();
-  const { models, refreshModels } = useModels();
+  const { models, refreshModels, hasDeployedModels } = useModels();
   const mobileMenuRef = useRef<HTMLDivElement>(null);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
@@ -620,7 +620,11 @@ export default function NavBar() {
     //   tooltipText: "Toggle Dark/Light Mode",
     //   onClick: null, // ModeToggle handles its own click
     // },
-    ...(isDeployedEnabled
+    // Hide the board reset button while any model is deployed. Resetting
+    // interrupts running deployments, and the reset path is unreliable on
+    // some machines while a model is active, so only expose it when the
+    // board is idle (no deployed models).
+    ...(isDeployedEnabled || hasDeployedModels
       ? []
       : [
           {

--- a/app/frontend/src/providers/ModelsContext.tsx
+++ b/app/frontend/src/providers/ModelsContext.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   fetchDeployments,
   fetchModels,
@@ -91,6 +91,17 @@ export const ModelsProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     }
   }, [setUserStoppedModel]);
+
+  // Keep deployed-model state fresh app-wide. UI that reacts to it (e.g. the
+  // navbar hides the board reset button while a model is deployed) should
+  // update on its own after a deploy or stop, without a manual refresh or a
+  // container restart, so poll the canonical deployments endpoint on a light
+  // interval in addition to the on-demand refreshes triggered elsewhere.
+  useEffect(() => {
+    refreshModels();
+    const intervalId = setInterval(refreshModels, 5000);
+    return () => clearInterval(intervalId);
+  }, [refreshModels]);
 
   return (
     <ModelsContext.Provider


### PR DESCRIPTION
On some machines the board reset is unreliable while a model is running, and resetting interrupts active deployments anyway. To avoid that footgun, the reset button is now hidden in the navbar whenever any model is deployed. Once everything is stopped and the board is idle, the button reappears and works as before.

Tested locally with no models deployed (button shows) and with a model deployed (button hidden).