### PR TITLE
Remove deprecated --easy flag remnants

### DIFF
--- a/app/backend/vector_db_control/data.py
+++ b/app/backend/vector_db_control/data.py
@@ -80676,7 +80676,7 @@ git clone https://github.com/tenstorrent/tt-studio.git && cd tt-studio && python
 5. **Builds containers** - Sets up Docker environments for frontend and backend
 6. **Starts all services** - Launches the web interface and backend server
 
-> **⚠️ Security Note:** The default setup uses default values that are **NOT secure for production**. Use it only for development, testing, and quick evaluation. For production deployments, configure secure values with `python3 run.py --configure-env` or use development mode (`python3 run.py --dev`).
+> **⚠️ Security Note:** The default setup uses default values that are **NOT secure for production**. Use it only for development, testing, and quick evaluation. For production deployments, configure secure values with `python3 run.py --configure-env` (or `python3 run.py --reconfigure` to update existing values).
 
 📖 **More Details:** See the [Complete run.py Guide](docs/run-py-guide.md#quick-setup-default) for a full comparison of setup modes.
 

--- a/app/backend/vector_db_control/data.py
+++ b/app/backend/vector_db_control/data.py
@@ -80664,21 +80664,21 @@ Before you start, make sure you have:
 **Quick Setup:**
 
 ```bash
-git clone https://github.com/tenstorrent/tt-studio.git && cd tt-studio && python3 run.py --easy
+git clone https://github.com/tenstorrent/tt-studio.git && cd tt-studio && python3 run.py
 ```
 
 **What happens step by step:**
 
 1. **Downloads TT-Studio** - Gets the code from GitHub
 2. **Enters the directory** - Changes to the tt-studio folder
-3. **Runs the setup script** - Automatically configures everything (easy mode: only prompts for your Hugging Face token; uses defaults for the rest)
+3. **Runs the setup script** - Automatically configures everything (the default setup only prompts for your Hugging Face token; uses defaults for the rest)
 4. **Initializes submodules** - Downloads TT Inference Server and dependencies
 5. **Builds containers** - Sets up Docker environments for frontend and backend
 6. **Starts all services** - Launches the web interface and backend server
 
-> **⚠️ Security Note:** Easy mode uses default values that are **NOT secure for production**. Use this mode only for development, testing, and quick evaluation. For production deployments, use the standard setup (`python3 run.py`) or development mode (`python3 run.py --dev`).
+> **⚠️ Security Note:** The default setup uses default values that are **NOT secure for production**. Use it only for development, testing, and quick evaluation. For production deployments, configure secure values with `python3 run.py --configure-env` or use development mode (`python3 run.py --dev`).
 
-📖 **More Details:** See the [Complete run.py Guide](docs/run-py-guide.md#easy-mode-setup) for a full comparison of setup modes.
+📖 **More Details:** See the [Complete run.py Guide](docs/run-py-guide.md#quick-setup-default) for a full comparison of setup modes.
 
 **After Setup:**
 
@@ -82187,10 +82187,10 @@ This directory contains development tools and utilities for the TT-Studio projec
 To run TT-Studio with minimal setup from the project root:
 
 ```bash
-python3 run.py --easy
+python3 run.py
 ```
 
-Easy mode only prompts for your Hugging Face token and uses defaults for everything else. See the [main README](../README.md) and [run.py guide](../docs/run-py-guide.md) for details.
+By default the setup only prompts for your Hugging Face token and uses defaults for everything else. To interactively configure all environment variables instead, run `python3 run.py --configure-env`. See the [main README](../README.md) and [run.py guide](../docs/run-py-guide.md) for details.
 
 ## SPDX Header Tool
 
@@ -83568,7 +83568,7 @@ You can use the playground with **remote endpoints only** (no local hardware), w
    - `CLOUD_STABLE_DIFFUSION_URL` – Image generation endpoint
 
 3. **Start TT-Studio**  
-   Run `python3 run.py --easy` (or `python3 run.py`). Open [http://localhost:3000](http://localhost:3000) to use the full AI Playground UI; requests go to your configured remote endpoints.
+   Run `python3 run.py`. Open [http://localhost:3000](http://localhost:3000) to use the full AI Playground UI; requests go to your configured remote endpoints.
 
 ## More details
 
@@ -83587,7 +83587,7 @@ The `run.py` script automates the complete TT-Studio setup process, including en
 ## Table of Contents
 1. [Basic Usage](#basic-usage)
 2. [Command-Line Options](#command-line-options)
-3. [Easy Mode Setup](#easy-mode-setup)
+3. [Quick Setup (Default)](#quick-setup-default)
 4. [Environment Configuration](#environment-configuration)
 5. [Automatic Tenstorrent Hardware Detection](#automatic-tenstorrent-hardware-detection)
 6. [Authentication Requirements](#authentication-requirements)
@@ -83624,7 +83624,7 @@ The script will guide you through all configuration options and set up everythin
 | --------------- | ---------------------------------------------------------------------------- |
 | `--help`        | Display help message with usage details.                                     |
 | `--dev`         | Run in development mode with suggested defaults.                             |
-| `--easy`        | Easy setup mode - only prompts for HF_TOKEN, uses defaults for everything else. |
+| `--configure-env` | Interactively configure all environment variables (secrets, modes, cloud endpoints). |
 | `--cleanup`     | Stop and remove all Docker services.                                         |
 | `--cleanup-all` | Clean up everything including persistent data and .env file.                 |
 | `--skip-fastapi`| Skip TT Inference Server FastAPI setup.                                      |
@@ -83643,39 +83643,41 @@ python run.py --help
 
 ---
 
-## Easy Mode Setup
+## Quick Setup (Default)
 
-Easy Mode provides a streamlined setup experience designed for first-time users, quick testing, and development environments. It minimizes the configuration prompts and uses sensible defaults for everything except the Hugging Face token.
+Running `python run.py` with no extra flags performs a streamlined setup designed for first-time users, quick testing, and development environments. It minimizes the configuration prompts and uses sensible defaults for everything except the Hugging Face token. To interactively configure every environment variable instead, use `--configure-env`.
 
-### When to Use Easy Mode
+### When the Default Setup Is Appropriate
 
-**✅ Use Easy Mode for:**
+**✅ Good for:**
 - First-time exploration of TT-Studio
 - Quick testing and evaluation
 - Development and debugging
 - Local prototyping
 - Learning how TT-Studio works
 
-**❌ Do NOT use Easy Mode for:**
+**❌ Not appropriate for:**
 - Production deployments
 - Public-facing services
 - Environments with sensitive data
 - Production model serving
 
-### How Easy Mode Works
+For those cases, use `--configure-env` and supply your own secure values.
 
-Easy Mode (`--easy`) simplifies setup by:
+### How the Default Setup Works
+
+The default setup simplifies things by:
 
 1. **Minimal Prompting**: Only prompts for your HF_TOKEN (Hugging Face token)
 2. **Automatic Defaults**: Uses pre-configured default values for all other settings
 3. **Faster Setup**: Skips local npm installation automatically
 4. **TT Studio Mode**: Automatically configures for TT Studio mode (not AI Playground)
-5. **Saves Configuration**: Stores settings in `.tt_studio_easy_config.json` for reference
+5. **Saves Configuration**: Stores settings in `.tt_studio_setup_config.json` for reference
 
 ### Usage
 
 ```bash
-python3 run.py --easy
+python3 run.py
 ```
 
 You'll only be prompted for:
@@ -83683,9 +83685,9 @@ You'll only be prompted for:
 
 All other values are set automatically using defaults.
 
-### Default Values Used in Easy Mode
+### Default Values Used
 
-Easy Mode uses the following default values:
+The default setup uses the following values:
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
@@ -83702,25 +83704,29 @@ Easy Mode uses the following default values:
 | Cloud Model Variables | Empty strings | All cloud/external model endpoints (disabled) |
 | npm Installation | Automatically skipped | Local IDE support (skipped) |
 
-> **⚠️ CRITICAL SECURITY WARNING**: The default values above are **NOT secure for production use**. They are intended only for development, testing, and quick evaluation. Never use Easy Mode for production deployments or public-facing services.
+> **⚠️ CRITICAL SECURITY WARNING**: The default values above are **NOT secure for production use**. They are intended only for development, testing, and quick evaluation. Never use these defaults for production deployments or public-facing services — use `--configure-env` and provide secure values instead.
 
 ### Configuration File
 
-Easy Mode saves your setup configuration to `.tt_studio_easy_config.json` in the repository root. This file contains:
+The default setup saves a snapshot of your setup to `.tt_studio_setup_config.json` in the repository root. This file contains:
 
 - Setup timestamp
-- Mode indicator (`"mode": "easy"`)
+- Mode indicator (`"mode": "quick"`)
 - Record of default values used
 - Configuration flags
 
 This file is for reference only and does not affect the actual runtime configuration (which is stored in `app/.env`).
 
+### Full Interactive Configuration
+
+To configure every environment variable yourself — secrets, application modes, and cloud endpoints — run `python3 run.py --configure-env`. This is the path to use for production-ready or public-facing setups where the insecure defaults above are not acceptable.
+
 ### Mode Comparison
 
-Here's how Easy Mode compares to other setup modes:
+Here's how the setup paths compare:
 
-| Feature | Easy Mode<br>`--easy` | Normal Mode<br>(default) | Development Mode<br>`--dev` |
-|---------|----------------------|-------------------------|----------------------------|
+| Feature | Default<br>`python run.py` | Full Config<br>`--configure-env` | Development<br>`--dev` |
+|---------|----------------------------|----------------------------------|------------------------|
 | **Primary Use** | First-time users, quick testing | Production deployments | Development work |
 | **Prompts Required** | HF_TOKEN only | All security credentials | All with suggested defaults |
 | **Security** | ⚠️ Insecure defaults | ✅ User-provided secure values | ⚠️ Dev defaults available |
@@ -83731,15 +83737,15 @@ Here's how Easy Mode compares to other setup modes:
 | **Setup Time** | Fastest (~1 minute) | Moderate (~5 minutes) | Moderate (~5 minutes) |
 | **Production Ready** | ❌ No | ✅ Yes | ❌ No |
 
-### Example: Easy Mode Setup
+### Example: Default Setup
 
 ```bash
 # Clone the repository
 git clone https://github.com/tenstorrent/tt-studio.git
 cd tt-studio
 
-# Run with easy mode
-python3 run.py --easy
+# Run the default setup
+python3 run.py
 
 # You'll only see:
 # 🤗 Enter HF_TOKEN (Hugging Face token): ****
@@ -83747,9 +83753,9 @@ python3 run.py --easy
 # That's it! Everything else is configured automatically.
 ```
 
-### Switching from Easy Mode to Production
+### Switching from the Default Setup to Production
 
-If you started with Easy Mode and want to switch to a production-ready setup:
+If you started with the default setup and want to switch to a production-ready setup:
 
 1. **Stop TT-Studio** (if running):
    ```bash
@@ -83758,12 +83764,12 @@ If you started with Easy Mode and want to switch to a production-ready setup:
 
 2. **Reconfigure with secure values**:
    ```bash
-   python3 run.py
+   python3 run.py --configure-env
    ```
-   
-   Or use the reconfigure flag:
+
+   Or use the reconfigure flag to reset preferences first:
    ```bash
-   python3 run.py --reconfigure
+   python3 run.py --reconfigure --configure-env
    ```
 
 3. **Provide secure credentials** when prompted:
@@ -83926,9 +83932,9 @@ These credentials are securely used by the TT Inference Server to authenticate r
 python run.py
 ```
 
-### Running in Easy Mode (First-Time Users)
+### Full Interactive Configuration
 ```bash
-python run.py --easy
+python run.py --configure-env
 ```
 
 ### Running in Development Mode

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -146,7 +146,7 @@ Here's how the setup paths compare:
 | Feature | Default<br>`python run.py` | Full Config<br>`--configure-env` | Development<br>`--dev` |
 |---------|----------------------------|----------------------------------|------------------------|
 | **Primary Use** | First-time users, quick testing | Production deployments | Development work |
-| **Prompts Required** | HF_TOKEN only | All security credentials | All with suggested defaults |
+| **Prompts Required** | HF_TOKEN only | All security credentials | HF_TOKEN only (use `--dev --configure-env` for full interactive prompts) |
 | **Security** | ⚠️ Insecure defaults | ✅ User-provided secure values | ⚠️ Dev defaults available |
 | **AI Playground** | Disabled | User choice | User choice |
 | **RAG Admin** | Disabled | User choice | User choice |

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -5,7 +5,7 @@ The `run.py` script automates the complete TT-Studio setup process, including en
 ## Table of Contents
 1. [Basic Usage](#basic-usage)
 2. [Command-Line Options](#command-line-options)
-3. [Easy Mode Setup](#easy-mode-setup)
+3. [Quick Setup (Default)](#quick-setup-default)
 4. [Environment Configuration](#environment-configuration)
 5. [Automatic Tenstorrent Hardware Detection](#automatic-tenstorrent-hardware-detection)
 6. [Authentication Requirements](#authentication-requirements)
@@ -36,7 +36,7 @@ The script will guide you through all configuration options and set up everythin
 | --------------- | ---------------------------------------------------------------------------- |
 | `--help`        | Display help message with usage details.                                     |
 | `--dev`         | Run in development mode with suggested defaults.                             |
-| `--easy`        | Easy setup mode - only prompts for HF_TOKEN, uses defaults for everything else. |
+| `--configure-env` | Interactively configure all environment variables (secrets, modes, cloud endpoints). |
 | `--cleanup`     | Stop and remove all Docker services.                                         |
 | `--cleanup-all` | Clean up everything including persistent data and .env file.                 |
 | `--skip-fastapi`| Skip TT Inference Server FastAPI setup.                                      |
@@ -55,39 +55,41 @@ python run.py --help
 
 ---
 
-## Easy Mode Setup
+## Quick Setup (Default)
 
-Easy Mode provides a streamlined setup experience designed for first-time users, quick testing, and development environments. It minimizes the configuration prompts and uses sensible defaults for everything except the Hugging Face token.
+Running `python run.py` with no extra flags performs a streamlined setup designed for first-time users, quick testing, and development environments. It minimizes the configuration prompts and uses sensible defaults for everything except the Hugging Face token. To interactively configure every environment variable instead, use [`--configure-env`](#full-interactive-configuration).
 
-### When to Use Easy Mode
+### When the Default Setup Is Appropriate
 
-**✅ Use Easy Mode for:**
+**✅ Good for:**
 - First-time exploration of TT-Studio
 - Quick testing and evaluation
 - Development and debugging
 - Local prototyping
 - Learning how TT-Studio works
 
-**❌ Do NOT use Easy Mode for:**
+**❌ Not appropriate for:**
 - Production deployments
 - Public-facing services
 - Environments with sensitive data
 - Production model serving
 
-### How Easy Mode Works
+For those cases, use `--configure-env` and supply your own secure values.
 
-Easy Mode (`--easy`) simplifies setup by:
+### How the Default Setup Works
+
+The default setup simplifies things by:
 
 1. **Minimal Prompting**: Only prompts for your HF_TOKEN (Hugging Face token)
 2. **Automatic Defaults**: Uses pre-configured default values for all other settings
 3. **Faster Setup**: Skips local npm installation automatically
 4. **TT Studio Mode**: Automatically configures for TT Studio mode (not AI Playground)
-5. **Saves Configuration**: Stores settings in `.tt_studio_easy_config.json` for reference
+5. **Saves Configuration**: Stores settings in `.tt_studio_setup_config.json` for reference
 
 ### Usage
 
 ```bash
-python3 run.py --easy
+python3 run.py
 ```
 
 You'll only be prompted for:
@@ -95,9 +97,9 @@ You'll only be prompted for:
 
 All other values are set automatically using defaults.
 
-### Default Values Used in Easy Mode
+### Default Values Used
 
-Easy Mode uses the following default values:
+The default setup uses the following values:
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
@@ -114,25 +116,35 @@ Easy Mode uses the following default values:
 | Cloud Model Variables | Empty strings | All cloud/external model endpoints (disabled) |
 | npm Installation | Automatically skipped | Local IDE support (skipped) |
 
-> **⚠️ CRITICAL SECURITY WARNING**: The default values above are **NOT secure for production use**. They are intended only for development, testing, and quick evaluation. Never use Easy Mode for production deployments or public-facing services.
+> **⚠️ CRITICAL SECURITY WARNING**: The default values above are **NOT secure for production use**. They are intended only for development, testing, and quick evaluation. Never use these defaults for production deployments or public-facing services — use `--configure-env` and provide secure values instead.
 
 ### Configuration File
 
-Easy Mode saves your setup configuration to `.tt_studio_easy_config.json` in the repository root. This file contains:
+The default setup saves a snapshot of your setup to `.tt_studio_setup_config.json` in the repository root. This file contains:
 
 - Setup timestamp
-- Mode indicator (`"mode": "easy"`)
+- Mode indicator (`"mode": "quick"`)
 - Record of default values used
 - Configuration flags
 
 This file is for reference only and does not affect the actual runtime configuration (which is stored in `app/.env`).
 
+### Full Interactive Configuration
+
+To configure every environment variable yourself — secrets, application modes, and cloud endpoints — run:
+
+```bash
+python3 run.py --configure-env
+```
+
+This is the path to use for production-ready or public-facing setups where the insecure defaults above are not acceptable.
+
 ### Mode Comparison
 
-Here's how Easy Mode compares to other setup modes:
+Here's how the setup paths compare:
 
-| Feature | Easy Mode<br>`--easy` | Normal Mode<br>(default) | Development Mode<br>`--dev` |
-|---------|----------------------|-------------------------|----------------------------|
+| Feature | Default<br>`python run.py` | Full Config<br>`--configure-env` | Development<br>`--dev` |
+|---------|----------------------------|----------------------------------|------------------------|
 | **Primary Use** | First-time users, quick testing | Production deployments | Development work |
 | **Prompts Required** | HF_TOKEN only | All security credentials | All with suggested defaults |
 | **Security** | ⚠️ Insecure defaults | ✅ User-provided secure values | ⚠️ Dev defaults available |
@@ -143,15 +155,15 @@ Here's how Easy Mode compares to other setup modes:
 | **Setup Time** | Fastest (~1 minute) | Moderate (~5 minutes) | Moderate (~5 minutes) |
 | **Production Ready** | ❌ No | ✅ Yes | ❌ No |
 
-### Example: Easy Mode Setup
+### Example: Default Setup
 
 ```bash
 # Clone the repository
 git clone https://github.com/tenstorrent/tt-studio.git
 cd tt-studio
 
-# Run with easy mode
-python3 run.py --easy
+# Run the default setup
+python3 run.py
 
 # You'll only see:
 # 🤗 Enter HF_TOKEN (Hugging Face token): ****
@@ -159,9 +171,9 @@ python3 run.py --easy
 # That's it! Everything else is configured automatically.
 ```
 
-### Switching from Easy Mode to Production
+### Switching from the Default Setup to Production
 
-If you started with Easy Mode and want to switch to a production-ready setup:
+If you started with the default setup and want to switch to a production-ready setup:
 
 1. **Stop TT-Studio** (if running):
    ```bash
@@ -170,12 +182,12 @@ If you started with Easy Mode and want to switch to a production-ready setup:
 
 2. **Reconfigure with secure values**:
    ```bash
-   python3 run.py
+   python3 run.py --configure-env
    ```
    
-   Or use the reconfigure flag:
+   Or use the reconfigure flag to reset preferences first:
    ```bash
-   python3 run.py --reconfigure
+   python3 run.py --reconfigure --configure-env
    ```
 
 3. **Provide secure credentials** when prompted:
@@ -338,9 +350,9 @@ These credentials are securely used by the TT Inference Server to authenticate r
 python run.py
 ```
 
-### Running in Easy Mode (First-Time Users)
+### Full Interactive Configuration
 ```bash
-python run.py --easy
+python run.py --configure-env
 ```
 
 ### Running in Development Mode

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -9,10 +9,10 @@ This directory contains development tools and utilities for the TT-Studio projec
 To run TT-Studio with minimal setup from the project root:
 
 ```bash
-python3 run.py --easy
+python3 run.py
 ```
 
-Easy mode only prompts for your Hugging Face token and uses defaults for everything else. See the [main README](../README.md) and [run.py guide](../dev-docs/run-py-guide.md) for details.
+By default the setup only prompts for your Hugging Face token and uses defaults for everything else. To interactively configure all environment variables instead, run `python3 run.py --configure-env`. See the [main README](../README.md) and [run.py guide](../dev-docs/run-py-guide.md) for details.
 
 ## SPDX Header Tool
 

--- a/run.py
+++ b/run.py
@@ -95,7 +95,7 @@ DOCKER_CONTROL_SERVICE_DIR = os.path.join(TT_STUDIO_ROOT, "docker-control-servic
 DOCKER_CONTROL_PID_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.pid")
 DOCKER_CONTROL_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.log")
 PREFS_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_preferences.json")
-EASY_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_easy_config.json")
+SETUP_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_setup_config.json")
 STARTUP_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "startup.log")
 
 # Map health check URLs to Docker container name prefixes (for auto-log-fetching on failure)
@@ -950,25 +950,14 @@ def get_existing_env_vars():
                     env_vars[key] = value.strip('"\'')
     return env_vars
 
-def save_easy_config(config_dict):
-    """Save easy mode configuration to JSON file"""
+def save_setup_config(config_dict):
+    """Save the quick-setup configuration snapshot to JSON file"""
     try:
-        with open(EASY_CONFIG_FILE_PATH, 'w') as f:
+        with open(SETUP_CONFIG_FILE_PATH, 'w') as f:
             json.dump(config_dict, f, indent=2)
         # Silent — no need to show config file path to user
     except Exception as e:
-        print(f"{C_YELLOW}⚠️  Warning: Could not save easy mode configuration: {e}{C_RESET}")
-
-def load_easy_config():
-    """Load easy mode configuration from JSON file"""
-    if os.path.exists(EASY_CONFIG_FILE_PATH):
-        try:
-            with open(EASY_CONFIG_FILE_PATH, 'r') as f:
-                return json.load(f)
-        except Exception as e:
-            print(f"{C_YELLOW}⚠️  Warning: Could not load easy mode configuration: {e}{C_RESET}")
-            return None
-    return None
+        print(f"{C_YELLOW}⚠️  Warning: Could not save setup configuration: {e}{C_RESET}")
 
 def should_configure_var(var_name, current_value):
     """
@@ -1270,7 +1259,7 @@ def check_hf_access(token):
         return (None, f"HF token access check:\n{summary}")
 
 
-def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, easy_mode=True, reconfigure_inference=False):
+def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, quick_setup=True, reconfigure_inference=False):
     """
     Handles all environment configuration in a sequential, top-to-bottom flow.
     Reads existing .env file and prompts for missing or placeholder values.
@@ -1278,7 +1267,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
     Args:
         dev_mode (bool): If True, show dev mode banner but still prompt for all values
         force_reconfigure (bool): If True, force reconfiguration and clear preferences
-        easy_mode (bool): If True, use minimal prompts and defaults for quick setup
+        quick_setup (bool): If True, use minimal prompts and defaults for quick setup
         reconfigure_inference (bool): If True, force reconfiguration of inference server artifact only
     """
     global FORCE_OVERWRITE
@@ -1303,7 +1292,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
         # When no .env file exists, we should configure everything without asking
         FORCE_OVERWRITE = True
 
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_TT_PURPLE}{C_BOLD}TT Studio Environment Configuration{C_RESET}")
         print(f"{C_GREEN}⚙️  Configure Env Mode: Full interactive setup for all variables{C_RESET}")
         if dev_mode:
@@ -1314,17 +1303,17 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
     # Get existing variables
     existing_vars = get_existing_env_vars()
     
-    # Only ask about overwrite preference if .env file existed before (skip for easy mode)
-    if not easy_mode and env_file_exists and existing_vars:
+    # Only ask about overwrite preference if .env file existed before (skip for quick setup)
+    if not quick_setup and env_file_exists and existing_vars:
         FORCE_OVERWRITE = ask_overwrite_preference(existing_vars, force_prompt=force_reconfigure)
     else:
         # No need to ask, we're configuring everything
         if not env_file_exists:
-            if not easy_mode:
+            if not quick_setup:
                 print(f"\n{C_CYAN}📝 Setting up TT Studio for the first time...{C_RESET}")
             FORCE_OVERWRITE = True
-        elif easy_mode:
-            # In easy mode with existing .env, don't force overwrite - let individual checks handle it
+        elif quick_setup:
+            # In quick setup with existing .env, don't force overwrite - let individual checks handle it
             if env_file_exists and existing_vars:
                 FORCE_OVERWRITE = False
             else:
@@ -1333,19 +1322,19 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
             print(f"\n{C_CYAN}📝 No existing configuration found. Will configure all environment variables.{C_RESET}")
             FORCE_OVERWRITE = True
 
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_CYAN}📁 Setting core application paths...{C_RESET}")
     write_env_var("TT_STUDIO_ROOT", TT_STUDIO_ROOT, quote_value=False)
     write_env_var("HOST_PERSISTENT_STORAGE_VOLUME", os.path.join(TT_STUDIO_ROOT, "tt_studio_persistent_volume"), quote_value=False)
     write_env_var("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/tt_studio_persistent_volume", quote_value=False)
     write_env_var("BACKEND_API_HOSTNAME", "tt-studio-backend-api")
 
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_TT_PURPLE}{C_BOLD}--- 🔑  Security Credentials  ---{C_RESET}")
 
     # JWT_SECRET
     current_jwt = get_env_var("JWT_SECRET")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("JWT_SECRET", current_jwt):
             write_env_var("JWT_SECRET", "test-secret-456", quote_value=False)
     elif should_configure_var("JWT_SECRET", current_jwt):
@@ -1364,12 +1353,12 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                 break
             print(f"{C_RED}⛔ This value cannot be empty.{C_RESET}")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ JWT_SECRET already configured (keeping existing value).")
 
     # DJANGO_SECRET_KEY
     current_django = get_env_var("DJANGO_SECRET_KEY")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("DJANGO_SECRET_KEY", current_django):
             write_env_var("DJANGO_SECRET_KEY", "django-insecure-default", quote_value=False)
     elif should_configure_var("DJANGO_SECRET_KEY", current_django):
@@ -1392,7 +1381,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
 
     # TTS_API_KEY
     current_tts_api_key = get_env_var("TTS_API_KEY")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("TTS_API_KEY", current_tts_api_key):
             write_env_var("TTS_API_KEY", "your-secret-key")
     elif should_configure_var("TTS_API_KEY", current_tts_api_key):
@@ -1411,12 +1400,12 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                 break
             print(f"{C_RED}⛔ This value cannot be empty.{C_RESET}")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ TTS_API_KEY already configured (keeping existing value).")
 
     # DOCKER_CONTROL_SERVICE_URL
     current_docker_url = get_env_var("DOCKER_CONTROL_SERVICE_URL")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("DOCKER_CONTROL_SERVICE_URL", current_docker_url):
             write_env_var("DOCKER_CONTROL_SERVICE_URL", "http://host.docker.internal:8002")
     elif should_configure_var("DOCKER_CONTROL_SERVICE_URL", current_docker_url):
@@ -1430,12 +1419,12 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
         write_env_var("DOCKER_CONTROL_SERVICE_URL", val)
         print("✅ DOCKER_CONTROL_SERVICE_URL saved.")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ DOCKER_CONTROL_SERVICE_URL already configured (keeping existing value).")
 
     # DOCKER_CONTROL_JWT_SECRET
     current_docker_jwt = get_env_var("DOCKER_CONTROL_JWT_SECRET")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("DOCKER_CONTROL_JWT_SECRET", current_docker_jwt):
             write_env_var("DOCKER_CONTROL_JWT_SECRET", "test-secret-456", quote_value=False)
     elif should_configure_var("DOCKER_CONTROL_JWT_SECRET", current_docker_jwt):
@@ -1454,12 +1443,12 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                 break
             print(f"{C_RED}⛔ This value cannot be empty.{C_RESET}")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ DOCKER_CONTROL_JWT_SECRET already configured (keeping existing value).")
 
     # TAVILY_API_KEY (optional)
     current_tavily = get_env_var("TAVILY_API_KEY")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("TAVILY_API_KEY", current_tavily):
             write_env_var("TAVILY_API_KEY", "tavily-api-key-not-configured", quote_value=False)
     elif should_configure_var("TAVILY_API_KEY", current_tavily):
@@ -1468,14 +1457,14 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
         write_env_var("TAVILY_API_KEY", (val or "").strip().strip('"\''), quote_value=False)
         print("✅ TAVILY_API_KEY saved.")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ TAVILY_API_KEY already configured (keeping existing value).")
 
     # HF_TOKEN
     current_hf = get_env_var("HF_TOKEN")
     needs_token = should_configure_var("HF_TOKEN", current_hf)
 
-    if easy_mode and needs_token:
+    if quick_setup and needs_token:
         print(f"\n{C_CYAN}A Hugging Face token is required to download models like Llama.{C_RESET}")
         print(f"{C_CYAN}Get yours at: https://huggingface.co/settings/tokens{C_RESET}\n")
 
@@ -1490,7 +1479,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                     print(f"{C_YELLOW}⚠️  Continuing with existing token. Re-run once you have access.{C_RESET}")
                     break
             else:
-                prompt = "🤗 Enter HF_TOKEN: " if easy_mode else "🤗 Enter HF_TOKEN (Hugging Face token): "
+                prompt = "🤗 Enter HF_TOKEN: " if quick_setup else "🤗 Enter HF_TOKEN (Hugging Face token): "
                 val = getpass.getpass(prompt)
                 if not val or not val.strip():
                     print(f"{C_RED}⛔ This value cannot be empty.{C_RESET}")
@@ -1500,7 +1489,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
             print("✅ HF_TOKEN saved.")
         else:
             val = current_hf
-            if not easy_mode:
+            if not quick_setup:
                 print(f"✅ HF_TOKEN already configured (keeping existing value).")
 
         ok, msg = check_hf_access(val)
@@ -1521,12 +1510,12 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
             # choice == "2": continue with current token
         break
 
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_TT_PURPLE}{C_BOLD}--- ⚙️  Application Configuration  ---{C_RESET}")
 
     # VITE_APP_TITLE
     current_title = get_env_var("VITE_APP_TITLE")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("VITE_APP_TITLE", current_title):
             write_env_var("VITE_APP_TITLE", "Tenstorrent | TT Studio")
     elif should_configure_var("VITE_APP_TITLE", current_title):
@@ -1535,15 +1524,15 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
         write_env_var("VITE_APP_TITLE", val)
         print("✅ VITE_APP_TITLE saved.")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ VITE_APP_TITLE already configured: {current_title}")
 
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_CYAN}{C_BOLD}------------------ Mode Selection ------------------{C_RESET}")
 
     # VITE_ENABLE_DEPLOYED
     current_deployed = get_env_var("VITE_ENABLE_DEPLOYED")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("VITE_ENABLE_DEPLOYED", current_deployed) or current_deployed not in ["true", "false"]:
             write_env_var("VITE_ENABLE_DEPLOYED", "false", quote_value=False)
     elif should_configure_var("VITE_ENABLE_DEPLOYED", current_deployed) or current_deployed not in ["true", "false"]:
@@ -1558,16 +1547,16 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                 break
             print(f"{C_RED}⛔ Invalid input. Please enter 'true' or 'false'.{C_RESET}")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ VITE_ENABLE_DEPLOYED already configured: {current_deployed}")
 
     is_deployed_mode = parse_boolean_env(get_env_var("VITE_ENABLE_DEPLOYED"))
-    if not easy_mode:
+    if not quick_setup:
         print(f"🔹 AI Playground Mode is {'ENABLED' if is_deployed_mode else 'DISABLED'}")
 
     # VITE_ENABLE_RAG_ADMIN
     current_rag = get_env_var("VITE_ENABLE_RAG_ADMIN")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("VITE_ENABLE_RAG_ADMIN", current_rag) or current_rag not in ["true", "false"]:
             write_env_var("VITE_ENABLE_RAG_ADMIN", "false", quote_value=False)
     elif should_configure_var("VITE_ENABLE_RAG_ADMIN", current_rag) or current_rag not in ["true", "false"]:
@@ -1582,16 +1571,16 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
                 break
             print(f"{C_RED}⛔ Invalid input. Please enter 'true' or 'false'.{C_RESET}")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"✅ VITE_ENABLE_RAG_ADMIN already configured: {current_rag}")
 
     is_rag_admin_enabled = parse_boolean_env(get_env_var("VITE_ENABLE_RAG_ADMIN"))
-    if not easy_mode:
+    if not quick_setup:
         print(f"🔹 RAG Admin Page is {'ENABLED' if is_rag_admin_enabled else 'DISABLED'}")
 
-    # RAG_ADMIN_PASSWORD (only if RAG is enabled, or set default in easy mode)
+    # RAG_ADMIN_PASSWORD (only if RAG is enabled, or set default in quick setup)
     current_rag_pass = get_env_var("RAG_ADMIN_PASSWORD")
-    if easy_mode:
+    if quick_setup:
         if should_configure_var("RAG_ADMIN_PASSWORD", current_rag_pass):
             write_env_var("RAG_ADMIN_PASSWORD", "tt-studio-rag-admin-password", quote_value=False)
     elif is_rag_admin_enabled:
@@ -1624,7 +1613,7 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
         ("CLOUD_STABLE_DIFFUSION_AUTH_TOKEN", "🔑 Stable Diffusion Auth Token", True),
     ]
     
-    if easy_mode:
+    if quick_setup:
         for var_name, _, _ in cloud_vars:
             current_val = get_env_var(var_name)
             if should_configure_var(var_name, current_val):
@@ -1646,11 +1635,11 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
             else:
                 print(f"✅ {var_name} already configured (keeping existing value).")
     else:
-        if not easy_mode:
+        if not quick_setup:
             print(f"\n{C_YELLOW}Skipping cloud model configuration (AI Playground mode is disabled).{C_RESET}")
 
-    # Frontend configuration (always set in easy mode, optional otherwise)
-    if easy_mode:
+    # Frontend configuration (always set in quick setup, optional otherwise)
+    if quick_setup:
         current_frontend_host = get_env_var("FRONTEND_HOST")
         current_frontend_port = get_env_var("FRONTEND_PORT")
         current_frontend_timeout = get_env_var("FRONTEND_TIMEOUT")
@@ -1663,9 +1652,9 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
             write_env_var("FRONTEND_TIMEOUT", "60", quote_value=False)
 
     # TT Inference Server Artifact Configuration
-    if not easy_mode:
+    if not quick_setup:
         print(f"\n{C_TT_PURPLE}{C_BOLD}--- 🔧 TT Inference Server Configuration  ---{C_RESET}")
-    configure_inference_server_artifact(dev_mode, easy_mode, force_reconfigure, reconfigure_inference)
+    configure_inference_server_artifact(dev_mode, quick_setup, force_reconfigure, reconfigure_inference)
 
     print(f"\n{C_GREEN}✅ Environment configuration complete.{C_RESET}")
 
@@ -2014,7 +2003,7 @@ def cleanup_resources(args):
         ("📜", os.path.join(TT_STUDIO_ROOT, "fastapi_logs"),
          "per-deployment FastAPI logs"),
         ("⚙️ ", PREFS_FILE_PATH, "CLI preferences"),
-        ("⚙️ ", EASY_CONFIG_FILE_PATH, "easy-mode setup snapshot"),
+        ("⚙️ ", SETUP_CONFIG_FILE_PATH, "quick-setup snapshot"),
         ("🎙️ ", os.path.join(TT_STUDIO_ROOT, "output.wav"), "TTS scratch output"),
         ("🎙️ ", os.path.join(TT_STUDIO_ROOT, "speech.wav"), "STT scratch output"),
         ("🐍", os.path.join(INFERENCE_API_DIR, ".venv"),
@@ -2552,21 +2541,21 @@ def is_valid_git_repo(path):
             return False
     return False  # Exists but not a git repo
 
-def configure_inference_server_artifact(dev_mode=False, easy_mode=False, force_reconfigure=False, reconfigure_inference=False):
+def configure_inference_server_artifact(dev_mode=False, quick_setup=False, force_reconfigure=False, reconfigure_inference=False):
     """
     Configure TT Inference Server artifact source (release version or branch).
 
     Args:
         dev_mode: Development mode flag
-        easy_mode: Easy mode flag
+        quick_setup: Quick setup flag (minimal prompts, defaults)
         force_reconfigure: Force reconfiguration of all options
         reconfigure_inference: Force reconfiguration of inference server artifact only
     """
     current_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION")
     current_branch = get_env_var("TT_INFERENCE_ARTIFACT_BRANCH")
 
-    # In easy mode with no reconfigure request: silently default to 'latest' if not already set
-    if easy_mode and not (force_reconfigure or reconfigure_inference):
+    # In quick setup with no reconfigure request: silently default to 'latest' if not already set
+    if quick_setup and not (force_reconfigure or reconfigure_inference):
         if not (current_version or current_branch):
             write_env_var("TT_INFERENCE_ARTIFACT_VERSION", "latest", quote_value=False)
         return
@@ -2601,8 +2590,8 @@ def configure_inference_server_artifact(dev_mode=False, easy_mode=False, force_r
     print(f"  1. Release version (stable, recommended for production)")
     print(f"  2. Branch (latest development code, may have new features)")
     
-    if easy_mode:
-        # In easy mode, default to latest release but still allow choice
+    if quick_setup:
+        # In quick setup, default to latest release but still allow choice
         while True:
             choice = input(f"{C_CYAN}Enter choice (1 or 2) [default: 1]: {C_RESET}").strip() or "1"
             if choice in ["1", "2"]:
@@ -4158,7 +4147,7 @@ def remove_artifact_with_sudo(directory_path, description="artifact directory"):
         print(f"\n{C_YELLOW}   Sudo removal cancelled by user.{C_RESET}")
         return False
 
-def ensure_frontend_dependencies(force_prompt=False, easy_mode=False):
+def ensure_frontend_dependencies(force_prompt=False, quick_setup=False):
     """
     Ensures frontend dependencies are available locally for IDE support.
     This is optional for running the app, as dependencies are always installed
@@ -4167,7 +4156,7 @@ def ensure_frontend_dependencies(force_prompt=False, easy_mode=False):
     
     Args:
         force_prompt (bool): If True, always prompt user even if preference exists
-        easy_mode (bool): If True, automatically skip npm installation without prompting
+        quick_setup (bool): If True, automatically skip npm installation without prompting
     """
     frontend_dir = os.path.join(TT_STUDIO_ROOT, "app", "frontend")
     node_modules_dir = os.path.join(frontend_dir, "node_modules")
@@ -4186,8 +4175,8 @@ def ensure_frontend_dependencies(force_prompt=False, easy_mode=False):
 
     try:
         if has_local_npm:
-            # In easy mode, automatically skip npm installation
-            if easy_mode:
+            # In quick setup, automatically skip npm installation
+            if quick_setup:
                 save_preference("npm_install_locally", 'n')
                 return True
             
@@ -4690,8 +4679,8 @@ def main():
 
 {C_MAGENTA}{C_BOLD}Usage Examples:{C_RESET}
 {'=' * 80}
-  {C_CYAN}python run.py{C_RESET}                        Normal setup with prompts
-  {C_CYAN}python run.py --easy{C_RESET}                 Easy setup - minimal prompts, only HF_TOKEN required
+  {C_CYAN}python run.py{C_RESET}                        Default setup - minimal prompts, only HF_TOKEN required
+  {C_CYAN}python run.py --configure-env{C_RESET}        Interactively configure all environment variables
   {C_CYAN}python run.py --dev{C_RESET}                  Development mode with defaults
   {C_CYAN}python run.py --reconfigure{C_RESET}          Reset preferences and reconfigure
   {C_CYAN}python run.py --cleanup{C_RESET}              Clean up containers only
@@ -4761,13 +4750,13 @@ def main():
         startup_log.step("docker_install_check", "OK")
 
         startup_log.step("configure_environment", "START")
-        configure_environment_sequentially(dev_mode=args.dev, force_reconfigure=args.reconfigure, easy_mode=not args.configure_env, reconfigure_inference=args.reconfigure_inference_server)
+        configure_environment_sequentially(dev_mode=args.dev, force_reconfigure=args.reconfigure, quick_setup=not args.configure_env, reconfigure_inference=args.reconfigure_inference_server)
         startup_log.step("configure_environment", "OK")
 
-        # Save easy mode configuration to JSON if not in --configure-env mode
+        # Save quick-setup configuration snapshot to JSON if not in --configure-env mode
         if not args.configure_env:
-            easy_config = {
-                "mode": "easy",
+            setup_config = {
+                "mode": "quick",
                 "setup_timestamp": datetime.now().isoformat(),
                 "jwt_secret_default": "test-secret-456",
                 "django_secret_key_default": "django-insecure-default",
@@ -4778,7 +4767,7 @@ def main():
                 "vite_enable_deployed": "false",
                 "vite_enable_rag_admin": "false"
             }
-            save_easy_config(easy_config)
+            save_setup_config(setup_config)
 
         # Create persistent storage directory
         host_persistent_volume = get_env_var("HOST_PERSISTENT_STORAGE_VOLUME") or os.path.join(TT_STUDIO_ROOT, "tt_studio_persistent_volume")
@@ -4864,7 +4853,7 @@ def main():
             sys.exit(1)
 
         # Ensure frontend dependencies are installed
-        ensure_frontend_dependencies(force_prompt=args.reconfigure, easy_mode=not args.configure_env)
+        ensure_frontend_dependencies(force_prompt=args.reconfigure, quick_setup=not args.configure_env)
 
         # Check if all required ports are available
 

--- a/run.py
+++ b/run.py
@@ -96,6 +96,7 @@ DOCKER_CONTROL_PID_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.p
 DOCKER_CONTROL_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "docker-control-service.log")
 PREFS_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_preferences.json")
 SETUP_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_setup_config.json")
+LEGACY_SETUP_CONFIG_FILE_PATH = os.path.join(TT_STUDIO_ROOT, ".tt_studio_easy_config.json")
 STARTUP_LOG_FILE = os.path.join(TT_STUDIO_ROOT, "startup.log")
 
 # Map health check URLs to Docker container name prefixes (for auto-log-fetching on failure)
@@ -2004,6 +2005,7 @@ def cleanup_resources(args):
          "per-deployment FastAPI logs"),
         ("⚙️ ", PREFS_FILE_PATH, "CLI preferences"),
         ("⚙️ ", SETUP_CONFIG_FILE_PATH, "quick-setup snapshot"),
+        ("⚙️ ", LEGACY_SETUP_CONFIG_FILE_PATH, "legacy quick-setup snapshot"),
         ("🎙️ ", os.path.join(TT_STUDIO_ROOT, "output.wav"), "TTS scratch output"),
         ("🎙️ ", os.path.join(TT_STUDIO_ROOT, "speech.wav"), "STT scratch output"),
         ("🐍", os.path.join(INFERENCE_API_DIR, ".venv"),

--- a/test_run_cleanup.py
+++ b/test_run_cleanup.py
@@ -14,7 +14,7 @@ import run
 
 class CleanupAllTests(unittest.TestCase):
     def _patch_cleanup_paths(self, root, sentinel):
-        easy_config = root / ".tt_studio_easy_config.json"
+        setup_config = root / ".tt_studio_setup_config.json"
         docker_log = root / "docker-control-service.log"
         docker_pid = root / "docker-control-service.pid"
         return (
@@ -22,7 +22,7 @@ class CleanupAllTests(unittest.TestCase):
             patch.object(run, "ENV_FILE_PATH", str(root / "app" / ".env")),
             patch.object(run, "STARTUP_LOG_FILE", str(root / "startup.log")),
             patch.object(run, "PREFS_FILE_PATH", str(root / ".tt_studio_preferences.json")),
-            patch.object(run, "EASY_CONFIG_FILE_PATH", str(easy_config)),
+            patch.object(run, "SETUP_CONFIG_FILE_PATH", str(setup_config)),
             patch.object(run, "FASTAPI_LOG_FILE", str(root / "fastapi.log")),
             patch.object(run, "FASTAPI_PID_FILE", str(root / "fastapi.pid")),
             patch.object(run, "DOCKER_CONTROL_LOG_FILE", str(docker_log)),
@@ -362,8 +362,8 @@ class TermsAcceptanceGateTests(unittest.TestCase):
                 # No prefs file → treated as first run (terms asked).
                 self.assertTrue(run.is_first_time_setup())
 
-                # Accepting terms writes the prefs file (the fix: in easy mode
-                # this was previously never created, so terms re-fired every run).
+                # Accepting terms writes the prefs file (the fix: in the default
+                # quick setup this was previously never created, so terms re-fired every run).
                 run.save_preference("terms_accepted", True)
                 self.assertTrue(prefs.exists())
 


### PR DESCRIPTION
## Summary

The `--easy` CLI flag was already removed from `run.py`'s argparse, so passing it today just errors with "unrecognized argument". But leftover references in the help text, docs, and RAG knowledge base still told users — and AI coding tools — to run `python run.py --easy`, which is confusing and broken. This PR purges those remnants. The former "easy mode" behavior is simply the **default** now (you get it unless you pass `--configure-env`), so the change is a rename + documentation-accuracy pass with **no behavior change**.

## Changes

- **`run.py`**: removed the `--easy` usage example from `--help-env`; renamed the internal `easy_mode` plumbing to `quick_setup` and the config artifacts to neutral names (`.tt_studio_setup_config.json`, `save_setup_config`, `SETUP_CONFIG_FILE_PATH`, `"mode": "quick"`); deleted the unused `load_easy_config` helper. Polarity and logic are identical.
- **`dev-docs/run-py-guide.md`** and **`dev-tools/README.md`**: reframed "Easy Mode" as the default quick setup and documented `--configure-env` as the full-interactive path; updated the options table, mode-comparison table, and examples.
- **`app/backend/vector_db_control/data.py`**: updated the embedded setup docs in the internal RAG knowledge base so retrieval no longer surfaces the dead `--easy` flag.
- **`test_run_cleanup.py`**: updated to the renamed `SETUP_CONFIG_FILE_PATH` constant.

Ordinary-English uses of the word "easy" (the "Made Easy" banner tagline, "Easy fix" Docker hints, CONTRIBUTING.md) were intentionally left untouched.

## Verification

- `grep` for `--easy` / `easy_mode` / `easy_config` / `EASY_CONFIG` across the changed files returns nothing.
- `run.py` and `data.py` parse cleanly (`ast.parse`).
- `python -m unittest test_run_cleanup` — all 15 tests pass, confirming cleanup still wires up the renamed config-path constant.
- `python run.py --help-env` no longer lists `--easy`.