### PR TITLE
Delete delayed reset in footer and premature closing of model deletion modal

### DIFF
--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -51,6 +51,15 @@ import { useDeleteStream } from "../../hooks/useDeleteStream";
 import axios from "axios";
 import { ChipStatusDisplay } from "../ChipStatusDisplay";
 
+const deviceIdsForRow = (
+  row?: { device_ids?: number[]; device_id?: number | null },
+): number[] | undefined => {
+  if (!row) return undefined;
+  if (Array.isArray(row.device_ids) && row.device_ids.length > 0) return row.device_ids;
+  if (row.device_id != null) return [row.device_id];
+  return undefined;
+};
+
 export default function ModelsDeployedCard(): JSX.Element {
   const { models, setModels, refreshModels, userStoppedModel, setUserStoppedModel, setIsDeleteInFlight } = useModels();
   const { refreshTrigger, triggerRefresh, triggerHardwareRefresh, resetAllNonce } =
@@ -175,6 +184,9 @@ export default function ModelsDeployedCard(): JSX.Element {
   // Delete state
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  // Snapshot at confirm time so the in-flight dialog keeps its device list even
+  // after the row leaves the table mid-reset.
+  const [deleteDeviceIds, setDeleteDeviceIds] = useState<number[] | undefined>(undefined);
   const deleteStream = useDeleteStream();
   const isDeleteInFlight = deleteStream.status === "running";
 
@@ -431,6 +443,7 @@ export default function ModelsDeployedCard(): JSX.Element {
 
     setShowDeleteModal(false);
     setDeleteTargetId(null);
+    setDeleteDeviceIds(undefined);
     deleteStream.reset();
   }, [deleteStream, refreshModels, triggerHardwareRefresh, refreshAllHealth]);
 
@@ -446,6 +459,7 @@ export default function ModelsDeployedCard(): JSX.Element {
         window.setTimeout(() => refreshAllHealth(), 1000);
         setShowDeleteModal(false);
         setDeleteTargetId(null);
+        setDeleteDeviceIds(undefined);
         deleteStream.reset();
       }, 1500);
     }
@@ -525,6 +539,26 @@ export default function ModelsDeployedCard(): JSX.Element {
     [register]
   );
 
+  // Rendered above the early returns so an in-flight delete survives the table
+  // collapsing to the empty state when its last model is removed.
+  const deleteDialog = (
+    <DeleteModelDialog
+      open={showDeleteModal}
+      modelId={deleteTargetId || ""}
+      deviceIds={deleteDeviceIds}
+      totalDevices={chipStatus?.total_slots}
+      boardType={chipStatus?.board_type}
+      isLoading={deleteStream.status === "running"}
+      deleteStep={deleteStream.step}
+      streamStatus={deleteStream.status}
+      stepLogs={deleteStream.stepLogs}
+      errorMessage={deleteStream.errorMessage}
+      onConfirm={handleConfirmDelete}
+      onMinimize={() => setShowDeleteModal(false)}
+      onCancel={handleCloseDeleteModal}
+    />
+  );
+
   if (loading) {
     return <ModelsDeployedSkeleton />;
   }
@@ -550,7 +584,12 @@ export default function ModelsDeployedCard(): JSX.Element {
   }
 
   if (rows.length === 0) {
-    return <NoModelsRunning userStopped={userStoppedModel} />;
+    return (
+      <>
+        <NoModelsRunning userStopped={userStoppedModel} />
+        {deleteDialog}
+      </>
+    );
   }
 
   return (
@@ -702,6 +741,7 @@ export default function ModelsDeployedCard(): JSX.Element {
                   }}
                   onDelete={(id: string) => {
                     setDeleteTargetId(id);
+                    setDeleteDeviceIds(deviceIdsForRow(rows.find((r) => r.id === id)));
                     setShowDeleteModal(true);
                   }}
                   onRedeploy={(image?: string) => image && handleRedeploy(image)}
@@ -749,27 +789,7 @@ export default function ModelsDeployedCard(): JSX.Element {
           }}
         />
 
-        <DeleteModelDialog
-          open={showDeleteModal}
-          modelId={deleteTargetId || ""}
-          deviceIds={(() => {
-            const row = rows.find((r) => r.id === deleteTargetId);
-            if (!row) return undefined;
-            if (Array.isArray(row.device_ids) && row.device_ids.length > 0) return row.device_ids;
-            if (row.device_id != null) return [row.device_id];
-            return undefined;
-          })()}
-          totalDevices={chipStatus?.total_slots}
-          boardType={chipStatus?.board_type}
-          isLoading={deleteStream.status === "running"}
-          deleteStep={deleteStream.step}
-          streamStatus={deleteStream.status}
-          stepLogs={deleteStream.stepLogs}
-          errorMessage={deleteStream.errorMessage}
-          onConfirm={handleConfirmDelete}
-          onMinimize={() => setShowDeleteModal(false)}
-          onCancel={handleCloseDeleteModal}
-        />
+        {deleteDialog}
 
         <RegisterModelDialog
           open={showRegisterDialog}

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -21,6 +21,7 @@ import { ModelsDeployedSkeleton } from "../ModelsDeployedSkeleton";
 import { useModels } from "../../hooks/useModels";
 import { useRefresh } from "../../hooks/useRefresh";
 import { useIsResetting } from "../../hooks/useIsResetting";
+import { useDeviceState } from "../../hooks/useDeviceState";
 import { useHealthRefresh } from "../../hooks/useHealthRefresh";
 import { useOpenLogsFromUrl } from "../../hooks/useOpenLogsFromUrl";
 import { useColumnPrefs } from "../../hooks/useColumnPrefs";
@@ -66,6 +67,7 @@ export default function ModelsDeployedCard(): JSX.Element {
     useRefresh();
   // True while any board/device reset is in progress (global, backend-sourced).
   const isResetting = useIsResetting();
+  const { refresh: refreshDeviceState } = useDeviceState();
 
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -554,7 +556,10 @@ export default function ModelsDeployedCard(): JSX.Element {
       stepLogs={deleteStream.stepLogs}
       errorMessage={deleteStream.errorMessage}
       onConfirm={handleConfirmDelete}
-      onMinimize={() => setShowDeleteModal(false)}
+      onMinimize={() => {
+        setShowDeleteModal(false);
+        refreshDeviceState();
+      }}
       onCancel={handleCloseDeleteModal}
     />
   );
@@ -586,14 +591,15 @@ export default function ModelsDeployedCard(): JSX.Element {
   if (rows.length === 0) {
     return (
       <>
-        <NoModelsRunning userStopped={userStoppedModel} />
         {deleteDialog}
+        <NoModelsRunning userStopped={userStoppedModel} />
       </>
     );
   }
 
   return (
     <>
+      {deleteDialog}
       <ElevatedCard accent="neutral" depth="lg" hover>
         <CardHeader className="pb-4">
           <div className="flex items-center justify-between gap-3">
@@ -788,8 +794,6 @@ export default function ModelsDeployedCard(): JSX.Element {
             setWorkflowDialogModelName(undefined);
           }}
         />
-
-        {deleteDialog}
 
         <RegisterModelDialog
           open={showRegisterDialog}


### PR DESCRIPTION
## Summary

Fixes the model deletion flow on the Models Deployed page, where deleting an individual model caused the progress modal to close prematurely and the board reset to appear to "restart" afterward.

## Background

The delete/reset progress modal (`DeleteModelDialog`) was rendered below the `rows.length === 0` early return in `ModelsDeployedCard`. Deleting a model marks it stopped immediately, so when its last model left the table the component switched render branches and **unmounted the modal mid-reset** — before the SSE stream's terminal `complete` event. The reset kept running in the background, which the global footer indicator then surfaced as a second, delayed "reset."

## Changes

- **Modal no longer closes early.** The dialog is hoisted to a stable top-level position rendered in both the populated and empty-state branches, so it survives the table collapsing to empty and stays open until the stream actually completes.
- **Footer updates instantly on "Run in background."** Minimizing now forces an immediate device-state refresh, so the footer's resetting indicator appears the moment the modal closes instead of waiting for the next scheduled poll.

No changes to the SSE protocol, close logic, or backend.

## Test Plan

1. Deploy a model and wait to reach Models Deployed page, not necessary to wait for status to become healthy.
2. Click **Delete** on the model and confirm.
3. Verify the modal **stays open throughout** both phases (stop container → reset devices) and does not flash, flicker, or close on its own — it should only close once the stream reports completion.
4. Repeat the delete, and this time click **Run in background** during the reset.
5. Verify the footer shows the **Resetting…** indicator immediately on close, not after a delay.
6. Confirm the model is gone and the board returns to a ready state afterward.
