### PR TITLE
Fix --cleanup-all reclaim size to include Docker volumes and images

### DIFF
--- a/run.py
+++ b/run.py
@@ -32,6 +32,7 @@ import platform
 import argparse
 import shutil
 import re
+import fnmatch
 import getpass
 import webbrowser
 import socket
@@ -1808,6 +1809,65 @@ _CLEANUP_IMAGE_REFS = (
 _CLEANUP_VOLUME_PREFIX = "volume_id_"
 
 
+def _parse_size_to_bytes(s):
+    """Parse a docker-formatted size string (e.g. "39.42GB", "545kB", "32B") to bytes.
+
+    Docker reports sizes in SI units (base 1000) via go-units, so this is the
+    inverse of `_format_bytes` but decimal — used only to total the daemon's own
+    numbers, not for display. Returns 0 on anything unparseable.
+    """
+    if not s:
+        return 0
+    m = re.match(r"\s*([0-9]*\.?[0-9]+)\s*([kKMGTP]?B)\s*$", s)
+    if not m:
+        return 0
+    value, unit = float(m.group(1)), m.group(2).upper()
+    factor = {"B": 1, "KB": 10**3, "MB": 10**6,
+              "GB": 10**9, "TB": 10**12, "PB": 10**15}.get(unit, 1)
+    return int(value * factor)
+
+
+def _docker_reclaimable_bytes(has_docker_access):
+    """Best-effort size of the Docker objects --cleanup-all removes.
+
+    Reads `docker system df -v --format json` (the daemon already computes exact
+    sizes) and sums the images and volumes cleanup-all actually deletes:
+      - images whose Repository matches `_CLEANUP_IMAGE_REFS`
+        (same set `_remove_local_tt_studio_images` removes),
+      - `volume_id_*` model-weight volumes (`_remove_tt_studio_model_volumes`)
+        plus dangling anonymous volumes (`_prune_anonymous_volumes`).
+    Build cache is intentionally excluded — cleanup-all does not prune it.
+    Returns {"images", "model_volumes", "anon_volumes"} byte counts; zeros if
+    docker is unavailable, so the reclaim total degrades to the host-side paths
+    just like before.
+    """
+    zero = {"images": 0, "model_volumes": 0, "anon_volumes": 0}
+    sudo_prefix = ["sudo"] if not has_docker_access else []
+    try:
+        result = subprocess.run(
+            sudo_prefix + ["docker", "system", "df", "-v", "--format", "json"],
+            capture_output=True, text=True, check=False,
+        )
+        data = json.loads(result.stdout)
+    except Exception:
+        return zero
+
+    sizes = dict(zero)
+    for img in data.get("Images") or []:
+        repo = img.get("Repository", "")
+        if any(fnmatch.fnmatch(repo, ref) for ref in _CLEANUP_IMAGE_REFS):
+            sizes["images"] += _parse_size_to_bytes(img.get("Size", ""))
+
+    for vol in data.get("Volumes") or []:
+        name = vol.get("Name", "")
+        if name.startswith(_CLEANUP_VOLUME_PREFIX):
+            sizes["model_volumes"] += _parse_size_to_bytes(vol.get("Size", ""))
+        elif "com.docker.volume.anonymous" in (vol.get("Labels") or ""):
+            sizes["anon_volumes"] += _parse_size_to_bytes(vol.get("Size", ""))
+
+    return sizes
+
+
 def _remove_local_tt_studio_images(has_docker_access):
     """Remove TT Studio + inference-server + chroma images. Returns count removed."""
     sudo_prefix = ["sudo"] if not has_docker_access else []
@@ -2027,7 +2087,14 @@ def cleanup_resources(args):
 
     existing = [(emoji, path, desc, _path_size(path))
                 for emoji, path, desc in items if os.path.exists(path) or os.path.islink(path)]
-    total_bytes = sum(sz for _, _, _, sz in existing)
+    host_bytes = sum(sz for _, _, _, sz in existing)
+
+    # Measure the Docker objects we are about to remove while they still exist,
+    # so both the estimate and the final "Reclaimed approximately X" reflect the
+    # model volumes + images (tens of GB), not just the host-side files.
+    has_docker_access = check_docker_access()
+    docker_sizes = _docker_reclaimable_bytes(has_docker_access)
+    total_bytes = host_bytes + sum(docker_sizes.values())
 
     print(f"\n{C_ORANGE}{C_BOLD}🗑️  --cleanup-all will reset TT Studio to a fresh-clone state.{C_RESET}")
     print(f"\n{C_BOLD}The following will be PERMANENTLY DELETED:{C_RESET}\n")
@@ -2043,11 +2110,16 @@ def cleanup_resources(args):
     else:
         print(f"  {C_CYAN}(no host-side state found){C_RESET}")
 
+    def _docker_size(key):
+        return f"  ({_format_bytes(docker_sizes[key])})" if docker_sizes[key] > 0 else ""
+
     print(f"\n  🐳 Running deployment containers on tt_studio_network (vLLM, YOLO, …)")
-    print(f"  💾 Docker named volumes holding model weights ({_CLEANUP_VOLUME_PREFIX}*)")
-    print(f"  💾 Dangling anonymous Docker volumes (frontend dev node_modules, …)")
+    print(f"  💾 Docker named volumes holding model weights ({_CLEANUP_VOLUME_PREFIX}*)"
+          f"{_docker_size('model_volumes')}")
+    print(f"  💾 Dangling anonymous Docker volumes (frontend dev node_modules, …)"
+          f"{_docker_size('anon_volumes')}")
     print(f"  🐳 Local images: tt-studio/*, tt-inference-server/*, "
-          f"tt-media-inference-server, chromadb/chroma")
+          f"tt-media-inference-server, chromadb/chroma{_docker_size('images')}")
     print(f"  🌐 Browser data (chat history, theme, login)  — wiped on next page load\n")
 
     if total_bytes > 0:
@@ -2068,7 +2140,6 @@ def cleanup_resources(args):
         print(f"\n{C_YELLOW}--yes passed; proceeding without prompt.{C_RESET}")
 
     print(f"\n{C_BOLD}🧹 Cleaning up TT Studio...{C_RESET}")
-    has_docker_access = check_docker_access()
     _cleanup_runtime(args, has_docker_access)
 
     # Volumes must come before images: removing a volume while its image is

--- a/test_run_cleanup.py
+++ b/test_run_cleanup.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -82,6 +83,8 @@ class CleanupAllTests(unittest.TestCase):
                 for patcher in self._patch_cleanup_paths(root, sentinel):
                     stack.enter_context(patcher)
                 stack.enter_context(patch.object(run, "check_docker_access", return_value=True))
+                stack.enter_context(patch.object(run, "_docker_reclaimable_bytes", return_value={
+                    "images": 0, "model_volumes": 0, "anon_volumes": 0}))
                 stack.enter_context(patch("builtins.input", return_value="n"))
                 stack.enter_context(patch.object(
                     run,
@@ -134,6 +137,8 @@ class CleanupAllTests(unittest.TestCase):
                     side_effect=lambda name, default="": default,
                 ))
                 stack.enter_context(patch.object(run, "check_docker_access", return_value=True))
+                stack.enter_context(patch.object(run, "_docker_reclaimable_bytes", return_value={
+                    "images": 0, "model_volumes": 0, "anon_volumes": 0}))
                 stack.enter_context(patch.object(run, "_cleanup_runtime"))
                 stack.enter_context(patch.object(run, "_remove_local_tt_studio_images", return_value=0))
                 stack.enter_context(patch.object(run, "_remove_tt_studio_model_volumes", return_value=0))
@@ -311,6 +316,61 @@ class CleanupDockerSurfaceTests(unittest.TestCase):
         # 1 network-filter ps + N ancestor-filter ps (one per image ref) + 1 rm.
         expected_calls = 2 + len(run._CLEANUP_IMAGE_REFS)
         self.assertEqual(seen_prefixes, ["sudo"] * expected_calls)
+
+    def test_parse_size_to_bytes_handles_docker_si_units(self):
+        # Docker reports sizes as SI (base 1000) strings via go-units.
+        self.assertEqual(run._parse_size_to_bytes("32B"), 32)
+        self.assertEqual(run._parse_size_to_bytes("545kB"), 545_000)
+        self.assertEqual(run._parse_size_to_bytes("628.7MB"), 628_700_000)
+        self.assertEqual(run._parse_size_to_bytes("39.42GB"), 39_420_000_000)
+        # Degrades to 0 on empty / unparseable input.
+        self.assertEqual(run._parse_size_to_bytes(""), 0)
+        self.assertEqual(run._parse_size_to_bytes("N/A"), 0)
+
+    def test_docker_reclaimable_bytes_sums_only_removed_objects(self):
+        # Mirrors `docker system df -v --format json`: only images matching
+        # _CLEANUP_IMAGE_REFS, volume_id_* model volumes, and anonymous volumes
+        # count — unrelated images/volumes and build cache must be ignored.
+        payload = {
+            "Images": [
+                {"Repository": "ghcr.io/tenstorrent/tt-studio/backend-dev", "Size": "11.6GB"},
+                {"Repository": "ghcr.io/tenstorrent/tt-inference-server/vllm", "Size": "23.3GB"},
+                {"Repository": "chromadb/chroma", "Size": "699MB"},
+                {"Repository": "alpine", "Size": "13.1MB"},  # unrelated — excluded
+            ],
+            "Volumes": [
+                {"Name": "volume_id_tt_transformers-Llama-3.1-8B", "Size": "39.42GB",
+                 "Labels": ""},
+                {"Name": "bc66deadbeef", "Size": "628.7MB",
+                 "Labels": "com.docker.volume.anonymous="},  # anonymous — counted
+                {"Name": "app_hf_cache", "Size": "91.58MB", "Labels": ""},  # named, unrelated
+            ],
+            "BuildCache": [{"Size": "35.97GB"}],  # never pruned by cleanup-all — excluded
+        }
+
+        def fake_run(cmd, **kwargs):
+            self.assertEqual(cmd[:5], ["docker", "system", "df", "-v", "--format"])
+            return SimpleNamespace(stdout=json.dumps(payload), returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            sizes = run._docker_reclaimable_bytes(has_docker_access=True)
+
+        self.assertEqual(sizes["images"],
+                         run._parse_size_to_bytes("11.6GB")
+                         + run._parse_size_to_bytes("23.3GB")
+                         + run._parse_size_to_bytes("699MB"))
+        self.assertEqual(sizes["model_volumes"], run._parse_size_to_bytes("39.42GB"))
+        self.assertEqual(sizes["anon_volumes"], run._parse_size_to_bytes("628.7MB"))
+
+    def test_docker_reclaimable_bytes_zero_when_docker_unavailable(self):
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(stdout="not json", returncode=1)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            self.assertEqual(
+                run._docker_reclaimable_bytes(has_docker_access=True),
+                {"images": 0, "model_volumes": 0, "anon_volumes": 0},
+            )
 
     def _record_runtime_order(self, args):
         order = []


### PR DESCRIPTION
## What

`run.py --cleanup-all` reported an "Estimated disk to reclaim" and final "Reclaimed approximately X" that only counted host-side files (~200–300 MB). The command also removes the large stuff — Docker model-weight volumes (`volume_id_*`, tens of GB) and local images (vLLM, tt-studio/*, chroma) — but those were never measured, so the number was off by tens of GB.

## How

- Added `_docker_reclaimable_bytes()`, which reads `docker system df -v --format json` once (before the confirmation prompt, while the objects still exist) and sums the images matching `_CLEANUP_IMAGE_REFS`, the `volume_id_*` model volumes, and dangling anonymous volumes — the same objects cleanup-all deletes.
- Added `_parse_size_to_bytes()` to parse docker's SI size strings.
- Each Docker inventory line now shows its size, and the estimate + final total include them. Build cache is excluded (cleanup-all doesn't prune it). Degrades gracefully to the old host-only number if docker is unavailable.

## Validation

- `python3 -m unittest test_run_cleanup` — 18 tests pass (added 3, made the two `cleanup_all` tests hermetic).
- `printf 'n\n' | python3 run.py --cleanup-all` now shows ~73 GB (model volume 36.7 GB + images 35.5 GB + anon 0.6 GB) instead of ~300 MB, and still aborts before deleting anything.