### PR TITLE
Removed WANI2V from models and added warnings to FLUX and WANT2V

### DIFF
--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.14.0",
     "generated_at": "2026-05-20T16:49:35.390566+00:00"
   },
-  "total_models": 56,
+  "total_models": 54,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -436,37 +436,6 @@
         "TORCHDYNAMO_DISABLE": "1"
       },
       "param_count": null
-    },
-    {
-      "model_name": "Wan2.2-I2V-A14B-Diffusers",
-      "model_type": "VIDEO",
-      "display_model_type": "VIDEO",
-      "device_configurations": [
-        "GALAXY",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
-      "inference_engine": "media",
-      "supported_modalities": [
-        "text"
-      ],
-      "status": "COMPLETE",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240",
-      "service_route": "/v1/videos/generations/i2v",
-      "health_route": "/health",
-      "shm_size": "32G",
-      "setup_type": "TT_INFERENCE_SERVER",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 14
     },
     {
       "model_name": "Wan2.2-T2V-A14B-Diffusers",

--- a/app/frontend/src/components/FirstStepForm.tsx
+++ b/app/frontend/src/components/FirstStepForm.tsx
@@ -12,6 +12,7 @@ import {
   CheckCircle2,
   Zap,
   FlaskConical,
+  AlertTriangle,
 } from "lucide-react";
 
 import {
@@ -73,6 +74,15 @@ const TYPE_CONFIG: Record<string, { label: string; order: number }> = {
   TEXT_TO_SPEECH: { label: "TTS Models", order: 6 },
   EMBEDDING: { label: "Embedding Models", order: 7 },
   CNN: { label: "CNN Models", order: 8 },
+};
+
+// Models whose automated deployment is still flaky. When one is selected we warn
+// the user and point them at the Hugging Face repo so they can pre-fetch weights
+// if the automatic download fails. Keyed by model name with its HF repo id.
+const EXPERIMENTAL_DEPLOY_MODELS: Record<string, string> = {
+  "FLUX.1-dev": "black-forest-labs/FLUX.1-dev",
+  "FLUX.1-schnell": "black-forest-labs/FLUX.1-schnell",
+  "Wan2.2-T2V-A14B-Diffusers": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
 };
 
 const FirstFormSchema = z.object({
@@ -526,6 +536,33 @@ export function FirstStepForm({
                         </span>
                       )}
                     </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Experimental-deploy warning for models with unreliable automated setup */}
+              {EXPERIMENTAL_DEPLOY_MODELS[field.value] && (
+                <div className="mt-4 flex gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                  <div className="space-y-1">
+                    <p className="font-semibold">This model is still experimental</p>
+                    <p>
+                      {field.value} may fail to deploy reliably. If automatic
+                      deployment fails, download the weights from{" "}
+                      <a
+                        href={`https://huggingface.co/${EXPERIMENTAL_DEPLOY_MODELS[field.value]}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-medium underline"
+                      >
+                        {EXPERIMENTAL_DEPLOY_MODELS[field.value]}
+                      </a>{" "}
+                      and place them in your{" "}
+                      <code className="rounded bg-amber-100 px-1 py-0.5 dark:bg-amber-900/40">
+                        ~/.cache/huggingface/hub
+                      </code>{" "}
+                      directory, then try again.
+                    </p>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Removes **WAN 2.2 I2V** (`Wan2.2-I2V-A14B-Diffusers`) from the model catalog so it no longer appears in the deploy dropdowns. 
- Adds an experimental-deploy warning on the model selection step for **Flux** (`FLUX.1-dev`, `FLUX.1-schnell`) and **WAN 2.2 T2V**. When selected, the user is told the model may fail to deploy reliably, with a link to the Hugging Face repo and instructions to place weights in `~/.cache/huggingface/hub` and retry.

## Changes

- `app/backend/shared_config/models_from_inference_server.json` — removed I2V entry, fixed model count.
- `app/frontend/src/components/FirstStepForm.tsx` — per-model experimental warning on selection.

## Testing

- Verified the sync exclusion drops I2V while keeping T2V; catalog JSON validates.
- Verified that warning message shows up when the user selects FLUX-Schnell, FLUX-dev, or WANT2V from the deployment dropdown.
<img width="820" height="533" alt="Screenshot 2026-06-29 at 7 29 01 PM" src="https://github.com/user-attachments/assets/996d667d-0a06-4ab8-ae32-652a4e637019" />
