### PR TITLE
Automate the release process: tag and GitHub Release on merge to main

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Fixes"
+      labels:
+        - bug
+    - title: "📖 Documentation"
+      labels:
+        - documentation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🔧 Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,119 @@
+name: Prepare Release (open RC PR)
+
+# Manually triggered from the Actions tab. Opens (or refreshes) the
+# dev -> main release-candidate PR, pre-filled with the version and the
+# list of PRs merged since the last release. Merging that PR triggers the
+# release workflow, which tags main and publishes the GitHub Release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 2.9.0). Leave empty to bump the minor version of the latest tag."
+        required: false
+        type: string
+
+jobs:
+  open-rc-pr:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0 # Full history and tags needed for version resolution
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+          echo "Latest existing tag: ${latest_tag:-<none>}"
+
+          version="${INPUT_VERSION#v}"
+          if [ -z "$version" ]; then
+            base=${latest_tag:-v0.0.0}
+            IFS=. read -r major minor _patch <<< "${base#v}"
+            version="$major.$((minor + 1)).0"
+            echo "No version input; auto-bumped minor: $version"
+          fi
+
+          if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<< "$version"; then
+            echo "Invalid version: '$version' (expected X.Y.Z)" >&2
+            exit 1
+          fi
+
+          tag="v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" > /dev/null; then
+            echo "Tag $tag already exists; pick a different version." >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "previous_tag=$latest_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compose RC PR description
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.version.outputs.previous_tag }}
+        run: |
+          set -euo pipefail
+
+          generate_args=(-f "tag_name=$TAG" -f "target_commitish=dev")
+          if [ -n "$PREVIOUS_TAG" ]; then
+            generate_args+=(-f "previous_tag_name=$PREVIOUS_TAG")
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            "${generate_args[@]}" --jq '.body' > generated-notes.md
+
+          {
+            echo "## Release candidate $TAG"
+            echo ""
+            echo "This PR promotes \`dev\` to \`main\` for the $TAG release."
+            echo "Changes since ${PREVIOUS_TAG:-the beginning}:"
+            echo ""
+            cat generated-notes.md
+            echo ""
+            echo "---"
+            echo ""
+            echo "### Release notes preview"
+            echo ""
+            echo "On merge, the release workflow tags \`main\` as \`$TAG\` and"
+            echo "publishes a GitHub Release titled \"TT Studio $TAG\" with the"
+            echo "notes above. Edit this PR title if the version should differ"
+            echo "(the workflow parses the version from the merge commit)."
+            echo ""
+            echo "### ⚠️ Merge instructions"
+            echo ""
+            echo "Merge with **\"Create a merge commit\"** — never squash."
+            echo "Squashing detaches \`main\` from \`dev\`'s history and brings"
+            echo "back merge conflicts on every future release."
+          } > pr-body.md
+
+      - name: Open or update RC PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --base main --head dev --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing RC PR #$existing"
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --title "Rc $TAG" --body-file pr-body.md
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base main --head dev \
+              --title "Rc $TAG" --body-file pr-body.md
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Tag and Release on Merge to Main
+
+# Every push to main produces a version tag and a published GitHub Release.
+# The version comes from the merge commit message (RC PRs are titled
+# "Rc vX.Y.Z"); pushes without a version fall back to a patch bump of the
+# latest tag. Add "[skip release]" to a commit message to opt out.
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history and tags needed for version resolution
+
+      - name: Resolve release version
+        id: version
+        env:
+          HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          if grep -qF '[skip release]' <<< "$HEAD_MESSAGE"; then
+            echo "Commit message contains [skip release]; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$(git tag --points-at HEAD)" ]; then
+            echo "HEAD is already tagged ($(git tag --points-at HEAD | tr '\n' ' ')); skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+          echo "Latest existing tag: ${latest_tag:-<none>}"
+
+          # GitHub merge commits carry the PR title in the message body,
+          # so search the full message for a version like v2.9.0 or 2.9.0.
+          version=$(grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' <<< "$HEAD_MESSAGE" | head -1 | sed 's/^v//') || true
+
+          if [ -n "$version" ]; then
+            echo "Version parsed from commit message: $version"
+          else
+            # No version in the message (e.g. a direct hotfix push):
+            # bump the patch component of the latest tag.
+            base=${latest_tag:-v0.0.0}
+            IFS=. read -r major minor patch <<< "${base#v}"
+            version="$major.$minor.$((patch + 1))"
+            echo "No version in commit message; auto-bumped patch: $version"
+          fi
+
+          tag="v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" > /dev/null; then
+            echo "Tag $tag already exists; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "skip=false"
+            echo "tag=$tag"
+            echo "previous_tag=$latest_tag"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.version.outputs.skip == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "TT Studio $TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/$TAG"
+
+      - name: Publish release
+        if: steps.version.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.version.outputs.previous_tag }}
+        run: |
+          set -euo pipefail
+
+          # Generated notes respect .github/release.yml categories and
+          # include the per-PR list plus the full-changelog compare link.
+          generate_args=(-f "tag_name=$TAG" -f "target_commitish=$GITHUB_SHA")
+          if [ -n "$PREVIOUS_TAG" ]; then
+            generate_args+=(-f "previous_tag_name=$PREVIOUS_TAG")
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            "${generate_args[@]}" --jq '.body' > generated-notes.md
+
+          {
+            echo "## 🚀 TT Studio $TAG is out!"
+            echo ""
+            cat generated-notes.md
+          } > release-notes.md
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "TT Studio $TAG" \
+            --notes-file release-notes.md \
+            --latest


### PR DESCRIPTION
## Summary

Releases are currently manual end to end: open an "Rc vX.Y.Z" PR, merge it, hand-create the tag, hand-write the release notes. This PR automates the whole pipeline with three new files (no existing files touched):

### `.github/workflows/release.yml` — tag + release on every push to `main`
- Parses the version from the merge commit message (our existing `Rc vX.Y.Z` PR-title convention); unversioned pushes (e.g. hotfixes) fall back to a patch bump of the latest tag.
- Creates and pushes an annotated `vX.Y.Z` tag, then publishes a GitHub Release titled "TT Studio vX.Y.Z" whose body is GitHub's generated notes (categorized per-PR list + full-changelog link) under our usual "🚀 TT Studio vX.Y.Z is out!" header.
- Safety: `[skip release]` in the commit message opts out; already-tagged commits and existing tags are skipped; runs are serialized via a concurrency group.

### `.github/workflows/prepare-release.yml` — one-click RC PR
Manually triggered from the Actions tab (optional `version` input, defaults to a minor bump). Opens — or refreshes, if one is already open — the `dev` → `main` PR titled `Rc vX.Y.Z`, pre-filled with the list of PRs merged since the last release and merge instructions.

### `.github/release.yml`
Release-notes categorization config mapping our existing labels (`enhancement`, `bug`, `documentation`, `dependencies`) to Features / Fixes / Documentation / Dependencies sections.

## How a release works after this lands

1. Click **Run workflow** on "Prepare Release" (optionally type the version) → RC PR appears with the changelog.
2. Review and merge it with **"Create a merge commit"**.
3. The push to `main` tags it and publishes the release automatically. Done.

## Prerequisites / rollout notes

- Depends on #1027 (history consolidation) landing first via a merge commit; per-PR notes generation needs `main` to share history with `dev`.
- **One-time step after #1027 merges:** tag the resulting `main` tip as `v2.8.1` (no content change, "history consolidation"). Without it, the first automated release would list every PR back to the original divergence point (~240 PRs) instead of just the ones since v2.8.0.
- The workflows take effect once they reach `main` via the next RC merge; the "Prepare Release" button appears in the Actions tab at the same time.
- All future RC PRs must be merged with "Create a merge commit" (never squash) to keep histories joined.

## Verification

- `actionlint` (with shellcheck integration) passes on both workflows.
- Version-resolution logic tested against real repo tags for: RC merge-commit messages, squash-style titles, unversioned hotfix messages, `[skip release]`, and versions without the `v` prefix.
- Notes composition dry-run against the live generate-notes API (read-only) confirms the body renders with the categorized PR list and changelog link.