### PR TITLE
Consolidate host-side logs into a single logs/ directory

### DIFF
--- a/.claude/skills/tt-studio-debug-bundle/SKILL.md
+++ b/.claude/skills/tt-studio-debug-bundle/SKILL.md
@@ -30,9 +30,9 @@ tt-studio-logs-ttbr-<hex>/
 ├── current_models.json             # Live docker containers + deploy_cache snapshot
 ├── deployments.json                # Persisted deploy records (id, device, device_ids, status)
 ├── docker-control-service.log      # docker daemon control
-├── fastapi.log                     # FastAPI inference-control server
-├── fastapi_logs/                   # Per-deploy FastAPI logs:
-│   └── fastapi_<ts>_<model>_<device>_server.log
+├── model_run.log                   # FastAPI inference-control server
+├── model_run_logs/                 # Per-deploy model run logs:
+│   └── model_run_<ts>_<model>_<device>_server.log
 ├── inference_artifacts/
 │   ├── docker_server/              # Container stdout per deploy. Two flavors:
 │   │   ├── vllm_<ts>_<model>_<device>_server.log    # LLMs (Llama, Qwen, …)
@@ -61,7 +61,7 @@ Triage Progress:
 ### 1. Inventory
 
 ```bash
-ls -la <bundle>/ <bundle>/fastapi_logs <bundle>/inference_artifacts/docker_server <bundle>/inference_artifacts/run_logs
+ls -la <bundle>/ <bundle>/model_run_logs <bundle>/inference_artifacts/docker_server <bundle>/inference_artifacts/run_logs
 ```
 
 Note: which models have logs, which deploys are most recent, whether `current_models.json` shows live containers or an empty `deploy_cache_entries`.
@@ -90,7 +90,7 @@ Read those lines. They reveal:
 
 ### 4. Failing-deploy logs
 
-For each FAILED deploy in `deployments.json`, read the matching `fastapi_logs/fastapi_<ts>_<model>_<device>_server.log` to capture the **exact `run.py` command line** (model, workflow, device, device-id flags). This is the request the backend produced.
+For each FAILED deploy in `deployments.json`, read the matching `model_run_logs/model_run_<ts>_<model>_<device>_server.log` to capture the **exact `run.py` command line** (model, workflow, device, device-id flags). This is the request the backend produced.
 
 If a container log exists under `inference_artifacts/docker_server/`, grep it for `Traceback`, `Error`, `OOM`, `Failed`, `tt::` and read context around the first hit. **Pick the right file** by `model_type` from `current_models.json:deploy_cache_entries[].model_impl.model_type`:
 
@@ -149,7 +149,7 @@ Don't propose patches unless the user asks. Stop after the report.
 | `compatible=False, boards=[...]` for the requested model | Model's `device_configurations` doesn't include the detected board | `models_from_inference_server.json` |
 | `Raw board_type: '<x>'` with unexpected enum chosen | Detection logic miscounts cards vs ASICs | `board_control/services.py` `get_board_type()` |
 | Frontend sends device_ids the backend can't honor | Per-board branching missing in the solution UI | `app/frontend/src/components/...SolutionStep.tsx`, `utils/*Placement.ts` |
-| `Job <id>` exits without inference log | run.py crashed before docker compose; check fastapi_logs `<ts>_<model>_<device>_server.log` for the run.py command and any traceback before it would have emitted | `inference-api/api.py` |
+| `Job <id>` exits without inference log | run.py crashed before docker compose; check model_run_logs `<ts>_<model>_<device>_server.log` for the run.py command and any traceback before it would have emitted | `inference-api/api.py` |
 | `ValueError: Unrecognized model in /home/container_app_user/cache_root/model_file_symlinks_map/<model>. Should have a 'model_type' key in its config.json` + `RuntimeError: Engine core initialization failed` | **Persistent docker volume for that model is corrupt / setup never finished** — the HF symlink view is missing `config.json` (or it lacks `model_type`). Tell-tale signs in `deployments.json`: multiple prior deploys of the same model with `status: stopped, stopped_by_user: false, workflow_log_path: null` — the volume has been broken across sessions. Not a code bug — go to the remediation playbook below. | (none — ops fix) |
 | Crash inside `model_config.py:_set_hf_params` / `AutoConfig.from_pretrained` / missing tokenizer file | Same as above — incomplete model setup in the volume | (none — ops fix) |
 

--- a/app/backend/docker_control/docker_control_client.py
+++ b/app/backend/docker_control/docker_control_client.py
@@ -372,8 +372,8 @@ class DockerControlClient:
         response = self._request("GET", "/api/v1/logs/startup", params={"tail": tail})
         return response.json()
 
-    def get_fastapi_log(self, tail: int = 500) -> Dict:
-        """Fetch fastapi.log content from the host"""
+    def get_model_run_log(self, tail: int = 500) -> Dict:
+        """Fetch model_run.log content from the host"""
         response = self._request("GET", "/api/v1/logs/fastapi", params={"tail": tail})
         return response.json()
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1704,7 +1704,9 @@ class DockerServiceLogsView(APIView):
             try:
                 # Check if fastapi.log exists in multiple possible locations using relative paths
                 possible_fastapi_logs = [
-                    "fastapi.log",  # Current directory
+                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "fastapi.log"),  # Consolidated logs/ dir (current location)
+                    "logs/fastapi.log",  # Relative to current directory
+                    "fastapi.log",  # Current directory (legacy)
                     os.path.join(os.getcwd(), "fastapi.log"),  # Current working directory
                     os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "fastapi.log"),  # Go up from backend/docker_control/views.py
                     os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "fastapi.log"),  # Relative to backend directory

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1068,19 +1068,19 @@ class DeploymentProgressView(APIView):
                         status=status.HTTP_200_OK
                     )
 
-                # Based on FastAPI logs - realistic timing for each stage
+                # Based on model run logs - realistic timing for each stage
                 if elapsed_time < 3:
                     progress = 5
                     stage = "initialization"
-                    message = "Loading environment files..."  # fastapi.log (13-14)
+                    message = "Loading environment files..."  # model_run.log (13-14)
                 elif elapsed_time < 8:
                     progress = 15
                     stage = "setup"
-                    message = "Running workflow configuration..."  # fastapi.log (19-27)
+                    message = "Running workflow configuration..."  # model_run.log (19-27)
                 elif elapsed_time < 15:
                     progress = 25
                     stage = "model_preparation"
-                    message = "Checking model setup and weights..."  # fastapi.log (83-91)
+                    message = "Checking model setup and weights..."  # model_run.log (83-91)
                 elif elapsed_time < 25:
                     progress = 40
                     stage = "model_preparation"
@@ -1088,7 +1088,7 @@ class DeploymentProgressView(APIView):
                 elif elapsed_time < 35:
                     progress = 55
                     stage = "container_setup"
-                    message = "Preparing Docker configuration..."  # fastapi.log (100-113)
+                    message = "Preparing Docker configuration..."  # model_run.log (100-113)
                 elif elapsed_time < 45:
                     progress = 70
                     stage = "container_setup"
@@ -1702,41 +1702,42 @@ class DockerServiceLogsView(APIView):
             
             # Also try to get system logs if available
             try:
-                # Check if fastapi.log exists in multiple possible locations using relative paths
-                possible_fastapi_logs = [
-                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "fastapi.log"),  # Consolidated logs/ dir (current location)
-                    "logs/fastapi.log",  # Relative to current directory
-                    "fastapi.log",  # Current directory (legacy)
-                    os.path.join(os.getcwd(), "fastapi.log"),  # Current working directory
-                    os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "fastapi.log"),  # Go up from backend/docker_control/views.py
-                    os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "fastapi.log"),  # Relative to backend directory
-                    os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "..", "fastapi.log"),  # Two levels up from backend
-                    "/app/fastapi.log",  # Container path as fallback
+                # Check if model_run.log exists in multiple possible locations using relative paths
+                possible_model_run_logs = [
+                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "model_run.log"),  # Consolidated logs/ dir (current location)
+                    "logs/model_run.log",  # Relative to current directory
+                    os.path.join(os.getcwd(), "model_run.log"),  # Current working directory
+                    "/app/model_run.log",  # Container path as fallback
+                    # Legacy fastapi.log locations (pre-rename) kept for backward compatibility
+                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "fastapi.log"),
+                    "logs/fastapi.log",
+                    "fastapi.log",
+                    "/app/fastapi.log",
                 ]
-                
-                fastapi_log_found = False
-                for fastapi_log_path in possible_fastapi_logs:
-                    if os.path.exists(fastapi_log_path):
+
+                model_run_log_found = False
+                for model_run_log_path in possible_model_run_logs:
+                    if os.path.exists(model_run_log_path):
                         try:
-                            with open(fastapi_log_path, 'r') as f:
+                            with open(model_run_log_path, 'r') as f:
                                 lines = f.readlines()
                                 # Get last 8 lines and limit size
                                 log_content = ''.join(lines[-8:])
                                 if len(log_content) > 800:
                                     log_content = log_content[-800:] + "\n\n... (truncated)"
-                                logs_data["fastapi"] = log_content
-                            fastapi_log_found = True
+                                logs_data["model_run"] = log_content
+                            model_run_log_found = True
                             break
                         except Exception as read_error:
-                            logger.error(f"Error reading {fastapi_log_path}: {str(read_error)}")
+                            logger.error(f"Error reading {model_run_log_path}: {str(read_error)}")
                             continue
-                
-                if not fastapi_log_found:
-                    logs_data["fastapi"] = "fastapi.log not accessible from container (logs available from Docker containers above)"
-                    
+
+                if not model_run_log_found:
+                    logs_data["model_run"] = "model_run.log not accessible from container (logs available from Docker containers above)"
+
             except Exception as e:
-                logger.error(f"Error reading fastapi.log: {str(e)}")
-                logs_data["fastapi"] = f"Error reading fastapi.log: {str(e)[:500]}"
+                logger.error(f"Error reading model_run.log: {str(e)}")
+                logs_data["model_run"] = f"Error reading model_run.log: {str(e)[:500]}"
             
             # Try to get backend log file if available
             try:

--- a/app/backend/logs_control/views.py
+++ b/app/backend/logs_control/views.py
@@ -34,7 +34,7 @@ BUG_REPORT_MANIFEST = [
     # ─────────────────────── ──────────────────────────────── ───────────────────────────────────────────
     ("backend_log",           "backend.log",                   "persistent volume: backend_volume/python_logs/"),
     ("fastapi_log",           "fastapi.log",                   "docker-control-service HTTP /api/v1/logs/fastapi"),
-    ("fastapi_deployment_logs","fastapi_logs/<name>.log (×5)", "volume mount: TT_STUDIO_ROOT/fastapi_logs/ (ro)"),
+    ("fastapi_deployment_logs","fastapi_logs/<name>.log (×5)", "volume mount: TT_STUDIO_ROOT/logs/fastapi_logs/ (ro)"),
     ("docker_control_log",    "docker-control-service.log",    "docker-control-service HTTP /api/v1/logs/service"),
     ("startup_log",           "startup.log",                   "docker-control-service HTTP /api/v1/logs/startup"),
     ("agent_log",             "agent.log",                     "docker-control-service HTTP /api/v1/containers/<id>/logs"),
@@ -125,7 +125,9 @@ class FastAPILogsView(APIView):
         
         # Check if fastapi.log exists in multiple possible locations using relative paths
         possible_fastapi_logs = [
-            "fastapi.log",  # Current directory
+            os.path.join(TT_STUDIO_ROOT, "logs", "fastapi.log"),  # Consolidated logs/ dir (current location)
+            "logs/fastapi.log",  # Relative to current directory
+            "fastapi.log",  # Current directory (legacy)
             os.path.join(os.getcwd(), "fastapi.log"),  # Current working directory
             os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "fastapi.log"),  # Go up from backend/logs_control/views.py
             os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "fastapi.log"),  # Relative to backend directory
@@ -434,8 +436,8 @@ def _collect_bug_report_data() -> dict:
     except Exception as _e0:
         data["fastapi_log"] = {"file": None, "content": f"fastapi.log not accessible: {_e0}"}
 
-    # 3. Per-deployment FastAPI logs (fastapi_logs/ directory, newest 5)
-    fastapi_logs_dir = os.path.join(TT_STUDIO_ROOT, "fastapi_logs")
+    # 3. Per-deployment FastAPI logs (logs/fastapi_logs/ directory, newest 5)
+    fastapi_logs_dir = os.path.join(TT_STUDIO_ROOT, "logs", "fastapi_logs")
     if os.path.isdir(fastapi_logs_dir):
         dep_logs = sorted(
             [

--- a/app/backend/logs_control/views.py
+++ b/app/backend/logs_control/views.py
@@ -33,8 +33,8 @@ BUG_REPORT_MANIFEST = [
     # key in data dict         zip path                         how it's fetched
     # ─────────────────────── ──────────────────────────────── ───────────────────────────────────────────
     ("backend_log",           "backend.log",                   "persistent volume: backend_volume/python_logs/"),
-    ("fastapi_log",           "fastapi.log",                   "docker-control-service HTTP /api/v1/logs/fastapi"),
-    ("fastapi_deployment_logs","fastapi_logs/<name>.log (×5)", "volume mount: TT_STUDIO_ROOT/logs/fastapi_logs/ (ro)"),
+    ("model_run_log",         "model_run.log",                 "docker-control-service HTTP /api/v1/logs/fastapi"),
+    ("model_run_deployment_logs","model_run_logs/<name>.log (×5)", "volume mount: TT_STUDIO_ROOT/logs/model_run_logs/ (ro)"),
     ("docker_control_log",    "docker-control-service.log",    "docker-control-service HTTP /api/v1/logs/service"),
     ("startup_log",           "startup.log",                   "docker-control-service HTTP /api/v1/logs/startup"),
     ("agent_log",             "agent.log",                     "docker-control-service HTTP /api/v1/containers/<id>/logs"),
@@ -123,46 +123,46 @@ class FastAPILogsView(APIView):
     def get(self, request, *args, **kwargs):
         logger.info("FastAPILogsView endpoint hit")
         
-        # Check if fastapi.log exists in multiple possible locations using relative paths
-        possible_fastapi_logs = [
-            os.path.join(TT_STUDIO_ROOT, "logs", "fastapi.log"),  # Consolidated logs/ dir (current location)
-            "logs/fastapi.log",  # Relative to current directory
-            "fastapi.log",  # Current directory (legacy)
-            os.path.join(os.getcwd(), "fastapi.log"),  # Current working directory
-            os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "fastapi.log"),  # Go up from backend/logs_control/views.py
-            os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "fastapi.log"),  # Relative to backend directory
-            os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "..", "fastapi.log"),  # Two levels up from backend
-            os.path.join(LOGS_ROOT, "fastapi.log"),  # Try in logs directory
-            "/app/fastapi.log",  # Container path as fallback
+        # Check if model_run.log exists in multiple possible locations using relative paths
+        possible_model_run_logs = [
+            os.path.join(TT_STUDIO_ROOT, "logs", "model_run.log"),  # Consolidated logs/ dir (current location)
+            "logs/model_run.log",  # Relative to current directory
+            os.path.join(LOGS_ROOT, "model_run.log"),  # Try in logs directory
+            "/app/model_run.log",  # Container path as fallback
+            # Legacy fastapi.log locations (pre-rename) kept for backward compatibility
+            os.path.join(TT_STUDIO_ROOT, "logs", "fastapi.log"),
+            "logs/fastapi.log",
+            "fastapi.log",
+            os.path.join(LOGS_ROOT, "fastapi.log"),
         ]
-        
-        fastapi_log_found = False
+
+        model_run_log_found = False
         log_content = ""
-        
-        for fastapi_log_path in possible_fastapi_logs:
-            if os.path.exists(fastapi_log_path):
+
+        for model_run_log_path in possible_model_run_logs:
+            if os.path.exists(model_run_log_path):
                 try:
-                    with open(fastapi_log_path, 'r') as f:
+                    with open(model_run_log_path, 'r') as f:
                         lines = f.readlines()
                         # Get last 20 lines and limit size
                         log_content = ''.join(lines[-20:])
                         if len(log_content) > 2000:
                             log_content = log_content[-2000:] + "\n\n... (truncated)"
-                    fastapi_log_found = True
-                    logger.info(f"Successfully read FastAPI logs from: {fastapi_log_path}")
+                    model_run_log_found = True
+                    logger.info(f"Successfully read model run logs from: {model_run_log_path}")
                     break
                 except Exception as read_error:
-                    logger.error(f"Error reading {fastapi_log_path}: {str(read_error)}")
+                    logger.error(f"Error reading {model_run_log_path}: {str(read_error)}")
                     continue
-        
-        if not fastapi_log_found:
-            log_content = "fastapi.log not accessible from container (logs available from Docker containers above)"
-            logger.warning("FastAPI log file not found in any expected location")
-        
+
+        if not model_run_log_found:
+            log_content = "model_run.log not accessible from container (logs available from Docker containers above)"
+            logger.warning("Model run log file not found in any expected location")
+
         return JsonResponse({
             "fastapi_logs": log_content,
-            "found": fastapi_log_found,
-            "timestamp": os.path.getmtime(fastapi_log_path) if fastapi_log_found else None
+            "found": model_run_log_found,
+            "timestamp": os.path.getmtime(model_run_log_path) if model_run_log_found else None
         }, status=200)
 
 
@@ -428,31 +428,31 @@ def _collect_bug_report_data() -> dict:
     else:
         data["backend_log"] = {"file": None, "content": f"python_logs directory not found: {python_logs_dir}"}
 
-    # 2. FastAPI inference main log — fetched from docker-control-service running on host
+    # 2. Model run main log — fetched from docker-control-service running on host
     try:
         from docker_control.docker_control_client import DockerControlClient as _DCSClient0
-        _fastapi_result = _DCSClient0().get_fastapi_log(tail=500)
-        data["fastapi_log"] = {"file": _fastapi_result.get("file"), "content": _fastapi_result.get("content", "")}
+        _model_run_result = _DCSClient0().get_model_run_log(tail=500)
+        data["model_run_log"] = {"file": _model_run_result.get("file"), "content": _model_run_result.get("content", "")}
     except Exception as _e0:
-        data["fastapi_log"] = {"file": None, "content": f"fastapi.log not accessible: {_e0}"}
+        data["model_run_log"] = {"file": None, "content": f"model_run.log not accessible: {_e0}"}
 
-    # 3. Per-deployment FastAPI logs (logs/fastapi_logs/ directory, newest 5)
-    fastapi_logs_dir = os.path.join(TT_STUDIO_ROOT, "logs", "fastapi_logs")
-    if os.path.isdir(fastapi_logs_dir):
+    # 3. Per-deployment model run logs (logs/model_run_logs/ directory, newest 5)
+    model_run_logs_dir = os.path.join(TT_STUDIO_ROOT, "logs", "model_run_logs")
+    if os.path.isdir(model_run_logs_dir):
         dep_logs = sorted(
             [
-                os.path.join(fastapi_logs_dir, f)
-                for f in os.listdir(fastapi_logs_dir)
+                os.path.join(model_run_logs_dir, f)
+                for f in os.listdir(model_run_logs_dir)
                 if f.endswith(".log")
             ],
             key=os.path.getmtime,
             reverse=True,
         )[:5]
-        data["fastapi_deployment_logs"] = [
+        data["model_run_deployment_logs"] = [
             {"file": f, "content": _read_log_tail(f, 300)} for f in dep_logs
         ]
     else:
-        data["fastapi_deployment_logs"] = []
+        data["model_run_deployment_logs"] = []
 
     # 4 & 5. Docker control service log + startup log — fetched from docker-control-service on host
     try:
@@ -573,14 +573,14 @@ class BugReportDownloadView(APIView):
 
             with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
                 zf.writestr("backend.log", data["backend_log"]["content"])
-                zf.writestr("fastapi.log", data["fastapi_log"]["content"])
+                zf.writestr("model_run.log", data["model_run_log"]["content"])
                 zf.writestr("docker-control-service.log", data["docker_control_log"]["content"])
                 zf.writestr("startup.log", data["startup_log"]["content"])
                 zf.writestr("agent.log", data["agent_log"]["content"])
 
-                for entry in data["fastapi_deployment_logs"]:
+                for entry in data["model_run_deployment_logs"]:
                     fname = os.path.basename(entry["file"])
-                    zf.writestr(f"fastapi_logs/{fname}", entry["content"])
+                    zf.writestr(f"model_run_logs/{fname}", entry["content"])
 
                 for entry in data["inference_run_logs"]:
                     fname = os.path.basename(entry["file"])

--- a/app/backend/logs_control/views.py
+++ b/app/backend/logs_control/views.py
@@ -436,9 +436,22 @@ def _collect_bug_report_data() -> dict:
     except Exception as _e0:
         data["model_run_log"] = {"file": None, "content": f"model_run.log not accessible: {_e0}"}
 
-    # 3. Per-deployment model run logs (logs/model_run_logs/ directory, newest 5)
-    model_run_logs_dir = os.path.join(TT_STUDIO_ROOT, "logs", "model_run_logs")
-    if os.path.isdir(model_run_logs_dir):
+    # 3. Per-deployment model run logs (logs/model_run_logs/ directory, newest 5).
+    # Fall back to the legacy fastapi_logs/ locations so bundles captured before
+    # the consolidation + rename still surface their per-deployment logs.
+    model_run_logs_dir = next(
+        (
+            d
+            for d in (
+                os.path.join(TT_STUDIO_ROOT, "logs", "model_run_logs"),
+                os.path.join(TT_STUDIO_ROOT, "logs", "fastapi_logs"),
+                os.path.join(TT_STUDIO_ROOT, "fastapi_logs"),
+            )
+            if os.path.isdir(d)
+        ),
+        None,
+    )
+    if model_run_logs_dir:
         dep_logs = sorted(
             [
                 os.path.join(model_run_logs_dir, f)

--- a/app/docker-compose.dev-mode.yml
+++ b/app/docker-compose.dev-mode.yml
@@ -10,8 +10,8 @@ services:
     volumes:
       # Mount the local api directory for live code changes
       - ./backend:/backend
-      # Mount logs/fastapi_logs/ directory so the backend can read per-deployment logs
-      - ${TT_STUDIO_ROOT}/logs/fastapi_logs:${TT_STUDIO_ROOT}/logs/fastapi_logs:ro
+      # Mount logs/model_run_logs/ directory so the backend can read per-deployment logs
+      - ${TT_STUDIO_ROOT}/logs/model_run_logs:${TT_STUDIO_ROOT}/logs/model_run_logs:ro
     command: >
       uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --reload
     environment:

--- a/app/docker-compose.dev-mode.yml
+++ b/app/docker-compose.dev-mode.yml
@@ -10,8 +10,8 @@ services:
     volumes:
       # Mount the local api directory for live code changes
       - ./backend:/backend
-      # Mount fastapi_logs/ directory so the backend can read per-deployment logs
-      - ${TT_STUDIO_ROOT}/fastapi_logs:${TT_STUDIO_ROOT}/fastapi_logs:ro
+      # Mount logs/fastapi_logs/ directory so the backend can read per-deployment logs
+      - ${TT_STUDIO_ROOT}/logs/fastapi_logs:${TT_STUDIO_ROOT}/logs/fastapi_logs:ro
     command: >
       uvicorn api.asgi:application --host 0.0.0.0 --port 8000 --reload
     environment:

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -67,8 +67,8 @@ services:
       - ./backend:/backend
       # Mount tt-inference-server workflow logs for viewing deployment logs
       - ${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:ro
-      # Mount fastapi_logs/ directory so the backend can read per-deployment logs
-      - ${TT_STUDIO_ROOT}/fastapi_logs:${TT_STUDIO_ROOT}/fastapi_logs:ro
+      # Mount logs/fastapi_logs/ directory so the backend can read per-deployment logs
+      - ${TT_STUDIO_ROOT}/logs/fastapi_logs:${TT_STUDIO_ROOT}/logs/fastapi_logs:ro
       # Persist the Hugging Face cache so the embedding model (all-MiniLM-L6-v2)
       # is downloaded once and survives container recreation on subsequent run.py.
       - hf_cache:/root/.cache/huggingface

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -67,8 +67,8 @@ services:
       - ./backend:/backend
       # Mount tt-inference-server workflow logs for viewing deployment logs
       - ${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:ro
-      # Mount logs/fastapi_logs/ directory so the backend can read per-deployment logs
-      - ${TT_STUDIO_ROOT}/logs/fastapi_logs:${TT_STUDIO_ROOT}/logs/fastapi_logs:ro
+      # Mount logs/model_run_logs/ directory so the backend can read per-deployment logs
+      - ${TT_STUDIO_ROOT}/logs/model_run_logs:${TT_STUDIO_ROOT}/logs/model_run_logs:ro
       # Persist the Hugging Face cache so the embedding model (all-MiniLM-L6-v2)
       # is downloaded once and survives container recreation on subsequent run.py.
       - hf_cache:/root/.cache/huggingface

--- a/app/frontend/src/components/bug-report/types.ts
+++ b/app/frontend/src/components/bug-report/types.ts
@@ -10,8 +10,8 @@ export interface LogEntry {
 
 export interface BugReportData {
   backend_log: LogEntry;
-  fastapi_log: LogEntry;
-  fastapi_deployment_logs: LogEntry[];
+  model_run_log: LogEntry;
+  model_run_deployment_logs: LogEntry[];
   docker_control_log: LogEntry;
   startup_log: LogEntry;
   agent_log: { content: string };

--- a/app/frontend/src/components/bug-report/useBugReport.ts
+++ b/app/frontend/src/components/bug-report/useBugReport.ts
@@ -19,10 +19,10 @@ const INITIAL_FORM: BugReportForm = {
 
 const INITIAL_SOURCES: LogSourceState[] = [
   { label: "Backend (Django) logs", key: "backend_log", status: "pending" },
-  { label: "FastAPI inference logs", key: "fastapi_log", status: "pending" },
+  { label: "Model run logs", key: "model_run_log", status: "pending" },
   {
-    label: "Per-deployment FastAPI logs",
-    key: "fastapi_deployment_logs",
+    label: "Per-deployment model run logs",
+    key: "model_run_deployment_logs",
     status: "pending",
   },
   {
@@ -152,13 +152,13 @@ ${JSON.stringify(data.current_models, null, 2)}
 ${data.backend_log.content}
 \`\`\`
 
-### FastAPI Log
+### Model Run Log
 \`\`\`
-${data.fastapi_log.content}
+${data.model_run_log.content}
 \`\`\`
 
-### Per-Deployment FastAPI Logs
-${renderEntries(data.fastapi_deployment_logs)}
+### Per-Deployment Model Run Logs
+${renderEntries(data.model_run_deployment_logs)}
 
 ### Docker Control Service Log
 \`\`\`

--- a/dev-docs/troubleshooting.md
+++ b/dev-docs/troubleshooting.md
@@ -73,7 +73,7 @@ Then restart TT-Studio.
 
 ### FastAPI Server Fails to Start
 
-Check the logs in `fastapi.log` for specific errors. Common causes include:
+Check the logs in `logs/model_run.log` for specific errors. Common causes include:
 
 - Insufficient permissions
 - Missing environment variables

--- a/docker-control-service/README.md
+++ b/docker-control-service/README.md
@@ -146,7 +146,7 @@ response = requests.get(
 
 ## Logging
 
-Logs are written to `fastapi.log` in the project root when managed by `run.py`.
+Logs are written to `logs/model_run.log` in the project root when managed by `run.py`.
 
 Log format:
 ```

--- a/docker-control-service/config.py
+++ b/docker-control-service/config.py
@@ -48,7 +48,7 @@ class Settings:
     # Host log file paths (passed in as env vars from run.py)
     SERVICE_LOG_FILE: str = os.getenv("DOCKER_CONTROL_LOG_FILE", "")
     STARTUP_LOG_FILE: str = os.getenv("STARTUP_LOG_FILE", "")
-    FASTAPI_LOG_FILE: str = os.getenv("FASTAPI_LOG_FILE", "")
+    MODEL_RUN_LOG_FILE: str = os.getenv("MODEL_RUN_LOG_FILE", "")
 
 
 # Global settings instance

--- a/docker-control-service/routers/logs.py
+++ b/docker-control-service/routers/logs.py
@@ -38,7 +38,7 @@ async def get_startup_log(tail: int = 200):
 
 @router.get("/logs/fastapi")
 async def get_fastapi_log(tail: int = 500):
-    if not settings.FASTAPI_LOG_FILE:
-        raise HTTPException(status_code=503, detail="FastAPI log path not configured")
-    logger.debug(f"Serving fastapi log: {settings.FASTAPI_LOG_FILE}")
-    return {"content": _read_tail(settings.FASTAPI_LOG_FILE, tail), "file": settings.FASTAPI_LOG_FILE}
+    if not settings.MODEL_RUN_LOG_FILE:
+        raise HTTPException(status_code=503, detail="Model run log path not configured")
+    logger.debug(f"Serving model run log: {settings.MODEL_RUN_LOG_FILE}")
+    return {"content": _read_tail(settings.MODEL_RUN_LOG_FILE, tail), "file": settings.MODEL_RUN_LOG_FILE}

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -142,15 +142,15 @@ logger.setLevel(logging.DEBUG)  # Set level on the logger itself
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 # Configure FastAPI logger to also write to file
-def setup_fastapi_file_logging():
-    """Set up file logging for FastAPI - writes to logs/fastapi.log under TT Studio root"""
+def setup_model_run_file_logging():
+    """Set up file logging for FastAPI - writes to logs/model_run.log under TT Studio root"""
     try:
         # Put the log file under the consolidated logs/ directory:
-        # <tt_studio_root>/logs/fastapi.log
+        # <tt_studio_root>/logs/model_run.log
         tt_studio_root = Path(__file__).parent.parent.resolve()
         root_log_dir = tt_studio_root / "logs"
         root_log_dir.mkdir(parents=True, exist_ok=True)
-        root_log_file = root_log_dir / "fastapi.log"
+        root_log_file = root_log_dir / "model_run.log"
 
         # Keep append mode here. run.py also streams uvicorn output to this file,
         # so truncate mode can create confusing interleaving/overwrite artifacts.
@@ -197,7 +197,7 @@ def setup_fastapi_file_logging():
 
         # Try to write error to a local fallback log
         try:
-            fallback_log = Path(__file__).parent / "fastapi_setup_error.log"
+            fallback_log = Path(__file__).parent / "model_run_setup_error.log"
             with open(fallback_log, "a") as f:
                 f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {error_msg}\n")
                 f.write(traceback.format_exc())
@@ -205,7 +205,7 @@ def setup_fastapi_file_logging():
             pass  # If even fallback fails, just continue
 
 # Initialize file logging
-setup_fastapi_file_logging()
+setup_model_run_file_logging()
 
 # Global progress store with thread-safe access
 progress_store: Dict[str, Dict[str, Any]] = {}
@@ -1120,7 +1120,7 @@ class ProgressHandler(logging.Handler):
             progress = 0
             status = "running"
         
-            # Based on the fastapi.log patterns, parse deployment stages
+            # Based on the model_run.log patterns, parse deployment stages
             if any(keyword in message.lower() for keyword in ["validate_runtime_args", "handle_secrets", "validate_local_setup"]):
                 stage = "initialization"
                 progress = 5
@@ -1323,21 +1323,21 @@ def normalize_device_alias(device: str) -> str:
     }
     return alias_map.get(device.strip().lower(), device)
 
-def get_fastapi_logs_dir():
-    """Get the per-deployment FastAPI logs directory under TT Studio root's logs/"""
+def get_model_run_logs_dir():
+    """Get the per-deployment model run logs directory under TT Studio root's logs/"""
     tt_studio_root = Path(__file__).parent.parent.resolve()
-    fastapi_logs_dir = tt_studio_root / "logs" / "fastapi_logs"
-    fastapi_logs_dir.mkdir(parents=True, exist_ok=True)
-    return fastapi_logs_dir
+    model_run_logs_dir = tt_studio_root / "logs" / "model_run_logs"
+    model_run_logs_dir.mkdir(parents=True, exist_ok=True)
+    return model_run_logs_dir
 
 def create_deployment_log_handler(job_id: str, model: str, device: str):
     """Create a per-deployment log file handler with model and device in filename"""
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    fastapi_logs_dir = get_fastapi_logs_dir()
-    
-    # Create log file with pattern: fastapi_YYYY-MM-DD_HH-MM-SS_ModelName_device_server.log
-    log_filename = f"fastapi_{timestamp}_{model}_{device}_server.log"
-    log_file_path = fastapi_logs_dir / log_filename
+    model_run_logs_dir = get_model_run_logs_dir()
+
+    # Create log file with pattern: model_run_YYYY-MM-DD_HH-MM-SS_ModelName_device_server.log
+    log_filename = f"model_run_{timestamp}_{model}_{device}_server.log"
+    log_file_path = model_run_logs_dir / log_filename
     
     # Create file handler
     file_handler = logging.FileHandler(log_file_path, mode='w')
@@ -1411,7 +1411,7 @@ async def test_logging():
     logger.warning("Warning level test message")
     return {
         "message": "Logging test completed", 
-        "check": "fastapi.log file for log messages",
+        "check": "model_run.log file for log messages",
         "timestamp": time.time()
     }
 

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -143,12 +143,12 @@ ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 # Configure FastAPI logger to also write to file
 def setup_fastapi_file_logging():
-    """Set up file logging for FastAPI - writes to fastapi.log at TT Studio root"""
+    """Set up file logging for FastAPI - writes to logs/fastapi.log under TT Studio root"""
     try:
-        # Put the log file at TT Studio root:
-        # <tt_studio_root>/fastapi.log
+        # Put the log file under the consolidated logs/ directory:
+        # <tt_studio_root>/logs/fastapi.log
         tt_studio_root = Path(__file__).parent.parent.resolve()
-        root_log_dir = tt_studio_root
+        root_log_dir = tt_studio_root / "logs"
         root_log_dir.mkdir(parents=True, exist_ok=True)
         root_log_file = root_log_dir / "fastapi.log"
 
@@ -1324,9 +1324,9 @@ def normalize_device_alias(device: str) -> str:
     return alias_map.get(device.strip().lower(), device)
 
 def get_fastapi_logs_dir():
-    """Get the FastAPI logs directory at TT Studio root"""
+    """Get the per-deployment FastAPI logs directory under TT Studio root's logs/"""
     tt_studio_root = Path(__file__).parent.parent.resolve()
-    fastapi_logs_dir = tt_studio_root / "fastapi_logs"
+    fastapi_logs_dir = tt_studio_root / "logs" / "fastapi_logs"
     fastapi_logs_dir.mkdir(parents=True, exist_ok=True)
     return fastapi_logs_dir
 

--- a/run.py
+++ b/run.py
@@ -94,7 +94,12 @@ INFERENCE_ARTIFACT_URL = None  # Will be set after get_env_var is defined
 # they don't clutter the repo root. Created eagerly because StartupLogger opens
 # startup.log at import time (below).
 LOGS_DIR = os.path.join(TT_STUDIO_ROOT, "logs")
-os.makedirs(LOGS_DIR, exist_ok=True)
+try:
+    os.makedirs(LOGS_DIR, exist_ok=True)
+except OSError:
+    # Keep run.py importable even if logs/ can't be created.
+    LOGS_DIR = TT_STUDIO_ROOT
+
 FASTAPI_PID_FILE = os.path.join(LOGS_DIR, "fastapi.pid")
 FASTAPI_LOG_FILE = os.path.join(LOGS_DIR, "fastapi.log")
 FASTAPI_DEPLOYMENT_LOGS_DIR = os.path.join(LOGS_DIR, "fastapi_logs")

--- a/run.py
+++ b/run.py
@@ -2060,6 +2060,25 @@ def cleanup_resources(args):
         os.path.join(TT_STUDIO_ROOT, "tt_studio_persistent_volume")
     artifacts_root = os.path.join(TT_STUDIO_ROOT, ".artifacts")
 
+    # All host-side runtime logs + PID files now live under logs/, so the whole
+    # directory is removed in one shot (it is always a proper subdir of the repo,
+    # never the repo root itself). The repo-root entries that follow clear logs
+    # left behind by TT Studio versions from before the logs/ consolidation +
+    # rename — and the degenerate case where logs/ couldn't be created and the
+    # files fell back to the repo root.
+    logs_dir = os.path.join(TT_STUDIO_ROOT, "logs")
+    log_items = [
+        ("📜", logs_dir, "host-side runtime logs & PID files (startup, model run, docker-control)"),
+    ]
+    log_items += [
+        ("📜", os.path.join(TT_STUDIO_ROOT, name), "legacy host-side log (pre-consolidation)")
+        for name in (
+            "model_run.log", "model_run_logs",
+            "fastapi.log", "fastapi.pid", "fastapi_logs",
+            "startup.log", "docker-control-service.log", "docker-control-service.pid",
+        )
+    ]
+
     items = [
         ("📁", host_persistent_volume,
          "HF token, JWT secret, deployment history, backend logs, RAG vector DB, model weights"),
@@ -2067,13 +2086,7 @@ def cleanup_resources(args):
          "configuration & secrets (DJANGO_SECRET_KEY, RAG_ADMIN_PASSWORD, cloud auth tokens)"),
         ("🔧", artifacts_root,
          "downloaded inference server + workflow logs + release tarball"),
-        ("📜", STARTUP_LOG_FILE, "startup log"),
-        ("📜", MODEL_RUN_LOG_FILE, "model run log"),
-        ("📜", FASTAPI_PID_FILE, "FastAPI server PID file"),
-        ("📜", DOCKER_CONTROL_LOG_FILE, "Docker Control Service log"),
-        ("📜", DOCKER_CONTROL_PID_FILE, "Docker Control Service PID file"),
-        ("📜", MODEL_RUN_LOGS_DIR,
-         "per-deployment model run logs"),
+        *log_items,
         ("⚙️ ", PREFS_FILE_PATH, "CLI preferences"),
         ("⚙️ ", SETUP_CONFIG_FILE_PATH, "quick-setup snapshot"),
         ("⚙️ ", LEGACY_SETUP_CONFIG_FILE_PATH, "legacy quick-setup snapshot"),

--- a/run.py
+++ b/run.py
@@ -101,8 +101,8 @@ except OSError:
     LOGS_DIR = TT_STUDIO_ROOT
 
 FASTAPI_PID_FILE = os.path.join(LOGS_DIR, "fastapi.pid")
-FASTAPI_LOG_FILE = os.path.join(LOGS_DIR, "fastapi.log")
-FASTAPI_DEPLOYMENT_LOGS_DIR = os.path.join(LOGS_DIR, "fastapi_logs")
+MODEL_RUN_LOG_FILE = os.path.join(LOGS_DIR, "model_run.log")
+MODEL_RUN_LOGS_DIR = os.path.join(LOGS_DIR, "model_run_logs")
 DOCKER_CONTROL_SERVICE_DIR = os.path.join(TT_STUDIO_ROOT, "docker-control-service")
 DOCKER_CONTROL_PID_FILE = os.path.join(LOGS_DIR, "docker-control-service.pid")
 DOCKER_CONTROL_LOG_FILE = os.path.join(LOGS_DIR, "docker-control-service.log")
@@ -2068,12 +2068,12 @@ def cleanup_resources(args):
         ("🔧", artifacts_root,
          "downloaded inference server + workflow logs + release tarball"),
         ("📜", STARTUP_LOG_FILE, "startup log"),
-        ("📜", FASTAPI_LOG_FILE, "FastAPI server log"),
+        ("📜", MODEL_RUN_LOG_FILE, "model run log"),
         ("📜", FASTAPI_PID_FILE, "FastAPI server PID file"),
         ("📜", DOCKER_CONTROL_LOG_FILE, "Docker Control Service log"),
         ("📜", DOCKER_CONTROL_PID_FILE, "Docker Control Service PID file"),
-        ("📜", FASTAPI_DEPLOYMENT_LOGS_DIR,
-         "per-deployment FastAPI logs"),
+        ("📜", MODEL_RUN_LOGS_DIR,
+         "per-deployment model run logs"),
         ("⚙️ ", PREFS_FILE_PATH, "CLI preferences"),
         ("⚙️ ", SETUP_CONFIG_FILE_PATH, "quick-setup snapshot"),
         ("⚙️ ", LEGACY_SETUP_CONFIG_FILE_PATH, "legacy quick-setup snapshot"),
@@ -2451,7 +2451,7 @@ def wait_for_all_services(skip_fastapi=False, is_deployed_mode=False, skip_docke
             "ChromaDB": "docker logs -f tt_studio_chroma",
             "Backend API": "docker logs -f tt_studio_backend",
             "Frontend": "docker logs -f tt_studio_frontend",
-            "FastAPI Server": f"tail -f {FASTAPI_LOG_FILE}",
+            "FastAPI Server": f"tail -f {MODEL_RUN_LOG_FILE}",
             "Docker Control Service": f"tail -f {DOCKER_CONTROL_LOG_FILE}",
         }
         print(f"\n{C_CYAN}📋 Check logs:{C_RESET}")
@@ -3673,7 +3673,7 @@ def start_fastapi_server(no_sudo=False, dev_mode=False):
 
     # Create PID and log files
     
-    for file_path in [FASTAPI_PID_FILE, FASTAPI_LOG_FILE]:
+    for file_path in [FASTAPI_PID_FILE, MODEL_RUN_LOG_FILE]:
         try:
             # Create files as regular user
             with open(file_path, 'w') as f:
@@ -3771,7 +3771,7 @@ cd "$1"
         os.chmod(temp_script_path, 0o755)
         
         # Start server
-        cmd = [temp_script_path, INFERENCE_API_DIR, FASTAPI_PID_FILE, ".venv", FASTAPI_LOG_FILE]
+        cmd = [temp_script_path, INFERENCE_API_DIR, FASTAPI_PID_FILE, ".venv", MODEL_RUN_LOG_FILE]
         process = subprocess.Popen(cmd, env=env)
         
         # Health check (silent — only prints on success or failure)
@@ -3782,14 +3782,14 @@ cd "$1"
             if process.poll() is not None:
                 print(f"{C_RED}⛔ FastAPI server process died{C_RESET}")
                 try:
-                    with open(FASTAPI_LOG_FILE, 'r') as f:
+                    with open(MODEL_RUN_LOG_FILE, 'r') as f:
                         lines = f.readlines()
                         for line in lines[-15:]:
                             print(f"   {line.rstrip()}")
                 except:
                     pass
                 try:
-                    with open(FASTAPI_LOG_FILE, 'r') as f:
+                    with open(MODEL_RUN_LOG_FILE, 'r') as f:
                         if "address already in use" in f.read():
                             print(f"{C_YELLOW}   Port 8001 still in use. Try: python run.py --cleanup && python run.py{C_RESET}")
                 except:
@@ -3816,7 +3816,7 @@ cd "$1"
 
             if i == health_check_retries:
                 print(f"{C_RED}⛔ FastAPI server failed to start{C_RESET}")
-                print(f"   Check logs: tail -50 {FASTAPI_LOG_FILE}")
+                print(f"   Check logs: tail -50 {MODEL_RUN_LOG_FILE}")
                 return False
 
             time.sleep(health_check_delay)
@@ -3881,7 +3881,7 @@ def cleanup_fastapi_server(no_sudo=False):
     kill_process_on_port(8001, no_sudo=no_sudo, quiet=True)
 
     # Remove PID and log files
-    for file_path in [FASTAPI_PID_FILE, FASTAPI_LOG_FILE]:
+    for file_path in [FASTAPI_PID_FILE, MODEL_RUN_LOG_FILE]:
         try:
             if os.path.exists(file_path):
                 os.remove(file_path)
@@ -3987,7 +3987,7 @@ def start_docker_control_service(no_sudo=False, dev_mode=False):
         env["DOCKER_CONTROL_JWT_SECRET"] = jwt_secret
     env["DOCKER_CONTROL_LOG_FILE"] = DOCKER_CONTROL_LOG_FILE
     env["STARTUP_LOG_FILE"] = STARTUP_LOG_FILE
-    env["FASTAPI_LOG_FILE"] = FASTAPI_LOG_FILE
+    env["MODEL_RUN_LOG_FILE"] = MODEL_RUN_LOG_FILE
 
     # Start the service using uvicorn
     try:
@@ -5014,27 +5014,27 @@ def main():
                         print()
                         sys.exit(1)
 
-        # Ensure fastapi_logs/ exists and is owned by the invoking user before
+        # Ensure model_run_logs/ exists and is owned by the invoking user before
         # inference-api writes per-deployment log files into it. If a prior
         # sudo'd process created this dir, writes from the non-root uvicorn
-        # process will fail with EACCES (see inference-api/api.py:get_fastapi_logs_dir).
-        fastapi_logs_dir = FASTAPI_DEPLOYMENT_LOGS_DIR
-        if not os.path.exists(fastapi_logs_dir):
+        # process will fail with EACCES (see inference-api/api.py:get_model_run_logs_dir).
+        model_run_logs_dir = MODEL_RUN_LOGS_DIR
+        if not os.path.exists(model_run_logs_dir):
             try:
-                os.makedirs(fastapi_logs_dir, mode=0o755, exist_ok=True)
+                os.makedirs(model_run_logs_dir, mode=0o755, exist_ok=True)
             except Exception as e:
-                print(f"{C_YELLOW}⚠️  Could not create fastapi_logs directory: {e}{C_RESET}")
+                print(f"{C_YELLOW}⚠️  Could not create model_run_logs directory: {e}{C_RESET}")
         elif OS_NAME != "Windows":
             current_user_uid = os.getuid()
-            if os.stat(fastapi_logs_dir).st_uid != current_user_uid:
-                print(f"{C_YELLOW}⚠️  fastapi_logs directory is owned by another user, fixing permissions...{C_RESET}")
+            if os.stat(model_run_logs_dir).st_uid != current_user_uid:
+                print(f"{C_YELLOW}⚠️  model_run_logs directory is owned by another user, fixing permissions...{C_RESET}")
                 try:
-                    os.chown(fastapi_logs_dir, current_user_uid, os.getgid())
-                    print(f"{C_GREEN}✅ Fixed fastapi_logs directory ownership{C_RESET}")
+                    os.chown(model_run_logs_dir, current_user_uid, os.getgid())
+                    print(f"{C_GREEN}✅ Fixed model_run_logs directory ownership{C_RESET}")
                 except (OSError, PermissionError) as e:
-                    print(f"{C_RED}⛔ Could not fix fastapi_logs permissions: {e}{C_RESET}")
+                    print(f"{C_RED}⛔ Could not fix model_run_logs permissions: {e}{C_RESET}")
                     print(f"{C_YELLOW}Please run the following in another terminal, then press Enter:{C_RESET}")
-                    print(f"   {C_WHITE}sudo chown -R $USER:$USER {fastapi_logs_dir}{C_RESET}")
+                    print(f"   {C_WHITE}sudo chown -R $USER:$USER {model_run_logs_dir}{C_RESET}")
                     input("Press Enter once you've run the command above to continue...")
 
         # Start Docker Control Service BEFORE starting Docker containers
@@ -5152,9 +5152,9 @@ def main():
                     sys.exit(1)
 
                 if not start_fastapi_server(no_sudo=args.no_sudo, dev_mode=args.dev):
-                    startup_log.step("fastapi_server", "FAIL", f"see {FASTAPI_LOG_FILE}")
+                    startup_log.step("fastapi_server", "FAIL", f"see {MODEL_RUN_LOG_FILE}")
                     print(f"{C_RED}⛔ Cannot start TT Studio: FastAPI server failed to start. Exiting.{C_RESET}")
-                    print(f"   Check logs: tail -50 {FASTAPI_LOG_FILE}")
+                    print(f"   Check logs: tail -50 {MODEL_RUN_LOG_FILE}")
                     startup_log.summary(exit_code=1)
                     startup_log.close()
                     sys.exit(1)
@@ -5191,7 +5191,7 @@ def main():
         print(f"{C_CYAN}📋 Logs:{C_RESET}")
         print(f"  Docker containers: cd app && docker compose logs -f")
         if fastapi_enabled:
-            print(f"  FastAPI server:    tail -f {FASTAPI_LOG_FILE}")
+            print(f"  FastAPI server:    tail -f {MODEL_RUN_LOG_FILE}")
         if docker_control_enabled:
             print(f"  Docker Control:    tail -f {DOCKER_CONTROL_LOG_FILE}")
         print()
@@ -5247,10 +5247,10 @@ def main():
                 cwd=os.path.join(TT_STUDIO_ROOT, "app")
             )
             
-            # Also check for FastAPI server logs
-            fastapi_logs_process = None
-            if not args.skip_fastapi and not is_deployed_mode and os.path.exists(FASTAPI_LOG_FILE):
-                fastapi_logs_process = subprocess.Popen(["tail", "-f", FASTAPI_LOG_FILE])
+            # Also check for model run logs
+            model_run_logs_process = None
+            if not args.skip_fastapi and not is_deployed_mode and os.path.exists(MODEL_RUN_LOG_FILE):
+                model_run_logs_process = subprocess.Popen(["tail", "-f", MODEL_RUN_LOG_FILE])
             
             try:
                 # Wait for Ctrl+C
@@ -5262,8 +5262,8 @@ def main():
                 # Clean up processes
                 if docker_logs_process:
                     docker_logs_process.terminate()
-                if fastapi_logs_process:
-                    fastapi_logs_process.terminate()
+                if model_run_logs_process:
+                    model_run_logs_process.terminate()
 
     except KeyboardInterrupt:
         print(f"\n\n{C_YELLOW}🛑 Setup interrupted by user (Ctrl+C){C_RESET}")

--- a/run.py
+++ b/run.py
@@ -90,15 +90,21 @@ INFERENCE_ARTIFACT_DIR = os.path.join(TT_STUDIO_ROOT, ".artifacts", "tt-inferenc
 # These will be read from .env file or environment variables
 INFERENCE_ARTIFACT_VERSION = None  # Will be set after get_env_var is defined
 INFERENCE_ARTIFACT_URL = None  # Will be set after get_env_var is defined
-FASTAPI_PID_FILE = os.path.join(TT_STUDIO_ROOT, "fastapi.pid")
-FASTAPI_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "fastapi.log")
+# All host-side runtime logs and PID files live under a single logs/ directory so
+# they don't clutter the repo root. Created eagerly because StartupLogger opens
+# startup.log at import time (below).
+LOGS_DIR = os.path.join(TT_STUDIO_ROOT, "logs")
+os.makedirs(LOGS_DIR, exist_ok=True)
+FASTAPI_PID_FILE = os.path.join(LOGS_DIR, "fastapi.pid")
+FASTAPI_LOG_FILE = os.path.join(LOGS_DIR, "fastapi.log")
+FASTAPI_DEPLOYMENT_LOGS_DIR = os.path.join(LOGS_DIR, "fastapi_logs")
 DOCKER_CONTROL_SERVICE_DIR = os.path.join(TT_STUDIO_ROOT, "docker-control-service")
-DOCKER_CONTROL_PID_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.pid")
-DOCKER_CONTROL_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.log")
+DOCKER_CONTROL_PID_FILE = os.path.join(LOGS_DIR, "docker-control-service.pid")
+DOCKER_CONTROL_LOG_FILE = os.path.join(LOGS_DIR, "docker-control-service.log")
 PREFS_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_preferences.json")
 SETUP_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_setup_config.json")
 LEGACY_SETUP_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_easy_config.json")
-STARTUP_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "startup.log")
+STARTUP_LOG_FILE = os.path.join(LOGS_DIR, "startup.log")
 
 # Map health check URLs to Docker container name prefixes (for auto-log-fetching on failure)
 # Container names vary by mode: tt_studio_backend_api_prod, tt_studio_frontend_dev, etc.
@@ -2061,7 +2067,7 @@ def cleanup_resources(args):
         ("📜", FASTAPI_PID_FILE, "FastAPI server PID file"),
         ("📜", DOCKER_CONTROL_LOG_FILE, "Docker Control Service log"),
         ("📜", DOCKER_CONTROL_PID_FILE, "Docker Control Service PID file"),
-        ("📜", os.path.join(TT_STUDIO_ROOT, "fastapi_logs"),
+        ("📜", FASTAPI_DEPLOYMENT_LOGS_DIR,
          "per-deployment FastAPI logs"),
         ("⚙️ ", PREFS_FILE_PATH, "CLI preferences"),
         ("⚙️ ", SETUP_CONFIG_FILE_PATH, "quick-setup snapshot"),
@@ -5007,7 +5013,7 @@ def main():
         # inference-api writes per-deployment log files into it. If a prior
         # sudo'd process created this dir, writes from the non-root uvicorn
         # process will fail with EACCES (see inference-api/api.py:get_fastapi_logs_dir).
-        fastapi_logs_dir = os.path.join(TT_STUDIO_ROOT, "fastapi_logs")
+        fastapi_logs_dir = FASTAPI_DEPLOYMENT_LOGS_DIR
         if not os.path.exists(fastapi_logs_dir):
             try:
                 os.makedirs(fastapi_logs_dir, mode=0o755, exist_ok=True)

--- a/test_run_cleanup.py
+++ b/test_run_cleanup.py
@@ -24,7 +24,7 @@ class CleanupAllTests(unittest.TestCase):
             patch.object(run, "STARTUP_LOG_FILE", str(root / "startup.log")),
             patch.object(run, "PREFS_FILE_PATH", str(root / ".tt_studio_preferences.json")),
             patch.object(run, "SETUP_CONFIG_FILE_PATH", str(setup_config)),
-            patch.object(run, "FASTAPI_LOG_FILE", str(root / "fastapi.log")),
+            patch.object(run, "MODEL_RUN_LOG_FILE", str(root / "model_run.log")),
             patch.object(run, "FASTAPI_PID_FILE", str(root / "fastapi.pid")),
             patch.object(run, "DOCKER_CONTROL_LOG_FILE", str(docker_log)),
             patch.object(run, "DOCKER_CONTROL_PID_FILE", str(docker_pid)),


### PR DESCRIPTION
All our host-side logs and PID files (`fastapi.log`, `docker-control-service.log`, `startup.log`, the two `.pid` files, and the per-deployment `fastapi_logs/`) were being dumped straight into the repo root. This cleans that up by moving them all under a single `logs/` folder.

Most of the work is in `run.py`, which already kept these paths as constants — so I just added one `LOGS_DIR` and pointed them at it. `inference-api` writes to the same place, and the read-only `fastapi_logs` mount in both compose files is remapped to `logs/fastapi_logs`.

The bug report still collects the exact same logs (just from the new path), so its ZIP output is unchanged.

I left container-internal logs alone — backend `python_logs` (persistent volume), the tt-inference-server `workflow_logs`, and model-container logs — since moving those would change how the containers themselves write.

### Update: renamed the FastAPI logs to `model_run`

While consolidating, the inference log files were also renamed so the names describe **what** they contain (a model run) instead of the framework that writes them (FastAPI):

| before | after |
| --- | --- |
| `logs/fastapi.log` | `logs/model_run.log` |
| `logs/fastapi_logs/` | `logs/model_run_logs/` |
| `fastapi_<ts>_<model>_<device>_server.log` | `model_run_<ts>_<model>_<device>_server.log` |

Everything that produces or consumes those paths was updated to match: `run.py` constants/labels, the inference-api log setup + per-deployment handler, the compose `:ro` mounts, the docker-control-service env var (`FASTAPI_LOG_FILE` → `MODEL_RUN_LOG_FILE`), the bug-report collection + ZIP entries (and the matching frontend keys/labels), the docs, and the debug-bundle skill. Both bug-report readers — the `model_run.log` tail and the per-deployment `model_run_logs/` collection — keep the legacy `fastapi.log` / `fastapi_logs/` locations as fallbacks, so bundles captured from runs before this rename still surface their logs.

The FastAPI **server process** itself is intentionally untouched — the `fastapi.pid` file, the `/api/v1/logs/fastapi` endpoint, and the start/stop functions keep their names; only the log artifacts are renamed.

### Cleanup

`--cleanup-all` now removes the entire `logs/` directory in one shot (rather than the individual files inside it, which left an empty `logs/` folder behind), and also clears logs left directly in the repo root by versions from before this consolidation + rename (`fastapi.log`, `fastapi.pid`, `fastapi_logs/`, …). The logs directory is derived from `TT_STUDIO_ROOT` as a proper subdir, so it can never resolve to — and delete — the repo root itself.

**Verify:** `python3 -m unittest test_run_cleanup` passes (15/15), the compose files parse and resolve the new `logs/model_run_logs` mount, and after a run the repo root stays clean with everything under `logs/`.


