### PR TITLE
Hotfix: Footer shows resetting status immediately when deletion modal is minimized

### DIFF
--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -200,6 +200,13 @@ export default function ModelsDeployedCard(): JSX.Element {
     };
   }, [isDeleteInFlight, setIsDeleteInFlight]);
 
+  // Repoll immediately when a backgrounded delete reaches its reset phase
+  useEffect(() => {
+    if (!showDeleteModal && deleteStream.step === "resetting") {
+      refreshDeviceState();
+    }
+  }, [showDeleteModal, deleteStream.step, refreshDeviceState]);
+
   useEffect(() => {
     loadModels();
   }, [loadModels, refreshTrigger]);


### PR DESCRIPTION
### The Bug
Footer has a delay in showing reset status when a model is deleted and the deletion modal is minimized.

### New Behaviour
Repoll immediately when a backgrounded delete reaches its reset phase and show the status on the footer immediately.