### PR TITLE
Hotfixed issue where device column for FLUX showed only device 00

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -326,6 +326,18 @@ def infer_inference_server_device(impl, board_type=None):
     return device
 
 
+def deploys_whole_board(impl, board_type=None):
+    """True when the inference server claims the entire board for this model, so
+    every chip slot must be reserved and recorded.
+
+    A model occupies the whole board whenever it resolves to a mesh device rather
+    than a single chip — this covers genuinely multi-chip models and media models
+    like FLUX that have no single-chip spec on a multi-chip board (e.g. p300x2),
+    even though `infer_chips_required` reports 1. Mirrors the device_id gate in
+    run_container, which omits device_id for exactly these mesh deployments."""
+    return infer_inference_server_device(impl, board_type) not in _SINGLE_CHIP_DEVICE_NAMES
+
+
 def run_container(impl, weights_id, device_id=0, host_port=None, use_image_override=True):
     """Run a docker container.
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -35,6 +35,7 @@ from .docker_utils import (
     detect_board_type,
     map_board_type_to_device_name,
     infer_inference_server_device,
+    deploys_whole_board,
     _BOARD_TO_SINGLE_CHIP_DEVICE,
     WHOLE_BOARD_DEFAULT_BOARDS,
     update_deploy_cache,
@@ -340,7 +341,17 @@ class DeployView(APIView):
 
             impl = model_implmentations[impl_id]
             chips_required = infer_chips_required(impl.device_configurations)
-            board_type = detect_board_type() if impl.model_type == ModelTypes.CHAT else None
+            board_type = detect_board_type()
+            # Media models (e.g. FLUX) can be inferred as single-chip yet deploy across
+            # a whole multi-chip board because they have no single-chip spec for the
+            # board's constituent chip. The inference server then claims the full mesh,
+            # so we must reserve and record every slot — not just slot 0.
+            mesh_whole_board = (
+                impl.model_type != ModelTypes.CHAT
+                and chips_required == 1
+                and not requested_device_ids
+                and deploys_whole_board(impl, board_type)
+            )
             should_force_full_board_llama = (
                 impl.model_type == ModelTypes.CHAT
                 and force_full_board_requested
@@ -374,9 +385,10 @@ class DeployView(APIView):
             # are always set correctly (port = 7000 + device_id).
             try:
                 allocator = ChipSlotAllocator()
-                if should_force_full_board_llama or use_whole_board_deploy:
-                    # Whole-board deploy (forced QB2 Llama, or a single-chip model on a
-                    # Wormhole mesh board) takes over the entire board — reserve all slots.
+                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+                    # Whole-board deploy (forced QB2 Llama, a single-chip model on a
+                    # Wormhole mesh board, or a media model like FLUX with no single-chip
+                    # spec) takes over the entire board — reserve all slots.
                     full_board_validation = allocator._validate_manual_allocation(
                         0, 4, impl.model_name
                     )
@@ -433,7 +445,7 @@ class DeployView(APIView):
                         device_ids = [device_id]
                 device_ids_str = ",".join(str(d) for d in device_ids)
                 # Full set of chip slots this model actually occupies, even though only the primary slot is passed to the inference server via device_ids_str
-                if should_force_full_board_llama or use_whole_board_deploy:
+                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
                     # Whole-board deploy takes over every slot on the board.
                     occupied_device_ids = list(range(allocator.total_slots))
                 elif chips_required > 1:
@@ -467,7 +479,7 @@ class DeployView(APIView):
                 }, status=status.HTTP_409_CONFLICT)
 
             BASE_SERVICE_PORT = 7000
-            if should_force_full_board_llama or use_whole_board_deploy:
+            if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
                 service_port = BASE_SERVICE_PORT
             else:
                 service_port = BASE_SERVICE_PORT + device_id


### PR DESCRIPTION
## Fix FLUX showing only device 0 on the Models Deployed page (P300x2)

### Problem

When FLUX is deployed on a P300x2, the Models Deployed page (device column and chip diagram) showed only **device 0**, even though FLUX actually runs across the whole 4-chip board.

FLUX is inferred as `chips_required = 1` because its supported-config list includes the single-card `P300`. In the deploy view, the "reserve the whole board" logic was gated to `ModelTypes.CHAT` only — so media models like FLUX fell through to the single-slot path: allocate slot 0, record `device_ids = [0]`. The deploy itself worked (it resolves to the `p300x2` mesh device and drops `device_id`, so the inference server claims every chip), but the persisted record didn't reflect that.

This was also a latent **allocator bug**: slots 1–3 looked free while FLUX owned them, so another model could be placed onto chips FLUX was already using.

### Solution

Backend-only change:

- **`docker_utils.py`** — added a shared `deploys_whole_board(impl, board_type)`helper: a model occupies the whole board iff it resolves to a mesh device rather than a single chip. Correctly returns `True` for FLUX on P300x2/P150X4/etc. and `False` for FLUX on a lone `P300`.

- **`views.py` (`DeployView`)** — detect `board_type` for all model types, compute a `mesh_whole_board` flag for non-CHAT single-chip models that resolve to a mesh, and route them through the existing whole-board branches (reserve all slots, record `device_ids = [0,1,2,3]`, service port 7000).

### Result

- FLUX now records all four chips → the device column and chip diagram show `0, 1, 2, 3`, matching what's actually deployed and consistent with other whole-board models.
- The allocator correctly blocks a FLUX deploy unless the whole board is free, and blocks anything else while FLUX is running.
- Single-`P300`, T3K/Galaxy, and genuinely multi-chip models are unaffected — the `chips_required == 1` + non-CHAT + mesh gate keeps the change narrow.
