### PR TITLE
updated to v0.17.0 artifact, fixed qwen image and device ids issue

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -19,8 +19,8 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # NOTE: pinned to a commit SHA — the Wan2.2-T2V TT_DIT_CACHE_DIR dev-catalog fix lands
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
-TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-# TT_INFERENCE_ARTIFACT_VERSION=v0.15.0
+# TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
+TT_INFERENCE_ARTIFACT_VERSION=v0.17.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -583,7 +583,7 @@ class DeployView(APIView):
                             model_name=impl.model_name,
                             device=device,
                             device_id=device_id,
-                            device_ids=device_ids,
+                            device_ids=occupied_device_ids,
                             status="starting",
                             port=service_port,
                         )

--- a/run.py
+++ b/run.py
@@ -3813,7 +3813,7 @@ def start_fastapi_server(no_sudo=False, dev_mode=False):
     # restart defaults to prod and Wan deploys uncached (and hang). Respects an explicit
     # operator override. Real fix: add TT_DIT_CACHE_DIR to tt-inference-server
     # prod/video.yaml (and land it on main), then delete this block.
-    env["MODEL_SPECS_ENV"] = os.getenv("MODEL_SPECS_ENV", "dev")
+    # env["MODEL_SPECS_ENV"] = os.getenv("MODEL_SPECS_ENV", "dev")  # TODO: remove this whole block once confirmed it's not needed
 
     # STOPGAP (excise when upstream catalog carries the var): overlay
     # HF_HUB_DISABLE_XET=1 onto every model-spec template in the freshly-extracted


### PR DESCRIPTION
## Transition to v0.17.0 + Qwen deployment fixes

Moves the TT Inference Server artifact to the `v0.17.0` release and fixes two
Qwen deployment issues that surfaced with it.

### Changes

**1. Pin artifact to v0.17.0**
Switched from the temporary `TT_INFERENCE_ARTIFACT_BRANCH` commit SHA to
`TT_INFERENCE_ARTIFACT_VERSION=v0.17.0`.

**2. Fix Qwen failing to deploy on v0.17.0**
`run.py` was forcing `MODEL_SPECS_ENV=dev`, which made Qwen resolve to the wrong
(dev) model spec/image and fail to deploy on v0.17.0. Commented out the override
so deployments use the correct prod specs. (Block is marked with a TODO to remove
entirely once confirmed unneeded.)

**3. Fix multi-device models showing only "Device 00"**
When a model's image wasn't already cached, the deploy flow created a placeholder
record with `device_ids=device_ids` (just the base slot, `[0]`) instead of the
full `occupied_device_ids` set (`[0,1,2,3]`). The placeholder is only repointed —
never corrected — so the Models Deployed device column showed a single device for
multi-chip models like Qwen. Fixed the placeholder to store `occupied_device_ids`,
matching the cached-image path.

### Impact
- Qwen (and other v0.17.0 models) deploy correctly.
- Multi-device models report their full device set regardless of image cache state.
- Single-chip / explicit-slot deployments are unaffected.
