### PR TITLE
Show model navbar entries only once the model is healthy

### DIFF
--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -5,6 +5,7 @@ import axios from "axios";
 import { customToast } from "../components/CustomToaster";
 import { NavigateFunction } from "react-router-dom";
 import { type Model } from "../contexts/ModelsContext";
+import { type HealthStatus } from "../types/models";
 
 const dockerAPIURL = "/docker-api/";
 const modelAPIURL = "/models-api/";
@@ -144,6 +145,24 @@ export const fetchDeployments = async (): Promise<CanonicalDeployment[]> => {
   );
   const data = response.data || {};
   return Object.entries(data).map(([id, entry]) => ({ id, ...entry }));
+};
+
+// Probe a single deployment's real readiness via the same endpoint HealthBadge
+// uses. 200 = ready to serve, 202 = still warming up, 503 = unavailable. This is
+// the authoritative "usable" signal; the deployments `health` field only carries
+// Docker's raw container health, which is not a readiness signal.
+export const fetchModelHealth = async (
+  deployId: string,
+): Promise<HealthStatus> => {
+  try {
+    const response = await fetch(`${modelAPIURL}health/?deploy_id=${deployId}`);
+    if (response.status === 200) return "healthy";
+    if (response.status === 202) return "starting";
+    if (response.status === 503) return "unavailable";
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
 };
 
 export const fetchModels = async (): Promise<Model[]> => {

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -50,7 +50,9 @@ import {
   ModelType,
   getModelTypeFromName,
   getModelTypeFromBackendType,
+  fetchModelHealth,
 } from "../api/modelsDeployedApis";
+import type { HealthStatus } from "../types/models";
 
 // Interfaces for our components
 interface AnimatedIconProps {
@@ -269,29 +271,68 @@ export default function NavBar() {
 
   const isDeployedEnabled = import.meta.env.VITE_ENABLE_DEPLOYED === "true";
 
+  // A model shows up in `models` (from the deployments endpoint) as soon as its
+  // container exists, but it isn't usable until it finishes warming up. Probe the
+  // authoritative readiness endpoint (the same one HealthBadge uses) so navbar
+  // entries only appear once a model is healthy. Poll on a light interval, keyed
+  // on the set of deployed model ids so the interval isn't torn down on every
+  // 5s provider refresh.
+  const [healthById, setHealthById] = useState<Record<string, HealthStatus>>({});
+  const modelIdsKey = useMemo(
+    () => models.map((m) => m.id).sort().join(","),
+    [models]
+  );
+
+  useEffect(() => {
+    const ids = modelIdsKey ? modelIdsKey.split(",") : [];
+    if (ids.length === 0) {
+      setHealthById({});
+      return;
+    }
+    let cancelled = false;
+    const probe = async () => {
+      const entries = await Promise.all(
+        ids.map(async (id) => [id, await fetchModelHealth(id)] as const)
+      );
+      if (!cancelled) setHealthById(Object.fromEntries(entries));
+    };
+    probe();
+    const intervalId = setInterval(probe, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [modelIdsKey]);
+
+  // Only models that are actually healthy/usable should surface in the navbar.
+  const healthyModels = useMemo(
+    () => models.filter((m) => healthById[m.id] === "healthy"),
+    [models, healthById]
+  );
+
   // Voice agent requires all three model types: LLM/VLM, speech recognition (Whisper), and TTS
   const isVoiceAgentReady = useMemo(() => {
-    const getType = (m: (typeof models)[number]) =>
+    const getType = (m: (typeof healthyModels)[number]) =>
       m.model_type
         ? getModelTypeFromBackendType(m.model_type)
         : getModelTypeFromName(m.name, m.image);
-    const hasLlm = models.some((m) => {
+    const hasLlm = healthyModels.some((m) => {
       const t = getType(m);
       return t === ModelType.ChatModel || t === ModelType.VLM;
     });
-    const hasStt = models.some(
+    const hasStt = healthyModels.some(
       (m) => getType(m) === ModelType.SpeechRecognitionModel
     );
-    const hasTts = models.some((m) => getType(m) === ModelType.TTS);
+    const hasTts = healthyModels.some((m) => getType(m) === ModelType.TTS);
     return hasLlm && hasStt && hasTts;
-  }, [models]);
+  }, [healthyModels]);
 
   // Coding Agents (Claude Code / OpenAI clients) requires a deployed model that
   // supports native tool calling. Eligibility is decided by the backend (SSOT:
   // shared_config.coding_agent_config) and surfaced per-deployment as a flag.
   const isCodingAgentReady = useMemo(
-    () => models.some((m) => m.coding_agent_eligible),
-    [models],
+    () => healthyModels.some((m) => m.coding_agent_eligible),
+    [healthyModels],
   );
 
   // Check if we're in Chat UI, Image Generation, or Video Generation mode
@@ -534,10 +575,11 @@ export default function NavBar() {
     console.log("models length:", models.length);
 
     if (isDeployedEnabled) {
-      // In AI Playground mode, show navigation based on deployed models
-      if (models.length > 0) {
-        // Show navigation items for each deployed model
-        return models.map((model) => {
+      // In AI Playground mode, show navigation for models that are healthy and
+      // ready to use. Models still deploying/warming up are intentionally hidden.
+      if (healthyModels.length > 0) {
+        // Show navigation items for each healthy model
+        return healthyModels.map((model) => {
           const modelType = model.model_type
             ? getModelTypeFromBackendType(model.model_type)
             : getModelTypeFromName(model.name, model.image);
@@ -601,9 +643,9 @@ export default function NavBar() {
         ];
       }
     } else {
-      // In TT-Studio mode, show only deployed models
-      console.log("TT-Studio mode - creating navigation for deployed models");
-      return models.map((model) => {
+      // In TT-Studio mode, show only models that are healthy and ready to use.
+      console.log("TT-Studio mode - creating navigation for healthy models");
+      return healthyModels.map((model) => {
         const modelType = model.model_type
           ? getModelTypeFromBackendType(model.model_type)
           : getModelTypeFromName(model.name, model.image);
@@ -617,11 +659,8 @@ export default function NavBar() {
             navigate(route, {
               state: { containerID: model.id, modelName: model.name },
             }),
-          isDisabled: models.length === 0,
-          tooltipText:
-            models.length > 0
-              ? `Open ${getModelPageNameFromModelType(modelType)}`
-              : `Deploy a model to use ${getModelPageNameFromModelType(modelType)}`,
+          isDisabled: false,
+          tooltipText: `Open ${getModelPageNameFromModelType(modelType)}`,
           route,
         };
       });


### PR DESCRIPTION
### Problem
Per-model navbar entries (Chat UI, Image Generation, etc.) and the Voice Agent / Coding Agents links appeared as soon as a model was deployed — while the container was still warming up and couldn't serve requests.

### Change
Gate these entries on the model's real readiness. The navbar now probes `/models-api/health/` (the same signal `HealthBadge` and the models-table "Open" button already use) and only shows entries for models that report healthy. Deploying models are hidden until they're ready.

Frontend only, no backend changes.

### Verification
- `npm run type-check` and `npm run build` pass; lint clean on the changed files.
- Verified in the running dev app (HMR compiled cleanly). The health mapping (200 healthy / 202 starting / 503 unavailable) mirrors the existing `HealthBadge` path.