### PR TITLE
Hotfix: Show correct auto-selected devices for FLUX and rename header

### DIFF
--- a/app/frontend/src/components/imageGen/Header.tsx
+++ b/app/frontend/src/components/imageGen/Header.tsx
@@ -20,12 +20,14 @@ import { ArrowLeft, PanelRight } from "lucide-react";
 
 interface HeaderProps {
   onBack: () => void;
+  modelName?: string | null;
   isHistoryPanelOpen: boolean;
   setIsHistoryPanelOpen: (isOpen: boolean) => void;
 }
 
 export default function Header({
   onBack,
+  modelName,
   isHistoryPanelOpen,
   setIsHistoryPanelOpen,
 }: HeaderProps) {
@@ -67,7 +69,7 @@ export default function Header({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <BreadcrumbPage className="text-gray-900 dark:text-white font-bold">
-                      Stable Diffusion
+                      {modelName || "Stable Diffusion"}
                     </BreadcrumbPage>
                   </TooltipTrigger>
                   <TooltipContent className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-white">

--- a/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx
+++ b/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx
@@ -46,6 +46,7 @@ const ImageGenParentComponent: React.FC = () => {
             <StableDiffusionChat
               onBack={() => setShowChat(false)}
               modelID={modelID}
+              modelName={modelName}
               initialPrompt={initialPrompt}
             />
           ) : (

--- a/app/frontend/src/components/imageGen/StableDiffusionChat.tsx
+++ b/app/frontend/src/components/imageGen/StableDiffusionChat.tsx
@@ -15,6 +15,7 @@ import { useChat } from "./hooks/useChat";
 const StableDiffusionChat: React.FC<StableDiffusionChatProps> = ({
   onBack,
   modelID,
+  modelName,
   initialPrompt = "",
 }) => {
   const {
@@ -43,6 +44,7 @@ const StableDiffusionChat: React.FC<StableDiffusionChatProps> = ({
     <div className="flex flex-col w-full h-full bg-white dark:bg-[#0a0b0f]">
       <Header
         onBack={onBack}
+        modelName={modelName}
         isHistoryPanelOpen={isHistoryPanelOpen}
         setIsHistoryPanelOpen={setIsHistoryPanelOpen}
       />

--- a/app/frontend/src/components/imageGen/types/chat.ts
+++ b/app/frontend/src/components/imageGen/types/chat.ts
@@ -10,5 +10,6 @@ export interface Message {
 export interface StableDiffusionChatProps {
   onBack: () => void;
   modelID: string;
+  modelName?: string | null;
   initialPrompt?: string;
 }

--- a/app/frontend/src/utils/deviceFit.ts
+++ b/app/frontend/src/utils/deviceFit.ts
@@ -8,7 +8,7 @@
 // To support a new model or change which device configurations a model allows,
 // edit getModelPlacement() below — nothing else in the frontend needs to change.
 
-import { isLlama31_8BModel, isP300x2Board } from "./p300x2Placement";
+import { isFluxModel, isLlama31_8BModel, isP300x2Board } from "./p300x2Placement";
 
 export interface DeviceSlotLike {
   slot_id: number;
@@ -31,6 +31,17 @@ const WHOLE_BOARD_DEFAULT_BOARDS = new Set([
 
 export function isWholeBoardDefaultBoard(boardType?: string): boolean {
   return !!boardType && WHOLE_BOARD_DEFAULT_BOARDS.has(boardType.toUpperCase());
+}
+
+// Multi-chip Blackhole boards are deliberately kept out of WHOLE_BOARD_DEFAULT_BOARDS
+// so single-card models stay pinned to one card. But FLUX media models have no
+// single-card spec on these boards, so the backend deploys them across the whole
+// board anyway (see infer_inference_server_device in docker_control/docker_utils.py,
+// where FLUX resolves to the mesh device and device_id is dropped). Mirror that here.
+const MULTI_CHIP_BLACKHOLE_BOARDS = new Set(["P150X4", "P150X8", "P300X2", "P300CX4"]);
+
+function isMultiChipBlackholeBoard(boardType?: string): boolean {
+  return !!boardType && MULTI_CHIP_BLACKHOLE_BOARDS.has(boardType.toUpperCase());
 }
 
 // Models declare 1 (single device) or >1 (full board: slots 0..3).
@@ -108,6 +119,11 @@ export function getModelPlacement(
   // Multi-chip models always take the full board.
   if (isMultiChipModel(chipsRequired)) {
     return { allowsSingle: false, allowsFullBoard: true, cardGroups: [] };
+  }
+  // FLUX has no single-card spec on multi-chip Blackhole boards, so the backend
+  // deploys it across the whole board even though chips_required is 1.
+  if (isFluxModel(modelName) && isMultiChipBlackholeBoard(boardType)) {
+    return { allowsSingle: false, allowsFullBoard: true, cardGroups: [], defaultsFullBoard: true };
   }
   // Single-device models on Wormhole mesh boards deploy board-wide by default;
   // advanced config can still pin them to one constituent chip.

--- a/app/frontend/src/utils/p300x2Placement.ts
+++ b/app/frontend/src/utils/p300x2Placement.ts
@@ -26,6 +26,11 @@ export function isLlama31_8BModel(modelNameOrId?: string | null): boolean {
   return token.includes("llama-3.1-8b") || token.includes("llama3.18b");
 }
 
+export function isFluxModel(modelNameOrId?: string | null): boolean {
+  if (!modelNameOrId) return false;
+  return normalizeToken(modelNameOrId).includes("flux");
+}
+
 export function parseDeviceIds(deviceId?: string | number): number[] {
   if (deviceId === undefined || deviceId === null) {
     return [];


### PR DESCRIPTION
# Fix FLUX deployment preview on multi-chip Blackhole boards

## Problem
On a **P300x2** (and other multi-chip Blackhole boards), the deployment step previewed **FLUX** as running on a single device (`Device: 0`), even though it actually deploys across all 4 chips.

### Why this happened:
* **The Classification:** FLUX is classified as `chips_required = 1` because its supported-config list includes the single-card P300. 
* **The Backend Logic:** The backend handles this correctly—FLUX has no single-card (`p150`) spec for a P300x2's constituent chips, so `infer_inference_server_device` resolves it to the `p300x2` mesh device and drops `device_id`, deploying whole-board. 
* **The Frontend Glitch:** The frontend re-derived placement strictly from `chips_required = 1` and previewed a single device. The actual deployment was correct; **only the UI preview was wrong.**
* **The Guardrail Constraint:** These boards are intentionally kept out of `WHOLE_BOARD_DEFAULT_BOARDS` so genuine single-card models (e.g., Llama-3.1-8B, which does support `p150`) stay pinned to a single card. Because of this, FLUX requires a model-specific exception.

---

## Solution
This is a **frontend-only change** that cleanly mirrors the existing backend behavior.

* **Added `isFluxModel()` matcher:** Identifies FLUX models explicitly.
* **Updated `getModelPlacement`:** Added a targeted branch in the file's single-source-of-truth extension point. FLUX on a multi-chip Blackhole board (`P150X4` / `P150X8` / `P300x2` / `P300Cx4`) now properly resolves to a **full-board placement**.

### Impact:
* The UI preview now accurately reflects all 4 devices.
* The UI correctly blocks the deployment action unless every single slot on the board is free.