### PR TITLE
Add feature-branch PR workflow skill and relocate project overview

### DIFF
--- a/.claude/skills/feature-branch-pr/SKILL.md
+++ b/.claude/skills/feature-branch-pr/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: feature-branch-pr
+description: >-
+  Make a change in TT-Studio the team way: branch off `dev` with a
+  `<username>/<feature>` branch, keep the diff minimal and in-scope, verify the
+  running app via its health endpoints before pushing, leave every other branch
+  untouched, and open a PR against `dev` with a human, professional title and
+  description. Use whenever the user asks to start a feature/fix/branch, make a
+  change and open a pull request, or "do this properly on a new branch" in this
+  repo. Enforces no AI-tool attribution in commits, PR text, or review comments.
+---
+
+# TT-Studio Feature Branch + PR Workflow
+
+Follow this when asked to make a change and/or open a PR in `tt-studio`. The
+goal is a small, verified, professional change that touches nothing it
+shouldn't.
+
+## Guardrails (always true)
+
+- **Base everything on `dev`.** Features branch off `dev` and PRs target `dev`.
+  `main` is production/tagged code only — never branch a feature off it or open
+  a feature PR against it.
+- **Never commit on `dev` or `main` directly**, and never `git push --force`
+  (or `--force-with-lease`) to a shared branch.
+- **Leave other branches alone.** No checkout-and-edit of unrelated branches, no
+  rebasing or deleting branches you didn't create for this task.
+- **No AI attribution anywhere.** Commit messages, PR titles/descriptions, and
+  review comments must read as a human wrote them. Do **not** add
+  `Co-Authored-By` trailers for AI tools and do **not** mention "Claude",
+  "Claude Code", "Cursor", "AI assistant", or similar.
+
+## Workflow checklist
+
+Copy this and tick as you go:
+
+```
+- [ ] 1. Identify the username
+- [ ] 2. Branch off dev
+- [ ] 3. Make the minimal change
+- [ ] 4. Verify (endpoints / tests)
+- [ ] 5. Clean up instrumentation
+- [ ] 6. Stage only intended files
+- [ ] 7. Commit (human message)
+- [ ] 8. Push + open PR against dev
+- [ ] 9. Return to the original branch
+```
+
+### 1. Identify the username
+
+Derive the branch prefix from git config:
+
+```bash
+git config user.name; git config user.email
+```
+
+Use the lowercased first name / email local-part (e.g. `jashansingh@...` →
+`jashan`). If it's ambiguous, ask the user which prefix to use. This repo's
+convention is `<username>/<feature>` (e.g. `jashan/ttft-fix`).
+
+### 2. Branch off dev
+
+Always start from the latest `dev`, and remember where you came from:
+
+```bash
+ORIG=$(git branch --show-current)        # so you can return in step 9
+git fetch origin
+git checkout -b <username>/<short-kebab-feature> origin/dev
+```
+
+Pick a short, descriptive kebab-case feature name (`reset-view-fix`,
+`p100-support`). Confirm `git status` is clean before editing.
+
+### 3. Make the minimal change
+
+- Touch only the files required for the stated task. No drive-by refactors,
+  no reformatting, no unrelated renames, no dependency bumps "while we're here."
+- New code files (`.py` / `.ts` / `.tsx` / `.js`) **must** carry the SPDX
+  headers required by `.cursor/rules/general.mdc`:
+  ```
+  # SPDX-License-Identifier: Apache-2.0
+  # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+  ```
+- Do not stage untracked files/dirs that aren't part of your change (e.g.
+  `fastapi_logs/`, local `.env`, editor scratch).
+
+### 4. Verify before pushing
+
+Verification is mandatory before any push. Pick what fits the change:
+
+**Running app (code changes).** Bring the stack up and confirm services are
+healthy:
+
+```bash
+python run.py --dev
+```
+
+| Service | Health check |
+|---|---|
+| Backend (Django) | `curl -f http://localhost:8000/up/` → 200 |
+| Backend model API | `curl -f http://localhost:8000/models/health/` |
+| Inference server (FastAPI) | `curl -f http://localhost:8001/health` → `{"status":"ok",...}` |
+| Frontend (Vite) | `curl -f http://localhost:3000/` → HTML |
+
+Then exercise the specific endpoint/flow your change affects and confirm the new
+behavior actually works (don't just trust that it compiles).
+
+**Tests (backend logic).** Run the relevant suite, e.g.:
+
+```bash
+cd app/backend && pytest model_control/test_model_api.py -v
+```
+
+**Docs / config-only changes.** App endpoint checks are N/A — instead state that
+explicitly and validate the artifacts you changed (frontmatter parses, links
+resolve, content is correct).
+
+Do not proceed to commit/push until verification passes. If it can't be verified
+(e.g. needs hardware), say so explicitly rather than implying it was checked.
+
+### 5. Clean up instrumentation
+
+Remove anything added only to validate: debug prints, temporary logging, scratch
+test files, commented-out experiments. The committed diff should contain only
+the intended change.
+
+### 6. Stage only intended files
+
+Never `git add -A` blindly. Stage explicit paths, then audit:
+
+```bash
+git add <path> <path>
+git status
+git diff --cached
+```
+
+Confirm the staged set is exactly your change — nothing unrelated, no stray
+untracked dirs.
+
+### 7. Commit with a human message
+
+Imperative, specific, professional. Describe what changed and why, as a
+teammate would. No AI attribution, no `Co-Authored-By` AI trailers.
+
+```
+git commit -m "Hide board reset button while a model is deployed"
+```
+
+### 8. Push and open the PR against dev
+
+```bash
+git push -u origin <username>/<short-kebab-feature>
+gh pr create --base dev \
+  --title "<human, professional title>" \
+  --body "<what changed, why, and how it was verified>"
+```
+
+PR description guidance: summarize the problem, the change, and the
+verification (endpoints hit / tests run). Plain, human prose — no AI mention.
+The repo squash-merges into `dev`; **leave the merge to a human reviewer unless
+the user explicitly tells you to merge.**
+
+### 9. Return to the original branch
+
+Leave the tree as you found it:
+
+```bash
+git checkout "$ORIG"
+```
+
+## Anti-patterns
+
+- **Don't** branch off `main` or off whatever branch happens to be checked out —
+  always `origin/dev`.
+- **Don't** bundle unrelated cleanups into the PR. Minimal and in-scope.
+- **Don't** push without verifying, or claim verification you didn't run.
+- **Don't** force-push, rebase shared branches, or modify branches you didn't
+  create.
+- **Don't** mention Claude / Claude Code / AI tooling, or add AI co-author
+  trailers, in commits, PR text, or review comments.

--- a/.claude/skills/feature-branch-pr/SKILL.md
+++ b/.claude/skills/feature-branch-pr/SKILL.md
@@ -54,9 +54,9 @@ Derive the branch prefix from git config:
 git config user.name; git config user.email
 ```
 
-Use the lowercased first name / email local-part (e.g. `jashansingh@...` →
-`jashan`). If it's ambiguous, ask the user which prefix to use. This repo's
-convention is `<username>/<feature>` (e.g. `jashan/ttft-fix`).
+Use the lowercased first name / email local-part (e.g. `johnsingh@...` →
+`john`). If it's ambiguous, ask the user which prefix to use. This repo's
+convention is `<username>/<feature>` (e.g. `john/ttft-fix`).
 
 ### 2. Branch off dev
 

--- a/.claude/skills/tt-studio-overview/SKILL.md
+++ b/.claude/skills/tt-studio-overview/SKILL.md
@@ -25,17 +25,17 @@ Important notes:
 ## Docs
 
 - [Main README](README.md): Complete overview, setup instructions, and quick start guide
-- [Setup Guide](docs/run-py-guide.md): Complete installation & configuration using run.py
-- [FAQ](docs/FAQ.md): Quick answers to common questions about TT-Studio
-- [Model Interface Guide](docs/model-interface.md): Using TT-Studio as AI playground (Chat, Vision, Speech, Images)
-- [Troubleshooting Guide](docs/troubleshooting.md): Solutions for common setup and runtime issues
+- [Setup Guide](dev-docs/run-py-guide.md): Complete installation & configuration using run.py
+- [FAQ](dev-docs/FAQ.md): Quick answers to common questions about TT-Studio
+- [Model Interface Guide](dev-docs/model-interface.md): Using TT-Studio as AI playground (Chat, Vision, Speech, Images)
+- [Troubleshooting Guide](dev-docs/troubleshooting.md): Solutions for common setup and runtime issues
 - [Contributing Guide](CONTRIBUTING.md): How to contribute code to the project
-- [Development Setup](docs/development.md): Development environment configuration
+- [Development Setup](dev-docs/development.md): Development environment configuration
 
 ## Examples
 
-- [AI Model Interface](docs/model-interface.md): Complete examples of using Chat, Vision, Speech, and Image models
-- [vLLM Models Guide](docs/HowToRun_vLLM_Models.md): Specific examples for running vLLM models
+- [AI Model Interface](dev-docs/model-interface.md): Complete examples of using Chat, Vision, Speech, and Image models
+- [vLLM Models Guide](dev-docs/HowToRun_vLLM_Models.md): Specific examples for running vLLM models
 - [AI Agent Setup](app/agent/README.md): Setting up and using the AI assistant functionality
 
 ## Key Components

--- a/.claude/skills/tt-studio-overview/SKILL.md
+++ b/.claude/skills/tt-studio-overview/SKILL.md
@@ -1,3 +1,13 @@
+---
+name: tt-studio-overview
+description: >-
+  Project map for TT-Studio — what the platform is, where its docs live, its
+  key components (React frontend, Django backend, FastAPI inference server,
+  Docker), and the AI model types it supports. Use when you need a high-level
+  orientation of the repo, want to know which doc covers a topic, or are trying
+  to locate where a component or capability lives before diving into code.
+---
+
 # TT-Studio
 
 > TT-Studio is an easy-to-use web interface for running AI models on Tenstorrent hardware.
@@ -31,7 +41,7 @@ Important notes:
 ## Key Components
 
 - **Frontend Interface**: Modern React-based UI for model interaction and management
-- **Backend API**: Django-based service for model management, deployment, and API endpoints  
+- **Backend API**: Django-based service for model management, deployment, and API endpoints
 - **TT Inference Server**: FastAPI server for handling model inference requests
 - **Docker Containers**: Complete containerization for isolation and easy deployment
 - **Automatic Hardware Detection**: Seamless integration and auto-mounting of Tenstorrent devices (/dev/tenstorrent)

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -1,0 +1,51 @@
+---
+description: Project overview and navigation map for TT-Studio - what it is, where the docs live, and its key components
+globs: "**/*"
+alwaysApply: true
+---
+
+# TT-Studio
+
+> TT-Studio is an easy-to-use web interface for running AI models on Tenstorrent hardware.
+  It combines TT Inference Server's core packaging setup, containerization,
+  and deployment automation with TT-Metal's model execution framework specifically optimized for Tenstorrent hardware.
+
+Important notes:
+
+- TT-Studio requires access to a Tenstorrent AI accelerator for full deployment features
+- Alternatively, you can connect just the frontend to a remote API endpoint without direct hardware access
+- The platform provides automatic hardware detection and seamless integration with Tenstorrent devices
+- Uses containerized deployment through Docker for isolation and easy deployment
+- The startup.sh script is deprecated - use `python run.py` for all operations
+
+## Docs
+
+- [Main README](README.md): Complete overview, setup instructions, and quick start guide
+- [Setup Guide](docs/run-py-guide.md): Complete installation & configuration using run.py
+- [FAQ](docs/FAQ.md): Quick answers to common questions about TT-Studio
+- [Model Interface Guide](docs/model-interface.md): Using TT-Studio as AI playground (Chat, Vision, Speech, Images)
+- [Troubleshooting Guide](docs/troubleshooting.md): Solutions for common setup and runtime issues
+- [Contributing Guide](CONTRIBUTING.md): How to contribute code to the project
+- [Development Setup](docs/development.md): Development environment configuration
+
+## Examples
+
+- [AI Model Interface](docs/model-interface.md): Complete examples of using Chat, Vision, Speech, and Image models
+- [vLLM Models Guide](docs/HowToRun_vLLM_Models.md): Specific examples for running vLLM models
+- [AI Agent Setup](app/agent/README.md): Setting up and using the AI assistant functionality
+
+## Key Components
+
+- **Frontend Interface**: Modern React-based UI for model interaction and management
+- **Backend API**: Django-based service for model management, deployment, and API endpoints
+- **TT Inference Server**: FastAPI server for handling model inference requests
+- **Docker Containers**: Complete containerization for isolation and easy deployment
+- **Automatic Hardware Detection**: Seamless integration and auto-mounting of Tenstorrent devices (/dev/tenstorrent)
+- **Automated Setup**: Complete environment configuration and model setup automation via run.py script
+
+## Supported AI Models
+
+- **Chat-based Language Models (LLMs)**: Text generation and conversational AI
+- **Computer Vision (YOLO)**: Object detection and image analysis
+- **Speech Recognition (Whisper)**: Audio-to-text transcription
+- **Image Generation (Stable Diffusion)**: AI-powered image creation

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -21,17 +21,17 @@ Important notes:
 ## Docs
 
 - [Main README](README.md): Complete overview, setup instructions, and quick start guide
-- [Setup Guide](docs/run-py-guide.md): Complete installation & configuration using run.py
-- [FAQ](docs/FAQ.md): Quick answers to common questions about TT-Studio
-- [Model Interface Guide](docs/model-interface.md): Using TT-Studio as AI playground (Chat, Vision, Speech, Images)
-- [Troubleshooting Guide](docs/troubleshooting.md): Solutions for common setup and runtime issues
+- [Setup Guide](dev-docs/run-py-guide.md): Complete installation & configuration using run.py
+- [FAQ](dev-docs/FAQ.md): Quick answers to common questions about TT-Studio
+- [Model Interface Guide](dev-docs/model-interface.md): Using TT-Studio as AI playground (Chat, Vision, Speech, Images)
+- [Troubleshooting Guide](dev-docs/troubleshooting.md): Solutions for common setup and runtime issues
 - [Contributing Guide](CONTRIBUTING.md): How to contribute code to the project
-- [Development Setup](docs/development.md): Development environment configuration
+- [Development Setup](dev-docs/development.md): Development environment configuration
 
 ## Examples
 
-- [AI Model Interface](docs/model-interface.md): Complete examples of using Chat, Vision, Speech, and Image models
-- [vLLM Models Guide](docs/HowToRun_vLLM_Models.md): Specific examples for running vLLM models
+- [AI Model Interface](dev-docs/model-interface.md): Complete examples of using Chat, Vision, Speech, and Image models
+- [vLLM Models Guide](dev-docs/HowToRun_vLLM_Models.md): Specific examples for running vLLM models
 - [AI Agent Setup](app/agent/README.md): Setting up and using the AI assistant functionality
 
 ## Key Components

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,6 @@ inference-api/__pycache__/
 !.claude/skills/
 !.claude/skills/**
 .cursor/agent/**/*
-CLAUDE.md
 docs/RAG_PRODUCTIONIZATION_PLAN.md
 docs/DOCKER_CONTROL_SERVICE_PLAN.md
 !app/backend/shared_config/models_from_inference_server.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# TT-Studio
+
+Web interface for running AI models on Tenstorrent hardware. It wraps TT
+Inference Server's packaging, containerization, and deployment automation around
+TT-Metal model execution. Full deployment needs a Tenstorrent accelerator
+(`/dev/tenstorrent`), but the frontend can also run against remote/cloud
+inference endpoints with no local hardware.
+
+> Use `python run.py` for everything — `startup.sh` is deprecated. There are no
+> git submodules; `run.py` fetches the tt-inference-server artifact.
+
+## Architecture & ports
+
+| Service | Port | Runtime | What it is |
+|---|---|---|---|
+| Frontend | 3000 | Docker (Nginx in prod) | React 18 + TypeScript + Vite + Tailwind |
+| Backend | 8000 | Docker | Django REST API via uvicorn (ASGI + Channels/WebSocket) |
+| Inference server | 8001 | Host | FastAPI wrapper over tt-inference-server (`inference-api/`) |
+| Agent | 8080 | Docker | LLM agent service (`app/agent/`) |
+| ChromaDB | 8111 | Docker | Vector DB for RAG |
+| Docker control | 8002 | Host | JWT-secured Docker API wrapper (`docker-control-service/`) |
+
+Containers share the `tt_studio_network` bridge; the backend reaches host
+services via `host.docker.internal`. Health checks: backend `GET /up/` and
+`GET /models/health/`, inference server `GET /health`, frontend `GET /`.
+
+## Repo layout
+
+- `app/backend/` — Django project. Apps: `api` (settings, ASGI/WSGI, URL routing),
+  `docker_control` (image pulls, container deploy, model execution),
+  `model_control` (model registry, inference, TTS), `board_control` (hardware
+  detection / telemetry), `vector_db_control` (Chroma RAG), `logs_control`,
+  `wakeword_control` (voice activation, WebSocket consumers), `shared_config`
+  (model/device config, model sync). Routes in `app/backend/api/urls.py`.
+- `app/frontend/` — React/TS/Vite app. Source under `src/`:
+  `components/`, `pages/`, `providers/`, `contexts/`, `hooks/`, `routes/`,
+  `api/`, `lib/`, `types/`. Backend proxy config in `vite.config.ts`.
+- `app/agent/` — agent service. `inference-api/` — FastAPI inference server.
+- `docker-control-service/` — standalone Docker control service.
+- `models/` — model definitions/config. `dev-tools/` — license/header tooling.
+- `dev-docs/` — developer docs. `.cursor/rules/` — editor rules.
+  `.claude/skills/` — assistant skills.
+
+## Common commands
+
+```bash
+python run.py                 # full setup + start (venv, .env, artifact, Docker)
+python run.py --dev           # dev mode: hot-reload frontend & backend, mount source
+python run.py --cleanup       # stop containers, keep the persistent volume
+python run.py --cleanup-all   # wipe containers, volumes, and .env
+python run.py --check-headers # report files missing SPDX headers
+```
+
+Frontend (in `app/frontend/`): `npm run dev`, `npm run build`,
+`npm run lint` / `lint:fix`, `npm run type-check`.
+Backend (in `app/backend/`): `./manage.py runserver 0.0.0.0:8000`, and tests via
+`pytest` (e.g. `pytest model_control/test_model_api.py -v`).
+
+## Conventions
+
+- **SPDX headers are mandatory on every new code file** (`.py`/`.ts`/`.tsx`/`.js`):
+  ```
+  # SPDX-License-Identifier: Apache-2.0
+  # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+  ```
+  Use `python run.py --add-headers` or `npm run header:fix` to apply.
+- **Pre-commit**: ruff lint + format (config in `dev-tools/`). Frontend also
+  enforces ESLint + header checks.
+- **Git workflow**: branch off `dev` as `<username>/<feature>`; PRs target `dev`
+  (squash-merge); `main` is tagged production only. Follow the `feature-branch-pr`
+  skill for the full flow.
+
+## Environment
+
+`.env` lives at `app/.env`, auto-created from `app/.env.default`. Key vars:
+`HF_TOKEN` (gated model downloads), `JWT_SECRET`, `DJANGO_SECRET_KEY`,
+`TAVILY_API_KEY` (agent search), `TT_INFERENCE_ARTIFACT_VERSION`, and the
+`CLOUD_*` endpoint/token vars used for deployed/remote-endpoint mode
+(`VITE_ENABLE_DEPLOYED=true`).
+
+## Docs & assistant config
+
+- Developer guides: [Setup](dev-docs/detailed-setup.md),
+  [run.py guide](dev-docs/run-py-guide.md), [FAQ](dev-docs/FAQ.md),
+  [Troubleshooting](dev-docs/troubleshooting.md),
+  [Model interface](dev-docs/model-interface.md),
+  [vLLM models](dev-docs/HowToRun_vLLM_Models.md). Also [README](README.md),
+  [Contributing](CONTRIBUTING.md), [Agent](app/agent/README.md).
+- `.cursor/rules/` — Cursor rules: `general`, `backend`, `frontend`,
+  `docker-deployment`, `ai-models`, `project-overview`.
+- `.claude/skills/` — skills: `tt-studio-overview` (project map),
+  `feature-branch-pr` (branch/PR workflow), `tt-studio-debug-bundle` (log triage).


### PR DESCRIPTION
## What

Adds a `feature-branch-pr` editor skill that captures the team's workflow for making a change in this repo, relocates the root `llm.txt` project overview into editor-native locations, and adds a committed root `CLAUDE.md` with current project context.

## Why

The branch/PR workflow only lived in people's heads. This writes it down so changes are consistent: branch off `dev`, keep the diff minimal, verify before pushing, and open a clean PR. Separately, `llm.txt` was a project-overview context file that nothing in the repo referenced; its content now lives in a skill, a Cursor rule, and a tracked `CLAUDE.md` so the project map is available to contributors and editors without a loose root file.

## Changes

- **New skill `.claude/skills/feature-branch-pr/`** — branch off `dev` as `<username>/<feature>`, minimal in-scope changes, verify the running app via its health endpoints (`/up/`, `/models/health/`, FastAPI `/health`, frontend `/`) or tests before pushing, never disturb other branches, and open a human-written PR against `dev`.
- **New skill `.claude/skills/tt-studio-overview/`** and **Cursor rule `.cursor/rules/project-overview.mdc`** — carry the former `llm.txt` content (overview, docs links, key components, supported models).
- **New root `CLAUDE.md`** (removed from `.gitignore`) — concise, current context: architecture and service ports, repo layout, common `run.py`/dev commands, conventions (SPDX headers, branch/PR workflow), and environment variables.
- **Removed root `llm.txt`** — content preserved in the files above; it was referenced nowhere.
- **Fixed stale doc links** — guides live under `dev-docs/`, not `docs/`.

## Verification

Docs/context-only change, so app endpoint checks are N/A. Validated that the new skill and rule frontmatter parse, that both skills register, that the overview content matches the original `llm.txt`, and that every documentation link resolves to a real file.
