### PR TITLE
Allow multiple instances of the same model to be deployed

### DIFF
--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -352,29 +352,10 @@ class DeployView(APIView):
                     board_type,
                 )
 
-            # Stop and clean up any existing starting/running deployments of this
-            # model before deploying a new instance. Prevents stale records with
-            # wrong device_id from persisting in the UI after a re-deploy.
-            try:
-                from docker_control.models import ModelDeployment
-                from docker_control.docker_utils import stop_container
-                stale = list(ModelDeployment.objects.filter(
-                    model_name=impl.model_name,
-                    status__in=["starting", "running"],
-                ))
-                for old_dep in stale:
-                    try:
-                        stop_container(old_dep.container_id)
-                    except Exception:
-                        pass
-                    old_dep.status = "stopped"
-                    old_dep.save()
-                    logger.info(
-                        f"Cleaned up stale deployment record {old_dep.id} "
-                        f"for {impl.model_name} (container_id={old_dep.container_id})"
-                    )
-            except Exception as e:
-                logger.warning(f"Could not clean up stale deployments for {impl.model_name}: {e}")
+            # Multiple concurrent instances of the same model are allowed when chip
+            # capacity is available. Slot allocation below enforces capacity and the
+            # canonical reconciliation frees genuinely stale records, so we must not
+            # stop existing same-model deployments here.
 
             # Allocate a chip slot for all model types so device_id and service_port
             # are always set correctly (port = 7000 + device_id).


### PR DESCRIPTION
## Summary

Fixes a bug where deploying a second instance of the same model would tear down the first one. On hardware with spare capacity (e.g. up to 4 single-chip models on a P300x2), users can now run multiple concurrent instances of the same model.

## Problem

On every deploy, `DeployView` ran a cleanup step that stopped and marked `stopped` **every** `starting`/`running` deployment with a matching `model_name`. So deploying a model that was already running silently killed the existing instance. In the Models Deployed page this showed up as the old row disappearing, replaced by the new one, with progress bars bound to the wrong deployment.

## Change

Removed the same-model teardown in `app/backend/docker_control/views.py`. It was redundant and harmful:

- **Stale records are already handled** — `get_canonical_deployments()` reconciles deployment records against live Docker and marks gone containers as `stopped`, freeing their slots. The chip allocator routes through this on every deploy.
- **Capacity is already enforced** — `allocate_chip_slot()` raises `AllocationError` / `MultiChipConflictError` (returned as `409`) when no slot is free, so an over-capacity deploy gets a clear error instead of stomping a running instance.

Concurrent instances naturally get distinct chip slots → distinct ports (`7000 + device_id`) → distinct container names and IDs, so the frontend renders them as separate rows with independent status and progress. No frontend changes required.

## Notes

- Full-board models (e.g. force-full-board Llama) that occupy all slots now return a `409` conflict on re-deploy ("stop running models first") instead of silently replacing the running instance. This is consistent with the capacity model.

## Testing plan

1. Deploy a single-chip model (e.g. Speech TTS or Whisper).
2. Once it's running, deploy a **second instance of the same model**.
3. Confirm on the Models Deployed page:
   - Both instances appear as separate rows on different devices/ports.
   - The original instance keeps running (it is not stopped or removed).
   - Each row shows its own status and progress.
4. Repeat until chip slots are exhausted and confirm the next deploy returns a clear "no slots available" error rather than removing an existing instance.




<img width="1920" height="645" alt="Screenshot 2026-06-25 at 6 50 56 PM" src="https://github.com/user-attachments/assets/ebb1076c-cce4-405f-a55c-09f1b022c98d" />
