### PR TITLE
Make Deployment History status consistent with Models Deployed

### DIFF
--- a/app/backend/docker_control/test_deployment_history_view.py
+++ b/app/backend/docker_control/test_deployment_history_view.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Unit tests for DeploymentHistoryView status reconciliation.
+
+The history endpoint must report the same truth as the Models Deployed page:
+"running" only when a live container backs the record, "unknown" when Docker
+liveness can't be verified. Run inside the backend container/image:
+
+    pytest docker_control/test_deployment_history_view.py -v
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+
+import django
+import docker_control.health_monitor as health_monitor
+
+# Keep the background health monitor from racing the tests' store writes.
+health_monitor.start_health_monitoring = lambda: None
+
+django.setup()
+
+from django.test import RequestFactory  # noqa: E402
+
+from docker_control import deployment_store  # noqa: E402
+from docker_control.models import ModelDeployment  # noqa: E402
+from docker_control.views import DeploymentHistoryView  # noqa: E402
+
+_GET_CONTAINER_STATUS = "docker_control.docker_utils.get_container_status"
+
+
+def _use_store(tmp_path):
+    deployment_store._STORE_PATH = tmp_path / "deployments.json"
+
+
+def _get_history():
+    request = RequestFactory().get("/docker/deployment-history/")
+    return DeploymentHistoryView.as_view()(request)
+
+
+def _create(status="running", **kwargs):
+    defaults = dict(
+        container_id="cid-1234567890ab",
+        container_name="test-history-model",
+        model_name="test-history-model",
+        device="p150",
+        status=status,
+        port=7000,
+        # Set so the view's lazy workflow-log backfill doesn't scan the host.
+        workflow_log_path="/dev/null",
+    )
+    defaults.update(kwargs)
+    return ModelDeployment.objects.create(**defaults)
+
+
+def test_running_with_no_live_container_reconciles_to_stopped(tmp_path):
+    _use_store(tmp_path)
+    _create(status="running")
+    with patch(_GET_CONTAINER_STATUS, return_value={}):
+        response = _get_history()
+    assert response.status_code == 200
+    assert response.data["docker_state"] == "ok"
+    assert response.data["deployments"][0]["status"] == "stopped"
+    assert response.data["deployments"][0]["stopped_at"] is not None
+    # Reconcile persisted the correction to the store.
+    assert ModelDeployment.objects.all()[0].status == "stopped"
+
+
+def test_running_with_live_container_stays_running(tmp_path):
+    _use_store(tmp_path)
+    dep = _create(status="running")
+    live = {
+        dep.container_id: {
+            "name": dep.container_name,
+            "status": "running",
+            "image_id": "sha256:abc",
+            "image_name": "test-image:latest",
+            "port_bindings": {},
+            "networks": {},
+            "env_vars": {},
+        }
+    }
+    with patch(_GET_CONTAINER_STATUS, return_value=live):
+        response = _get_history()
+    assert response.data["docker_state"] == "ok"
+    assert response.data["deployments"][0]["status"] == "running"
+    assert ModelDeployment.objects.all()[0].status == "running"
+
+
+def test_docker_unreachable_reports_unknown_without_persisting(tmp_path):
+    _use_store(tmp_path)
+    _create(status="running")
+    with patch(
+        _GET_CONTAINER_STATUS,
+        side_effect=RuntimeError("docker-control-service unreachable"),
+    ):
+        response = _get_history()
+    assert response.status_code == 200
+    assert response.data["docker_state"] == "unavailable"
+    assert response.data["deployments"][0]["status"] == "unknown"
+    # The store keeps the last verified status — "unknown" is response-only.
+    assert ModelDeployment.objects.all()[0].status == "running"
+
+
+def test_docker_unreachable_keeps_terminal_statuses(tmp_path):
+    _use_store(tmp_path)
+    _create(status="stopped", container_id="cid-a", stopped_by_user=True)
+    _create(status="exited", container_id="cid-b")
+    with patch(_GET_CONTAINER_STATUS, side_effect=RuntimeError("down")):
+        response = _get_history()
+    assert response.data["docker_state"] == "unavailable"
+    statuses = {
+        d["container_id"]: d["status"] for d in response.data["deployments"]
+    }
+    assert statuses == {"cid-a": "stopped", "cid-b": "exited"}
+
+
+def test_docker_unreachable_keeps_starting_within_grace(tmp_path):
+    _use_store(tmp_path)
+    _create(status="starting")  # deployed_at = now, inside the 60s grace
+    with patch(_GET_CONTAINER_STATUS, side_effect=RuntimeError("down")):
+        response = _get_history()
+    assert response.data["deployments"][0]["status"] == "starting"
+
+
+def test_docker_unreachable_marks_stale_starting_unknown(tmp_path):
+    _use_store(tmp_path)
+    dep = _create(status="starting")
+    dep.deployed_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    dep.save()
+    with patch(_GET_CONTAINER_STATUS, side_effect=RuntimeError("down")):
+        response = _get_history()
+    assert response.data["deployments"][0]["status"] == "unknown"

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1908,7 +1908,21 @@ class DeploymentHistoryView(APIView):
         """Return all deployments ordered by most recent first"""
         try:
             from docker_control.models import ModelDeployment
-            
+
+            # Reconcile the store against live Docker state before reading, so
+            # history reflects the same truth as the Models Deployed page
+            # (get_canonical_deployments flips stale running/starting records
+            # to stopped). If Docker can't be queried, liveness is unverifiable
+            # and non-terminal statuses are reported as "unknown" below.
+            docker_state = "ok"
+            try:
+                get_canonical_deployments()
+            except Exception as reconcile_err:
+                docker_state = "unavailable"
+                logger.warning(
+                    f"Deployment history: could not reconcile against Docker: {reconcile_err}"
+                )
+
             # Get all deployments, ordered by most recent first
             deployments = ModelDeployment.objects.all().order_by('-deployed_at')
             
@@ -1940,16 +1954,17 @@ class DeploymentHistoryView(APIView):
                     'device_id': deployment.device_id,
                     'deployed_at': deployment.deployed_at.isoformat() if deployment.deployed_at else None,
                     'stopped_at': deployment.stopped_at.isoformat() if deployment.stopped_at else None,
-                    'status': deployment.status,
+                    'status': self._effective_status(deployment, docker_state),
                     'stopped_by_user': deployment.stopped_by_user,
                     'port': deployment.port,
                     'workflow_log_path': deployment.workflow_log_path,
                 })
-            
+
             return Response({
                 'status': 'success',
                 'deployments': deployment_data,
-                'count': len(deployment_data)
+                'count': len(deployment_data),
+                'docker_state': docker_state
             }, status=status.HTTP_200_OK)
             
         except Exception as e:
@@ -1958,6 +1973,37 @@ class DeploymentHistoryView(APIView):
                 {'status': 'error', 'message': str(e)},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+
+    @staticmethod
+    def _effective_status(deployment, docker_state):
+        """Stored status, downgraded to "unknown" when Docker liveness can't be
+        verified. Response-only: the store keeps the last verified status, so a
+        Docker outage never overwrites real state.
+        """
+        if docker_state == "ok" or deployment.status not in ("running", "starting"):
+            return deployment.status
+        if deployment.status == "starting" and deployment.deployed_at is not None:
+            # Trust fresh deploys through the same grace window the canonical
+            # reconcile uses, so a legitimate startup doesn't flash "unknown".
+            from datetime import datetime, timezone
+            from .docker_utils import (
+                _CANONICAL_STARTING_GRACE_SECONDS,
+                _CANONICAL_STARTING_GRACE_MEDIA_SECONDS,
+            )
+            impl = next(
+                (v for v in model_implmentations.values()
+                 if v.model_name == deployment.model_name),
+                None,
+            )
+            grace = (
+                _CANONICAL_STARTING_GRACE_MEDIA_SECONDS
+                if impl and getattr(impl, "inference_engine", None) == "media"
+                else _CANONICAL_STARTING_GRACE_SECONDS
+            )
+            age = (datetime.now(timezone.utc) - deployment.deployed_at).total_seconds()
+            if age < grace:
+                return "starting"
+        return "unknown"
 
 
 class DiscoverContainersView(APIView):

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -287,6 +287,9 @@ export default function ModelsDeployedCard(): JSX.Element {
     for (const d of history) {
       if (!d.container_id || d.container_id.startsWith("pending_")) continue;
       if (d.stopped_by_user) continue;
+      // "unknown" means the backend couldn't verify liveness (Docker service
+      // unreachable) — not evidence of death, so never mint a failed row.
+      if (d.status === "unknown") continue;
       // Only flag deployments we've actually seen alive this session OR that
       // are still in the live set (so a row that's currently visible can flip
       // to failed). Anything we never saw is ignored — that's history.

--- a/app/frontend/src/pages/DeploymentHistoryPage.tsx
+++ b/app/frontend/src/pages/DeploymentHistoryPage.tsx
@@ -50,6 +50,7 @@ interface DeploymentHistoryResponse {
   status: string;
   deployments: Deployment[];
   count: number;
+  docker_state?: "ok" | "unavailable";
 }
 
 const fetchDeploymentHistory = async (): Promise<DeploymentHistoryResponse> => {
@@ -62,6 +63,26 @@ const fetchDeploymentHistory = async (): Promise<DeploymentHistoryResponse> => {
 const getStatusBadge = (status: string, stoppedByUser: boolean) => {
   if (status === "running") {
     return <Badge className="bg-green-500">Running</Badge>;
+  }
+  if (status === "unknown") {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge className="bg-yellow-500 text-white cursor-help">
+              Unknown
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            <p className="text-sm">
+              The live container state can't be verified right now — the Docker
+              service is unreachable or the last refresh failed. The status
+              will update automatically once the connection recovers.
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
   }
   if (status === "stopped" && stoppedByUser) {
     return <Badge variant="outline">Stopped by User</Badge>;
@@ -129,6 +150,18 @@ export default function DeploymentHistoryPage() {
     refetchOnWindowFocus: true, // Refetch when window regains focus
   });
 
+  // React Query keeps the last successful data when a background refetch
+  // fails, so a fetch error means the table below may be stale. In that case
+  // (or when the backend reports it couldn't reach Docker) we can't vouch for
+  // "running" rows and downgrade them to "unknown".
+  const liveStateUnknown = !!error || data?.docker_state === "unavailable";
+  const effectiveStatus = (deployment: Deployment) =>
+    deployment.status === "running" || deployment.status === "starting"
+      ? liveStateUnknown
+        ? "unknown"
+        : deployment.status
+      : deployment.status;
+
   const closeLogDialog = () => {
     setSelectedDeploymentId(null);
     setSelectedModelName(undefined);
@@ -184,12 +217,24 @@ export default function DeploymentHistoryPage() {
             </div>
           )}
 
-          {error && (
+          {error && !data && (
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
               <AlertTitle>Error</AlertTitle>
               <AlertDescription>
                 Failed to load deployment history. Please try again later.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {data && liveStateUnknown && (
+            <Alert className="mb-4 border-yellow-500/50 text-yellow-600 dark:text-yellow-500 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-500">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Live status unavailable</AlertTitle>
+              <AlertDescription>
+                Can't verify which containers are actually running right now.
+                Deployments are shown as "Unknown" until the connection
+                recovers.
               </AlertDescription>
             </Alert>
           )}
@@ -236,7 +281,7 @@ export default function DeploymentHistoryPage() {
                       </TableCell>
                       <TableCell>
                         {getStatusBadge(
-                          deployment.status,
+                          effectiveStatus(deployment),
                           deployment.stopped_by_user
                         )}
                       </TableCell>
@@ -247,10 +292,13 @@ export default function DeploymentHistoryPage() {
                         {formatDate(deployment.stopped_at)}
                       </TableCell>
                       <TableCell className="text-sm">
-                        {formatDuration(
-                          deployment.deployed_at,
-                          deployment.stopped_at
-                        )}
+                        {effectiveStatus(deployment) === "unknown" &&
+                        !deployment.stopped_at
+                          ? "Unknown"
+                          : formatDuration(
+                              deployment.deployed_at,
+                              deployment.stopped_at
+                            )}
                       </TableCell>
                       <TableCell>
                         {deployment.port ? (


### PR DESCRIPTION
## Problem
Deployment History could show a model as **Running** when nothing was actually deployed (e.g. after a board reset, or when the Docker control service was unreachable). The history endpoint returned raw store records, while Models Deployed checks live containers.

## Change
- `DeploymentHistoryView` now runs the same canonical reconciliation as Models Deployed before reading the store, so stale running/starting records are corrected to stopped.
- When Docker liveness can't be verified, running/starting records are reported as `unknown` (response-only, never persisted) plus a top-level `docker_state` flag.
- The history page shows a yellow **Unknown** badge and a warning banner in that case, and also downgrades stale rows if its own refresh fails.
- Models Deployed ignores `unknown` records so they can't produce false "Died Unexpectedly" rows.

## Verification
- New unit tests (`docker_control/test_deployment_history_view.py`, 6 passing) cover reconcile-to-stopped, unknown on Docker outage without persisting, terminal statuses untouched, and the starting grace window.
- Smoke-tested the endpoint against a real store containing a stale "running" record with the Docker control service down: it returned `unknown` + `docker_state: unavailable` and left the store unchanged.
- `npm run type-check` and ESLint clean on changed files.