### PR TITLE
fix: use rsplit to strip full service_route in _video_base_url

### DIFF
--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -746,7 +746,11 @@ def _video_base_url(deploy_id):
     """Resolve the tt-media-server base URL for a deployed video model."""
     deploy = get_deploy_cache()[deploy_id]
     internal_url = "http://" + deploy["internal_url"]
-    return internal_url.replace("/v1/videos/generations", "").rstrip("/")
+    service_route = deploy["model_impl"].service_route
+    # Use rsplit to strip the full service_route suffix (e.g. "/v1/videos/generations/i2v")
+    # instead of replace which only strips "/v1/videos/generations" and leaves a dangling
+    # suffix like "/i2v" on the base URL.
+    return internal_url.rsplit(service_route, 1)[0].rstrip("/")
 
 
 def _normalize_video_phase(raw_status):


### PR DESCRIPTION
## Summary

The `_video_base_url` function used `str.replace("/v1/videos/generations", "")` to derive the base URL from the `internal_url`. For I2V models whose `service_route` is `/v1/videos/generations/i2v`, this left a dangling `/i2v` segment on the base URL, causing all status polling and download URLs to 404.

## Root Cause

- I2V models use service route `/v1/videos/generations/i2v`
- `_video_base_url()` called `internal_url.replace("/v1/videos/generations", "")` 
- This only stripped the base prefix, leaving `/i2v` attached
- Result: poll URL became `http://host:port/i2v/v1/videos/generations/{job_id}` instead of `http://host:port/v1/videos/generations/{job_id}`

## Fix

Now uses `rsplit(service_route, 1)` to strip the full service_route suffix (including any model-specific path like `/i2v`), producing correct base URLs for both T2V and I2V models.

## Test Plan

- [x] Verified fix handles both `/v1/videos/generations` (T2V) and `/v1/videos/generations/i2v` (I2V) service routes correctly
- [x] No existing tests broken

Closes #1000