### PR TITLE
Show a blocking overlay when the backend is unreachable

### DIFF
--- a/app/frontend/nginx.conf
+++ b/app/frontend/nginx.conf
@@ -65,6 +65,16 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Lightweight backend liveness probe used by the frontend to detect when the
+    # backend becomes unreachable.
+    location = /up/ {
+        proxy_pass http://tt-studio-backend-api:8000/up/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Serve static files for React app
     location / {
         # This is the key for client-side routing:

--- a/app/frontend/public/offline.html
+++ b/app/frontend/public/offline.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<!--
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+Offline fallback served by sw.js when a page navigation fails because the
+TT-Studio frontend server is unreachable (run.py stopped, dev server
+restarting, container down). Must stay fully self-contained — no external
+scripts, styles, or images — since it renders precisely when nothing else
+can be fetched. It polls the server and reloads automatically once it's back.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TT-Studio is not running</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f7f7f8;
+        --card: #ffffff;
+        --border: #e4e4e7;
+        --fg: #18181b;
+        --muted: #71717a;
+        --muted-bg: #f4f4f5;
+        --accent: #dc2626;
+        --accent-bg: rgba(220, 38, 38, 0.1);
+        --btn-bg: #18181b;
+        --btn-fg: #fafafa;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0c0c0d;
+          --card: #17171a;
+          --border: #2a2a2e;
+          --fg: #fafafa;
+          --muted: #a1a1aa;
+          --muted-bg: #202024;
+          --btn-bg: #fafafa;
+          --btn-fg: #18181b;
+        }
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        background: var(--bg);
+        color: var(--fg);
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+      }
+      .card {
+        width: 100%;
+        max-width: 28rem;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        padding: 2rem;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        text-align: center;
+      }
+      .icon {
+        width: 3.5rem;
+        height: 3.5rem;
+        margin: 0 auto 1.25rem;
+        border-radius: 9999px;
+        background: var(--accent-bg);
+        color: var(--accent);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+      .sub {
+        margin-top: 0.5rem;
+        font-size: 0.875rem;
+        color: var(--muted);
+      }
+      .tips {
+        margin-top: 1.25rem;
+        border: 1px solid var(--border);
+        background: var(--muted-bg);
+        border-radius: 0.375rem;
+        padding: 1rem;
+        text-align: left;
+        font-size: 0.875rem;
+        color: var(--muted);
+      }
+      .tips p {
+        font-weight: 500;
+        color: var(--fg);
+        margin-bottom: 0.5rem;
+      }
+      .tips ul {
+        padding-left: 1.25rem;
+        display: grid;
+        gap: 0.375rem;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.75rem;
+        background: var(--border);
+        color: var(--fg);
+        border-radius: 0.25rem;
+        padding: 0.125rem 0.375rem;
+      }
+      button {
+        margin-top: 1.5rem;
+        width: 100%;
+        padding: 0.625rem 1rem;
+        border: none;
+        border-radius: 0.375rem;
+        background: var(--btn-bg);
+        color: var(--btn-fg);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+      .note {
+        margin-top: 0.75rem;
+        font-size: 0.75rem;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card" role="alertdialog" aria-labelledby="title">
+      <div class="icon" aria-hidden="true">
+        <!-- server-crash glyph -->
+        <svg
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M6 10H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2" />
+          <path d="M6 14H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2h-2" />
+          <path d="M6 6h.01" />
+          <path d="M6 18h.01" />
+          <path d="m13 6-4 6h6l-4 6" />
+        </svg>
+      </div>
+
+      <h1 id="title">TT-Studio is not running</h1>
+      <p class="sub">
+        The app can't reach the TT-Studio server. It may have been stopped or
+        is restarting.
+      </p>
+
+      <div class="tips">
+        <p>Try this:</p>
+        <ul>
+          <li>Restart the application with <code>python run.py</code>.</li>
+          <li>Confirm the host machine is powered on and reachable.</li>
+          <li>
+            If you're connected over SSH, check that the port forward is still
+            active.
+          </li>
+        </ul>
+      </div>
+
+      <button type="button" id="retry">Retry now</button>
+      <p class="note">This page reloads automatically once TT-Studio is back.</p>
+    </div>
+
+    <script>
+      // Poll the server root; any HTTP response means the frontend is
+      // serving again, so reload into the real app (which then handles a
+      // still-down backend with its own overlay).
+      const POLL_INTERVAL_MS = 2500;
+      const POLL_TIMEOUT_MS = 3000;
+      const button = document.getElementById("retry");
+
+      async function probe() {
+        button.disabled = true;
+        button.textContent = "Checking…";
+        try {
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
+          const response = await fetch("/", { cache: "no-store", signal: controller.signal });
+          clearTimeout(timer);
+          if (response.ok) {
+            location.reload();
+            return;
+          }
+        } catch {
+          // still unreachable
+        }
+        button.disabled = false;
+        button.textContent = "Retry now";
+      }
+
+      button.addEventListener("click", probe);
+      setInterval(probe, POLL_INTERVAL_MS);
+      probe();
+    </script>
+  </body>
+</html>

--- a/app/frontend/public/sw.js
+++ b/app/frontend/public/sw.js
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Minimal service worker with a single job: when a page NAVIGATION fails
+// because the frontend server is unreachable (run.py stopped, dev-server
+// restarting, container down), serve the cached offline.html instead of the
+// browser's dead error page. offline.html polls the server and reloads once
+// it is back, so the tab always recovers on its own.
+//
+// It deliberately never caches or intercepts app assets or API calls — only
+// `mode === "navigate"` requests — so it cannot serve stale application code.
+
+// Bump the version suffix whenever offline.html changes so clients re-cache it.
+const CACHE_NAME = "tt-studio-offline-v1";
+const OFFLINE_URL = "/offline.html";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      // `cache: "reload"` bypasses the HTTP cache so we always store the
+      // server's current copy of offline.html.
+      .then((cache) => cache.add(new Request(OFFLINE_URL, { cache: "reload" })))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.mode !== "navigate") return;
+  event.respondWith(
+    fetch(event.request).catch(async () => {
+      const cached = await caches.match(OFFLINE_URL);
+      return cached || Response.error();
+    })
+  );
+});

--- a/app/frontend/src/components/BackendDisconnectedOverlay.tsx
+++ b/app/frontend/src/components/BackendDisconnectedOverlay.tsx
@@ -8,8 +8,8 @@ import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
 import type { BackendStatus } from "../contexts/BackendHealthContext";
 
-// Sit above the toaster (z-index 99999) so stray per-feature error toasts are
-// covered by the overlay rather than competing with it.
+// Sit above the toaster (z-index 99999) so any lingering per-feature error
+// toasts are covered by the screen rather than showing through it.
 const OVERLAY_Z_INDEX = 100000;
 
 interface BackendDisconnectedOverlayProps {
@@ -22,15 +22,17 @@ export const BackendDisconnectedOverlay: React.FC<
 > = ({ status, onRetry }) => {
   const isChecking = status === "checking";
 
+  // Fully opaque, full-screen wrapper. The rest of the app is unmounted while
+  // this is shown, so it stands in for the whole UI rather than layering over it.
   const overlay = (
     <div
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="backend-disconnected-title"
-      className="fixed inset-0 flex items-center justify-center bg-black/90 p-4 backdrop-blur-sm"
+      className="fixed inset-0 flex items-center justify-center bg-background p-4 text-foreground"
       style={{ zIndex: OVERLAY_Z_INDEX }}
     >
-      <div className="w-full max-w-md rounded-lg border border-border bg-background p-8 text-foreground shadow-2xl">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-8 shadow-2xl">
         <div className="flex flex-col items-center text-center">
           <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10 text-destructive">
             <ServerCrash className="h-7 w-7" />
@@ -40,19 +42,19 @@ export const BackendDisconnectedOverlay: React.FC<
             id="backend-disconnected-title"
             className="text-xl font-semibold"
           >
-            Backend disconnected
+            Not connected to the backend
           </h2>
 
           <p className="mt-2 text-sm text-muted-foreground">
-            TT-Studio can't reach its backend service, so the app can't load or
-            run anything right now.
+            TT-Studio has lost connection to its backend service. The app is
+            paused until the connection is restored.
           </p>
 
           <div className="mt-5 w-full rounded-md border border-border bg-muted/40 p-4 text-left text-sm text-muted-foreground">
             <p className="mb-2 font-medium text-foreground">Try this:</p>
             <ul className="list-disc space-y-1.5 pl-5">
               <li>
-                Restart the service with{" "}
+                Restart the application with{" "}
                 <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
                   python run.py
                 </code>

--- a/app/frontend/src/components/BackendDisconnectedOverlay.tsx
+++ b/app/frontend/src/components/BackendDisconnectedOverlay.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import type React from "react";
+import { createPortal } from "react-dom";
+import { ServerCrash, RefreshCw } from "lucide-react";
+import { Button } from "./ui/button";
+import { Spinner } from "./ui/spinner";
+import type { BackendStatus } from "../contexts/BackendHealthContext";
+
+// Sit above the toaster (z-index 99999) so stray per-feature error toasts are
+// covered by the overlay rather than competing with it.
+const OVERLAY_Z_INDEX = 100000;
+
+interface BackendDisconnectedOverlayProps {
+  status: BackendStatus;
+  onRetry: () => void;
+}
+
+export const BackendDisconnectedOverlay: React.FC<
+  BackendDisconnectedOverlayProps
+> = ({ status, onRetry }) => {
+  const isChecking = status === "checking";
+
+  const overlay = (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="backend-disconnected-title"
+      className="fixed inset-0 flex items-center justify-center bg-black/90 p-4 backdrop-blur-sm"
+      style={{ zIndex: OVERLAY_Z_INDEX }}
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-background p-8 text-foreground shadow-2xl">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <ServerCrash className="h-7 w-7" />
+          </div>
+
+          <h2
+            id="backend-disconnected-title"
+            className="text-xl font-semibold"
+          >
+            Backend disconnected
+          </h2>
+
+          <p className="mt-2 text-sm text-muted-foreground">
+            TT-Studio can't reach its backend service, so the app can't load or
+            run anything right now.
+          </p>
+
+          <div className="mt-5 w-full rounded-md border border-border bg-muted/40 p-4 text-left text-sm text-muted-foreground">
+            <p className="mb-2 font-medium text-foreground">Try this:</p>
+            <ul className="list-disc space-y-1.5 pl-5">
+              <li>
+                Restart the service with{" "}
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+                  python run.py
+                </code>
+                .
+              </li>
+              <li>Confirm the host machine is powered on and reachable.</li>
+              <li>
+                If you're connected over SSH, check that the port forward is
+                still active.
+              </li>
+            </ul>
+          </div>
+
+          <Button
+            type="button"
+            onClick={onRetry}
+            disabled={isChecking}
+            className="mt-6 w-full"
+          >
+            {isChecking ? (
+              <>
+                <Spinner size="sm" className="mr-2" />
+                Checking…
+              </>
+            ) : (
+              <>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Retry now
+              </>
+            )}
+          </Button>
+
+          <p className="mt-3 text-xs text-muted-foreground">
+            This screen clears automatically once the backend is back.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return typeof document !== "undefined"
+    ? createPortal(overlay, document.body)
+    : overlay;
+};

--- a/app/frontend/src/contexts/BackendHealthContext.ts
+++ b/app/frontend/src/contexts/BackendHealthContext.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { createContext } from "react";
+
+export type BackendStatus = "connected" | "disconnected" | "checking";
+
+export interface BackendHealthContextType {
+  /**
+   * "connected"    — the backend responded to the most recent liveness poll.
+   * "disconnected" — the backend has failed enough consecutive polls to be
+   *                  considered unreachable (the blocking overlay is shown).
+   * "checking"     — a poll is in flight (used to show a spinner on the
+   *                  overlay's retry button).
+   */
+  status: BackendStatus;
+  /** Cancel the scheduled poll and probe the backend immediately. */
+  retry: () => void;
+}
+
+export const BackendHealthContext = createContext<
+  BackendHealthContextType | undefined
+>(undefined);

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -59,6 +59,20 @@ async function applyCleanupSentinel(): Promise<void> {
   }
 }
 
+// Fallback for when the frontend server itself is unreachable (run.py
+// stopped, dev-server restart, container down): sw.js serves offline.html for
+// failed page navigations, so the tab shows "TT-Studio is not running" instead
+// of a dead browser error page, and reloads itself once the server is back.
+// (Backend-only outages are handled in-app by BackendHealthProvider.)
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch(() => {
+      // Non-secure context or registration failure: degrade to current
+      // behavior (browser error page on refresh while down).
+    });
+  });
+}
+
 applyCleanupSentinel().finally(() => {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/app/frontend/src/providers/BackendHealthProvider.tsx
+++ b/app/frontend/src/providers/BackendHealthProvider.tsx
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  BackendHealthContext,
+  type BackendStatus,
+} from "../contexts/BackendHealthContext";
+import { BackendDisconnectedOverlay } from "../components/BackendDisconnectedOverlay";
+
+// Poll the backend's bare liveness endpoint. It returns an empty 200 and does no
+// work, so it is cheap to hit frequently.
+const HEALTH_URL = "/up/";
+// How long to wait for a response before treating the poll as a failure, so a
+// hung/half-open connection (e.g. a dropped SSH tunnel) can't stall detection.
+const REQUEST_TIMEOUT_MS = 5_000;
+// Poll cadence: relaxed while healthy, snappier once a failure is seen so both
+// disconnect and recovery are detected quickly.
+const HEALTHY_INTERVAL_MS = 5_000;
+const UNHEALTHY_INTERVAL_MS = 3_000;
+// Require a couple of consecutive failures before showing the overlay so a
+// single transient blip doesn't flash it.
+const FAILURE_THRESHOLD = 2;
+
+export const BackendHealthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  // Optimistic default: assume connected so the overlay never flashes on load.
+  // The first poll confirms reachability within a poll interval.
+  const [disconnected, setDisconnected] = useState(false);
+  const [checking, setChecking] = useState(false);
+
+  const failuresRef = useRef(0);
+  // Mirror `disconnected` in a ref so the polling closure reads the latest value
+  // without being re-created on every state change.
+  const disconnectedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollRef = useRef<() => Promise<void>>(async () => {});
+
+  const scheduleNext = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    const interval =
+      failuresRef.current > 0 ? UNHEALTHY_INTERVAL_MS : HEALTHY_INTERVAL_MS;
+    timerRef.current = setTimeout(() => pollRef.current(), interval);
+  }, []);
+
+  useEffect(() => {
+    const poll = async () => {
+      // Only surface the "checking" spinner while the overlay is already up.
+      if (disconnectedRef.current) setChecking(true);
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      try {
+        const response = await fetch(HEALTH_URL, {
+          signal: controller.signal,
+          cache: "no-store",
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        // Reachable again: clear failure count and drop the overlay.
+        failuresRef.current = 0;
+        if (disconnectedRef.current) {
+          disconnectedRef.current = false;
+          setDisconnected(false);
+        }
+        setChecking(false);
+      } catch {
+        failuresRef.current += 1;
+        if (failuresRef.current >= FAILURE_THRESHOLD && !disconnectedRef.current) {
+          disconnectedRef.current = true;
+          setDisconnected(true);
+        }
+        setChecking(false);
+      } finally {
+        clearTimeout(timeout);
+        scheduleNext();
+      }
+    };
+
+    pollRef.current = poll;
+    poll();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const retry = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    pollRef.current();
+  }, []);
+
+  const status: BackendStatus = disconnected
+    ? checking
+      ? "checking"
+      : "disconnected"
+    : "connected";
+
+  const value = useMemo(() => ({ status, retry }), [status, retry]);
+
+  return (
+    <BackendHealthContext.Provider value={value}>
+      {children}
+      {status !== "connected" && (
+        <BackendDisconnectedOverlay status={status} onRetry={retry} />
+      )}
+    </BackendHealthContext.Provider>
+  );
+};

--- a/app/frontend/src/providers/BackendHealthProvider.tsx
+++ b/app/frontend/src/providers/BackendHealthProvider.tsx
@@ -13,7 +13,7 @@ import { BackendDisconnectedOverlay } from "../components/BackendDisconnectedOve
 const HEALTH_URL = "/up/";
 // How long to wait for a response before treating the poll as a failure, so a
 // hung/half-open connection (e.g. a dropped SSH tunnel) can't stall detection.
-const REQUEST_TIMEOUT_MS = 5_000;
+const REQUEST_TIMEOUT_MS = 4_000;
 // Poll cadence: relaxed while healthy, snappier once a failure is seen so both
 // disconnect and recovery are detected quickly.
 const HEALTHY_INTERVAL_MS = 5_000;
@@ -99,10 +99,15 @@ export const BackendHealthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const value = useMemo(() => ({ status, retry }), [status, retry]);
 
+  // Hard gate: while the backend is unreachable we render only the disconnected
+  // screen and unmount the rest of the app, so no page keeps displaying (or
+  // firing its own failing requests) behind it. The app remounts automatically
+  // once the backend responds again.
   return (
     <BackendHealthContext.Provider value={value}>
-      {children}
-      {status !== "connected" && (
+      {status === "connected" ? (
+        children
+      ) : (
         <BackendDisconnectedOverlay status={status} onRetry={retry} />
       )}
     </BackendHealthContext.Provider>

--- a/app/frontend/src/routes/index.tsx
+++ b/app/frontend/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { RefreshProvider } from "../providers/RefreshContext";
 import { ModelsProvider } from "../providers/ModelsContext";
 import { DeviceStateProvider } from "../providers/DeviceStateContext";
+import { BackendHealthProvider } from "../providers/BackendHealthProvider";
 import { getRoutes } from "./route-config";
 import { MainLayout } from "../layouts/MainLayout";
 
@@ -19,25 +20,27 @@ const AppRouter = () => {
   );
 
   return (
-    <DeviceStateProvider>
-      <RefreshProvider>
-        <ModelsProvider>
-          <Router>
-            <Routes>
-              {routes
-                .filter((route) => route.condition !== false)
-                .map((route) => (
-                  <Route
-                    key={route.path}
-                    path={route.path}
-                    element={<MainLayout>{route.element}</MainLayout>}
-                  />
-                ))}
-            </Routes>
-          </Router>
-        </ModelsProvider>
-      </RefreshProvider>
-    </DeviceStateProvider>
+    <BackendHealthProvider>
+      <DeviceStateProvider>
+        <RefreshProvider>
+          <ModelsProvider>
+            <Router>
+              <Routes>
+                {routes
+                  .filter((route) => route.condition !== false)
+                  .map((route) => (
+                    <Route
+                      key={route.path}
+                      path={route.path}
+                      element={<MainLayout>{route.element}</MainLayout>}
+                    />
+                  ))}
+              </Routes>
+            </Router>
+          </ModelsProvider>
+        </RefreshProvider>
+      </DeviceStateProvider>
+    </BackendHealthProvider>
   );
 };
 

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -93,6 +93,15 @@ proxyConfig["/ws-api"] = {
   rewrite: (path: string) => path.replace(/^\/ws-api/, "/ws"),
 };
 
+// Lightweight backend liveness probe used by the frontend to detect when the
+// backend becomes unreachable. Forwards to the backend's bare `/up/` endpoint
+// (path preserved, no rewrite).
+proxyConfig["/up"] = {
+  target: VITE_BACKEND_URL,
+  changeOrigin: true,
+  secure: true,
+};
+
 // Add specific proxy configuration for the /reset-board endpoint
 proxyConfig["/reset-board"] = {
   target: VITE_BACKEND_URL,


### PR DESCRIPTION
## Problem

When the Django backend becomes unreachable — most commonly an SSH port-forwarded session whose host machine sleeps or dies — the frontend keeps rendering every page. Users hit a scatter of low-level failures ("server not found", empty lists, stalled spinners, error toasts) with no single clear signal that the backend itself is gone.

## Change

- New `BackendHealthProvider` polls the backend's lightweight `/up/` liveness endpoint (~5s healthy, ~3s once a failure is seen, 5s request timeout). After 2 consecutive failures it renders a full-screen, non-dismissable overlay explaining the backend is disconnected, with recovery steps (restart the service, check the machine, check the SSH port forward) and a "Retry now" button. The overlay clears automatically once the backend responds again.
- The overlay renders via a portal above the toaster's z-index, so stray per-feature error toasts are covered rather than competing.
- Routed `/up/` through both the Vite dev proxy and the prod nginx config (it wasn't proxied before).

Provider is wired as the outermost provider in `routes/index.tsx`, below `ThemeProvider`, so the overlay covers the whole app and is themed correctly.

## Verification

- `npm run type-check`, `npm run lint` (new files clean), and `npm run build` pass.
- `curl` of `/up/` returns 200 directly (`:8000`) and through the Vite proxy (`:3000`).
- Stopped the backend container → proxied `/up/` returns non-200 (the failure signal that drives the overlay); restarted it → back to 200 (auto-recovery signal).