### PR TITLE
Fix comments in .env.default

### DIFF
--- a/app/.env.default
+++ b/app/.env.default
@@ -34,16 +34,16 @@ TAVILY_API_KEY=tvly-xxx
 VITE_APP_TITLE="TT Studio"
 
 # Application Modes
-VITE_ENABLE_DEPLOYED=true or false to enable deployed mode
-VITE_ENABLE_RAG_ADMIN=true or false to enable RAG admin
+VITE_ENABLE_DEPLOYED=true # or false to enable deployed mode
+VITE_ENABLE_RAG_ADMIN=true # or false to enable RAG admin
 
 # RAG Configuration (required if VITE_ENABLE_RAG_ADMIN=true)
 RAG_ADMIN_PASSWORD=tt-studio-rag-admin-password
 
 # Cloud/External Model APIs (only used when VITE_ENABLE_DEPLOYED=true)
 # Chat UI
-CLOUD_CHAT_UI_URL=cloud llama chat ui url
-CLOUD_CHAT_UI_AUTH_TOKEN=cloud llama chat ui auth token
+CLOUD_CHAT_UI_URL="" # cloud llama chat ui url
+CLOUD_CHAT_UI_AUTH_TOKEN="" # cloud llama chat ui auth token
 
 # Computer Vision
 CLOUD_YOLOV4_API_URL=


### PR DESCRIPTION
Correct merging flow for PR #918 

@tsingletaryTT's description for PR #918:

This pull request updates the .env.default file to clarify configuration options and provide default values for cloud chat UI environment variables. The changes improve the documentation and usability of environment variable settings.

Configuration documentation improvements:

Updated comments for VITE_ENABLE_DEPLOYED and VITE_ENABLE_RAG_ADMIN to clarify usage and indicate that the value should be true or false, and changed the format to use # for comments.
Default values for environment variables:

Set default empty string values for CLOUD_CHAT_UI_URL and CLOUD_CHAT_UI_AUTH_TOKEN to make it clear that these should be filled in with actual credentials as needed.