### PR TITLE
Add root ruff config and clear Python lint debt

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -13,11 +13,11 @@ from .llm_discovery import LLMDiscoveryService, LLMInfo, HealthStatus
 from .health_monitor import LLMHealthMonitor
 
 __all__ = [
-    'app',
-    'AgentConfig', 
-    'CustomLLM',
-    'LLMDiscoveryService',
-    'LLMInfo',
-    'HealthStatus',
-    'LLMHealthMonitor'
+    "app",
+    "AgentConfig",
+    "CustomLLM",
+    "LLMDiscoveryService",
+    "LLMInfo",
+    "HealthStatus",
+    "LLMHealthMonitor",
 ]

--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from langchain.memory import ConversationBufferMemory
 from langchain_community.tools.tavily_search import TavilySearchResults
-import os 
+import os
 import jwt
 import json
 import asyncio
@@ -29,7 +29,7 @@ import requests
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
-from typing import Optional, Dict, Any
+from typing import Optional
 
 app = FastAPI()
 
@@ -41,17 +41,21 @@ cloud_auth_token = os.getenv("CLOUD_CHAT_UI_AUTH_TOKEN")
 # Use cloud auth token if available, otherwise fall back to JWT
 if cloud_auth_token:
     encoded_jwt = cloud_auth_token
-    print(f"Using cloud auth token for authentication")
+    print("Using cloud auth token for authentication")
 elif jwt_secret:
     encoded_jwt = jwt.encode(json_payload, jwt_secret, algorithm="HS256")
-    print(f"Using JWT authentication")
+    print("Using JWT authentication")
 else:
     encoded_jwt = None
-    print("Warning: No authentication token available (neither CLOUD_CHAT_UI_AUTH_TOKEN nor JWT_SECRET)")
+    print(
+        "Warning: No authentication token available (neither CLOUD_CHAT_UI_AUTH_TOKEN nor JWT_SECRET)"
+    )
+
 
 class RequestPayload(BaseModel):
     message: str
     thread_id: str
+
 
 # Global variables for LLM management
 discovery_service = LLMDiscoveryService()
@@ -70,100 +74,120 @@ if config_issues:
 # Print configuration
 AgentConfig.print_config()
 
+
 def setup_cloud_llm() -> CustomLLM:
     """Setup cloud LLM endpoint"""
     cloud_endpoint = AgentConfig.CLOUD_ENDPOINT
     cloud_auth_token = AgentConfig.CLOUD_AUTH_TOKEN
-    
+
     print(f"Cloud endpoint: {cloud_endpoint}")
-    print(f"Cloud auth token length: {len(cloud_auth_token) if cloud_auth_token else 0}")
-    
+    print(
+        f"Cloud auth token length: {len(cloud_auth_token) if cloud_auth_token else 0}"
+    )
+
     if not cloud_auth_token:
-        print("ERROR: No cloud chat UI auth token provided. Agent will not work correctly.")
-        print("Please set CLOUD_CHAT_UI_AUTH_TOKEN environment variable with a valid API key.")
+        print(
+            "ERROR: No cloud chat UI auth token provided. Agent will not work correctly."
+        )
+        print(
+            "Please set CLOUD_CHAT_UI_AUTH_TOKEN environment variable with a valid API key."
+        )
         raise Exception("No cloud auth token available")
-    
+
     cloud_model_name = AgentConfig.CLOUD_MODEL_NAME
     llm = CustomLLM(
-        server_url=cloud_endpoint, 
+        server_url=cloud_endpoint,
         encoded_jwt=cloud_auth_token,
         streaming=True,
         is_cloud=True,
-        cloud_model_name=cloud_model_name
+        cloud_model_name=cloud_model_name,
     )
-    print(f"Agent configured to use cloud LLM endpoint: {cloud_endpoint} with model: {cloud_model_name}")
+    print(
+        f"Agent configured to use cloud LLM endpoint: {cloud_endpoint} with model: {cloud_model_name}"
+    )
     return llm
+
 
 def setup_local_container_llm(container_name: str) -> CustomLLM:
     """Setup LLM using environment-specified container"""
     llm = CustomLLM(
-        server_url=f"http://{container_name}:7000", 
-        encoded_jwt=encoded_jwt, 
+        server_url=f"http://{container_name}:7000",
+        encoded_jwt=encoded_jwt,
         streaming=True,
-        is_cloud=False
+        is_cloud=False,
     )
     print(f"Agent configured to use local LLM container: {container_name}")
     return llm
 
+
 def setup_discovered_llm(llm_info: LLMInfo) -> CustomLLM:
     """Setup LLM using discovered container info with dynamic model type handling"""
-    print(f"[DYNAMIC_LLM_SETUP] Setting up discovered LLM:")
+    print("[DYNAMIC_LLM_SETUP] Setting up discovered LLM:")
     print(f"  - Container: {llm_info.container_name}")
     print(f"  - Model: {llm_info.model_name}")
     print(f"  - Model Type: {llm_info.model_type}")
     print(f"  - Internal URL: {llm_info.internal_url}")
     print(f"  - Health URL: {llm_info.health_url}")
     print(f"  - Status: {llm_info.status}")
-    
+
     # Determine the correct endpoint based on model type
     server_url = f"http://{llm_info.internal_url}"
-    
+
     # For different model types, we might need different endpoints
     # Most vLLM models use /v1/chat/completions, but some might use different endpoints
-    if llm_info.model_type == 'chat':
+    if llm_info.model_type == "chat":
         # Standard chat completion endpoint
-        if not llm_info.internal_url.endswith('/v1/chat/completions'):
+        if not llm_info.internal_url.endswith("/v1/chat/completions"):
             server_url = f"http://{llm_info.internal_url}/v1/chat/completions"
-    elif llm_info.model_type == 'completion':
+    elif llm_info.model_type == "completion":
         # For completion models, use /v1/completions
         server_url = f"http://{llm_info.internal_url.replace('/v1/chat/completions', '/v1/completions')}"
     else:
         # Default to chat completions for unknown types
-        print(f"[WARNING] Unknown model type '{llm_info.model_type}', using chat completions endpoint")
-    
+        print(
+            f"[WARNING] Unknown model type '{llm_info.model_type}', using chat completions endpoint"
+        )
+
     print(f"[DYNAMIC_LLM_SETUP] Final server URL: {server_url}")
-    
+
     llm_info_dict = {
-        'deploy_id': llm_info.deploy_id,
-        'container_name': llm_info.container_name,
-        'internal_url': llm_info.internal_url,
-        'health_url': llm_info.health_url,
-        'model_name': llm_info.model_name,
-        'model_type': llm_info.model_type,
-        'status': llm_info.status.value,
-        'hf_model_id': llm_info.hf_model_id if hasattr(llm_info, 'hf_model_id') else None
+        "deploy_id": llm_info.deploy_id,
+        "container_name": llm_info.container_name,
+        "internal_url": llm_info.internal_url,
+        "health_url": llm_info.health_url,
+        "model_name": llm_info.model_name,
+        "model_type": llm_info.model_type,
+        "status": llm_info.status.value,
+        "hf_model_id": llm_info.hf_model_id
+        if hasattr(llm_info, "hf_model_id")
+        else None,
     }
     print(f"[DEBUG] Setting up LLM with llm_info: {llm_info_dict}")
-    
+
     llm = CustomLLM(
         server_url=server_url,
         encoded_jwt=encoded_jwt,
         streaming=True,
         is_cloud=False,
         is_discovered=True,
-        llm_info=llm_info_dict
+        llm_info=llm_info_dict,
     )
-    
-    print(f"[DYNAMIC_LLM_SETUP] Agent configured to use discovered LLM: {llm_info.model_name} ({llm_info.container_name})")
+
+    print(
+        f"[DYNAMIC_LLM_SETUP] Agent configured to use discovered LLM: {llm_info.model_name} ({llm_info.container_name})"
+    )
     print(f"[DYNAMIC_LLM_SETUP] LLM server URL: {llm.server_url}")
-    
+
     # Test the connection with model-specific parameters
     if test_llm_connection(llm, llm_info.model_name, llm_info.model_type):
         print(f"[SUCCESS] LLM connection test passed for {llm_info.model_name}")
         return llm
     else:
-        print(f"[WARNING] LLM connection test failed for {llm_info.model_name}, but continuing...")
+        print(
+            f"[WARNING] LLM connection test failed for {llm_info.model_name}, but continuing..."
+        )
         return llm
+
 
 def check_local_host_llm() -> bool:
     """Check if there's a local host LLM available"""
@@ -173,81 +197,92 @@ def check_local_host_llm() -> bool:
         health_url = f"http://{local_host}:{local_port}/health"
         response = requests.get(health_url, timeout=AgentConfig.HEALTH_CHECK_TIMEOUT)
         return response.status_code == 200
-    except:
+    except Exception:
         return False
+
 
 def setup_local_host_llm() -> CustomLLM:
     """Setup LLM using local host endpoint"""
     local_host = AgentConfig.LOCAL_HOST
     local_port = AgentConfig.LOCAL_PORT
     local_model = AgentConfig.LOCAL_MODEL_NAME
-    
+
     llm = CustomLLM(
         server_url=f"http://{local_host}:{local_port}/v1/chat/completions",
         encoded_jwt=encoded_jwt,
         streaming=True,
-        is_cloud=False
+        is_cloud=False,
     )
-    print(f"Agent configured to use local host LLM: {local_host}:{local_port} ({local_model})")
+    print(
+        f"Agent configured to use local host LLM: {local_host}:{local_port} ({local_model})"
+    )
     return llm
+
 
 def test_llm_connection(llm: CustomLLM, model_name: str, model_type: str) -> bool:
     """Test if the agent can connect to the LLM"""
     try:
         print(f"[DEBUG] Testing LLM connection to: {llm.server_url}")
-        
+
         # Test basic connectivity first
-        if hasattr(llm, 'llm_info') and llm.llm_info and 'health_url' in llm.llm_info:
+        if hasattr(llm, "llm_info") and llm.llm_info and "health_url" in llm.llm_info:
             health_url = f"http://{llm.llm_info['health_url']}"
             print(f"[DEBUG] Testing health endpoint: {health_url}")
             response = requests.get(health_url, timeout=5)
             if response.status_code == 200:
-                print(f"[DEBUG] Health check passed")
+                print("[DEBUG] Health check passed")
             else:
                 print(f"[WARNING] Health check failed: {response.status_code}")
-        
+
         # Test the actual chat endpoint with a simple request
         # Use hf_model_id if available, otherwise use model_name
-        test_model = llm.llm_info.get('hf_model_id') if llm.llm_info else model_name
+        test_model = llm.llm_info.get("hf_model_id") if llm.llm_info else model_name
         test_payload = {
             "model": test_model,
             "messages": [{"role": "user", "content": "Hello"}],
             "max_tokens": 1,
-            "stream": False
+            "stream": False,
         }
-        
+
         headers = {"Authorization": f"Bearer {llm.encoded_jwt}"}
-        print(f"[DEBUG] Testing chat endpoint with simple request")
-        
-        response = requests.post(llm.server_url, json=test_payload, headers=headers, timeout=10)
+        print("[DEBUG] Testing chat endpoint with simple request")
+
+        response = requests.post(
+            llm.server_url, json=test_payload, headers=headers, timeout=10
+        )
         print(f"[DEBUG] Test request status: {response.status_code}")
-        
-        if response.status_code in [200, 400, 422]:  # 400/422 are expected for invalid model names
-            print(f"[DEBUG] LLM connection test successful")
+
+        if response.status_code in [
+            200,
+            400,
+            422,
+        ]:  # 400/422 are expected for invalid model names
+            print("[DEBUG] LLM connection test successful")
             return True
         else:
             print(f"[ERROR] LLM connection test failed: {response.status_code}")
             print(f"[ERROR] Response: {response.text}")
             return False
-            
+
     except Exception as e:
         print(f"[ERROR] LLM connection test exception: {str(e)}")
         return False
 
+
 def initialize_llm() -> CustomLLM:
     """Initialize LLM with fallback strategy"""
     print("=== Initializing LLM with Enhanced Discovery ===")
-    
+
     # Priority 1: Cloud LLM (if configured)
     if AgentConfig.USE_CLOUD_LLM and AgentConfig.CLOUD_AUTH_TOKEN:
         print("Priority 1: Using cloud LLM")
         return setup_cloud_llm()
-    
+
     # Priority 2: Environment-specified local container
     if AgentConfig.LLM_CONTAINER_NAME:
         print("Priority 2: Using environment-specified local container")
         return setup_local_container_llm(AgentConfig.LLM_CONTAINER_NAME)
-    
+
     # Priority 3: Auto-discovered local containers
     if AgentConfig.AUTO_DISCOVERY_ENABLED:
         print("Priority 3: Attempting auto-discovery of local LLMs")
@@ -260,44 +295,51 @@ def initialize_llm() -> CustomLLM:
                     return setup_discovered_llm(selected_llm)
         except Exception as e:
             print(f"Auto-discovery failed: {e}")
-    
+
     # Priority 4: Local host LLM (fallback)
     if AgentConfig.FALLBACK_TO_LOCAL and check_local_host_llm():
         print("Priority 4: Using local host LLM")
         return setup_local_host_llm()
-    
+
     # No LLM available
     print("ERROR: No LLM endpoint available")
     raise Exception("No LLM endpoint available")
+
 
 def on_llm_change(new_llm: CustomLLM):
     """Callback when LLM changes during health monitoring"""
     global current_llm, agent_executer
     print("LLM changed, updating agent executor...")
     current_llm = new_llm
-    
+
     # Recreate agent executor with new LLM
     memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
-    tools = [TavilySearchResults(max_results=2, include_answer=True, include_raw_content=True)]
+    tools = [
+        TavilySearchResults(
+            max_results=2, include_answer=True, include_raw_content=True
+        )
+    ]
     agent_executer = setup_executer(new_llm, memory, tools)
     print("Agent executor updated with new LLM")
+
 
 def start_health_monitoring():
     """Start health monitoring for the current LLM"""
     global health_monitor
     if health_monitor:
         health_monitor.stop_monitoring()
-    
+
     if current_llm and not current_llm.is_cloud and AgentConfig.HEALTH_CHECK_ENABLED:
         health_monitor = LLMHealthMonitor(current_llm, discovery_service)
         health_monitor.set_llm_change_callback(on_llm_change)
-        
+
         # Start monitoring in background
         loop = asyncio.get_event_loop()
         loop.create_task(health_monitor.start_monitoring())
         print("Health monitoring started")
     else:
         print("Health monitoring disabled or not applicable")
+
 
 # Reset global variables for agent state (removing duplicates)
 # current_llm is already declared above
@@ -306,28 +348,30 @@ memory = None
 tools = []
 llm_initialization_complete = False
 
+
 def initialize_agent_components():
     """Initialize agent components once LLM is available"""
     global current_llm, agent_executer, memory, tools, llm_initialization_complete
-    
+
     if current_llm is None:
         return False
-    
+
     try:
         # Setup agent executor
-        memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+        memory = ConversationBufferMemory(
+            memory_key="chat_history", return_messages=True
+        )
         os.environ["TAVILY_API_KEY"] = os.getenv("TAVILY_API_KEY")
-        
+
         # Initialize tools
         tools = []
-        
+
         # Add search tool
         search = TavilySearchResults(
-            max_results=2,
-            include_answer=True,
-            include_raw_content=True)
+            max_results=2, include_answer=True, include_raw_content=True
+        )
         tools.append(search)
-        
+
         # Add code interpreter tool if E2B_API_KEY is available
         try:
             code_tool = CodeInterpreterFunctionTool()
@@ -335,53 +379,56 @@ def initialize_agent_components():
             print("✓ Code interpreter tool enabled")
         except Exception as e:
             print(f"⚠ Code interpreter tool disabled: {e}")
-            print("   To enable code execution, set the E2B_API_KEY environment variable")
+            print(
+                "   To enable code execution, set the E2B_API_KEY environment variable"
+            )
             print("   Get your API key from: https://e2b.dev/docs")
-        
+
         agent_executer = setup_executer(current_llm, memory, tools)
-        
+
         # Start health monitoring for local LLMs
         start_health_monitoring()
-        
+
         llm_initialization_complete = True
         print("=== Agent Initialization Complete ===")
         print(f"Available tools: {[tool.name for tool in tools]}")
         return True
-        
+
     except Exception as e:
         print(f"Failed to initialize agent components: {e}")
         return False
 
+
 async def poll_for_llm():
     """Continuously poll for LLM availability"""
     global current_llm, llm_initialization_complete
-    
+
     # Check if polling is enabled
     if not AgentConfig.LLM_POLLING_ENABLED:
         print("LLM polling is disabled, agent will not wait for LLM")
         return False
-    
+
     poll_interval = AgentConfig.LLM_POLLING_INTERVAL
     max_attempts = AgentConfig.LLM_POLLING_MAX_ATTEMPTS
-    
+
     print("=== Starting LLM Polling ===")
     print(f"Will poll every {poll_interval} seconds for LLM availability...")
     if max_attempts > 0:
         print(f"Maximum attempts: {max_attempts}")
     else:
         print("Will poll indefinitely until LLM becomes available")
-    
+
     attempt = 0
     while True:
         attempt += 1
         if max_attempts > 0 and attempt > max_attempts:
             print(f"Reached maximum attempts ({max_attempts}), stopping polling")
             break
-            
+
         try:
             print(f"\n[Attempt {attempt}] Trying to initialize LLM...")
             current_llm = initialize_llm()
-            
+
             if current_llm:
                 print(f"✓ LLM found: {current_llm}")
                 if initialize_agent_components():
@@ -392,16 +439,17 @@ async def poll_for_llm():
                     current_llm = None
             else:
                 print("⚠ No LLM available yet")
-                
+
         except Exception as e:
             print(f"⚠ LLM initialization attempt {attempt} failed: {e}")
             current_llm = None
-        
+
         if current_llm is None:
             print(f"⏳ Waiting {poll_interval} seconds before next attempt...")
             await asyncio.sleep(poll_interval)
-    
+
     return current_llm is not None
+
 
 # Start LLM polling in background
 @app.on_event("startup")
@@ -413,31 +461,43 @@ async def startup_event():
     else:
         print("LLM polling is disabled, agent will not wait for LLM")
 
+
 @app.post("/poll_requests")
 async def handle_requests(payload: RequestPayload):
     global current_llm, agent_executer, llm_initialization_complete
-    
-    print('[TRACE_FLOW_STEP_4_AGENT_ENTRY] handle_requests called', {'thread_id': payload.thread_id, 'message': payload.message})
-    
+
+    print(
+        "[TRACE_FLOW_STEP_4_AGENT_ENTRY] handle_requests called",
+        {"thread_id": payload.thread_id, "message": payload.message},
+    )
+
     # Check if agent is ready
     if not llm_initialization_complete or current_llm is None or agent_executer is None:
         return StreamingResponse(
-            iter([f"data: {json.dumps({'status': 'waiting', 'message': 'Agent is still initializing, waiting for LLM to become available...'})}\n\n"]),
-            media_type="text/plain"
+            iter(
+                [
+                    f"data: {json.dumps({'status': 'waiting', 'message': 'Agent is still initializing, waiting for LLM to become available...'})}\n\n"
+                ]
+            ),
+            media_type="text/plain",
         )
-    
+
     config = {"configurable": {"thread_id": payload.thread_id}}
     try:
         # use await to prevent handle_requests from blocking, allow other tasks to execute
-        return StreamingResponse(poll_requests(agent_executer, config, tools, memory, payload.message), media_type="text/plain")
+        return StreamingResponse(
+            poll_requests(agent_executer, config, tools, memory, payload.message),
+            media_type="text/plain",
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 @app.get("/")
 def read_root():
     """Health check endpoint with enhanced status information"""
     global current_llm, health_monitor, llm_initialization_complete
-    
+
     # Check if agent is ready
     if not llm_initialization_complete or current_llm is None:
         return {
@@ -447,43 +507,46 @@ def read_root():
             "llm_info": "No LLM available yet",
             "health_monitoring": "N/A",
             "discovery_summary": "N/A",
-            "next_poll": "Will retry every 3 minutes"
+            "next_poll": "Will retry every 3 minutes",
         }
-    
+
     # Get LLM status
     llm_mode = "cloud" if current_llm and current_llm.is_cloud else "local"
     llm_info = "N/A"
-    
+
     if current_llm:
         if current_llm.is_cloud:
             llm_info = f"Cloud: {current_llm.cloud_model_name}"
         elif current_llm.is_discovered and current_llm.llm_info:
-            llm_info = f"Discovered: {current_llm.llm_info.get('model_name', 'Unknown')}"
+            llm_info = (
+                f"Discovered: {current_llm.llm_info.get('model_name', 'Unknown')}"
+            )
         else:
             llm_info = f"Container: {current_llm.server_url}"
-    
+
     # Get health monitoring status
     health_status = "N/A"
     if health_monitor:
         health_status = health_monitor.get_health_status()
-    
+
     # Get discovery summary
     discovery_summary = discovery_service.get_llm_status_summary()
-    
+
     return {
         "message": "Agent server is running",
         "status": "ready",
         "llm_mode": llm_mode,
         "llm_info": llm_info,
         "health_monitoring": health_status,
-        "discovery_summary": discovery_summary
+        "discovery_summary": discovery_summary,
     }
+
 
 @app.get("/status")
 def get_status():
     """Get dynamic status of the agent and all available LLMs"""
     global current_llm, discovery_service, llm_initialization_complete
-    
+
     try:
         # Check if agent is ready
         if not llm_initialization_complete or current_llm is None:
@@ -492,17 +555,22 @@ def get_status():
                 "message": "Agent is still initializing, waiting for LLM to become available",
                 "current_llm": None,
                 "available_models": [],
-                "discovery_summary": {"total": 0, "healthy": 0, "degraded": 0, "unhealthy": 0},
+                "discovery_summary": {
+                    "total": 0,
+                    "healthy": 0,
+                    "degraded": 0,
+                    "unhealthy": 0,
+                },
                 "configuration": {
                     "auto_discovery_enabled": AgentConfig.AUTO_DISCOVERY_ENABLED,
                     "health_check_enabled": AgentConfig.HEALTH_CHECK_ENABLED,
                     "fallback_to_local": AgentConfig.FALLBACK_TO_LOCAL,
                     "use_cloud_llm": AgentConfig.USE_CLOUD_LLM,
-                    "priority_models": AgentConfig.get_priority_models()
+                    "priority_models": AgentConfig.get_priority_models(),
                 },
-                "next_poll": "Will retry every 3 minutes"
+                "next_poll": "Will retry every 3 minutes",
             }
-        
+
         # Get current LLM info
         current_llm_info = None
         if current_llm:
@@ -510,13 +578,15 @@ def get_status():
                 "server_url": current_llm.server_url,
                 "is_cloud": current_llm.is_cloud,
                 "is_discovered": current_llm.is_discovered,
-                "llm_info": current_llm.llm_info if hasattr(current_llm, 'llm_info') else None
+                "llm_info": current_llm.llm_info
+                if hasattr(current_llm, "llm_info")
+                else None,
             }
-        
+
         # Discover all available LLMs
         all_llms = discovery_service.discover_local_llms()
         available_models = []
-        
+
         for llm in all_llms:
             model_info = {
                 "deploy_id": llm.deploy_id,
@@ -526,16 +596,18 @@ def get_status():
                 "internal_url": llm.internal_url,
                 "health_url": llm.health_url,
                 "status": llm.status.value,
-                "is_current": (current_llm and 
-                              hasattr(current_llm, 'llm_info') and 
-                              current_llm.llm_info and 
-                              current_llm.llm_info.get('deploy_id') == llm.deploy_id)
+                "is_current": (
+                    current_llm
+                    and hasattr(current_llm, "llm_info")
+                    and current_llm.llm_info
+                    and current_llm.llm_info.get("deploy_id") == llm.deploy_id
+                ),
             }
             available_models.append(model_info)
-        
+
         # Get discovery service status
         discovery_status = discovery_service.get_llm_status_summary()
-        
+
         return {
             "status": "ready",
             "current_llm": current_llm_info,
@@ -546,37 +618,40 @@ def get_status():
                 "health_check_enabled": AgentConfig.HEALTH_CHECK_ENABLED,
                 "fallback_to_local": AgentConfig.FALLBACK_TO_LOCAL,
                 "use_cloud_llm": AgentConfig.USE_CLOUD_LLM,
-                "priority_models": AgentConfig.get_priority_models()
-            }
+                "priority_models": AgentConfig.get_priority_models(),
+            },
         }
-        
+
     except Exception as e:
         print(f"[STATUS] Error getting status: {e}")
         return {
             "status": "error",
             "error": str(e),
-            "current_llm": current_llm_info if 'current_llm_info' in locals() else None
+            "current_llm": current_llm_info if "current_llm_info" in locals() else None,
         }
+
 
 @app.post("/refresh")
 def refresh_llm():
     """Dynamically refresh LLM selection and configuration"""
     global current_llm, agent_executer, discovery_service
-    
+
     print("[DYNAMIC_REFRESH] Starting LLM refresh process...")
-    
+
     try:
         # Clear discovery cache to force fresh discovery
         discovery_service.clear_cache()
         print("[DYNAMIC_REFRESH] Cleared discovery cache")
-        
+
         # Discover available LLMs
         local_llms = discovery_service.discover_local_llms()
         print(f"[DYNAMIC_REFRESH] Discovered {len(local_llms)} local LLMs")
-        
+
         if not local_llms:
-            print("[DYNAMIC_REFRESH] No local LLMs discovered, checking fallback options...")
-            
+            print(
+                "[DYNAMIC_REFRESH] No local LLMs discovered, checking fallback options..."
+            )
+
             # Try fallback options
             if AgentConfig.FALLBACK_TO_LOCAL and check_local_host_llm():
                 print("[DYNAMIC_REFRESH] Using local host LLM as fallback")
@@ -585,7 +660,10 @@ def refresh_llm():
                 print("[DYNAMIC_REFRESH] Using cloud LLM as fallback")
                 new_llm = setup_cloud_llm()
             else:
-                return {"status": "error", "message": "No LLMs available and no fallback configured"}
+                return {
+                    "status": "error",
+                    "message": "No LLMs available and no fallback configured",
+                }
         else:
             # Select best LLM from discovered ones
             selected_llm = discovery_service.select_best_llm(local_llms)
@@ -593,26 +671,45 @@ def refresh_llm():
                 print(f"[DYNAMIC_REFRESH] Selected LLM: {selected_llm.model_name}")
                 new_llm = setup_discovered_llm(selected_llm)
             else:
-                return {"status": "error", "message": "No suitable LLM found among discovered models"}
-        
+                return {
+                    "status": "error",
+                    "message": "No suitable LLM found among discovered models",
+                }
+
         # Update current LLM and agent executor
-        old_llm_name = current_llm.llm_info.get('model_name', 'Unknown') if current_llm and hasattr(current_llm, 'llm_info') else 'Unknown'
+        old_llm_name = (
+            current_llm.llm_info.get("model_name", "Unknown")
+            if current_llm and hasattr(current_llm, "llm_info")
+            else "Unknown"
+        )
         current_llm = new_llm
-        new_llm_name = current_llm.llm_info.get('model_name', 'Unknown') if hasattr(current_llm, 'llm_info') else 'Unknown'
-        
+        new_llm_name = (
+            current_llm.llm_info.get("model_name", "Unknown")
+            if hasattr(current_llm, "llm_info")
+            else "Unknown"
+        )
+
         # Recreate agent executor with new LLM
-        memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
-        tools = [TavilySearchResults(max_results=2, include_answer=True, include_raw_content=True)]
+        memory = ConversationBufferMemory(
+            memory_key="chat_history", return_messages=True
+        )
+        tools = [
+            TavilySearchResults(
+                max_results=2, include_answer=True, include_raw_content=True
+            )
+        ]
         agent_executer = setup_executer(current_llm, memory, tools)
-        
+
         # Restart health monitoring
         start_health_monitoring()
-        
-        print(f"[DYNAMIC_REFRESH] Successfully switched from {old_llm_name} to {new_llm_name}")
-        
+
+        print(
+            f"[DYNAMIC_REFRESH] Successfully switched from {old_llm_name} to {new_llm_name}"
+        )
+
         return {
             "status": "success",
-            "message": f"LLM refreshed successfully",
+            "message": "LLM refreshed successfully",
             "old_model": old_llm_name,
             "new_model": new_llm_name,
             "available_models": [
@@ -620,72 +717,83 @@ def refresh_llm():
                     "model_name": llm.model_name,
                     "model_type": llm.model_type,
                     "status": llm.status.value,
-                    "container_name": llm.container_name
+                    "container_name": llm.container_name,
                 }
                 for llm in local_llms
-            ]
+            ],
         }
-        
+
     except Exception as e:
         print(f"[DYNAMIC_REFRESH] Error during refresh: {e}")
         return {"status": "error", "message": str(e)}
+
 
 @app.post("/select_model")
 def select_model(deploy_id: str):
     """Dynamically select a specific model by deploy_id"""
     global current_llm, agent_executer, discovery_service
-    
+
     print(f"[DYNAMIC_SELECTION] Attempting to select model with deploy_id: {deploy_id}")
-    
+
     try:
         # Discover all available LLMs
         local_llms = discovery_service.discover_local_llms()
-        
+
         # Find the specific model
         target_llm = None
         for llm in local_llms:
             if llm.deploy_id == deploy_id:
                 target_llm = llm
                 break
-        
+
         if not target_llm:
             return {
-                "status": "error", 
+                "status": "error",
                 "message": f"Model with deploy_id {deploy_id} not found",
                 "available_models": [
                     {
                         "deploy_id": llm.deploy_id,
                         "model_name": llm.model_name,
-                        "status": llm.status.value
+                        "status": llm.status.value,
                     }
                     for llm in local_llms
-                ]
+                ],
             }
-        
+
         # Check if the model is healthy enough
         if target_llm.status == HealthStatus.UNHEALTHY:
             return {
                 "status": "error",
-                "message": f"Model {target_llm.model_name} is unhealthy (status: {target_llm.status.value})"
+                "message": f"Model {target_llm.model_name} is unhealthy (status: {target_llm.status.value})",
             }
-        
+
         # Setup the selected LLM
         new_llm = setup_discovered_llm(target_llm)
-        
+
         # Update current LLM and agent executor
-        old_llm_name = current_llm.llm_info.get('model_name', 'Unknown') if current_llm and hasattr(current_llm, 'llm_info') else 'Unknown'
+        old_llm_name = (
+            current_llm.llm_info.get("model_name", "Unknown")
+            if current_llm and hasattr(current_llm, "llm_info")
+            else "Unknown"
+        )
         current_llm = new_llm
-        
+
         # Recreate agent executor with new LLM
-        memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
-        tools = [TavilySearchResults(max_results=2, include_answer=True, include_raw_content=True)]
+        memory = ConversationBufferMemory(
+            memory_key="chat_history", return_messages=True
+        )
+        tools = [
+            TavilySearchResults(
+                max_results=2, include_answer=True, include_raw_content=True
+            )
+        ]
         agent_executer = setup_executer(current_llm, memory, tools)
-        
+
         # Restart health monitoring
         start_health_monitoring()
-        
+
         print(f"[DYNAMIC_SELECTION] Successfully switched to {target_llm.model_name}")
-        
+
         return {
             "status": "success",
             "message": f"Successfully switched to {target_llm.model_name}",
@@ -696,55 +804,65 @@ def select_model(deploy_id: str):
                 "model_name": target_llm.model_name,
                 "model_type": target_llm.model_type,
                 "status": target_llm.status.value,
-                "container_name": target_llm.container_name
-            }
+                "container_name": target_llm.container_name,
+            },
         }
-        
+
     except Exception as e:
         print(f"[DYNAMIC_SELECTION] Error selecting model: {e}")
         return {"status": "error", "message": str(e)}
+
 
 @app.get("/test_llm")
 def test_llm():
     """Test LLM connectivity"""
     global current_llm
-    
+
     if not current_llm:
         return {"status": "error", "message": "No LLM configured"}
-    
+
     try:
-        result = test_llm_connection(current_llm, current_llm.llm_info.get('model_name'), current_llm.llm_info.get('model_type'))
+        result = test_llm_connection(
+            current_llm,
+            current_llm.llm_info.get("model_name"),
+            current_llm.llm_info.get("model_type"),
+        )
         return {
             "status": "success" if result else "error",
             "llm_url": current_llm.server_url,
             "llm_info": current_llm.llm_info,
-            "connection_test": result
+            "connection_test": result,
         }
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
 
 @app.post("/refresh_config")
 def refresh_config():
     """Refresh agent configuration from environment variables"""
     try:
         print("[CONFIG_REFRESH_ENDPOINT] Refreshing configuration...")
-        
+
         # Refresh configuration
         AgentConfig.refresh_config()
-        
+
         # Optionally trigger LLM refresh if configuration changed
         # This could be useful if priority models changed
-        should_refresh_llm = os.getenv("AGENT_REFRESH_LLM_ON_CONFIG_CHANGE", "false").lower() == "true"
-        
+        should_refresh_llm = (
+            os.getenv("AGENT_REFRESH_LLM_ON_CONFIG_CHANGE", "false").lower() == "true"
+        )
+
         if should_refresh_llm:
-            print("[CONFIG_REFRESH_ENDPOINT] Configuration changed, triggering LLM refresh...")
+            print(
+                "[CONFIG_REFRESH_ENDPOINT] Configuration changed, triggering LLM refresh..."
+            )
             refresh_result = refresh_llm()
             return {
                 "status": "success",
                 "message": "Configuration refreshed and LLM updated",
-                "llm_refresh": refresh_result
+                "llm_refresh": refresh_result,
             }
-        
+
         return {
             "status": "success",
             "message": "Configuration refreshed successfully",
@@ -754,10 +872,10 @@ def refresh_config():
                 "auto_discovery_enabled": AgentConfig.AUTO_DISCOVERY_ENABLED,
                 "health_check_enabled": AgentConfig.HEALTH_CHECK_ENABLED,
                 "fallback_to_local": AgentConfig.FALLBACK_TO_LOCAL,
-                "use_cloud_llm": AgentConfig.USE_CLOUD_LLM
-            }
+                "use_cloud_llm": AgentConfig.USE_CLOUD_LLM,
+            },
         }
-        
+
     except Exception as e:
         print(f"[CONFIG_REFRESH_ENDPOINT] Error refreshing configuration: {e}")
         return {"status": "error", "message": str(e)}

--- a/app/agent/code_tool.py
+++ b/app/agent/code_tool.py
@@ -15,6 +15,7 @@ from langchain_core.tools import Tool
 
 class LangchainCodeInterpreterToolInput(BaseModel):
     """Input schema for the Langchain Code Interpreter tool."""
+
     code: str = Field(description="Python code to execute.")
 
 
@@ -24,6 +25,7 @@ class CodeInterpreterFunctionTool:
     It requires an E2B_API_KEY to create a sandbox and is designed
     as a context manager to ensure the sandbox is always closed.
     """
+
     tool_name: str = "code_interpreter"
 
     def __init__(self, timeout: int = 1800):
@@ -60,10 +62,10 @@ class CodeInterpreterFunctionTool:
                 code = code[3:]
             if code.endswith("```"):
                 code = code[:-3]
-        
+
         print(f"--- Executing Code ---\n{code}\n----------------------")
         execution = self.code_interpreter.run_code(code)
-        
+
         return {
             "results": execution.results,
             "stdout": execution.logs.stdout,
@@ -86,7 +88,7 @@ class CodeInterpreterFunctionTool:
             name=self.tool_name,
             description="Execute python code in a Jupyter notebook cell and returns any rich data (eg charts), stdout, stderr, and error.",
             func=self.langchain_call,
-            args_schema=LangchainCodeInterpreterToolInput
+            args_schema=LangchainCodeInterpreterToolInput,
         )
         return tool
 
@@ -119,15 +121,19 @@ class CodeInterpreterFunctionTool:
         """
         new_messages = list(agent_action.message_log)
 
-        results_summary = CodeInterpreterFunctionTool._format_results_for_llm(observation.get("results", []))
+        results_summary = CodeInterpreterFunctionTool._format_results_for_llm(
+            observation.get("results", [])
+        )
 
         content_parts = {
             "results_summary": results_summary,
             "stdout": observation.get("stdout"),
             "stderr": observation.get("stderr"),
-            "error": str(observation.get("error")) if observation.get("error") else None,
+            "error": str(observation.get("error"))
+            if observation.get("error")
+            else None,
         }
-        
+
         content_dict = {k: v for k, v in content_parts.items() if v}
         content = json.dumps(content_dict, indent=2)
 
@@ -157,8 +163,8 @@ class CodeInterpreterFunctionTool:
                 # Gracefully handle other tools if they exist
                 messages.append(
                     ToolMessage(
-                        content=json.dumps(observation), 
-                        tool_call_id=agent_action.tool_call_id
+                        content=json.dumps(observation),
+                        tool_call_id=agent_action.tool_call_id,
                     )
                 )
         return messages

--- a/app/agent/config.py
+++ b/app/agent/config.py
@@ -5,71 +5,96 @@
 import os
 from typing import Optional
 
+
 class AgentConfig:
     """Configuration class for the enhanced agent"""
-    
+
     # Discovery Configuration
-    AUTO_DISCOVERY_ENABLED: bool = os.getenv("AGENT_AUTO_DISCOVERY", "true").lower() == "true"
+    AUTO_DISCOVERY_ENABLED: bool = (
+        os.getenv("AGENT_AUTO_DISCOVERY", "true").lower() == "true"
+    )
     DISCOVERY_CACHE_TTL: int = int(os.getenv("AGENT_DISCOVERY_CACHE_TTL", "30"))
     DISCOVERY_INTERVAL: int = int(os.getenv("AGENT_DISCOVERY_INTERVAL", "60"))
-    
+
     # Health Monitoring Configuration
-    HEALTH_CHECK_ENABLED: bool = os.getenv("AGENT_HEALTH_CHECK_ENABLED", "true").lower() == "true"
+    HEALTH_CHECK_ENABLED: bool = (
+        os.getenv("AGENT_HEALTH_CHECK_ENABLED", "true").lower() == "true"
+    )
     HEALTH_CHECK_INTERVAL: int = int(os.getenv("AGENT_HEALTH_CHECK_INTERVAL", "30"))
     HEALTH_CHECK_TIMEOUT: int = int(os.getenv("AGENT_HEALTH_CHECK_TIMEOUT", "5"))
     MAX_FAILURES: int = int(os.getenv("AGENT_MAX_FAILURES", "3"))
-    
+
     # Fallback Configuration
-    FALLBACK_TO_LOCAL: bool = os.getenv("AGENT_FALLBACK_TO_LOCAL", "true").lower() == "true"
-    FALLBACK_TO_CLOUD: bool = os.getenv("AGENT_FALLBACK_TO_CLOUD", "false").lower() == "true"
-    
+    FALLBACK_TO_LOCAL: bool = (
+        os.getenv("AGENT_FALLBACK_TO_LOCAL", "true").lower() == "true"
+    )
+    FALLBACK_TO_CLOUD: bool = (
+        os.getenv("AGENT_FALLBACK_TO_CLOUD", "false").lower() == "true"
+    )
+
     # LLM Priority Configuration
     # Priority models can be set via environment variable AGENT_PRIORITY_MODELS
     # Format: "model1,model2,model3" (comma-separated)
     # Default priority models (will be used if no environment variable is set)
     DEFAULT_PRIORITY_MODELS: list = [
-        'meta-llama/Llama-3.2-1B-Instruct',
-        'meta-llama/Llama-3.2-3B-Instruct',
-        'meta-llama/Llama-3.2-8B-Instruct',
-        'meta-llama/Llama-3.3-70B-Instruct',
-        'meta-llama/Llama-3.1-70B-Instruct',
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct",
+        "meta-llama/Llama-3.2-8B-Instruct",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "meta-llama/Llama-3.1-70B-Instruct",
     ]
-    
+
     # Model Type Preferences (for selection when multiple models are available)
     # Order: chat models first, then completion models, then others
-    MODEL_TYPE_PRIORITY: list = ['chat', 'completion', 'embedding', 'other']
-    
+    MODEL_TYPE_PRIORITY: list = ["chat", "completion", "embedding", "other"]
+
     # Dynamic Configuration
-    DYNAMIC_CONFIG_ENABLED: bool = os.getenv("AGENT_DYNAMIC_CONFIG", "true").lower() == "true"
-    CONFIG_REFRESH_INTERVAL: int = int(os.getenv("AGENT_CONFIG_REFRESH_INTERVAL", "300"))  # 5 minutes
-    
+    DYNAMIC_CONFIG_ENABLED: bool = (
+        os.getenv("AGENT_DYNAMIC_CONFIG", "true").lower() == "true"
+    )
+    CONFIG_REFRESH_INTERVAL: int = int(
+        os.getenv("AGENT_CONFIG_REFRESH_INTERVAL", "300")
+    )  # 5 minutes
+
     # LLM Polling Configuration
-    LLM_POLLING_ENABLED: bool = os.getenv("AGENT_LLM_POLLING_ENABLED", "true").lower() == "true"
-    LLM_POLLING_INTERVAL: int = int(os.getenv("AGENT_LLM_POLLING_INTERVAL", "180"))  # 3 minutes
-    LLM_POLLING_MAX_ATTEMPTS: int = int(os.getenv("AGENT_LLM_POLLING_MAX_ATTEMPTS", "0"))  # 0 means infinite
-    
+    LLM_POLLING_ENABLED: bool = (
+        os.getenv("AGENT_LLM_POLLING_ENABLED", "true").lower() == "true"
+    )
+    LLM_POLLING_INTERVAL: int = int(
+        os.getenv("AGENT_LLM_POLLING_INTERVAL", "180")
+    )  # 3 minutes
+    LLM_POLLING_MAX_ATTEMPTS: int = int(
+        os.getenv("AGENT_LLM_POLLING_MAX_ATTEMPTS", "0")
+    )  # 0 means infinite
+
     # Network Configuration
-    BACKEND_URL: str = os.getenv("AGENT_BACKEND_URL", "http://tt-studio-backend-api:8000")
+    BACKEND_URL: str = os.getenv(
+        "AGENT_BACKEND_URL", "http://tt-studio-backend-api:8000"
+    )
     LOCAL_HOST: str = os.getenv("LOCAL_LLM_HOST", "localhost")
     LOCAL_PORT: str = os.getenv("LOCAL_LLM_PORT", "7000")
-    
+
     # Authentication Configuration
     JWT_SECRET: Optional[str] = os.getenv("JWT_SECRET")
     CLOUD_AUTH_TOKEN: Optional[str] = os.getenv("CLOUD_CHAT_UI_AUTH_TOKEN")
-    
+
     # Cloud Configuration
     USE_CLOUD_LLM: bool = os.getenv("USE_CLOUD_LLM", "false").lower() == "true"
-    CLOUD_ENDPOINT: str = os.getenv("CLOUD_CHAT_UI_URL", "https://api.openai.com/v1/chat/completions")
-    CLOUD_MODEL_NAME: str = os.getenv("CLOUD_MODEL_NAME", "meta-llama/Llama-3.3-70B-Instruct")
-    
+    CLOUD_ENDPOINT: str = os.getenv(
+        "CLOUD_CHAT_UI_URL", "https://api.openai.com/v1/chat/completions"
+    )
+    CLOUD_MODEL_NAME: str = os.getenv(
+        "CLOUD_MODEL_NAME", "meta-llama/Llama-3.3-70B-Instruct"
+    )
+
     # Local Container Configuration
     LLM_CONTAINER_NAME: Optional[str] = os.getenv("LLM_CONTAINER_NAME")
     LOCAL_MODEL_NAME: str = os.getenv("LOCAL_MODEL_NAME", "llama-3.1-70b")
-    
+
     # Logging Configuration
     LOG_LEVEL: str = os.getenv("AGENT_LOG_LEVEL", "INFO")
     DEBUG_MODE: bool = os.getenv("AGENT_DEBUG_MODE", "false").lower() == "true"
-    
+
     @classmethod
     def get_priority_models(cls) -> list:
         """Get priority models from environment or use defaults"""
@@ -77,7 +102,7 @@ class AgentConfig:
         if env_priority:
             return [model.strip() for model in env_priority.split(",")]
         return cls.DEFAULT_PRIORITY_MODELS
-    
+
     @classmethod
     def get_model_type_priority(cls) -> list:
         """Get model type priority order"""
@@ -85,52 +110,62 @@ class AgentConfig:
         if env_priority:
             return [model_type.strip() for model_type in env_priority.split(",")]
         return cls.MODEL_TYPE_PRIORITY
-    
+
     @classmethod
     def refresh_config(cls):
         """Refresh configuration from environment variables"""
         if not cls.DYNAMIC_CONFIG_ENABLED:
             return
-        
+
         print("[CONFIG_REFRESH] Refreshing agent configuration...")
-        
+
         # Refresh priority models
         old_priority = cls.get_priority_models()
         new_priority = cls.get_priority_models()  # This will re-read from env
-        
+
         if old_priority != new_priority:
-            print(f"[CONFIG_REFRESH] Priority models updated: {old_priority} -> {new_priority}")
-        
+            print(
+                f"[CONFIG_REFRESH] Priority models updated: {old_priority} -> {new_priority}"
+            )
+
         # Refresh other dynamic settings
-        cls.AUTO_DISCOVERY_ENABLED = os.getenv("AGENT_AUTO_DISCOVERY", "true").lower() == "true"
-        cls.HEALTH_CHECK_ENABLED = os.getenv("AGENT_HEALTH_CHECK_ENABLED", "true").lower() == "true"
-        cls.FALLBACK_TO_LOCAL = os.getenv("AGENT_FALLBACK_TO_LOCAL", "true").lower() == "true"
+        cls.AUTO_DISCOVERY_ENABLED = (
+            os.getenv("AGENT_AUTO_DISCOVERY", "true").lower() == "true"
+        )
+        cls.HEALTH_CHECK_ENABLED = (
+            os.getenv("AGENT_HEALTH_CHECK_ENABLED", "true").lower() == "true"
+        )
+        cls.FALLBACK_TO_LOCAL = (
+            os.getenv("AGENT_FALLBACK_TO_LOCAL", "true").lower() == "true"
+        )
         cls.USE_CLOUD_LLM = os.getenv("USE_CLOUD_LLM", "false").lower() == "true"
-        
+
         print("[CONFIG_REFRESH] Configuration refresh complete")
-    
+
     @classmethod
     def validate_config(cls) -> list:
         """Validate configuration and return any issues"""
         issues = []
-        
+
         # Check required authentication
         if not cls.JWT_SECRET and not cls.CLOUD_AUTH_TOKEN:
-            issues.append("No authentication configured (neither JWT_SECRET nor CLOUD_CHAT_UI_AUTH_TOKEN)")
-        
+            issues.append(
+                "No authentication configured (neither JWT_SECRET nor CLOUD_CHAT_UI_AUTH_TOKEN)"
+            )
+
         # Check cloud configuration
         if cls.USE_CLOUD_LLM and not cls.CLOUD_AUTH_TOKEN:
             issues.append("Cloud LLM enabled but no CLOUD_CHAT_UI_AUTH_TOKEN provided")
-        
+
         # Check health monitoring configuration
         if cls.HEALTH_CHECK_INTERVAL < 10:
             issues.append("Health check interval too low (minimum 10 seconds)")
-        
+
         if cls.HEALTH_CHECK_TIMEOUT < 1:
             issues.append("Health check timeout too low (minimum 1 second)")
-        
+
         return issues
-    
+
     @classmethod
     def print_config(cls):
         """Print current configuration for debugging"""
@@ -147,4 +182,4 @@ class AgentConfig:
         print(f"Backend URL: {cls.BACKEND_URL}")
         print(f"Priority Models: {cls.get_priority_models()}")
         print(f"Debug Mode: {cls.DEBUG_MODE}")
-        print("==========================") 
+        print("==========================")

--- a/app/agent/custom_llm.py
+++ b/app/agent/custom_llm.py
@@ -8,13 +8,12 @@ from typing import (
     Sequence,
     Any,
     Optional,
-    Iterator,
     Union,
     Dict,
     Type,
     Callable,
     Literal,
-    AsyncGenerator
+    AsyncGenerator,
 )
 
 from langchain_core.language_models import BaseChatModel, LanguageModelInput
@@ -24,10 +23,12 @@ from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_core.tools import BaseTool
 from langchain_core.runnables import Runnable
 from langchain_core.utils.function_calling import convert_to_openai_tool
-from langchain.callbacks.streaming_stdout_final_only import FinalStreamingStdOutCallbackHandler
+from langchain.callbacks.streaming_stdout_final_only import (
+    FinalStreamingStdOutCallbackHandler,
+)
 import requests
-import json 
-import os 
+import json
+import os
 
 
 class CustomLLM(BaseChatModel):
@@ -45,7 +46,9 @@ class CustomLLM(BaseChatModel):
         super().__init__(**kwargs)
         # Set default cloud model name if not provided
         if self.is_cloud and not self.cloud_model_name:
-            self.cloud_model_name = os.getenv("CLOUD_MODEL_NAME", "meta-llama/Llama-3.3-70B-Instruct")
+            self.cloud_model_name = os.getenv(
+                "CLOUD_MODEL_NAME", "meta-llama/Llama-3.3-70B-Instruct"
+            )
 
     def _generate(
         self,
@@ -75,11 +78,21 @@ class CustomLLM(BaseChatModel):
         self,
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = FinalStreamingStdOutCallbackHandler(),
+        run_manager: Optional[
+            CallbackManagerForLLMRun
+        ] = FinalStreamingStdOutCallbackHandler(),
         **kwargs: Any,
     ) -> AsyncGenerator[ChatGenerationChunk, None]:
-        print('[TRACE_FLOW_STEP_5_AGENT_TO_LLM] _astream called', {'server_url': self.server_url, 'is_cloud': self.is_cloud, 'is_discovered': self.is_discovered, 'llm_info': self.llm_info})
-        
+        print(
+            "[TRACE_FLOW_STEP_5_AGENT_TO_LLM] _astream called",
+            {
+                "server_url": self.server_url,
+                "is_cloud": self.is_cloud,
+                "is_discovered": self.is_discovered,
+                "llm_info": self.llm_info,
+            },
+        )
+
         # Convert LangChain messages to standard role/content format
         message_payload = []
         for msg in messages:
@@ -94,16 +107,18 @@ class CustomLLM(BaseChatModel):
             else:
                 role = "user"  # Fallback
             message_payload.append({"role": role, "content": str(msg.content)})
-        
+
         # Check if tools are available in kwargs
         tools = kwargs.get("tools", [])
         if tools:
-            print(f"[DEBUG] Tools available: {[tool.get('function', {}).get('name', 'unknown') for tool in tools]}")
-        
+            print(
+                f"[DEBUG] Tools available: {[tool.get('function', {}).get('name', 'unknown') for tool in tools]}"
+            )
+
         if self.is_cloud:
             # Handle cloud LLM endpoint (e.g., OpenAI API format)
             headers = {"Authorization": f"Bearer {self.encoded_jwt}"}
-            
+
             json_data = {
                 "model": self.cloud_model_name,  # Use configurable model name
                 "messages": message_payload,
@@ -111,24 +126,24 @@ class CustomLLM(BaseChatModel):
                 "max_tokens": 512,
                 "stream": True,
             }
-            
+
             # Add tools if available
             if tools:
                 json_data["tools"] = tools
                 json_data["tool_choice"] = "auto"
-            
+
         else:
             # Handle local or discovered LLM containers
             headers = {"Authorization": f"Bearer {self.encoded_jwt}"}
-            
+
             # Prioritize hf_model_id if available, then model_name, then env var
             if self.llm_info:
                 print(f"[DEBUG] llm_info contents: {self.llm_info}")
-                hf_model_id = self.llm_info.get('hf_model_id')
-                model_name = self.llm_info.get('model_name')
+                hf_model_id = self.llm_info.get("hf_model_id")
+                model_name = self.llm_info.get("model_name")
                 print(f"[DEBUG] hf_model_id from llm_info: {hf_model_id}")
                 print(f"[DEBUG] model_name from llm_info: {model_name}")
-                
+
                 # Use hf_model_id if it exists and is not None/empty, otherwise fall back to model_name
                 if hf_model_id and hf_model_id.strip():
                     hf_model_path = hf_model_id
@@ -140,7 +155,7 @@ class CustomLLM(BaseChatModel):
             else:
                 hf_model_path = os.getenv("HF_MODEL_PATH")
                 print(f"Using model from environment variable: {hf_model_path}")
-            
+
             json_data = {
                 "model": hf_model_path,
                 "messages": message_payload,
@@ -150,65 +165,100 @@ class CustomLLM(BaseChatModel):
                 "max_tokens": 512,
                 "stream": True,
                 "stop": ["<|eot_id|>"],
-                "stream_options": {"include_usage": True, "continuous_usage_stats": True}
+                "stream_options": {
+                    "include_usage": True,
+                    "continuous_usage_stats": True,
+                },
             }
-            
+
             # Add tools if available
             if tools:
                 json_data["tools"] = tools
                 json_data["tool_choice"] = "auto"
 
         print(f"***Making request to: {self.server_url}")
-        redacted_headers = {key: ("<REDACTED>" if key.lower() == "authorization" else value) for key, value in headers.items()}
+        redacted_headers = {
+            key: ("<REDACTED>" if key.lower() == "authorization" else value)
+            for key, value in headers.items()
+        }
         print(f"Headers: {redacted_headers}")
-        print(f"[LLM REQUEST PAYLOAD] Sending to LLM: {json.dumps(json_data, indent=2)}")
+        print(
+            f"[LLM REQUEST PAYLOAD] Sending to LLM: {json.dumps(json_data, indent=2)}"
+        )
         print(f"[DEBUG] Request URL: {self.server_url}")
-        print(f"[DEBUG] Request method: POST")
-        print(f"[DEBUG] Request timeout: 30 seconds")
-        
+        print("[DEBUG] Request method: POST")
+        print("[DEBUG] Request timeout: 30 seconds")
+
         try:
-            print(f"[DEBUG] Starting HTTP request to LLM...")
+            print("[DEBUG] Starting HTTP request to LLM...")
             with requests.post(
-                self.server_url, json=json_data, headers=headers, stream=True, timeout=30
+                self.server_url,
+                json=json_data,
+                headers=headers,
+                stream=True,
+                timeout=30,
             ) as response:
                 print(f"[DEBUG] Response received - Status: {response.status_code}")
                 print(f"[DEBUG] Response headers: {dict(response.headers)}")
-                if response.status_code == 404 and 'does not exist' in response.text:
-                    print(f"[ERROR] LLM model not found (404): {response.text.splitlines()[0]}")
-                    error_chunk = ChatGenerationChunk(message=AIMessageChunk(content=f"Error: LLM model not found (404). Please check model name."))
+                if response.status_code == 404 and "does not exist" in response.text:
+                    print(
+                        f"[ERROR] LLM model not found (404): {response.text.splitlines()[0]}"
+                    )
+                    error_chunk = ChatGenerationChunk(
+                        message=AIMessageChunk(
+                            content="Error: LLM model not found (404). Please check model name."
+                        )
+                    )
                     yield error_chunk
                     return
                 if response.status_code != 200:
-                    print(f"[ERROR] LLM returned non-200 status: {response.status_code}")
-                    print(f"[ERROR] Response text: {response.text.splitlines()[0] if response.text else ''}")
-                    error_chunk = ChatGenerationChunk(message=AIMessageChunk(content=f"Error: HTTP {response.status_code}"))
+                    print(
+                        f"[ERROR] LLM returned non-200 status: {response.status_code}"
+                    )
+                    print(
+                        f"[ERROR] Response text: {response.text.splitlines()[0] if response.text else ''}"
+                    )
+                    error_chunk = ChatGenerationChunk(
+                        message=AIMessageChunk(
+                            content=f"Error: HTTP {response.status_code}"
+                        )
+                    )
                     yield error_chunk
                     return
-                
-                print(f"[DEBUG] LLM request successful, starting to stream response...")
+
+                print("[DEBUG] LLM request successful, starting to stream response...")
                 chunk_count = 0
-                for chunk in response.iter_content(chunk_size=None, decode_unicode=True):
+                for chunk in response.iter_content(
+                    chunk_size=None, decode_unicode=True
+                ):
                     chunk_count += 1
                     print(f"[DEBUG] Received chunk {chunk_count}: {repr(chunk)}")
-                    
+
                     if not chunk.strip():
-                        print(f"[DEBUG] Skipping empty chunk")
+                        print("[DEBUG] Skipping empty chunk")
                         continue
-                        
+
                     if self.is_cloud:
                         # Handle cloud response format (standard OpenAI streaming)
                         if chunk.startswith("data: "):
                             chunk_data = chunk[6:].strip()
                             if chunk_data == "[DONE]":
-                                print(f"[DEBUG] Received [DONE] marker")
-                                new_chunk = ChatGenerationChunk(message=AIMessageChunk(content=""))
+                                print("[DEBUG] Received [DONE] marker")
+                                new_chunk = ChatGenerationChunk(
+                                    message=AIMessageChunk(content="")
+                                )
                                 yield new_chunk
                             else:
                                 try:
                                     parsed_chunk = json.loads(chunk_data)
-                                    if "choices" in parsed_chunk and len(parsed_chunk["choices"]) > 0:
-                                        delta = parsed_chunk["choices"][0].get("delta", {})
-                                        
+                                    if (
+                                        "choices" in parsed_chunk
+                                        and len(parsed_chunk["choices"]) > 0
+                                    ):
+                                        delta = parsed_chunk["choices"][0].get(
+                                            "delta", {}
+                                        )
+
                                         # Handle tool calls
                                         if "tool_calls" in delta:
                                             tool_calls = delta["tool_calls"]
@@ -217,7 +267,7 @@ class CustomLLM(BaseChatModel):
                                                 new_chunk = ChatGenerationChunk(
                                                     message=AIMessageChunk(
                                                         content="",
-                                                        tool_calls=[tool_call]
+                                                        tool_calls=[tool_call],
                                                     )
                                                 )
                                                 yield new_chunk
@@ -225,75 +275,106 @@ class CustomLLM(BaseChatModel):
                                             # Handle regular content
                                             content = delta.get("content", "")
                                             if content:
-                                                new_chunk = ChatGenerationChunk(message=AIMessageChunk(content=content))
+                                                new_chunk = ChatGenerationChunk(
+                                                    message=AIMessageChunk(
+                                                        content=content
+                                                    )
+                                                )
                                                 yield new_chunk
                                 except json.JSONDecodeError as e:
-                                    print(f"[DEBUG] JSON decode error in cloud response: {e}")
+                                    print(
+                                        f"[DEBUG] JSON decode error in cloud response: {e}"
+                                    )
                                     continue
                     else:
                         # Handle local container response format (existing logic)
                         if chunk.startswith("data: "):
-                            new_chunk = chunk[len("data: "):]
+                            new_chunk = chunk[len("data: ") :]
                             new_chunk = new_chunk.strip()
                             print(f"[DEBUG] Processing local chunk: {repr(new_chunk)}")
                             if new_chunk == "[DONE]":
-                                print(f"[DEBUG] Received [DONE] marker from local LLM")
+                                print("[DEBUG] Received [DONE] marker from local LLM")
                                 # Yield [DONE] to signal that streaming is complete
-                                new_chunk = ChatGenerationChunk(message=AIMessageChunk(content=""))
+                                new_chunk = ChatGenerationChunk(
+                                    message=AIMessageChunk(content="")
+                                )
                                 yield new_chunk
                             else:
                                 try:
                                     parsed_chunk = json.loads(new_chunk)
                                     print(f"[DEBUG] Parsed chunk: {parsed_chunk}")
-                                    if "choices" in parsed_chunk and len(parsed_chunk["choices"]) > 0:
+                                    if (
+                                        "choices" in parsed_chunk
+                                        and len(parsed_chunk["choices"]) > 0
+                                    ):
                                         choice = parsed_chunk["choices"][0]
                                         if "delta" in choice:
                                             delta = choice["delta"]
-                                            
+
                                             # Handle tool calls
                                             if "tool_calls" in delta:
                                                 tool_calls = delta["tool_calls"]
                                                 for tool_call in tool_calls:
-                                                    print(f"[DEBUG] Tool call: {tool_call}")
+                                                    print(
+                                                        f"[DEBUG] Tool call: {tool_call}"
+                                                    )
                                                     new_chunk = ChatGenerationChunk(
                                                         message=AIMessageChunk(
                                                             content="",
-                                                            tool_calls=[tool_call]
+                                                            tool_calls=[tool_call],
                                                         )
                                                     )
                                                     yield new_chunk
                                             elif "content" in delta:
                                                 content = delta["content"]
-                                                print(f"[DEBUG] Extracted content: {repr(content)}")
-                                                new_chunk = ChatGenerationChunk(message=AIMessageChunk(content=content))
+                                                print(
+                                                    f"[DEBUG] Extracted content: {repr(content)}"
+                                                )
+                                                new_chunk = ChatGenerationChunk(
+                                                    message=AIMessageChunk(
+                                                        content=content
+                                                    )
+                                                )
                                                 yield new_chunk
                                             else:
-                                                print(f"[DEBUG] No content or tool_calls in delta: {delta}")
+                                                print(
+                                                    f"[DEBUG] No content or tool_calls in delta: {delta}"
+                                                )
                                         else:
-                                            print(f"[DEBUG] No delta in choice: {choice}")
+                                            print(
+                                                f"[DEBUG] No delta in choice: {choice}"
+                                            )
                                     else:
-                                        print(f"[DEBUG] No choices in response: {parsed_chunk}")
+                                        print(
+                                            f"[DEBUG] No choices in response: {parsed_chunk}"
+                                        )
                                 except (json.JSONDecodeError, KeyError) as e:
                                     print(f"[DEBUG] Error parsing local response: {e}")
-                                    print(f"[DEBUG] Problematic chunk: {repr(new_chunk)}")
+                                    print(
+                                        f"[DEBUG] Problematic chunk: {repr(new_chunk)}"
+                                    )
                                     continue
                         else:
                             print(f"[DEBUG] Non-data chunk received: {repr(chunk)}")
-                
+
                 print(f"[DEBUG] Stream completed after {chunk_count} chunks")
         except requests.RequestException as e:
             print(f"[ERROR] Request exception: {str(e)}")
             print(f"[ERROR] Request exception type: {type(e)}")
-            error_chunk = ChatGenerationChunk(message=AIMessageChunk(content=f"Request failed: {str(e)}"))
+            error_chunk = ChatGenerationChunk(
+                message=AIMessageChunk(content=f"Request failed: {str(e)}")
+            )
             yield error_chunk
         except Exception as e:
             print(f"[ERROR] Unexpected exception: {str(e)}")
             print(f"[ERROR] Exception type: {type(e)}")
             import traceback
-            print(f"[ERROR] Traceback: {traceback.format_exc()}")
-            error_chunk = ChatGenerationChunk(message=AIMessageChunk(content=f"Unexpected error: {str(e)}"))
-            yield error_chunk
 
+            print(f"[ERROR] Traceback: {traceback.format_exc()}")
+            error_chunk = ChatGenerationChunk(
+                message=AIMessageChunk(content=f"Unexpected error: {str(e)}")
+            )
+            yield error_chunk
 
     def bind_tools(
         self,
@@ -341,7 +422,7 @@ class CustomLLM(BaseChatModel):
 
             kwargs["tool_choice"] = tool_choice
         return super().bind(tools=formatted_tools, **kwargs)
-    
+
     @property
     def _llm_type(self) -> str:
         """Get the type of language model used by this chat model. Used for logging purposes only."""

--- a/app/agent/health_monitor.py
+++ b/app/agent/health_monitor.py
@@ -3,13 +3,18 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import asyncio
-import time
 import requests
 from typing import Optional, Callable, Dict, Any
+
 try:
-    from .llm_discovery import LLMDiscoveryService, LLMInfo, HealthStatus
+    from .llm_discovery import (
+        LLMDiscoveryService,
+        LLMInfo,
+        HealthStatus,  # noqa: F401  (re-exported for `from .health_monitor import HealthStatus`)
+    )
 except ImportError:
-    from llm_discovery import LLMDiscoveryService, LLMInfo, HealthStatus
+    from llm_discovery import LLMDiscoveryService, LLMInfo
+
 
 class LLMHealthMonitor:
     def __init__(self, llm, discovery_service: LLMDiscoveryService):
@@ -26,52 +31,57 @@ class LLMHealthMonitor:
         self.is_monitoring = False
         self.on_llm_change: Optional[Callable] = None
         self.current_llm_info: Optional[LLMInfo] = None
-        
+
     async def start_monitoring(self):
         """Start health monitoring in background"""
         if self.is_monitoring:
             return
-            
+
         self.is_monitoring = True
         print("Starting LLM health monitoring...")
-        
+
         while self.is_monitoring:
             try:
                 if not await self._check_health():
                     self.failure_count += 1
-                    print(f"LLM health check failed ({self.failure_count}/{self.max_failures})")
-                    
+                    print(
+                        f"LLM health check failed ({self.failure_count}/{self.max_failures})"
+                    )
+
                     if self.failure_count >= self.max_failures:
                         await self._switch_to_fallback()
                 else:
                     if self.failure_count > 0:
                         print("LLM health recovered")
                     self.failure_count = 0
-                    
+
             except Exception as e:
                 print(f"Health check error: {e}")
                 self.failure_count += 1
-                
+
                 if self.failure_count >= self.max_failures:
                     await self._switch_to_fallback()
-            
+
             await asyncio.sleep(self.health_check_interval)
-    
+
     def stop_monitoring(self):
         """Stop health monitoring"""
         self.is_monitoring = False
         print("Stopping LLM health monitoring...")
-    
+
     async def _check_health(self) -> bool:
         """Check if current LLM is healthy"""
         try:
-            if hasattr(self.llm, 'llm_info') and self.llm.llm_info:
+            if hasattr(self.llm, "llm_info") and self.llm.llm_info:
                 health_url = f"http://{self.llm.llm_info['health_url']}"
                 response = requests.get(health_url, timeout=5)
                 return response.status_code == 200
-            elif hasattr(self.llm, 'server_url') and 'localhost' in self.llm.server_url:
+            elif hasattr(self.llm, "server_url") and "localhost" in self.llm.server_url:
                 # For local host LLMs, try a simple ping
-                response = requests.get(self.llm.server_url.replace('/v1/chat/completions', '/health'), timeout=5)
+                response = requests.get(
+                    self.llm.server_url.replace("/v1/chat/completions", "/health"),
+                    timeout=5,
+                )
                 return response.status_code == 200
             else:
                 # For cloud LLMs, assume healthy (they have their own monitoring)
@@ -79,27 +89,28 @@ class LLMHealthMonitor:
         except Exception as e:
             print(f"Health check failed: {e}")
             return False
-    
+
     async def _switch_to_fallback(self):
         """Switch to fallback LLM"""
         print("LLM unhealthy, attempting to switch to fallback...")
-        
+
         try:
             # Discover available LLMs
             local_llms = self.discovery_service.discover_local_llms()
-            
+
             if not local_llms:
                 print("No fallback LLMs available")
                 return
-            
+
             # Select best fallback
             fallback_llm = self.discovery_service.select_best_llm(local_llms)
-            
+
             if fallback_llm and fallback_llm != self.current_llm_info:
                 print(f"Switching to fallback LLM: {fallback_llm.model_name}")
-                
+
                 # Create new LLM instance
                 from custom_llm import CustomLLM
+
                 new_llm = CustomLLM(
                     server_url=f"http://{fallback_llm.internal_url}",
                     encoded_jwt=self.llm.encoded_jwt,
@@ -107,40 +118,46 @@ class LLMHealthMonitor:
                     is_cloud=False,
                     is_discovered=True,
                     llm_info={
-                        'deploy_id': fallback_llm.deploy_id,
-                        'container_name': fallback_llm.container_name,
-                        'internal_url': fallback_llm.internal_url,
-                        'health_url': fallback_llm.health_url,
-                        'model_name': fallback_llm.model_name
-                    }
+                        "deploy_id": fallback_llm.deploy_id,
+                        "container_name": fallback_llm.container_name,
+                        "internal_url": fallback_llm.internal_url,
+                        "health_url": fallback_llm.health_url,
+                        "model_name": fallback_llm.model_name,
+                    },
                 )
-                
+
                 # Update current LLM
                 self.llm = new_llm
                 self.current_llm_info = fallback_llm
                 self.failure_count = 0
-                
+
                 # Notify callback if set
                 if self.on_llm_change:
                     self.on_llm_change(new_llm)
-                    
+
                 print(f"Successfully switched to {fallback_llm.model_name}")
             else:
                 print("No suitable fallback LLM found")
-                
+
         except Exception as e:
             print(f"Failed to switch to fallback: {e}")
-    
+
     def set_llm_change_callback(self, callback: Callable):
         """Set callback to be called when LLM changes"""
         self.on_llm_change = callback
-    
+
     def get_health_status(self) -> Dict[str, Any]:
         """Get current health status"""
         return {
-            'is_monitoring': self.is_monitoring,
-            'failure_count': self.failure_count,
-            'last_health_check': self.last_health_check,
-            'current_llm': self.current_llm_info.model_name if self.current_llm_info else None,
-            'health_status': 'healthy' if self.failure_count == 0 else 'degraded' if self.failure_count < self.max_failures else 'unhealthy'
-        } 
+            "is_monitoring": self.is_monitoring,
+            "failure_count": self.failure_count,
+            "last_health_check": self.last_health_check,
+            "current_llm": self.current_llm_info.model_name
+            if self.current_llm_info
+            else None,
+            "health_status": "healthy"
+            if self.failure_count == 0
+            else "degraded"
+            if self.failure_count < self.max_failures
+            else "unhealthy",
+        }

--- a/app/agent/improved_react_agent.py
+++ b/app/agent/improved_react_agent.py
@@ -7,33 +7,32 @@ Improved ReAct Agent implementation using modern LangGraph patterns.
 This provides better performance, error handling, and response formatting.
 """
 
-from typing import Annotated, Dict, Any, List, Optional
-from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, ToolMessage
+from typing import Dict, Any, List
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langchain_core.language_models import BaseLLM
 from langchain.memory.chat_memory import BaseChatMemory
-import json
 
 
 class ImprovedReActAgent:
     """
     Enhanced ReAct Agent with better response processing and structured output.
     """
-    
+
     def __init__(self, llm: BaseLLM, tools: List[BaseTool], memory: BaseChatMemory):
         self.llm = llm
         self.tools = {tool.name: tool for tool in tools}
         self.memory = memory
         self.max_iterations = 10
         self.timeout = 30
-        
+
     def _format_tools(self) -> str:
         """Format tools for the prompt."""
         tool_descriptions = []
         for tool in self.tools.values():
             tool_descriptions.append(f"- {tool.name}: {tool.description}")
         return "\n".join(tool_descriptions)
-    
+
     def _get_system_prompt(self) -> str:
         """Enhanced system prompt with better instructions."""
         return f"""You are a helpful AI assistant that can use tools to answer questions.
@@ -66,122 +65,151 @@ Begin!"""
         try:
             if tool_name not in self.tools:
                 return f"Error: Tool '{tool_name}' not found. Available tools: {list(self.tools.keys())}"
-            
+
             tool = self.tools[tool_name]
-            result = await tool.ainvoke(tool_input) if hasattr(tool, 'ainvoke') else tool.invoke(tool_input)
+            result = (
+                await tool.ainvoke(tool_input)
+                if hasattr(tool, "ainvoke")
+                else tool.invoke(tool_input)
+            )
             return str(result)
         except Exception as e:
             return f"Error executing {tool_name}: {str(e)}"
-    
+
     async def _process_llm_response(self, response: str) -> Dict[str, Any]:
         """Process LLM response and extract action or final answer."""
         response = response.strip()
-        
+
         # Check for final answer
         if "Final Answer:" in response:
             final_answer = response.split("Final Answer:")[-1].strip()
             return {"type": "final_answer", "content": final_answer}
-        
+
         # Check for action
         if "Action:" in response and "Action Input:" in response:
             try:
                 action_start = response.find("Action:") + len("Action:")
                 action_input_start = response.find("Action Input:", action_start)
-                
+
                 if action_input_start == -1:
-                    return {"type": "error", "content": "Invalid format: Missing Action Input"}
-                
+                    return {
+                        "type": "error",
+                        "content": "Invalid format: Missing Action Input",
+                    }
+
                 action = response[action_start:action_input_start].strip()
-                action_input = response[action_input_start + len("Action Input:"):].strip()
-                
+                action_input = response[
+                    action_input_start + len("Action Input:") :
+                ].strip()
+
                 return {
-                    "type": "action", 
-                    "action": action, 
+                    "type": "action",
+                    "action": action,
                     "action_input": action_input,
-                    "thought": response.split("Action:")[0].replace("Thought:", "").strip()
+                    "thought": response.split("Action:")[0]
+                    .replace("Thought:", "")
+                    .strip(),
                 }
             except Exception as e:
                 return {"type": "error", "content": f"Failed to parse action: {str(e)}"}
-        
+
         # If we get here, the response doesn't match expected format
         return {"type": "error", "content": "Invalid response format"}
-    
+
     async def stream_response(self, message: str):
         """Stream the agent's response, yielding only the final answer content."""
-        
+
         # Prepare conversation history
         chat_history = self.memory.buffer_as_messages
         messages = [HumanMessage(content=self._get_system_prompt())]
         messages.extend(chat_history)
         messages.append(HumanMessage(content=message))
-        
+
         scratchpad = ""
         iteration = 0
-        
+
         try:
             while iteration < self.max_iterations:
                 iteration += 1
-                
+
                 # Add scratchpad to prompt if we have previous steps
-                current_prompt = message
+                current_prompt = message  # noqa: F841
                 if scratchpad:
-                    current_prompt = f"{message}\n\nPrevious steps:\n{scratchpad}"
-                
+                    current_prompt = f"{message}\n\nPrevious steps:\n{scratchpad}"  # noqa: F841
+
                 # Get LLM response
-                if hasattr(self.llm, 'astream'):
+                if hasattr(self.llm, "astream"):
                     # Streaming LLM
                     full_response = ""
                     async for chunk in self.llm.astream(messages):
-                        if hasattr(chunk, 'content'):
+                        if hasattr(chunk, "content"):
                             full_response += chunk.content
                 else:
                     # Non-streaming LLM
-                    response = await self.llm.ainvoke(messages) if hasattr(self.llm, 'ainvoke') else self.llm.invoke(messages)
-                    full_response = response.content if hasattr(response, 'content') else str(response)
-                
+                    response = (
+                        await self.llm.ainvoke(messages)
+                        if hasattr(self.llm, "ainvoke")
+                        else self.llm.invoke(messages)
+                    )
+                    full_response = (
+                        response.content
+                        if hasattr(response, "content")
+                        else str(response)
+                    )
+
                 # Process the response
                 parsed = await self._process_llm_response(full_response)
-                
+
                 if parsed["type"] == "final_answer":
                     # Clean final answer - yield only the answer content
                     final_content = parsed["content"].strip()
                     # Save to memory
-                    self.memory.save_context({"input": message}, {"output": final_content})
-                    
+                    self.memory.save_context(
+                        {"input": message}, {"output": final_content}
+                    )
+
                     # Stream the final answer character by character for better UX
                     for char in final_content:
                         yield char
                     break
-                    
+
                 elif parsed["type"] == "action":
                     # Execute the tool
-                    tool_result = await self._execute_tool(parsed["action"], parsed["action_input"])
-                    
+                    tool_result = await self._execute_tool(
+                        parsed["action"], parsed["action_input"]
+                    )
+
                     # Add to scratchpad
                     scratchpad += f"\nThought: {parsed['thought']}\n"
                     scratchpad += f"Action: {parsed['action']}\n"
                     scratchpad += f"Action Input: {parsed['action_input']}\n"
                     scratchpad += f"Observation: {tool_result}\n"
-                    
+
                     # Add tool result to messages
                     messages.append(AIMessage(content=full_response))
-                    messages.append(ToolMessage(content=tool_result, tool_call_id=f"call_{iteration}"))
-                    
+                    messages.append(
+                        ToolMessage(
+                            content=tool_result, tool_call_id=f"call_{iteration}"
+                        )
+                    )
+
                 elif parsed["type"] == "error":
                     yield f"I encountered an issue: {parsed['content']}. Let me try to help you anyway."
                     break
-                    
+
             else:
                 # Max iterations reached
                 yield "I've reached my maximum thinking steps. Let me provide the best answer I can with the information I have."
-                
+
         except Exception as e:
             print(f"[ERROR] Agent execution failed: {e}")
             yield f"Sorry, I encountered an error while processing your request: {str(e)}"
 
 
 # Factory function to create the improved agent
-def create_improved_react_agent(llm: BaseLLM, tools: List[BaseTool], memory: BaseChatMemory) -> ImprovedReActAgent:
+def create_improved_react_agent(
+    llm: BaseLLM, tools: List[BaseTool], memory: BaseChatMemory
+) -> ImprovedReActAgent:
     """Create an improved ReAct agent with better performance and error handling."""
     return ImprovedReActAgent(llm, tools, memory)
 

--- a/app/agent/llm_discovery.py
+++ b/app/agent/llm_discovery.py
@@ -4,17 +4,17 @@
 
 import requests
 import time
-import json
-import os
 from typing import List, Dict, Optional
 from dataclasses import dataclass
 from enum import Enum
+
 
 class HealthStatus(Enum):
     HEALTHY = "healthy"
     DEGRADED = "degraded"
     UNHEALTHY = "unhealthy"
     UNKNOWN = "unknown"
+
 
 @dataclass
 class LLMInfo:
@@ -25,6 +25,7 @@ class LLMInfo:
     model_name: str
     model_type: str
     status: HealthStatus = HealthStatus.UNKNOWN
+
 
 class LLMDiscoveryService:
     def __init__(self):
@@ -37,28 +38,25 @@ class LLMDiscoveryService:
         self.cache_ttl = AgentConfig.DISCOVERY_CACHE_TTL
         self.health_check_timeout = AgentConfig.HEALTH_CHECK_TIMEOUT
         self.max_failures = AgentConfig.MAX_FAILURES
-        
+
     def discover_local_llms(self) -> List[LLMInfo]:
         """Discover all available local LLM containers"""
         try:
             # Check cache first
             cache_key = "local_llms"
             cached = self.cache.get(cache_key)
-            
-            if cached and (time.time() - cached['timestamp']) < self.cache_ttl:
-                return cached['data']
-            
+
+            if cached and (time.time() - cached["timestamp"]) < self.cache_ttl:
+                return cached["data"]
+
             # Get deployed models from backend
             response = requests.get(f"{self.backend_url}/models/deployed/", timeout=10)
             if response.status_code == 200:
                 deployed_models = response.json()
                 llms = self._filter_healthy_llms(deployed_models)
-                
+
                 # Update cache
-                self.cache[cache_key] = {
-                    'data': llms,
-                    'timestamp': time.time()
-                }
+                self.cache[cache_key] = {"data": llms, "timestamp": time.time()}
                 return llms
             else:
                 print(f"Failed to fetch deployed models: {response.status_code}")
@@ -66,56 +64,64 @@ class LLMDiscoveryService:
         except Exception as e:
             print(f"Error discovering LLMs: {e}")
             return []
-    
+
     def _filter_healthy_llms(self, deployed_models: Dict) -> List[LLMInfo]:
         """Filter only healthy LLM containers with support for different model types"""
         healthy_llms = []
-        
+
         for deploy_id, model_info in deployed_models.items():
             try:
                 # Support multiple model types, not just chat
-                model_type = model_info.get('model_impl', {}).get('model_type', 'chat')
-                model_name = model_info.get('model_impl', {}).get('model_name', 'Unknown')
-                hf_model_id = model_info.get('model_impl', {}).get('hf_model_id', None)
-                
-                print(f"[DISCOVERY] Processing model: {model_name} (type: {model_type}) hf_model_id: {hf_model_id}")
-                
+                model_type = model_info.get("model_impl", {}).get("model_type", "chat")
+                model_name = model_info.get("model_impl", {}).get(
+                    "model_name", "Unknown"
+                )
+                hf_model_id = model_info.get("model_impl", {}).get("hf_model_id", None)
+
+                print(
+                    f"[DISCOVERY] Processing model: {model_name} (type: {model_type}) hf_model_id: {hf_model_id}"
+                )
+
                 # Check health status
                 health_url = f"http://{model_info['health_url']}"
                 status = self._check_health_status(health_url)
-                
+
                 llm_info = LLMInfo(
                     deploy_id=deploy_id,
-                    container_name=model_info.get('name', ''),
-                    internal_url=model_info['internal_url'],
-                    health_url=model_info['health_url'],
+                    container_name=model_info.get("name", ""),
+                    internal_url=model_info["internal_url"],
+                    health_url=model_info["health_url"],
                     model_name=model_name,
                     model_type=model_type,
-                    status=status
+                    status=status,
                 )
                 # Attach hf_model_id as an extra attribute
                 llm_info.hf_model_id = hf_model_id
-                
+
                 # Accept healthy and degraded models
                 if status in [HealthStatus.HEALTHY, HealthStatus.DEGRADED]:
                     healthy_llms.append(llm_info)
-                    print(f"[DISCOVERY] Added healthy model: {model_name} ({status.value})")
+                    print(
+                        f"[DISCOVERY] Added healthy model: {model_name} ({status.value})"
+                    )
                 else:
-                    print(f"[DISCOVERY] Skipped unhealthy model: {model_name} ({status.value})")
-                    
+                    print(
+                        f"[DISCOVERY] Skipped unhealthy model: {model_name} ({status.value})"
+                    )
+
             except Exception as e:
                 print(f"[DISCOVERY] Error processing model {deploy_id}: {e}")
                 continue
-                
+
         return healthy_llms
-    
+
     def _check_health_status(self, health_url: str) -> HealthStatus:
         """Check health status of an LLM container"""
         try:
             start_time = time.time()
             response = requests.get(health_url, timeout=self.health_check_timeout)
             response_time = time.time() - start_time
-            
+
             if response.status_code == 200:
                 if response_time < 2:  # Fast response
                     return HealthStatus.HEALTHY
@@ -125,22 +131,22 @@ class LLMDiscoveryService:
                     return HealthStatus.DEGRADED
             else:
                 return HealthStatus.UNHEALTHY
-                
+
         except requests.exceptions.Timeout:
             return HealthStatus.UNHEALTHY
         except Exception:
             return HealthStatus.UNHEALTHY
-    
+
     def select_best_llm(self, local_llms: List[LLMInfo]) -> Optional[LLMInfo]:
         """Select the best LLM based on dynamic priority criteria"""
         if not local_llms:
             print("[SELECTION] No LLMs available for selection")
             return None
-            
+
         print(f"[SELECTION] Selecting from {len(local_llms)} available LLMs:")
         for llm in local_llms:
             print(f"  - {llm.model_name} ({llm.model_type}) - {llm.status.value}")
-        
+
         # Get priority models and model type priority from configuration
         try:
             from .config import AgentConfig
@@ -148,82 +154,96 @@ class LLMDiscoveryService:
             from config import AgentConfig
         priority_models = AgentConfig.get_priority_models()
         model_type_priority = AgentConfig.get_model_type_priority()
-        
+
         print(f"[SELECTION] Priority models: {priority_models}")
         print(f"[SELECTION] Model type priority: {model_type_priority}")
-        
+
         # First, try to find a healthy priority model (any type)
         for model_name in priority_models:
             for llm in local_llms:
-                if (model_name.lower() in llm.model_name.lower() and 
-                    llm.status == HealthStatus.HEALTHY):
-                    print(f"[SELECTION] Selected healthy priority model: {llm.model_name}")
+                if (
+                    model_name.lower() in llm.model_name.lower()
+                    and llm.status == HealthStatus.HEALTHY
+                ):
+                    print(
+                        f"[SELECTION] Selected healthy priority model: {llm.model_name}"
+                    )
                     return llm
-        
+
         # If no priority model is healthy, try degraded priority models
         for model_name in priority_models:
             for llm in local_llms:
-                if (model_name.lower() in llm.model_name.lower() and 
-                    llm.status == HealthStatus.DEGRADED):
-                    print(f"[SELECTION] Selected degraded priority model: {llm.model_name}")
+                if (
+                    model_name.lower() in llm.model_name.lower()
+                    and llm.status == HealthStatus.DEGRADED
+                ):
+                    print(
+                        f"[SELECTION] Selected degraded priority model: {llm.model_name}"
+                    )
                     return llm
-        
+
         # If no priority models, use model type priority
         for model_type in model_type_priority:
             # Try healthy models of this type
             for llm in local_llms:
-                if (llm.model_type == model_type and 
-                    llm.status == HealthStatus.HEALTHY):
-                    print(f"[SELECTION] Selected healthy {model_type} model: {llm.model_name}")
+                if llm.model_type == model_type and llm.status == HealthStatus.HEALTHY:
+                    print(
+                        f"[SELECTION] Selected healthy {model_type} model: {llm.model_name}"
+                    )
                     return llm
-            
+
             # Try degraded models of this type
             for llm in local_llms:
-                if (llm.model_type == model_type and 
-                    llm.status == HealthStatus.DEGRADED):
-                    print(f"[SELECTION] Selected degraded {model_type} model: {llm.model_name}")
+                if llm.model_type == model_type and llm.status == HealthStatus.DEGRADED:
+                    print(
+                        f"[SELECTION] Selected degraded {model_type} model: {llm.model_name}"
+                    )
                     return llm
-        
+
         # If no models match type priority, return the first healthy one (any type)
         for llm in local_llms:
             if llm.status == HealthStatus.HEALTHY:
                 print(f"[SELECTION] Selected first healthy model: {llm.model_name}")
                 return llm
-        
+
         # If no healthy models, return the first degraded one (any type)
         for llm in local_llms:
             if llm.status == HealthStatus.DEGRADED:
                 print(f"[SELECTION] Selected first degraded model: {llm.model_name}")
                 return llm
-        
+
         # Last resort: return the first available
         if local_llms:
             print(f"[SELECTION] Last resort selection: {local_llms[0].model_name}")
             return local_llms[0]
-        
+
         print("[SELECTION] No suitable LLM found")
         return None
-    
+
     def clear_cache(self):
         """Clear the discovery cache"""
         self.cache.clear()
-    
+
     def get_llm_status_summary(self) -> Dict:
         """Get a summary of all discovered LLMs and their status"""
         llms = self.discover_local_llms()
         summary = {
-            'total_llms': len(llms),
-            'healthy': len([llm for llm in llms if llm.status == HealthStatus.HEALTHY]),
-            'degraded': len([llm for llm in llms if llm.status == HealthStatus.DEGRADED]),
-            'unhealthy': len([llm for llm in llms if llm.status == HealthStatus.UNHEALTHY]),
-            'llms': [
+            "total_llms": len(llms),
+            "healthy": len([llm for llm in llms if llm.status == HealthStatus.HEALTHY]),
+            "degraded": len(
+                [llm for llm in llms if llm.status == HealthStatus.DEGRADED]
+            ),
+            "unhealthy": len(
+                [llm for llm in llms if llm.status == HealthStatus.UNHEALTHY]
+            ),
+            "llms": [
                 {
-                    'deploy_id': llm.deploy_id,
-                    'model_name': llm.model_name,
-                    'status': llm.status.value,
-                    'internal_url': llm.internal_url
+                    "deploy_id": llm.deploy_id,
+                    "model_name": llm.model_name,
+                    "status": llm.status.value,
+                    "internal_url": llm.internal_url,
                 }
                 for llm in llms
-            ]
+            ],
         }
-        return summary 
+        return summary

--- a/app/agent/test_code_tool.py
+++ b/app/agent/test_code_tool.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 
-
 #!/usr/bin/env python3
 """
 Test script to verify the code tool functionality
@@ -13,80 +12,83 @@ import os
 import sys
 from .code_tool import CodeInterpreterFunctionTool
 
+
 def test_code_tool():
     """Test the code interpreter tool"""
-    
+
     # Check if E2B_API_KEY is set
     if "E2B_API_KEY" not in os.environ:
         print("❌ E2B_API_KEY environment variable is not set")
         print("   To enable code execution, set the E2B_API_KEY environment variable")
         print("   Get your API key from: https://e2b.dev/docs")
         return False
-    
+
     try:
         # Initialize the code tool
         print("🔧 Initializing code interpreter tool...")
         code_tool = CodeInterpreterFunctionTool()
-        
+
         # Test simple code execution
         print("🧪 Testing simple code execution...")
         test_code = "print('Hello from code tool!')"
         result = code_tool.langchain_call(test_code)
-        
-        print(f"✅ Code tool test successful!")
+
+        print("✅ Code tool test successful!")
         print(f"   Input: {test_code}")
         print(f"   Output: {result}")
-        
+
         # Clean up
         code_tool.close()
         return True
-        
+
     except Exception as e:
         print(f"❌ Code tool test failed: {e}")
         return False
 
+
 def test_langchain_tool():
     """Test the LangChain tool wrapper"""
-    
+
     if "E2B_API_KEY" not in os.environ:
         print("❌ E2B_API_KEY not set, skipping LangChain tool test")
         return False
-    
+
     try:
         print("🔧 Testing LangChain tool wrapper...")
         code_tool = CodeInterpreterFunctionTool()
         langchain_tool = code_tool.to_langchain_tool()
-        
-        print(f"✅ LangChain tool created successfully!")
+
+        print("✅ LangChain tool created successfully!")
         print(f"   Tool name: {langchain_tool.name}")
         print(f"   Tool description: {langchain_tool.description}")
         print(f"   Tool args schema: {langchain_tool.args_schema}")
-        
+
         # Test the tool
         test_code = "import math; print(f'Pi: {math.pi}')"
         result = langchain_tool.invoke({"code": test_code})
-        
-        print(f"✅ LangChain tool test successful!")
+
+        print("✅ LangChain tool test successful!")
         print(f"   Input: {test_code}")
         print(f"   Output: {result}")
-        
+
         code_tool.close()
         return True
-        
+
     except Exception as e:
         print(f"❌ LangChain tool test failed: {e}")
         return False
 
+
 if __name__ == "__main__":
     print("🧪 Testing Code Interpreter Tool")
     print("=" * 50)
-    
+
     success1 = test_code_tool()
     success2 = test_langchain_tool()
-    
+
     print("\n" + "=" * 50)
     if success1 and success2:
         print("🎉 All tests passed! Code tool is ready to use.")
     else:
         print("⚠️  Some tests failed. Check the output above for details.")
-        sys.exit(1) 
+        sys.exit(1)

--- a/app/agent/utils.py
+++ b/app/agent/utils.py
@@ -5,6 +5,7 @@
 from langchain.agents import AgentExecutor, create_react_agent
 from langchain import hub
 
+
 async def poll_requests(agent_executor, config, tools, memory, message):
     """
     Enhanced polling function with better response processing and error handling.
@@ -14,62 +15,67 @@ async def poll_requests(agent_executor, config, tools, memory, message):
     chat_history = memory.buffer_as_messages
     final_answer = False
     print(f"Processing message: {message}")
-    received_done_signal = False
-    
+
     try:
         async for event in agent_executor.astream_events(
-            {"input": message, "chat_history": chat_history}, version="v2", config=config
+            {"input": message, "chat_history": chat_history},
+            version="v2",
+            config=config,
         ):
             kind = event["event"]
-            
+
             # Handle agent lifecycle events
             if kind == "on_chain_start" and event["name"] == "Agent":
                 print(f"[AGENT] Starting with input: {event['data'].get('input')}")
-                
+
             elif kind == "on_chain_end" and event["name"] == "Agent":
-                print(f"[AGENT] Completed with output")
-                
+                print("[AGENT] Completed with output")
+
             # Process streaming chat model responses
             elif kind == "on_chat_model_stream":
                 content = event["data"]["chunk"].content
                 complete_output += content
-                
+
                 # Detect when we reach the final answer
                 if "Final Answer:" in complete_output and not final_answer:
                     final_answer = True
                     position = complete_output.find("Final Answer:")
                     # Extract only the content after "Final Answer: "
-                    final_content = complete_output[position + len("Final Answer:"):].strip()
+                    final_content = complete_output[
+                        position + len("Final Answer:") :
+                    ].strip()
                     complete_output = ""  # Reset for next chunks
-                    
+
                     # Yield the clean final answer content
                     if final_content:
                         yield final_content
-                        
+
                 elif final_answer and content:
                     # Continue yielding content in final answer mode
                     if content == "[DONE]":
-                        received_done_signal = True
                         break
                     else:
                         yield content
-                        
+
             # Handle tool events (for debugging)
             elif kind == "on_tool_start":
-                print(f"[TOOL] Starting: {event['name']} with {event['data'].get('input')}")
-                
+                print(
+                    f"[TOOL] Starting: {event['name']} with {event['data'].get('input')}"
+                )
+
             elif kind == "on_tool_end":
                 print(f"[TOOL] Completed: {event['name']}")
-                
+
     except Exception as e:
         print(f"[ERROR] Agent execution failed: {e}")
         yield f"Sorry, I encountered an error: {str(e)}"
+
 
 def setup_executer(llm, memory, tools):
     # Use the React chat prompt which is better for conversational agents
     prompt = hub.pull("hwchase17/react-chat")
     agent = create_react_agent(llm, tools, prompt)
-    
+
     # Enhanced agent executor with better error handling and performance settings
     agent_executor = AgentExecutor(
         agent=agent,
@@ -79,7 +85,7 @@ def setup_executer(llm, memory, tools):
         return_intermediate_steps=True,
         handle_parsing_errors=True,
         max_execution_time=30,  # Timeout after 30 seconds
-        verbose=False  # Disable verbose to reduce noise
-    )       
+        verbose=False,  # Disable verbose to reduce noise
+    )
 
     return agent_executor

--- a/app/backend/api/asgi.py
+++ b/app/backend/api/asgi.py
@@ -19,9 +19,9 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
 
 django_asgi_app = get_asgi_application()
 
-from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
 
-import wakeword_control.routing
+import wakeword_control.routing  # noqa: E402
 
 application = ProtocolTypeRouter(
     {

--- a/app/backend/api/settings.py
+++ b/app/backend/api/settings.py
@@ -45,9 +45,10 @@ CORS_ALLOWED_ORIGINS = [
 CORS_ALLOW_ALL_ORIGINS = False
 
 # Add explicit CORS header settings for SSE
-from corsheaders.defaults import default_headers
+from corsheaders.defaults import default_headers  # noqa: E402
+
 CORS_ALLOW_HEADERS = list(default_headers) + [
-    'accept',
+    "accept",
 ]
 # Allow credentials for EventSource with withCredentials: true
 CORS_ALLOW_CREDENTIALS = True

--- a/app/backend/board_control/apps.py
+++ b/app/backend/board_control/apps.py
@@ -5,5 +5,5 @@ from django.apps import AppConfig
 
 
 class BoardControlConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'board_control' 
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "board_control"

--- a/app/backend/board_control/models.py
+++ b/app/backend/board_control/models.py
@@ -8,71 +8,83 @@ from django.utils import timezone
 
 class HardwareSnapshot(models.Model):
     """Store hardware snapshots from tt-smi"""
+
     timestamp = models.DateTimeField(default=timezone.now)
     raw_data = models.JSONField()
     host_info = models.JSONField()
     devices_count = models.IntegerField(default=0)
-    
+
     class Meta:
-        ordering = ['-timestamp']
+        ordering = ["-timestamp"]
 
 
 class DeviceTelemetry(models.Model):
     """Store device telemetry data"""
-    snapshot = models.ForeignKey(HardwareSnapshot, on_delete=models.CASCADE, related_name='devices')
+
+    snapshot = models.ForeignKey(
+        HardwareSnapshot, on_delete=models.CASCADE, related_name="devices"
+    )
     device_index = models.IntegerField()
     board_type = models.CharField(max_length=50)
     bus_id = models.CharField(max_length=20)
     board_id = models.CharField(max_length=50)
     coords = models.CharField(max_length=50)
-    
+
     # Telemetry data
     voltage = models.FloatField(null=True)
     current = models.FloatField(null=True)
     power = models.FloatField(null=True)
     aiclk = models.IntegerField(null=True)
     asic_temperature = models.FloatField(null=True)
-    
+
     # Status
     dram_status = models.BooleanField(default=False)
     dram_speed = models.CharField(max_length=10, null=True)
     pcie_speed = models.IntegerField(null=True)
     pcie_width = models.CharField(max_length=10, null=True)
-    
+
     class Meta:
-        unique_together = ['snapshot', 'device_index']
+        unique_together = ["snapshot", "device_index"]
 
 
 class SystemGuardrails(models.Model):
     """Store system guardrails configuration"""
+
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField()
     is_enabled = models.BooleanField(default=True)
     threshold_value = models.FloatField(null=True)
-    threshold_type = models.CharField(max_length=20, choices=[
-        ('temperature', 'Temperature'),
-        ('power', 'Power'),
-        ('voltage', 'Voltage'),
-        ('frequency', 'Frequency'),
-    ])
+    threshold_type = models.CharField(
+        max_length=20,
+        choices=[
+            ("temperature", "Temperature"),
+            ("power", "Power"),
+            ("voltage", "Voltage"),
+            ("frequency", "Frequency"),
+        ],
+    )
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
 
 
 class HardwareAlert(models.Model):
     """Store hardware alerts and notifications"""
+
     device_index = models.IntegerField()
     alert_type = models.CharField(max_length=50)
-    severity = models.CharField(max_length=20, choices=[
-        ('info', 'Info'),
-        ('warning', 'Warning'),
-        ('error', 'Error'),
-        ('critical', 'Critical'),
-    ])
+    severity = models.CharField(
+        max_length=20,
+        choices=[
+            ("info", "Info"),
+            ("warning", "Warning"),
+            ("error", "Error"),
+            ("critical", "Critical"),
+        ],
+    )
     message = models.TextField()
     is_resolved = models.BooleanField(default=False)
     created_at = models.DateTimeField(default=timezone.now)
     resolved_at = models.DateTimeField(null=True)
-    
+
     class Meta:
-        ordering = ['-created_at'] 
+        ordering = ["-created_at"]

--- a/app/backend/board_control/services.py
+++ b/app/backend/board_control/services.py
@@ -6,7 +6,6 @@ import json
 import os
 import psutil
 import signal
-import time
 from pathlib import Path
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -17,6 +16,7 @@ from .models import HardwareSnapshot, DeviceTelemetry, HardwareAlert
 
 logger = get_logger(__name__)
 
+
 class SystemResourceService:
     """Service for monitoring system resources and TT device telemetry"""
 
@@ -24,7 +24,9 @@ class SystemResourceService:
     TT_SMI_CACHE_KEY = "tt_smi_data"
     TT_SMI_CACHE_TIMEOUT = 3600  # Cache for 1 hour (since we'll refresh on events only)
     BOARD_TYPE_CACHE_KEY = "board_type_data"
-    BOARD_TYPE_CACHE_TIMEOUT = 3600  # Cache board type for 1 hour (since it rarely changes)
+    BOARD_TYPE_CACHE_TIMEOUT = (
+        3600  # Cache board type for 1 hour (since it rarely changes)
+    )
 
     # Device state cache keys
     DEVICE_STATE_CACHE_KEY = "device_state_v2"
@@ -43,13 +45,18 @@ class SystemResourceService:
         the model-stopping phase that precedes the tt-smi reset.
         """
         try:
-            path = Path(backend_config.backend_cache_root) / SystemResourceService.RESET_ALL_STATE_FILENAME
+            path = (
+                Path(backend_config.backend_cache_root)
+                / SystemResourceService.RESET_ALL_STATE_FILENAME
+            )
             with open(path) as f:
                 state = json.load(f)
             if state.get("done"):
                 return False
             updated = parse_datetime(state.get("updated_at") or "")
-            return updated is not None and (timezone.now() - updated).total_seconds() < 120
+            return (
+                updated is not None and (timezone.now() - updated).total_seconds() < 120
+            )
         except Exception:
             return False
 
@@ -58,8 +65,10 @@ class SystemResourceService:
         """True if any board/device reset is active — the single-device reset cache
         flag or the whole-board reset job. Used to report RESETTING and to block
         conflicting actions (e.g. new deployments)."""
-        return bool(cache.get(SystemResourceService.DEVICE_RESETTING_KEY)) or \
-            SystemResourceService._board_reset_job_active()
+        return (
+            bool(cache.get(SystemResourceService.DEVICE_RESETTING_KEY))
+            or SystemResourceService._board_reset_job_active()
+        )
 
     @staticmethod
     def get_tt_smi_data(timeout=30):
@@ -69,65 +78,87 @@ class SystemResourceService:
         if cached_data is not None:
             logger.debug("Using cached tt-smi data")
             return cached_data
-        
+
         try:
             logger.info("Running tt-smi -s to get device telemetry")
-            
+
             process = subprocess.Popen(
                 ["tt-smi", "-s"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.DEVNULL,
                 text=True,
-                preexec_fn=os.setsid  # Create new process group
+                preexec_fn=os.setsid,  # Create new process group
             )
-            
+
             try:
                 # Wait for process with timeout
                 stdout, stderr = process.communicate(timeout=timeout)
-                
+
                 if process.returncode != 0:
-                    logger.error(f"tt-smi -s failed with return code {process.returncode}, stderr: {stderr}")
+                    logger.error(
+                        f"tt-smi -s failed with return code {process.returncode}, stderr: {stderr}"
+                    )
                     # Cache the None result for a longer time to avoid repeated failures
-                    cache.set(SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120)  # 2 minutes for failures
+                    cache.set(
+                        SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120
+                    )  # 2 minutes for failures
                     return None
-                
+
                 # Parse JSON output
                 try:
                     data = json.loads(stdout)
                     logger.info("Successfully parsed tt-smi data")
                     # Cache the successful result
-                    cache.set(SystemResourceService.TT_SMI_CACHE_KEY, data, timeout=SystemResourceService.TT_SMI_CACHE_TIMEOUT)
+                    cache.set(
+                        SystemResourceService.TT_SMI_CACHE_KEY,
+                        data,
+                        timeout=SystemResourceService.TT_SMI_CACHE_TIMEOUT,
+                    )
                     return data
                 except json.JSONDecodeError as e:
-                    logger.error(f"Failed to parse tt-smi JSON output: {e}, stdout: {stdout}")
-                    cache.set(SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120)  # 2 minutes for parse errors
+                    logger.error(
+                        f"Failed to parse tt-smi JSON output: {e}, stdout: {stdout}"
+                    )
+                    cache.set(
+                        SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120
+                    )  # 2 minutes for parse errors
                     return None
-                    
+
             except subprocess.TimeoutExpired:
                 logger.error(f"tt-smi -s command timed out after {timeout} seconds")
                 # Kill the process group to ensure cleanup
                 try:
                     os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                     process.wait(timeout=2)
-                except:
+                except Exception:
                     try:
-                        logger.error(f"Killing tt-smi process group {os.getpgid(process.pid)}")
+                        logger.error(
+                            f"Killing tt-smi process group {os.getpgid(process.pid)}"
+                        )
                         os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-                    except:
-                        logger.error(f"Failed to kill tt-smi process group {os.getpgid(process.pid)}")
+                    except Exception:
+                        logger.error(
+                            f"Failed to kill tt-smi process group {os.getpgid(process.pid)}"
+                        )
                         pass
                 # Cache the None result for a longer time to avoid repeated timeouts
-                cache.set(SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120)  # 2 minutes for timeouts
+                cache.set(
+                    SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120
+                )  # 2 minutes for timeouts
                 return None
-                
+
         except FileNotFoundError:
             logger.error("tt-smi command not found")
-            cache.set(SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=300)  # Cache longer for missing command
+            cache.set(
+                SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=300
+            )  # Cache longer for missing command
             return None
         except Exception as e:
             logger.error(f"Error getting tt-smi data: {str(e)}")
-            cache.set(SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120)  # 2 minutes for general errors
+            cache.set(
+                SystemResourceService.TT_SMI_CACHE_KEY, None, timeout=120
+            )  # 2 minutes for general errors
             return None
 
     @staticmethod
@@ -138,11 +169,11 @@ class SystemResourceService:
         if cached_board_type is not None:
             logger.debug(f"Using cached board type: {cached_board_type}")
             return cached_board_type
-        
+
         try:
             # Get tt-smi data (which is also cached)
             tt_data = SystemResourceService.get_tt_smi_data()
-            
+
             if not tt_data:
                 board_type = "unknown"
             else:
@@ -154,27 +185,33 @@ class SystemResourceService:
                         if "board_info" in info:
                             board_info = info["board_info"]
                             board_types.append(board_info.get("board_type", "unknown"))
-                    
+
                     if not board_types:
                         logger.warning("No 'board_info' found in any device info")
                         board_type = "unknown"
                     else:
                         # Remove "local" and "remote" designations, if they exist
-                        filtered_board_types = [bt.rsplit(" ", 1)[0] for bt in board_types]
+                        filtered_board_types = [
+                            bt.rsplit(" ", 1)[0] for bt in board_types
+                        ]
                         unique_board_types = set(filtered_board_types)
-                        
+
                         # Validate homogeneous board types (all devices must be same type)
                         if len(unique_board_types) > 1:
-                            logger.warning(f"Mixed board types detected: {unique_board_types}. Only homogeneous setups are supported.")
+                            logger.warning(
+                                f"Mixed board types detected: {unique_board_types}. Only homogeneous setups are supported."
+                            )
                             board_type = "unknown"
                         else:
                             raw_board_type = unique_board_types.pop()
                             num_devices = len(tt_data["device_info"])
-                            logger.info(f"Raw board_type: '{raw_board_type}', num_devices: {num_devices}")
-                            
+                            logger.info(
+                                f"Raw board_type: '{raw_board_type}', num_devices: {num_devices}"
+                            )
+
                             # Detect board type based on raw_board_type and device count
                             raw_lower = raw_board_type.lower()
-                            
+
                             # Wormhole devices
                             if "n150" in raw_lower:
                                 if num_devices >= 4:
@@ -186,17 +223,17 @@ class SystemResourceService:
                                     board_type = "T3K"
                                 else:
                                     board_type = "N300"
-                            
+
                             # Blackhole devices (P300 has 2 chips per card)
                             elif "p300" in raw_lower:
                                 if num_devices >= 8:
                                     board_type = "P300Cx4"  # 8 chips = 4 cards
                                 elif num_devices >= 4:
-                                    board_type = "P300x2"   # 4 chips = 2 cards
+                                    board_type = "P300x2"  # 4 chips = 2 cards
                                 elif num_devices == 2:
-                                    board_type = "P300"     # 2 chips = 1 card
+                                    board_type = "P300"  # 2 chips = 1 card
                                 else:
-                                    board_type = "P300"     # Single chip fallback
+                                    board_type = "P300"  # Single chip fallback
                             elif "p150" in raw_lower:
                                 if num_devices >= 8:
                                     board_type = "P150X8"
@@ -208,30 +245,36 @@ class SystemResourceService:
                                 board_type = "P100"
                             elif "e150" in raw_lower:
                                 board_type = "E150"
-                            
+
                             # Galaxy systems (may need refinement based on actual tt-smi output)
                             elif "galaxy" in raw_lower:
                                 if "t3k" in raw_lower:
                                     board_type = "GALAXY_T3K"
                                 else:
                                     board_type = "GALAXY"
-                            
+
                             else:
                                 logger.warning(f"Unknown board type: {raw_board_type}")
                                 board_type = "unknown"
                 else:
                     logger.warning("No device info found in tt-smi data")
                     board_type = "unknown"
-            
+
             # Cache the result
-            cache.set(SystemResourceService.BOARD_TYPE_CACHE_KEY, board_type, timeout=SystemResourceService.BOARD_TYPE_CACHE_TIMEOUT)
+            cache.set(
+                SystemResourceService.BOARD_TYPE_CACHE_KEY,
+                board_type,
+                timeout=SystemResourceService.BOARD_TYPE_CACHE_TIMEOUT,
+            )
             logger.info(f"Detected and cached board type: {board_type}")
             return board_type
-            
+
         except Exception as e:
             logger.error(f"Error detecting board type: {str(e)}")
             board_type = "unknown"
-            cache.set(SystemResourceService.BOARD_TYPE_CACHE_KEY, board_type, timeout=60)  # Cache error for 1 minute
+            cache.set(
+                SystemResourceService.BOARD_TYPE_CACHE_KEY, board_type, timeout=60
+            )  # Cache error for 1 minute
             return board_type
 
     @staticmethod
@@ -243,7 +286,7 @@ class SystemResourceService:
             memory = psutil.virtual_memory()
             memory_usage_percent = memory.percent
             memory_total_gb = round(memory.total / (1024**3), 2)
-            
+
             # Initialize basic system status with fallbacks
             system_status = {
                 "timestamp": timezone.now().isoformat(),
@@ -252,84 +295,108 @@ class SystemResourceService:
                     "memory_usage": round(memory_usage_percent, 1),
                     "memory_total": f"{memory_total_gb} GB",
                     "memory_used_gb": round(memory.used / (1024**3), 2),
-                    "memory_available_gb": round(memory.available / (1024**3), 2)
+                    "memory_available_gb": round(memory.available / (1024**3), 2),
                 },
                 "devices": [],
                 "board_name": "Unknown",
                 "hardware_status": "unknown",
-                "hardware_error": None
+                "hardware_error": None,
             }
-            
+
             # Try to get TT device data with timeout
             try:
                 tt_data = SystemResourceService.get_tt_smi_data(timeout=10)
-                
+
                 if tt_data:
                     system_status["hardware_status"] = "healthy"
-                    
+
                     # Add host info from tt-smi if available
                     if "host_info" in tt_data:
                         host_info = tt_data["host_info"]
-                        system_status["host_info"].update({
-                            "os": host_info.get("OS"),
-                            "distro": host_info.get("Distro"),
-                            "kernel": host_info.get("Kernel"),
-                            "hostname": host_info.get("Hostname"),
-                            "driver": host_info.get("Driver")
-                        })
-                    
+                        system_status["host_info"].update(
+                            {
+                                "os": host_info.get("OS"),
+                                "distro": host_info.get("Distro"),
+                                "kernel": host_info.get("Kernel"),
+                                "hostname": host_info.get("Hostname"),
+                                "driver": host_info.get("Driver"),
+                            }
+                        )
+
                     # Process device information
                     if "device_info" in tt_data and tt_data["device_info"]:
                         devices = []
                         board_types = []
-                        
+
                         for idx, device in enumerate(tt_data["device_info"]):
                             board_info = device.get("board_info", {})
                             telemetry = device.get("telemetry", {})
                             limits = device.get("limits", {})
-                            
+
                             # Track board types
                             board_type = board_info.get("board_type", "Unknown")
                             board_types.append(board_type)
-                            
+
                             device_data = {
                                 "index": idx,
                                 "board_type": board_type,
                                 "bus_id": board_info.get("bus_id", "N/A"),
                                 "coords": board_info.get("coords", "N/A"),
-                                "voltage": float(telemetry.get("voltage", 0)) if telemetry.get("voltage") else 0,
-                                "current": float(telemetry.get("current", 0)) if telemetry.get("current") else 0,
-                                "power": float(telemetry.get("power", 0)) if telemetry.get("power") else 0,
-                                "aiclk": int(telemetry.get("aiclk", 0)) if telemetry.get("aiclk") else 0,
-                                "temperature": float(telemetry.get("asic_temperature", 0)) if telemetry.get("asic_temperature") else 0,
+                                "voltage": float(telemetry.get("voltage", 0))
+                                if telemetry.get("voltage")
+                                else 0,
+                                "current": float(telemetry.get("current", 0))
+                                if telemetry.get("current")
+                                else 0,
+                                "power": float(telemetry.get("power", 0))
+                                if telemetry.get("power")
+                                else 0,
+                                "aiclk": int(telemetry.get("aiclk", 0))
+                                if telemetry.get("aiclk")
+                                else 0,
+                                "temperature": float(
+                                    telemetry.get("asic_temperature", 0)
+                                )
+                                if telemetry.get("asic_temperature")
+                                else 0,
                                 "limits": {
-                                    "tdp_limit": int(limits.get("tdp_limit", 0)) if limits.get("tdp_limit") else 0,
-                                    "tdc_limit": int(limits.get("tdc_limit", 0)) if limits.get("tdc_limit") else 0,
-                                    "thm_limit": int(limits.get("thm_limit", 0)) if limits.get("thm_limit") else 0
-                                }
+                                    "tdp_limit": int(limits.get("tdp_limit", 0))
+                                    if limits.get("tdp_limit")
+                                    else 0,
+                                    "tdc_limit": int(limits.get("tdc_limit", 0))
+                                    if limits.get("tdc_limit")
+                                    else 0,
+                                    "thm_limit": int(limits.get("thm_limit", 0))
+                                    if limits.get("thm_limit")
+                                    else 0,
+                                },
                             }
                             devices.append(device_data)
-                        
+
                         system_status["devices"] = devices
-                        
+
                         # Determine primary board name using detected board type (supports P300x2/P300Cx4)
                         detected_board_type = SystemResourceService.get_board_type()
                         system_status["board_name"] = detected_board_type
                 else:
                     # tt-smi failed - indicate potential hardware issue
                     system_status["hardware_status"] = "error"
-                    system_status["hardware_error"] = "Unable to communicate with TT hardware. The card may be in a bad state or tt-smi is not responding."
+                    system_status["hardware_error"] = (
+                        "Unable to communicate with TT hardware. The card may be in a bad state or tt-smi is not responding."
+                    )
                     system_status["board_name"] = "TT Board (Error)"
                     logger.warning("tt-smi failed - hardware may be in bad state")
-                    
+
             except Exception as hardware_error:
                 logger.error(f"Hardware monitoring failed: {str(hardware_error)}")
                 system_status["hardware_status"] = "error"
-                system_status["hardware_error"] = f"Hardware monitoring error: {str(hardware_error)}"
+                system_status["hardware_error"] = (
+                    f"Hardware monitoring error: {str(hardware_error)}"
+                )
                 system_status["board_name"] = "TT Board (Error)"
-            
+
             return system_status
-            
+
         except Exception as e:
             logger.error(f"Error getting system resources: {str(e)}")
             return {
@@ -339,13 +406,13 @@ class SystemResourceService:
                     "memory_usage": 0,
                     "memory_total": "0 GB",
                     "memory_used_gb": 0,
-                    "memory_available_gb": 0
+                    "memory_available_gb": 0,
                 },
                 "devices": [],
                 "board_name": "System Error",
                 "hardware_status": "error",
                 "hardware_error": str(e),
-                "error": str(e)
+                "error": str(e),
             }
 
     @staticmethod
@@ -354,18 +421,18 @@ class SystemResourceService:
         try:
             tt_data = SystemResourceService.get_tt_smi_data()
             system_resources = SystemResourceService.get_system_resources()
-            
+
             if not tt_data:
                 logger.warning("No tt-smi data available for snapshot")
                 return None
-            
+
             # Create snapshot
             snapshot = HardwareSnapshot.objects.create(
                 raw_data=tt_data,
                 host_info=system_resources["host_info"],
-                devices_count=len(system_resources["devices"])
+                devices_count=len(system_resources["devices"]),
             )
-            
+
             # Create device telemetry records
             for device_data in system_resources["devices"]:
                 DeviceTelemetry.objects.create(
@@ -373,22 +440,34 @@ class SystemResourceService:
                     device_index=device_data["index"],
                     board_type=device_data["board_type"],
                     bus_id=device_data["bus_id"],
-                    board_id=tt_data["device_info"][device_data["index"]].get("board_info", {}).get("board_id", ""),
+                    board_id=tt_data["device_info"][device_data["index"]]
+                    .get("board_info", {})
+                    .get("board_id", ""),
                     coords=device_data["coords"],
                     voltage=device_data["voltage"],
                     current=device_data["current"],
                     power=device_data["power"],
                     aiclk=device_data["aiclk"],
                     asic_temperature=device_data["temperature"],
-                    dram_status=tt_data["device_info"][device_data["index"]].get("board_info", {}).get("dram_status", False),
-                    dram_speed=tt_data["device_info"][device_data["index"]].get("board_info", {}).get("dram_speed"),
-                    pcie_speed=tt_data["device_info"][device_data["index"]].get("board_info", {}).get("pcie_speed"),
-                    pcie_width=tt_data["device_info"][device_data["index"]].get("board_info", {}).get("pcie_width")
+                    dram_status=tt_data["device_info"][device_data["index"]]
+                    .get("board_info", {})
+                    .get("dram_status", False),
+                    dram_speed=tt_data["device_info"][device_data["index"]]
+                    .get("board_info", {})
+                    .get("dram_speed"),
+                    pcie_speed=tt_data["device_info"][device_data["index"]]
+                    .get("board_info", {})
+                    .get("pcie_speed"),
+                    pcie_width=tt_data["device_info"][device_data["index"]]
+                    .get("board_info", {})
+                    .get("pcie_width"),
                 )
-            
-            logger.info(f"Hardware snapshot saved with {len(system_resources['devices'])} devices")
+
+            logger.info(
+                f"Hardware snapshot saved with {len(system_resources['devices'])} devices"
+            )
             return snapshot
-            
+
         except Exception as e:
             logger.error(f"Error saving hardware snapshot: {str(e)}")
             return None
@@ -397,36 +476,40 @@ class SystemResourceService:
     def check_hardware_alerts(system_resources):
         """Check for hardware alerts based on current telemetry"""
         alerts = []
-        
+
         try:
             for device in system_resources.get("devices", []):
                 device_idx = device["index"]
                 temperature = device["temperature"]
                 power = device["power"]
                 limits = device["limits"]
-                
+
                 # Temperature alerts
                 if temperature > limits.get("thm_limit", 75):
-                    alerts.append({
-                        "device_index": device_idx,
-                        "alert_type": "temperature",
-                        "severity": "critical" if temperature > 85 else "warning",
-                        "message": f"Device {device_idx} temperature ({temperature}°C) exceeds limit ({limits.get('thm_limit', 75)}°C)",
-                        "value": temperature,
-                        "limit": limits.get("thm_limit", 75)
-                    })
-                
-                # Power alerts  
+                    alerts.append(
+                        {
+                            "device_index": device_idx,
+                            "alert_type": "temperature",
+                            "severity": "critical" if temperature > 85 else "warning",
+                            "message": f"Device {device_idx} temperature ({temperature}°C) exceeds limit ({limits.get('thm_limit', 75)}°C)",
+                            "value": temperature,
+                            "limit": limits.get("thm_limit", 75),
+                        }
+                    )
+
+                # Power alerts
                 if power > limits.get("tdp_limit", 85):
-                    alerts.append({
-                        "device_index": device_idx,
-                        "alert_type": "power",
-                        "severity": "warning",
-                        "message": f"Device {device_idx} power ({power}W) exceeds TDP limit ({limits.get('tdp_limit', 85)}W)",
-                        "value": power,
-                        "limit": limits.get("tdp_limit", 85)
-                    })
-            
+                    alerts.append(
+                        {
+                            "device_index": device_idx,
+                            "alert_type": "power",
+                            "severity": "warning",
+                            "message": f"Device {device_idx} power ({power}W) exceeds TDP limit ({limits.get('tdp_limit', 85)}W)",
+                            "value": power,
+                            "limit": limits.get("tdp_limit", 85),
+                        }
+                    )
+
             # Save critical alerts to database
             for alert in alerts:
                 if alert["severity"] in ["critical", "error"]:
@@ -434,14 +517,14 @@ class SystemResourceService:
                         device_index=alert["device_index"],
                         alert_type=alert["alert_type"],
                         severity=alert["severity"],
-                        message=alert["message"]
+                        message=alert["message"],
                     )
-            
+
             return alerts
-            
+
         except Exception as e:
             logger.error(f"Error checking hardware alerts: {str(e)}")
-            return [] 
+            return []
 
     @staticmethod
     def force_refresh_tt_smi_cache():
@@ -530,14 +613,16 @@ class SystemResourceService:
                 except (TypeError, ValueError):
                     return 0.0
 
-            devices.append({
-                "index": idx,
-                "board_type": board_info.get("board_type", "Unknown"),
-                "bus_id": board_info.get("bus_id", "N/A"),
-                "temperature": _f(telemetry.get("asic_temperature")),
-                "power": _f(telemetry.get("power")),
-                "voltage": _f(telemetry.get("voltage")),
-            })
+            devices.append(
+                {
+                    "index": idx,
+                    "board_type": board_info.get("board_type", "Unknown"),
+                    "bus_id": board_info.get("bus_id", "N/A"),
+                    "temperature": _f(telemetry.get("asic_temperature")),
+                    "power": _f(telemetry.get("power")),
+                    "voltage": _f(telemetry.get("voltage")),
+                }
+            )
         return devices
 
     @staticmethod
@@ -616,11 +701,15 @@ class SystemResourceService:
                     "last_updated": timezone.now().isoformat(),
                     "reset_suggested": True,
                 }
-                cache.set(SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10)
+                cache.set(
+                    SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10
+                )
                 return result
 
             if process.returncode != 0:
-                logger.error(f"tt-smi -s exit code {process.returncode}: {stderr.strip()!r}")
+                logger.error(
+                    f"tt-smi -s exit code {process.returncode}: {stderr.strip()!r}"
+                )
                 result = {
                     "state": "BAD_STATE",
                     "board_type": "unknown",
@@ -629,7 +718,9 @@ class SystemResourceService:
                     "last_updated": timezone.now().isoformat(),
                     "reset_suggested": True,
                 }
-                cache.set(SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10)
+                cache.set(
+                    SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10
+                )
                 return result
 
             try:
@@ -644,7 +735,9 @@ class SystemResourceService:
                     "last_updated": timezone.now().isoformat(),
                     "reset_suggested": True,
                 }
-                cache.set(SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10)
+                cache.set(
+                    SystemResourceService.DEVICE_STATE_CACHE_KEY, result, timeout=10
+                )
                 return result
 
             board_type = SystemResourceService._extract_board_type_from_data(data)

--- a/app/backend/board_control/urls.py
+++ b/app/backend/board_control/urls.py
@@ -9,17 +9,17 @@ urlpatterns = [
     path("status/", views.SystemStatusView.as_view(), name="system-status"),
     path("footer-data/", views.FooterDataView.as_view(), name="footer-data"),
     path("telemetry/", views.DeviceTelemetryView.as_view(), name="device-telemetry"),
-    
     # Hardware snapshot endpoints
     path("snapshots/", views.HardwareSnapshotView.as_view(), name="hardware-snapshots"),
-    
     # Alert endpoints
     path("alerts/", views.HardwareAlertsView.as_view(), name="hardware-alerts"),
-    path("alerts/<int:alert_id>/resolve/", views.HardwareAlertsView.as_view(), name="resolve-alert"),
-    
+    path(
+        "alerts/<int:alert_id>/resolve/",
+        views.HardwareAlertsView.as_view(),
+        name="resolve-alert",
+    ),
     # Cache management
     path("refresh-cache/", views.RefreshCacheView.as_view(), name="refresh-cache"),
-
     # Unified device state & reset (new)
     path("device-state/", views.DeviceStateView.as_view(), name="device-state"),
     path("device-reset/", views.DeviceResetView.as_view(), name="device-reset"),

--- a/app/backend/board_control/views.py
+++ b/app/backend/board_control/views.py
@@ -4,50 +4,51 @@
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from shared_config.logger_config import get_logger
 from .services import SystemResourceService
-from .models import HardwareSnapshot, DeviceTelemetry, HardwareAlert
+from .models import HardwareSnapshot, HardwareAlert
 from django.utils import timezone
 
 logger = get_logger(__name__)
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class SystemStatusView(APIView):
     """Get current system resources and device telemetry"""
-    
+
     def get(self, request, *args, **kwargs):
         try:
             logger.info("Fetching system status")
             system_resources = SystemResourceService.get_system_resources()
-            
+
             # Check for alerts
             alerts = SystemResourceService.check_hardware_alerts(system_resources)
             system_resources["alerts"] = alerts
-            
-            logger.info(f"System status retrieved: {len(system_resources.get('devices', []))} devices, {len(alerts)} alerts")
+
+            logger.info(
+                f"System status retrieved: {len(system_resources.get('devices', []))} devices, {len(alerts)} alerts"
+            )
             return Response(system_resources, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching system status: {str(e)}")
             return Response(
                 {"error": "Failed to fetch system status", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class FooterDataView(APIView):
     """Simplified endpoint specifically for Footer component data"""
-    
+
     def get(self, request, *args, **kwargs):
         try:
             logger.info("Fetching footer data")
             system_resources = SystemResourceService.get_system_resources()
-            
+
             # Extract data specifically for Footer component
             footer_data = {
                 "cpuUsage": system_resources["host_info"]["cpu_usage"],
@@ -55,15 +56,21 @@ class FooterDataView(APIView):
                 "memoryTotal": system_resources["host_info"]["memory_total"],
                 "boardName": system_resources["board_name"],
                 "temperature": 0,  # Will be set from device data
-                "devices": []
+                "devices": [],
             }
-            
+
             # Get average temperature and device info
             if system_resources["devices"]:
-                temperatures = [device["temperature"] for device in system_resources["devices"] if device["temperature"] > 0]
+                temperatures = [
+                    device["temperature"]
+                    for device in system_resources["devices"]
+                    if device["temperature"] > 0
+                ]
                 if temperatures:
-                    footer_data["temperature"] = round(sum(temperatures) / len(temperatures), 1)
-                
+                    footer_data["temperature"] = round(
+                        sum(temperatures) / len(temperatures), 1
+                    )
+
                 # Include device summary
                 footer_data["devices"] = [
                     {
@@ -71,137 +78,151 @@ class FooterDataView(APIView):
                         "board_type": device["board_type"],
                         "temperature": device["temperature"],
                         "power": device["power"],
-                        "voltage": device["voltage"]
+                        "voltage": device["voltage"],
                     }
                     for device in system_resources["devices"]
                 ]
-            
-            logger.info(f"Footer data retrieved for {len(footer_data['devices'])} devices")
+
+            logger.info(
+                f"Footer data retrieved for {len(footer_data['devices'])} devices"
+            )
             return Response(footer_data, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching footer data: {str(e)}")
             # Return safe fallback data
-            return Response({
-                "cpuUsage": 0,
-                "memoryUsage": 0,
-                "memoryTotal": "0 GB",
-                "boardName": "Error",
-                "temperature": 0,
-                "devices": [],
-                "error": str(e)
-            }, status=status.HTTP_200_OK)  # Return 200 to avoid breaking UI
+            return Response(
+                {
+                    "cpuUsage": 0,
+                    "memoryUsage": 0,
+                    "memoryTotal": "0 GB",
+                    "boardName": "Error",
+                    "temperature": 0,
+                    "devices": [],
+                    "error": str(e),
+                },
+                status=status.HTTP_200_OK,
+            )  # Return 200 to avoid breaking UI
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class DeviceTelemetryView(APIView):
     """Get detailed device telemetry data"""
-    
+
     def get(self, request, *args, **kwargs):
         try:
             logger.info("Fetching device telemetry")
             tt_data = SystemResourceService.get_tt_smi_data()
-            
+
             if not tt_data:
                 return Response(
                     {"error": "No telemetry data available"},
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
-            
+
             return Response(tt_data, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching device telemetry: {str(e)}")
             return Response(
                 {"error": "Failed to fetch device telemetry", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class HardwareSnapshotView(APIView):
     """Create and retrieve hardware snapshots"""
-    
+
     def post(self, request, *args, **kwargs):
         """Create a new hardware snapshot"""
         try:
             logger.info("Creating hardware snapshot")
             snapshot = SystemResourceService.save_hardware_snapshot()
-            
+
             if snapshot:
-                return Response({
-                    "status": "success",
-                    "snapshot_id": snapshot.id,
-                    "timestamp": snapshot.timestamp.isoformat(),
-                    "devices_count": snapshot.devices_count
-                }, status=status.HTTP_201_CREATED)
+                return Response(
+                    {
+                        "status": "success",
+                        "snapshot_id": snapshot.id,
+                        "timestamp": snapshot.timestamp.isoformat(),
+                        "devices_count": snapshot.devices_count,
+                    },
+                    status=status.HTTP_201_CREATED,
+                )
             else:
                 return Response(
                     {"error": "Failed to create hardware snapshot"},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-                
+
         except Exception as e:
             logger.error(f"Error creating hardware snapshot: {str(e)}")
             return Response(
                 {"error": "Failed to create hardware snapshot", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-    
+
     def get(self, request, *args, **kwargs):
         """Get recent hardware snapshots"""
         try:
             snapshots = HardwareSnapshot.objects.all()[:10]  # Get last 10 snapshots
-            
+
             data = []
             for snapshot in snapshots:
-                data.append({
-                    "id": snapshot.id,
-                    "timestamp": snapshot.timestamp.isoformat(),
-                    "devices_count": snapshot.devices_count,
-                    "host_info": snapshot.host_info
-                })
-            
+                data.append(
+                    {
+                        "id": snapshot.id,
+                        "timestamp": snapshot.timestamp.isoformat(),
+                        "devices_count": snapshot.devices_count,
+                        "host_info": snapshot.host_info,
+                    }
+                )
+
             return Response(data, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching hardware snapshots: {str(e)}")
             return Response(
                 {"error": "Failed to fetch hardware snapshots", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class HardwareAlertsView(APIView):
     """Get hardware alerts"""
-    
+
     def get(self, request, *args, **kwargs):
         try:
             # Get unresolved alerts
-            alerts = HardwareAlert.objects.filter(is_resolved=False).order_by('-created_at')[:50]
-            
+            alerts = HardwareAlert.objects.filter(is_resolved=False).order_by(
+                "-created_at"
+            )[:50]
+
             data = []
             for alert in alerts:
-                data.append({
-                    "id": alert.id,
-                    "device_index": alert.device_index,
-                    "alert_type": alert.alert_type,
-                    "severity": alert.severity,
-                    "message": alert.message,
-                    "created_at": alert.created_at.isoformat(),
-                    "is_resolved": alert.is_resolved
-                })
-            
+                data.append(
+                    {
+                        "id": alert.id,
+                        "device_index": alert.device_index,
+                        "alert_type": alert.alert_type,
+                        "severity": alert.severity,
+                        "message": alert.message,
+                        "created_at": alert.created_at.isoformat(),
+                        "is_resolved": alert.is_resolved,
+                    }
+                )
+
             return Response(data, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching hardware alerts: {str(e)}")
             return Response(
                 {"error": "Failed to fetch hardware alerts", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-    
+
     def patch(self, request, alert_id, *args, **kwargs):
         """Mark alert as resolved"""
         try:
@@ -209,23 +230,22 @@ class HardwareAlertsView(APIView):
             alert.is_resolved = True
             alert.resolved_at = timezone.now()
             alert.save()
-            
+
             return Response({"status": "success"}, status=status.HTTP_200_OK)
-            
+
         except HardwareAlert.DoesNotExist:
             return Response(
-                {"error": "Alert not found"},
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Alert not found"}, status=status.HTTP_404_NOT_FOUND
             )
         except Exception as e:
             logger.error(f"Error resolving alert: {str(e)}")
             return Response(
                 {"error": "Failed to resolve alert", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            ) 
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class RefreshCacheView(APIView):
     """Manual cache refresh endpoint for debugging and manual triggering"""
 
@@ -234,20 +254,20 @@ class RefreshCacheView(APIView):
             logger.info("Manual cache refresh requested")
             SystemResourceService.force_refresh_tt_smi_cache()
 
-            return Response({
-                "status": "success",
-                "message": "tt-smi cache refreshed successfully"
-            }, status=status.HTTP_200_OK)
+            return Response(
+                {"status": "success", "message": "tt-smi cache refreshed successfully"},
+                status=status.HTTP_200_OK,
+            )
 
         except Exception as e:
             logger.error(f"Error manually refreshing cache: {str(e)}")
             return Response(
                 {"error": "Failed to refresh cache", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class DeviceStateView(APIView):
     """
     GET /board-api/device-state/
@@ -263,17 +283,20 @@ class DeviceStateView(APIView):
             return Response(state, status=status.HTTP_200_OK)
         except Exception as e:
             logger.error(f"Error getting device state: {e}")
-            return Response({
-                "state": "UNKNOWN",
-                "board_type": "unknown",
-                "board_name": "Unknown",
-                "devices": [],
-                "last_updated": timezone.now().isoformat(),
-                "reset_suggested": False,
-            }, status=status.HTTP_200_OK)
+            return Response(
+                {
+                    "state": "UNKNOWN",
+                    "board_type": "unknown",
+                    "board_name": "Unknown",
+                    "devices": [],
+                    "last_updated": timezone.now().isoformat(),
+                    "reset_suggested": False,
+                },
+                status=status.HTTP_200_OK,
+            )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class DeviceResetView(APIView):
     """
     POST /board-api/device-reset/
@@ -284,21 +307,28 @@ class DeviceResetView(APIView):
 
     def post(self, request, *args, **kwargs):
         from docker_control.docker_utils import perform_reset
+
         try:
             logger.info("Device reset requested via /board-api/device-reset/")
             result = perform_reset()
             http_status_code = result.pop("http_status", 200)
 
             success = result.get("status") == "success"
-            return Response({
-                "success": success,
-                "message": result.get("message", ""),
-                "attempts_used": result.get("attempts_used", 0),
-            }, status=http_status_code)
+            return Response(
+                {
+                    "success": success,
+                    "message": result.get("message", ""),
+                    "attempts_used": result.get("attempts_used", 0),
+                },
+                status=http_status_code,
+            )
         except Exception as e:
             logger.error(f"Error in device reset: {e}")
-            return Response({
-                "success": False,
-                "message": str(e),
-                "attempts_used": 0,
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {
+                    "success": False,
+                    "message": str(e),
+                    "attempts_used": 0,
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/app/backend/docker_control/apps.py
+++ b/app/backend/docker_control/apps.py
@@ -7,6 +7,7 @@ from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
 
+
 class DockerControlConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "docker_control"
@@ -18,6 +19,7 @@ class DockerControlConfig(AppConfig):
         # Log how many deployments are already tracked
         try:
             from docker_control.models import ModelDeployment
+
             count = ModelDeployment.objects.count()
             logger.info(f"Deployment store loaded. Existing records: {count}")
         except Exception as e:
@@ -26,6 +28,7 @@ class DockerControlConfig(AppConfig):
         # Start container health monitoring service
         try:
             from docker_control.health_monitor import start_health_monitoring
+
             start_health_monitoring()
             logger.info("Container health monitoring service started")
         except Exception as e:
@@ -36,6 +39,7 @@ class DockerControlConfig(AppConfig):
         # so the deployment store is fully initialized.
         try:
             from docker_control.deployment_sync import recover_orphaned_starting_records
+
             recover_orphaned_starting_records()
         except Exception as e:
             logger.warning(f"Could not run startup deployment recovery: {e}")

--- a/app/backend/docker_control/chip_allocator.py
+++ b/app/backend/docker_control/chip_allocator.py
@@ -11,7 +11,6 @@ Manages automatic chip slot allocation based on:
 - Board topology
 """
 
-import re
 import threading
 from datetime import timedelta
 from datetime import timezone as datetime_timezone
@@ -28,8 +27,10 @@ logger = get_logger(__name__)
 # Exception Classes
 # ---------------------------------------------------------------------------
 
+
 class AllocationError(Exception):
     """Base exception for chip slot allocation errors"""
+
     pass
 
 
@@ -41,6 +42,7 @@ class MultiChipConflictError(AllocationError):
         message: Error message
         conflicts: List of conflicting deployment info dicts
     """
+
     def __init__(self, message: str, conflicts: List[Dict] = None):
         super().__init__(message)
         self.conflicts = conflicts or []
@@ -80,11 +82,14 @@ class ChipSlotAllocator:
         self._lock = threading.Lock()
         self.board_type = self._detect_board_type()
         self.total_slots = self._get_total_slots()
-        logger.info(f"ChipSlotAllocator initialized: board={self.board_type}, slots={self.total_slots}")
+        logger.info(
+            f"ChipSlotAllocator initialized: board={self.board_type}, slots={self.total_slots}"
+        )
 
     def _detect_board_type(self) -> str:
         """Detect current board type"""
         from docker_control.docker_utils import detect_board_type
+
         return detect_board_type()
 
     def _get_total_slots(self) -> int:
@@ -122,7 +127,9 @@ class ChipSlotAllocator:
 
             if model_chips == 4:
                 # Multi-chip: mark ALL slots as occupied
-                for slot_id in range(min(4, self.total_slots)):  # Multi-chip models use up to 4 slots
+                for slot_id in range(
+                    min(4, self.total_slots)
+                ):  # Multi-chip models use up to 4 slots
                     occupied_map[slot_id] = {
                         "model_name": deployment.model_name,
                         "deployment_id": deployment.id,
@@ -144,24 +151,21 @@ class ChipSlotAllocator:
         # Build slot status list
         for slot_id in range(self.total_slots):
             if slot_id in occupied_map:
-                slots_info.append({
-                    "slot_id": slot_id,
-                    "status": "occupied",
-                    **occupied_map[slot_id]
-                })
+                slots_info.append(
+                    {"slot_id": slot_id, "status": "occupied", **occupied_map[slot_id]}
+                )
             else:
-                slots_info.append({
-                    "slot_id": slot_id,
-                    "status": "available"
-                })
+                slots_info.append({"slot_id": slot_id, "status": "available"})
 
         return {
             "board_type": self.board_type,
             "total_slots": self.total_slots,
-            "slots": slots_info
+            "slots": slots_info,
         }
 
-    def allocate_chip_slot(self, model_name: str, manual_override: Optional[int] = None) -> int:
+    def allocate_chip_slot(
+        self, model_name: str, manual_override: Optional[int] = None
+    ) -> int:
         """
         Auto-allocate chip slot or use manual override.
 
@@ -181,10 +185,14 @@ class ChipSlotAllocator:
 
             # Advanced mode: manual override
             if manual_override is not None:
-                validation = self._validate_manual_allocation(manual_override, chips_required, model_name)
+                validation = self._validate_manual_allocation(
+                    manual_override, chips_required, model_name
+                )
                 if not validation["valid"]:
                     raise AllocationError(validation["message"])
-                logger.info(f"Manual allocation: device_id={manual_override} for {model_name}")
+                logger.info(
+                    f"Manual allocation: device_id={manual_override} for {model_name}"
+                )
                 return manual_override
 
             # Auto-allocation
@@ -193,7 +201,9 @@ class ChipSlotAllocator:
             else:
                 device_id = self._allocate_single_chip(model_name)
 
-            logger.info(f"Auto-allocated: device_id={device_id} for {model_name} ({chips_required} chips)")
+            logger.info(
+                f"Auto-allocated: device_id={device_id} for {model_name} ({chips_required} chips)"
+            )
             return device_id
 
     def _allocate_single_chip(self, model_name: str) -> int:
@@ -242,23 +252,27 @@ class ChipSlotAllocator:
 
             for deployment in active_deployments:
                 model_chips = self._get_chips_required(deployment.model_name)
-                conflicts.append({
-                    "model": deployment.model_name,
-                    "deployment_id": deployment.id,
-                    "slot": deployment.device_id,
-                    "chips": model_chips
-                })
+                conflicts.append(
+                    {
+                        "model": deployment.model_name,
+                        "deployment_id": deployment.id,
+                        "slot": deployment.device_id,
+                        "chips": model_chips,
+                    }
+                )
 
             raise MultiChipConflictError(
                 f"{model_name} requires all 4 chip slots. "
                 f"Currently occupied: {len(occupied_slots)} slot(s). "
                 f"Stop all running models first.",
-                conflicts=conflicts
+                conflicts=conflicts,
             )
 
         return 0  # Multi-chip models always use device_id=0
 
-    def _validate_manual_allocation(self, device_id: int, chips_required: int, model_name: str) -> Dict:
+    def _validate_manual_allocation(
+        self, device_id: int, chips_required: int, model_name: str
+    ) -> Dict:
         """
         Validate manual chip slot selection in advanced mode.
 
@@ -274,7 +288,7 @@ class ChipSlotAllocator:
         if device_id < 0 or device_id >= self.total_slots:
             return {
                 "valid": False,
-                "message": f"Invalid device_id {device_id}. Must be 0-{self.total_slots - 1}."
+                "message": f"Invalid device_id {device_id}. Must be 0-{self.total_slots - 1}.",
             }
 
         occupied_slots = self._get_occupied_slots()
@@ -284,7 +298,7 @@ class ChipSlotAllocator:
             if occupied_slots:
                 return {
                     "valid": False,
-                    "message": f"{model_name} requires all 4 chip slots. Currently occupied: {len(occupied_slots)} slot(s)."
+                    "message": f"{model_name} requires all 4 chip slots. Currently occupied: {len(occupied_slots)} slot(s).",
                 }
         else:
             # Single-chip: ensure selected slot is free
@@ -304,7 +318,7 @@ class ChipSlotAllocator:
 
                 return {
                     "valid": False,
-                    "message": f"Chip slot {device_id} is occupied by {occupying_model or 'another model'}."
+                    "message": f"Chip slot {device_id} is occupied by {occupying_model or 'another model'}.",
                 }
 
         return {"valid": True}
@@ -325,16 +339,19 @@ class ChipSlotAllocator:
             logger.warning(
                 f"Falling back to raw deployment_store list: canonical query failed: {e}"
             )
-            return list(ModelDeployment.objects.filter(status__in=["starting", "running"]))
+            return list(
+                ModelDeployment.objects.filter(status__in=["starting", "running"])
+            )
 
         live_deployment_ids = {
             entry.get("deployment_id")
             for entry in canonical.values()
-            if entry.get("source") == "managed" and entry.get("deployment_id") is not None
+            if entry.get("source") == "managed"
+            and entry.get("deployment_id") is not None
         }
         if not live_deployment_ids:
             return []
-        
+
         # To comply with the current interface, we return a list of ModelDeployment objects despite having canonical data.
         return list(ModelDeployment.objects.filter(id__in=live_deployment_ids))
 
@@ -358,7 +375,11 @@ class ChipSlotAllocator:
         # yet be visible in Docker and the sync thread will handle transition.
         if deployment.status == "starting":
             now_utc = _dt.now(datetime_timezone.utc)
-            age = (now_utc - deployment.deployed_at).total_seconds() if deployment.deployed_at else 0
+            age = (
+                (now_utc - deployment.deployed_at).total_seconds()
+                if deployment.deployed_at
+                else 0
+            )
             if age < self._STARTING_GRACE_SECONDS:
                 return deployment
 
@@ -369,7 +390,10 @@ class ChipSlotAllocator:
             return deployment
 
         # Check by container_name
-        if deployment.container_name and deployment.container_name in live_containers_by_name:
+        if (
+            deployment.container_name
+            and deployment.container_name in live_containers_by_name
+        ):
             return deployment
 
         # Container is gone — free the slot immediately.
@@ -393,7 +417,9 @@ class ChipSlotAllocator:
         try:
             return get_container_status()
         except Exception as e:
-            logger.warning(f"Could not query Docker for live containers; using DB records as-is: {e}")
+            logger.warning(
+                f"Could not query Docker for live containers; using DB records as-is: {e}"
+            )
             return None
 
     def _get_occupied_slots(self) -> Set[int]:

--- a/app/backend/docker_control/deployment_store.py
+++ b/app/backend/docker_control/deployment_store.py
@@ -21,7 +21,9 @@ from shared_config.logger_config import get_logger
 logger = get_logger(__name__)
 
 _STORE_PATH = (
-    Path(os.getenv("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/tt_studio_persistent_volume"))
+    Path(
+        os.getenv("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/tt_studio_persistent_volume")
+    )
     / "backend_volume"
     / "deployments.json"
 )
@@ -284,7 +286,9 @@ class ModelDeployment:
                     _save_raw(data)
                     return
             # Not found — append as new (shouldn't happen in normal flow)
-            logger.warning(f"save() called on deployment id={self.id} not found in store; appending")
+            logger.warning(
+                f"save() called on deployment id={self.id} not found in store; appending"
+            )
             data["records"].append(self._to_dict())
             _save_raw(data)
 

--- a/app/backend/docker_control/deployment_sync.py
+++ b/app/backend/docker_control/deployment_sync.py
@@ -45,6 +45,7 @@ _active_syncs_lock = threading.Lock()
 # Internal sync logic
 # ---------------------------------------------------------------------------
 
+
 def _do_sync(job_id: str, progress_data: dict) -> None:
     """Apply a FastAPI progress update to the corresponding ModelDeployment record.
 
@@ -70,6 +71,7 @@ def _do_sync(job_id: str, progress_data: dict) -> None:
                 if real_container_id:
                     try:
                         from docker_control.docker_utils import stop_container
+
                         stop_container(real_container_id)
                     except Exception as e:
                         logger.warning(
@@ -95,7 +97,9 @@ def _do_sync(job_id: str, progress_data: dict) -> None:
                 try:
                     update_deploy_cache()
                 except Exception as e:
-                    logger.warning(f"[deployment_sync] Could not refresh deploy cache: {e}")
+                    logger.warning(
+                        f"[deployment_sync] Could not refresh deploy cache: {e}"
+                    )
             else:
                 logger.warning(
                     f"[deployment_sync] Job {job_id} completed but no container_id in response; "
@@ -136,10 +140,18 @@ def _poll_and_sync(job_id: str) -> None:
 
                     if status == "completed":
                         _do_sync(job_id, progress)
-                        logger.info(f"[deployment_sync] Job {job_id} completed — sync done")
+                        logger.info(
+                            f"[deployment_sync] Job {job_id} completed — sync done"
+                        )
                         return
 
-                    if status in ("error", "failed", "cancelled", "timeout", "not_found"):
+                    if status in (
+                        "error",
+                        "failed",
+                        "cancelled",
+                        "timeout",
+                        "not_found",
+                    ):
                         _do_sync(job_id, progress)
                         logger.info(
                             f"[deployment_sync] Job {job_id} terminal ({status}) — freeing slot"
@@ -174,6 +186,7 @@ def _poll_and_sync(job_id: str) -> None:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def start_deployment_sync(job_id: str) -> None:
     """Spawn a daemon thread to sync the ModelDeployment record for *job_id*.
@@ -212,24 +225,31 @@ def recover_orphaned_starting_records() -> None:
     try:
         from docker_control.models import ModelDeployment
     except Exception as e:
-        logger.warning(f"[deployment_sync] Could not import ModelDeployment at startup: {e}")
+        logger.warning(
+            f"[deployment_sync] Could not import ModelDeployment at startup: {e}"
+        )
         return
 
     try:
         starting = list(ModelDeployment.objects.filter(status="starting"))
     except Exception as e:
-        logger.warning(f"[deployment_sync] Could not query starting records at startup: {e}")
+        logger.warning(
+            f"[deployment_sync] Could not query starting records at startup: {e}"
+        )
         return
 
     # Filter to job_id-style records (not pending_ placeholders — those are
     # handled by health_monitor's _cleanup_stale_starting_records)
     job_id_records = [
-        dep for dep in starting
+        dep
+        for dep in starting
         if dep.container_id and not dep.container_id.startswith("pending_")
     ]
 
     if not job_id_records:
-        logger.info("[deployment_sync] No orphaned CHAT starting records found at startup")
+        logger.info(
+            "[deployment_sync] No orphaned CHAT starting records found at startup"
+        )
         return
 
     logger.info(

--- a/app/backend/docker_control/docker_control_client.py
+++ b/app/backend/docker_control/docker_control_client.py
@@ -13,7 +13,7 @@ import json
 import os
 import jwt
 import requests
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
@@ -34,23 +34,22 @@ class DockerControlClient:
         self.jwt_secret = jwt_secret or os.getenv("DOCKER_CONTROL_JWT_SECRET")
 
         if not self.url:
-            raise ValueError("DOCKER_CONTROL_SERVICE_URL environment variable is required")
+            raise ValueError(
+                "DOCKER_CONTROL_SERVICE_URL environment variable is required"
+            )
         if not self.jwt_secret:
-            raise ValueError("DOCKER_CONTROL_JWT_SECRET environment variable is required")
+            raise ValueError(
+                "DOCKER_CONTROL_JWT_SECRET environment variable is required"
+            )
 
         logger.info(f"Initialized DockerControlClient with URL: {self.url}")
 
     def _get_headers(self) -> Dict[str, str]:
         """Generate authentication headers with JWT token"""
         token = jwt.encode(
-            {"service": "tt_studio_backend"},
-            self.jwt_secret,
-            algorithm="HS256"
+            {"service": "tt_studio_backend"}, self.jwt_secret, algorithm="HS256"
         )
-        return {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json"
-        }
+        return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
     def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
         """Make an authenticated request to the docker-control-service"""
@@ -72,7 +71,9 @@ class DockerControlClient:
 
     # Container operations
 
-    def list_containers(self, all: bool = False, filters: Optional[Dict] = None) -> List[Dict]:
+    def list_containers(
+        self, all: bool = False, filters: Optional[Dict] = None
+    ) -> List[Dict]:
         """
         List containers
 
@@ -107,7 +108,7 @@ class DockerControlClient:
         volumes: Optional[Dict] = None,
         network: Optional[str] = None,
         detach: bool = True,
-        **kwargs
+        **kwargs,
     ) -> Dict:
         """
         Run a new container
@@ -126,11 +127,7 @@ class DockerControlClient:
         Returns:
             Container information dict
         """
-        payload = {
-            "image": image,
-            "detach": detach,
-            **kwargs
-        }
+        payload = {"image": image, "detach": detach, **kwargs}
 
         if name:
             payload["name"] = name
@@ -151,25 +148,37 @@ class DockerControlClient:
     def stop_container(self, container_id: str, timeout: int = 10) -> Dict:
         """Stop a running container"""
         payload = {"timeout": timeout}
-        response = self._request("POST", f"/api/v1/containers/{container_id}/stop", json=payload)
+        response = self._request(
+            "POST", f"/api/v1/containers/{container_id}/stop", json=payload
+        )
         return response.json()
 
-    def remove_container(self, container_id: str, force: bool = False, v: bool = False) -> Dict:
+    def remove_container(
+        self, container_id: str, force: bool = False, v: bool = False
+    ) -> Dict:
         """Remove a container"""
         payload = {"force": force, "v": v}
-        response = self._request("POST", f"/api/v1/containers/{container_id}/remove", json=payload)
+        response = self._request(
+            "POST", f"/api/v1/containers/{container_id}/remove", json=payload
+        )
         return response.json()
 
     def rename_container(self, container_id: str, new_name: str) -> Dict:
         """Rename a container"""
-        response = self._request("POST", f"/api/v1/containers/{container_id}/rename", params={"new_name": new_name})
+        response = self._request(
+            "POST",
+            f"/api/v1/containers/{container_id}/rename",
+            params={"new_name": new_name},
+        )
         return response.json()
 
     def inspect_container(self, container_id: str) -> Dict:
         """Inspect a container (alias for get_container)"""
         return self.get_container(container_id)
 
-    def dir_size(self, container_id: str, path: str, timeout: float = 4.0) -> Optional[int]:
+    def dir_size(
+        self, container_id: str, path: str, timeout: float = 4.0
+    ) -> Optional[int]:
         """Recursive byte count of `path` inside the running container.
 
         Wraps the docker-control-service's read-only `du` helper. Returns None
@@ -198,7 +207,9 @@ class DockerControlClient:
             logger.warning(f"dir_size({container_id[:12]}) parse failure: {e}")
             return None
 
-    def tail_logs(self, container_id: str, tail: int = 200, timeout: float = 5.0) -> List[str]:
+    def tail_logs(
+        self, container_id: str, tail: int = 200, timeout: float = 5.0
+    ) -> List[str]:
         """Fetch a one-shot snapshot of the most recent container log lines.
 
         Wraps the SSE-based logs endpoint with follow=false: the upstream stream
@@ -229,7 +240,7 @@ class DockerControlClient:
             for raw_line in response.iter_lines(decode_unicode=True):
                 if not raw_line or not raw_line.startswith("data: "):
                     continue
-                payload = raw_line[len("data: "):]
+                payload = raw_line[len("data: ") :]
                 try:
                     obj = json.loads(payload)
                 except json.JSONDecodeError:
@@ -264,7 +275,9 @@ class DockerControlClient:
 
         try:
             # Use stream=True to get streaming response
-            response = requests.get(url, headers=headers, params=params, stream=True, timeout=None)
+            response = requests.get(
+                url, headers=headers, params=params, stream=True, timeout=None
+            )
             response.raise_for_status()
 
             # Stream the response in chunks (no buffering)
@@ -317,7 +330,9 @@ class DockerControlClient:
         response = self._request("POST", "/api/v1/images/pull/start", json=payload)
         return response.json()
 
-    def get_image_pull_progress(self, pull_id: str, timeout: float = 5.0) -> Optional[Dict]:
+    def get_image_pull_progress(
+        self, pull_id: str, timeout: float = 5.0
+    ) -> Optional[Dict]:
         """Fetch the latest progress snapshot for a streamed pull.
 
         Returns None if the pull is not tracked (404) or the service is unreachable,
@@ -356,13 +371,19 @@ class DockerControlClient:
     def connect_container_to_network(self, network_name: str, container: str) -> Dict:
         """Connect a container to a network"""
         payload = {"container": container}
-        response = self._request("POST", f"/api/v1/networks/{network_name}/connect", json=payload)
+        response = self._request(
+            "POST", f"/api/v1/networks/{network_name}/connect", json=payload
+        )
         return response.json()
 
-    def disconnect_container_from_network(self, network_name: str, container: str, force: bool = False) -> Dict:
+    def disconnect_container_from_network(
+        self, network_name: str, container: str, force: bool = False
+    ) -> Dict:
         """Disconnect a container from a network"""
         payload = {"container": container, "force": force}
-        response = self._request("POST", f"/api/v1/networks/{network_name}/disconnect", json=payload)
+        response = self._request(
+            "POST", f"/api/v1/networks/{network_name}/disconnect", json=payload
+        )
         return response.json()
 
     # Host log files

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -3,7 +3,10 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # docker_control/docker_utils.py
-import socket, os, subprocess, json, signal, time
+import os
+import subprocess
+import signal
+import time
 import copy
 from pathlib import Path
 
@@ -21,7 +24,9 @@ from docker_control.models import ModelDeployment
 from docker_control.docker_control_client import get_docker_client
 
 
-CONFIG_PATH = Path(backend_config.backend_cache_root).joinpath("tenstorrent", "reset_config.json")
+CONFIG_PATH = Path(backend_config.backend_cache_root).joinpath(
+    "tenstorrent", "reset_config.json"
+)
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
 
@@ -31,7 +36,9 @@ DEPLOYMENT_TIMEOUT_SECONDS = 5 * 60 * 60  # 5 hours
 FASTAPI_BASE_URL = backend_config.tt_inference_api_url
 
 
-def _poll_deployment_to_completion(job_id: str, timeout_seconds: int = DEPLOYMENT_TIMEOUT_SECONDS) -> dict:
+def _poll_deployment_to_completion(
+    job_id: str, timeout_seconds: int = DEPLOYMENT_TIMEOUT_SECONDS
+) -> dict:
     """Poll FastAPI /run/progress/{job_id} until the job reaches a terminal state.
 
     Returns the final progress dict (status=="completed") or raises RuntimeError on failure/timeout.
@@ -55,7 +62,9 @@ def _poll_deployment_to_completion(job_id: str, timeout_seconds: int = DEPLOYMEN
                         progress.get("message", f"Deployment job {job_id} failed")
                     )
                 if job_status == "not_found":
-                    raise RuntimeError(f"Deployment job {job_id} not found in progress store")
+                    raise RuntimeError(
+                        f"Deployment job {job_id} not found in progress store"
+                    )
                 logger.debug(
                     "Job %s: status=%s progress=%s%%",
                     job_id,
@@ -67,7 +76,10 @@ def _poll_deployment_to_completion(job_id: str, timeout_seconds: int = DEPLOYMEN
 
         time.sleep(poll_interval)
 
-    raise TimeoutError(f"Deployment job {job_id} did not complete within {timeout_seconds}s")
+    raise TimeoutError(
+        f"Deployment job {job_id} did not complete within {timeout_seconds}s"
+    )
+
 
 # Ensure the bridge network exists on startup
 def _ensure_network():
@@ -79,12 +91,15 @@ def _ensure_network():
         network_names = [net.get("Name") for net in networks]
         if backend_config.docker_bridge_network_name not in network_names:
             docker_client.create_network(
-                name=backend_config.docker_bridge_network_name,
-                driver="bridge"
+                name=backend_config.docker_bridge_network_name, driver="bridge"
             )
-            logger.info(f"Created Docker network via docker-control-service: {backend_config.docker_bridge_network_name}")
+            logger.info(
+                f"Created Docker network via docker-control-service: {backend_config.docker_bridge_network_name}"
+            )
         else:
-            logger.info(f"Docker network already exists: {backend_config.docker_bridge_network_name}")
+            logger.info(
+                f"Docker network already exists: {backend_config.docker_bridge_network_name}"
+            )
     except Exception as e:
         logger.warning(f"Could not create Docker network: {e}")
 
@@ -97,24 +112,24 @@ _ensure_network()
 # chip of a T3K board), not the board-level name ("t3k").
 _BOARD_TO_SINGLE_CHIP_DEVICE = {
     # Multi-chip Wormhole boards → constituent N300 chip
-    "T3K":    "n300",
-    "T3000":  "n300",
+    "T3K": "n300",
+    "T3000": "n300",
     "N300x4": "n300",
     "N150X4": "n150",
     # Multi-chip Blackhole boards → constituent single-chip device
-    "P150X4":  "p150",
-    "P150X8":  "p150",
-    "P300x2": "p150",   # single-chip mode only: each P300 card uses --tt-device p150
+    "P150X4": "p150",
+    "P150X8": "p150",
+    "P300x2": "p150",  # single-chip mode only: each P300 card uses --tt-device p150
     "P300Cx4": "p150",  # single-chip mode only: each P300 card uses --tt-device p150
     # Galaxy (N300-based)
-    "GALAXY":     "n300",
+    "GALAXY": "n300",
     "GALAXY_T3K": "n300",
     # True single-chip boards are unchanged
-    "N150":  "n150",
-    "N300":  "n300",
-    "E150":  "e150",
-    "P100":  "p100",
-    "P150":  "p150",
+    "N150": "n150",
+    "N300": "n300",
+    "E150": "e150",
+    "P100": "p100",
+    "P150": "p150",
     "P300": "p300",
     "unknown": "cpu",
 }
@@ -124,7 +139,14 @@ _BOARD_TO_SINGLE_CHIP_DEVICE = {
 # physical chips itself. The user can still pin one constituent chip (e.g. n300) via the
 # advanced "1 Device" mode. Per-chip-default boards (e.g. P300x2/QB2) are intentionally
 # absent so their existing per-card behavior is preserved.
-WHOLE_BOARD_DEFAULT_BOARDS = {"T3K", "T3000", "N300x4", "N150X4", "GALAXY", "GALAXY_T3K"}
+WHOLE_BOARD_DEFAULT_BOARDS = {
+    "T3K",
+    "T3000",
+    "N300x4",
+    "N150X4",
+    "GALAXY",
+    "GALAXY_T3K",
+}
 
 # Inference-server device names that denote a single chip/card (as opposed to a
 # whole-board mesh like p300x2/p150x4/t3k). Only these get pinned to a device_id;
@@ -139,33 +161,29 @@ def map_board_type_to_device_name(board_type):
         "N150": "n150",
         "N300": "n300",
         "E150": "e150",
-        
         # Wormhole multi-device
         "N150X4": "n150x4",
         "T3000": "t3k",  # T3000 maps to t3k for TT Inference Server
         "T3K": "t3k",
-        
         # Blackhole devices
         "P100": "p100",
         "P150": "p150",
         "P300": "p300",
-
         # Blackhole multi-device
         "P150X4": "p150x4",
         "P150X8": "p150x8",
-        "P300x2": "p300x2",   # 2 cards (4 chips)
+        "P300x2": "p300x2",  # 2 cards (4 chips)
         "P300Cx4": "p300cx4",  # 4 cards (8 chips)
-        
         # Galaxy systems
         "GALAXY": "galaxy",
         "GALAXY_T3K": "galaxy_t3k",
-        
-        "unknown": "cpu"  # Fallback to cpu for unknown boards
+        "unknown": "cpu",  # Fallback to cpu for unknown boards
     }
 
     device_name = board_to_device_map.get(board_type, "cpu")
     logger.info(f"Mapped board type '{board_type}' to device name '{device_name}'")
     return device_name
+
 
 def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
     """Run a docker container directly via docker-control-service (bypasses TT Inference Server).
@@ -173,7 +191,9 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
     Used for model types that are not managed by TT Inference Server (e.g. FACE_RECOGNITION).
     """
     try:
-        logger.info(f"run_container (direct) called for {impl.model_name} with device_id={device_id}, host_port={host_port}")
+        logger.info(
+            f"run_container (direct) called for {impl.model_name} with device_id={device_id}, host_port={host_port}"
+        )
 
         run_kwargs = copy.deepcopy(impl.docker_config)
 
@@ -192,7 +212,9 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
         actual_host_port = list(run_kwargs["ports"].values())[0]
         logger.info(f"host_port for container naming: {actual_host_port}")
         run_kwargs.update({"name": f"{impl.container_base_name}_p{actual_host_port}"})
-        run_kwargs.update({"hostname": f"{impl.container_base_name}_p{actual_host_port}"})
+        run_kwargs.update(
+            {"hostname": f"{impl.container_base_name}_p{actual_host_port}"}
+        )
 
         # Environment variables
         run_kwargs["environment"]["DEVICE_ID"] = str(device_id)
@@ -215,12 +237,16 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
         ports = {}
         if ports_raw:
             for container_port, h_port in ports_raw.items():
-                ports[str(container_port)] = int(h_port) if isinstance(h_port, (int, str)) else h_port
+                ports[str(container_port)] = (
+                    int(h_port) if isinstance(h_port, (int, str)) else h_port
+                )
 
         # Stringify all environment variable values (PosixPath → str)
         environment = run_kwargs.get("environment", {})
         if environment:
-            environment = {str(k): str(v) if v is not None else "" for k, v in environment.items()}
+            environment = {
+                str(k): str(v) if v is not None else "" for k, v in environment.items()
+            }
 
         api_kwargs = {
             "image": impl.image_version,
@@ -253,17 +279,29 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
         container_result = docker_client.run_container(**api_kwargs)
         logger.info(f"Container started via docker-control-service: {container_result}")
 
-        if isinstance(container_result, dict) and container_result.get("status") == "error":
-            return {"status": "error", "message": container_result.get("message", "Unknown error")}
+        if (
+            isinstance(container_result, dict)
+            and container_result.get("status") == "error"
+        ):
+            return {
+                "status": "error",
+                "message": container_result.get("message", "Unknown error"),
+            }
 
-        container_id = container_result.get("container_id") or container_result.get("id")
-        container_name = container_result.get("container_name") or container_result.get("name")
+        container_id = container_result.get("container_id") or container_result.get(
+            "id"
+        )
+        container_name = container_result.get("container_name") or container_result.get(
+            "name"
+        )
 
         # Save deployment record
         try:
             if container_id:
                 if isinstance(device_id, str):
-                    deployment_device_ids = [int(x.strip()) for x in device_id.split(",")]
+                    deployment_device_ids = [
+                        int(x.strip()) for x in device_id.split(",")
+                    ]
                 elif isinstance(device_id, (list, tuple)):
                     deployment_device_ids = [int(x) for x in device_id]
                 else:
@@ -279,7 +317,9 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
                     stopped_by_user=False,
                     port=actual_host_port,
                 )
-                logger.info(f"Saved deployment record for {container_name} (ID: {container_id})")
+                logger.info(
+                    f"Saved deployment record for {container_name} (ID: {container_id})"
+                )
         except Exception as e:
             logger.error(f"Failed to save deployment record: {e}")
 
@@ -304,6 +344,7 @@ def infer_inference_server_device(impl, board_type=None):
     truth shared by run_container and the pre-pull image resolver so they never
     disagree on which model_spec (and therefore which image) the deploy uses."""
     from shared_config.model_config import infer_chips_required
+
     if board_type is None:
         board_type = detect_board_type()
     chips_required = infer_chips_required(impl.device_configurations)
@@ -313,7 +354,10 @@ def infer_inference_server_device(impl, board_type=None):
         # if the model actually declares support for it. Media models like FLUX have no
         # p150 spec — only the whole-board mesh (p300x2). When the single chip isn't a
         # supported device for this model but the whole board is, deploy on the board mesh.
-        supported = {map_board_type_to_device_name(cfg.name) for cfg in impl.device_configurations}
+        supported = {
+            map_board_type_to_device_name(cfg.name)
+            for cfg in impl.device_configurations
+        }
         board_device = map_board_type_to_device_name(board_type)
         if device not in supported and board_device in supported:
             device = board_device
@@ -321,7 +365,13 @@ def infer_inference_server_device(impl, board_type=None):
         device = map_board_type_to_device_name(board_type)
     # Speech models need a single n150-class chip even on n300-based boards.
     if impl.model_type in [ModelTypes.TTS, ModelTypes.SPEECH_RECOGNITION]:
-        if device == "n300" and board_type in {"T3K", "T3000", "N300x4", "GALAXY", "GALAXY_T3K"}:
+        if device == "n300" and board_type in {
+            "T3K",
+            "T3000",
+            "N300x4",
+            "GALAXY",
+            "GALAXY_T3K",
+        }:
             device = "n150"
     return device
 
@@ -335,10 +385,14 @@ def deploys_whole_board(impl, board_type=None):
     like FLUX that have no single-chip spec on a multi-chip board (e.g. p300x2),
     even though `infer_chips_required` reports 1. Mirrors the device_id gate in
     run_container, which omits device_id for exactly these mesh deployments."""
-    return infer_inference_server_device(impl, board_type) not in _SINGLE_CHIP_DEVICE_NAMES
+    return (
+        infer_inference_server_device(impl, board_type) not in _SINGLE_CHIP_DEVICE_NAMES
+    )
 
 
-def run_container(impl, weights_id, device_id=0, host_port=None, use_image_override=True):
+def run_container(
+    impl, weights_id, device_id=0, host_port=None, use_image_override=True
+):
     """Run a docker container.
 
     For FACE_RECOGNITION model type, uses docker-control-service directly.
@@ -346,10 +400,12 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
     """
     # Face recognition bypasses TT Inference Server — deploy via docker-control-service
     if impl.model_type == ModelTypes.FACE_RECOGNITION:
-        return _run_direct_container(impl, weights_id, device_id=device_id, host_port=host_port)
+        return _run_direct_container(
+            impl, weights_id, device_id=device_id, host_port=host_port
+        )
 
     try:
-        logger.info(f"Calling TT Inference Server API")
+        logger.info("Calling TT Inference Server API")
         logger.info(f"run_container called for {impl.model_name}")
 
         # Determine the correct inference-server device name.
@@ -357,6 +413,7 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # must use the constituent chip device ("n300"), not the board device
         # ("t3k"). We use chips_required + board_type to pick the right name.
         from shared_config.model_config import infer_chips_required
+
         board_type = detect_board_type()
         chips_required = infer_chips_required(impl.device_configurations)
         device = infer_inference_server_device(impl, board_type)
@@ -417,8 +474,9 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # Pinned explicitly because per-device resolution would otherwise pick older
         # images on some boards (e.g. 0.10.0-555f240 for Wan on p150x4) that lack the fix.
         if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
-
+            payload["override_docker_image"] = (
+                "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+            )
 
         logger.info(f"API payload: {payload}")
 
@@ -428,32 +486,46 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         response = requests.post(
             api_url,
             json=payload,
-            timeout=60  # Short timeout: the /run endpoint returns 202 immediately
+            timeout=60,  # Short timeout: the /run endpoint returns 202 immediately
         )
 
         if response.status_code in [200, 202]:
             api_result = response.json()
-            logger.info(f"API call successful (status {response.status_code}): {api_result}")
-            logger.info(f"api_result contains docker_log_file_path: {'docker_log_file_path' in api_result}")
-            if 'docker_log_file_path' in api_result:
-                logger.info(f"api_result['docker_log_file_path'] = {api_result.get('docker_log_file_path')}")
+            logger.info(
+                f"API call successful (status {response.status_code}): {api_result}"
+            )
+            logger.info(
+                f"api_result contains docker_log_file_path: {'docker_log_file_path' in api_result}"
+            )
+            if "docker_log_file_path" in api_result:
+                logger.info(
+                    f"api_result['docker_log_file_path'] = {api_result.get('docker_log_file_path')}"
+                )
             else:
-                logger.warning(f"docker_log_file_path NOT found in api_result. Available keys: {list(api_result.keys())}")
+                logger.warning(
+                    f"docker_log_file_path NOT found in api_result. Available keys: {list(api_result.keys())}"
+                )
 
             job_id = api_result.get("job_id")
-            logger.info(f"Deployment job submitted with job_id={job_id}; handing off to background sync")
+            logger.info(
+                f"Deployment job submitted with job_id={job_id}; handing off to background sync"
+            )
 
             if job_id:
                 try:
                     # Record the full set of chip slots the model occupies but only the primary slot is passed to inference server
-                    explicit_device_ids = [int(x.strip()) for x in str(device_id).split(",")]
+                    explicit_device_ids = [
+                        int(x.strip()) for x in str(device_id).split(",")
+                    ]
                     if len(explicit_device_ids) > 1:
                         # Caller passed an explicit multi-slot list — respect it as-is.
                         deployment_device_ids = explicit_device_ids
                     elif chips_required > 1:
                         # Multi-chip models occupy `chips_required` contiguous slots starting at the allocated base slot.
                         base_slot = explicit_device_ids[0]
-                        deployment_device_ids = list(range(base_slot, base_slot + chips_required))
+                        deployment_device_ids = list(
+                            range(base_slot, base_slot + chips_required)
+                        )
                     else:
                         deployment_device_ids = explicit_device_ids
                     ModelDeployment.objects.create(
@@ -467,14 +539,21 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
                         stopped_by_user=False,
                         port=service_port,
                     )
-                    logger.info(f"Created starting deployment record for {impl.model_name} (job_id={job_id})")
+                    logger.info(
+                        f"Created starting deployment record for {impl.model_name} (job_id={job_id})"
+                    )
                 except Exception as e:
-                    logger.warning(f"Could not create ModelDeployment for job {job_id}: {e}")
+                    logger.warning(
+                        f"Could not create ModelDeployment for job {job_id}: {e}"
+                    )
                 try:
                     from docker_control.deployment_sync import start_deployment_sync
+
                     start_deployment_sync(job_id)
                 except Exception as e:
-                    logger.warning(f"Could not start deployment sync for job {job_id}: {e}")
+                    logger.warning(
+                        f"Could not start deployment sync for job {job_id}: {e}"
+                    )
             else:
                 logger.warning("No job_id in 202 response")
 
@@ -484,7 +563,9 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
                 "message": "Deployment started",
             }
         else:
-            error_msg = f"API call failed with status {response.status_code}: {response.text}"
+            error_msg = (
+                f"API call failed with status {response.status_code}: {response.text}"
+            )
             logger.error(error_msg)
 
             # Try to extract job_id and error details from response
@@ -494,18 +575,14 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
                 error_data = response.json()
                 if isinstance(error_data, dict):
                     # Extract job_id if present
-                    job_id = error_data.get('job_id')
+                    job_id = error_data.get("job_id")
                     # Extract error message if present
-                    error_detail = error_data.get('message', error_msg)
+                    error_detail = error_data.get("message", error_msg)
                     logger.info(f"Extracted job_id from error response: {job_id}")
             except Exception as parse_error:
                 logger.warning(f"Could not parse error response: {parse_error}")
 
-            return {
-                "status": "error",
-                "message": error_detail,
-                "job_id": job_id
-            }
+            return {"status": "error", "message": error_detail, "job_id": job_id}
 
     except requests.exceptions.RequestException as e:
         error_msg = f"Network error calling TT Inference Server API: {str(e)}"
@@ -516,27 +593,31 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         logger.error(error_msg)
         return {"status": "error", "message": error_msg}
 
+
 def run_agent_container(container_name, port_bindings, impl):
     # runs agent container after associated llm container runs
     run_kwargs = copy.deepcopy(impl.docker_config)
-    host_agent_port = get_host_agent_port()
-    llm_host_port = list(port_bindings.values())[0] # port that llm is using for naming convention (for easier removal later)
+    host_agent_port = get_host_port(impl)
+    llm_host_port = list(port_bindings.values())[
+        0
+    ]  # port that llm is using for naming convention (for easier removal later)
 
     docker_client = get_docker_client()
     docker_client.run_container(
-        image='agent_image:v1',
+        image="agent_image:v1",
         command=f"uvicorn agent:app --reload --host 0.0.0.0 --port {host_agent_port}",
-        name=f'ai_agent_container_p{llm_host_port}',
-        network='tt_studio_network',
-        ports={'8080/tcp': host_agent_port},
+        name=f"ai_agent_container_p{llm_host_port}",
+        network="tt_studio_network",
+        ports={"8080/tcp": host_agent_port},
         environment={
-            'TAVILY_API_KEY': os.getenv('TAVILY_API_KEY'),
-            'LLM_CONTAINER_NAME': container_name,
-            'JWT_SECRET': run_kwargs["environment"]['JWT_SECRET'],
-            'HF_MODEL_PATH': run_kwargs["environment"]["HF_MODEL_PATH"]
+            "TAVILY_API_KEY": os.getenv("TAVILY_API_KEY"),
+            "LLM_CONTAINER_NAME": container_name,
+            "JWT_SECRET": run_kwargs["environment"]["JWT_SECRET"],
+            "HF_MODEL_PATH": run_kwargs["environment"]["HF_MODEL_PATH"],
         },
-        detach=True
+        detach=True,
     )
+
 
 def stop_container(container_id):
     """Stop and remove a specific docker container"""
@@ -648,14 +729,15 @@ def get_host_port(impl):
     return None
 
 
-
 def get_managed_containers():
     """get containers configured in model_config.py for LLM-studio management"""
     docker_client = get_docker_client()
     response = docker_client.list_containers(all=False)
 
     # Extract containers array from response
-    containers_list = response.get("containers", []) if isinstance(response, dict) else []
+    containers_list = (
+        response.get("containers", []) if isinstance(response, dict) else []
+    )
 
     managed_images = set([impl.image_version for impl in model_implmentations.values()])
     managed_containers = []
@@ -669,9 +751,9 @@ def get_managed_containers():
                 self.status = data.get("status")
                 self.attrs = data
                 # Create image object
-                self.image = type('obj', (object,), {
-                    'tags': data.get("image_tags", [])
-                })()
+                self.image = type(
+                    "obj", (object,), {"tags": data.get("image_tags", [])}
+                )()
 
             @property
             def health(self):
@@ -820,13 +902,12 @@ def _enrich_container_with_model_impl(con, con_id):
     This is the matching logic previously inline in ``update_deploy_cache``.
     It is now reusable from both that function and ``get_canonical_deployments``.
     """
-    con_model_id = con['env_vars'].get("MODEL_ID")
+    con_model_id = con["env_vars"].get("MODEL_ID")
     model_impl = model_implmentations.get(con_model_id)
     if not model_impl:
         # TT Inference Server containers identify themselves via cache env vars.
         is_tt_inference_container = (
-            "CACHE_ROOT" in con['env_vars']
-            or "TT_CACHE_PATH" in con['env_vars']
+            "CACHE_ROOT" in con["env_vars"] or "TT_CACHE_PATH" in con["env_vars"]
         )
 
         if is_tt_inference_container:
@@ -838,6 +919,7 @@ def _enrich_container_with_model_impl(con, con_id):
             deployment_found = False
             try:
                 from docker_control.models import ModelDeployment
+
                 deployment = ModelDeployment.objects.filter(container_id=con_id).first()
 
                 if deployment:
@@ -883,7 +965,10 @@ def _enrich_container_with_model_impl(con, con_id):
                 if not model_impl:
                     best_match_len = 0
                     for _k, v in model_implmentations.items():
-                        if v.model_name in con["name"] and len(v.model_name) > best_match_len:
+                        if (
+                            v.model_name in con["name"]
+                            and len(v.model_name) > best_match_len
+                        ):
                             model_impl = v
                             best_match_len = len(v.model_name)
                     if model_impl:
@@ -899,12 +984,14 @@ def _enrich_container_with_model_impl(con, con_id):
         else:
             # Legacy containers: match by container name then by image version.
             candidates = [
-                v for _k, v in model_implmentations.items()
+                v
+                for _k, v in model_implmentations.items()
                 if v.model_name == con["name"]
             ]
             if not candidates:
                 candidates = [
-                    v for _k, v in model_implmentations.items()
+                    v
+                    for _k, v in model_implmentations.items()
                     if v.image_version == con["image_name"]
                 ]
             if not candidates:
@@ -919,7 +1006,9 @@ def _enrich_container_with_model_impl(con, con_id):
     con["model_impl"] = model_impl
 
     if backend_config.docker_bridge_network_name in con["networks"].keys():
-        hostname = con["networks"][backend_config.docker_bridge_network_name]["DNSNames"][0]
+        hostname = con["networks"][backend_config.docker_bridge_network_name][
+            "DNSNames"
+        ][0]
         # Resolve the real bound port (slot-based 7000+device_id) instead of
         # the static catalog service_port.
         actual_port = model_impl.service_port
@@ -940,14 +1029,16 @@ def _enrich_container_with_model_impl(con, con_id):
 
 # Mirrors ChipSlotAllocator._STARTING_GRACE_SECONDS. Records younger than this are trusted during the placeholder
 # window between Django creating the row and deployment_sync swapping in the real container_id.
-_CANONICAL_STARTING_GRACE_SECONDS = 60        # chat/LLM: container appears within seconds
-_CANONICAL_STARTING_GRACE_MEDIA_SECONDS = 3600  # media: weight download can take 60+ min on host
+_CANONICAL_STARTING_GRACE_SECONDS = 60  # chat/LLM: container appears within seconds
+_CANONICAL_STARTING_GRACE_MEDIA_SECONDS = (
+    3600  # media: weight download can take 60+ min on host
+)
 
 
 def get_canonical_deployments():
     """Single source of truth for current deployed models.
 
-    Joins DB records with live Docker container information by matching on container_id OR container_name. 
+    Joins DB records with live Docker container information by matching on container_id OR container_name.
     The name match fallback is load-bearing for the CHAT-model placeholder window: until
     deployment_sync swaps the real container_id in, the store's container_id is the FastAPI job_id, but the actual container exists under its name.
     Records with status="running" or status="starting" beyond the grace window that have no matching live container are reconciled to status="stopped".
@@ -964,6 +1055,7 @@ def get_canonical_deployments():
 
     try:
         from docker_control.models import ModelDeployment
+
         active_deployments = list(
             ModelDeployment.objects.filter(status__in=["starting", "running"])
         )
@@ -994,7 +1086,9 @@ def get_canonical_deployments():
             enriched = _enrich_container_with_model_impl(entry, match_id)
             entry["source"] = "managed"
             entry["is_pending"] = False
-            entry["deployed_at"] = dep.deployed_at.isoformat() if dep.deployed_at else None
+            entry["deployed_at"] = (
+                dep.deployed_at.isoformat() if dep.deployed_at else None
+            )
             entry["stopped_by_user"] = bool(getattr(dep, "stopped_by_user", False))
             entry["deployment_id"] = dep.id
             entry["deployment_model_name"] = dep.model_name
@@ -1008,7 +1102,11 @@ def get_canonical_deployments():
         if dep.status == "starting" and dep.deployed_at is not None:
             age = (now_utc - dep.deployed_at).total_seconds()
             _impl = next(
-                (v for v in model_implmentations.values() if v.model_name == dep.model_name),
+                (
+                    v
+                    for v in model_implmentations.values()
+                    if v.model_name == dep.model_name
+                ),
                 None,
             )
             _grace = (
@@ -1029,7 +1127,7 @@ def get_canonical_deployments():
                     "env_vars": {},
                     "device_id": dep.device_id,
                     "device_ids": list(getattr(dep, "device_ids", None) or [])
-                                  or ([dep.device_id] if dep.device_id is not None else None),
+                    or ([dep.device_id] if dep.device_id is not None else None),
                     "model_impl": None,
                     "model_id": None,
                     "weights_id": None,
@@ -1037,7 +1135,9 @@ def get_canonical_deployments():
                     "health_url": None,
                     "source": "managed",
                     "is_pending": True,
-                    "deployed_at": dep.deployed_at.isoformat() if dep.deployed_at else None,
+                    "deployed_at": dep.deployed_at.isoformat()
+                    if dep.deployed_at
+                    else None,
                     "stopped_by_user": False,
                     "deployment_id": dep.id,
                     "deployment_model_name": dep.model_name,
@@ -1094,7 +1194,10 @@ def serialize_canonical_entry_for_http(entry):
         except Exception:
             impl_dict = {}
         # device_configurations is a list of enums — render names
-        if "device_configurations" in impl_dict and impl_dict["device_configurations"] is not None:
+        if (
+            "device_configurations" in impl_dict
+            and impl_dict["device_configurations"] is not None
+        ):
             impl_dict["device_configurations"] = [
                 getattr(e, "name", str(e)) for e in impl_dict["device_configurations"]
             ]
@@ -1115,7 +1218,7 @@ def serialize_canonical_entry_for_http(entry):
 def update_deploy_cache():
     """Materialize get_canonical_deployments() into the LocMemCache.
 
-    Only running, fully-enriched "managed" deployments (those with a resolved model_impl and an internal_url) are written. 
+    Only running, fully-enriched "managed" deployments (those with a resolved model_impl and an internal_url) are written.
     This preserves the existing semantics callers of get_deploy_cache() rely on: every cached entry has a Python-object model_impl they can read attributes off.
     """
     canonical = get_canonical_deployments()
@@ -1127,7 +1230,8 @@ def update_deploy_cache():
         cached_container_ids.add(clean_key)
 
     keepable_ids = {
-        con_id for con_id, entry in canonical.items()
+        con_id
+        for con_id, entry in canonical.items()
         if entry.get("source") == "managed"
         and entry.get("model_impl") is not None
         and entry.get("internal_url")
@@ -1196,7 +1300,9 @@ def perform_reset():
                 try:
                     stdout, _ = process.communicate(timeout=90)
                     last_output = stdout
-                    logger.info(f"tt-smi -r attempt {attempt} output: {stdout.strip()!r:.200}")
+                    logger.info(
+                        f"tt-smi -r attempt {attempt} output: {stdout.strip()!r:.200}"
+                    )
 
                     if process.returncode == 0:
                         logger.info(f"Reset succeeded on attempt {attempt}")
@@ -1254,13 +1360,16 @@ def perform_reset():
             "http_status": 500,
         }
 
+
 def perform_device_reset(device_id: int):
     """
     Reset a specific TT chip/device using tt-smi -r <device_id>.
     Up to 2 attempts with 30-second timeout each.
     """
     try:
-        logger.info(f"Starting chip reset for device {device_id} — running tt-smi -r {device_id}")
+        logger.info(
+            f"Starting chip reset for device {device_id} — running tt-smi -r {device_id}"
+        )
 
         SystemResourceService.set_resetting_state()
 
@@ -1282,10 +1391,14 @@ def perform_device_reset(device_id: int):
                 try:
                     stdout, _ = process.communicate(timeout=30)
                     last_output = stdout
-                    logger.info(f"tt-smi -r {device_id} attempt {attempt} output: {stdout.strip()!r:.200}")
+                    logger.info(
+                        f"tt-smi -r {device_id} attempt {attempt} output: {stdout.strip()!r:.200}"
+                    )
 
                     if process.returncode == 0:
-                        logger.info(f"Device {device_id} reset succeeded on attempt {attempt}")
+                        logger.info(
+                            f"Device {device_id} reset succeeded on attempt {attempt}"
+                        )
                         SystemResourceService.clear_device_state_cache()
                         return {
                             "status": "success",
@@ -1300,7 +1413,9 @@ def perform_device_reset(device_id: int):
                     )
 
                 except subprocess.TimeoutExpired:
-                    logger.warning(f"Device {device_id} reset attempt {attempt} timed out after 30s")
+                    logger.warning(
+                        f"Device {device_id} reset attempt {attempt} timed out after 30s"
+                    )
                     try:
                         os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                         process.wait(timeout=2)
@@ -1312,7 +1427,9 @@ def perform_device_reset(device_id: int):
                     last_output = "(timeout)"
 
             except Exception as exc:
-                logger.error(f"Device {device_id} reset attempt {attempt} raised exception: {exc}")
+                logger.error(
+                    f"Device {device_id} reset attempt {attempt} raised exception: {exc}"
+                )
                 last_output = str(exc)
 
         logger.error(f"All {MAX_ATTEMPTS} reset attempts for device {device_id} failed")
@@ -1487,9 +1604,7 @@ def perform_devices_reset(device_ids):
         }
 
     except Exception as e:
-        logger.exception(
-            f"Unexpected error during batched reset of devices {pretty}"
-        )
+        logger.exception(f"Unexpected error during batched reset of devices {pretty}")
         SystemResourceService.clear_device_state_cache()
         per_device = [
             {
@@ -1526,40 +1641,33 @@ def check_image_exists(image_name, image_tag):
             # Get all images to find size info
             response = docker_client.list_images()
             # Extract images array from response dict
-            images_list = response.get("images", []) if isinstance(response, dict) else []
+            images_list = (
+                response.get("images", []) if isinstance(response, dict) else []
+            )
             for image_data in images_list:
                 tags = image_data.get("tags", [])
-                if target_image in tags or any(image_name in tag and image_tag in tag for tag in tags):
+                if target_image in tags or any(
+                    image_name in tag and image_tag in tag for tag in tags
+                ):
                     size_bytes = image_data.get("size", 0)
                     size_mb = round(size_bytes / (1024 * 1024), 2)
                     logger.info(f"Found image: {target_image}")
                     return {
                         "exists": True,
                         "size": f"{size_mb}MB",
-                        "status": "available"
+                        "status": "available",
                     }
 
             # Image exists but no size info
-            return {
-                "exists": True,
-                "size": "unknown",
-                "status": "available"
-            }
+            return {"exists": True, "size": "unknown", "status": "available"}
 
         logger.warning(f"Image not found: {target_image}")
-        return {
-            "exists": False,
-            "size": "0MB",
-            "status": "not_pulled"
-        }
+        return {"exists": False, "size": "0MB", "status": "not_pulled"}
 
     except Exception as e:
         logger.error(f"Error checking image status: {str(e)}")
-        return {
-            "exists": False,
-            "size": "0MB",
-            "status": "error"
-        }
+        return {"exists": False, "size": "0MB", "status": "error"}
+
 
 def detect_board_type():
     """Detect board type using cached data from SystemResourceService"""
@@ -1574,14 +1682,21 @@ def notify_agent_of_new_container(container_name):
     """Notify the agent about a new container deployment"""
     try:
         import requests
+
         agent_url = "http://tt_studio_agent:8080/refresh"
         response = requests.post(agent_url, timeout=10)
-        
+
         if response.status_code == 200:
-            logger.info(f"Successfully notified agent about new container: {container_name}")
+            logger.info(
+                f"Successfully notified agent about new container: {container_name}"
+            )
         else:
-            logger.warning(f"Failed to notify agent (status {response.status_code}): {response.text}")
-            
+            logger.warning(
+                f"Failed to notify agent (status {response.status_code}): {response.text}"
+            )
+
     except Exception as e:
-        logger.warning(f"Failed to notify agent about new container {container_name}: {e}")
+        logger.warning(
+            f"Failed to notify agent about new container {container_name}: {e}"
+        )
         # Don't fail the deployment if agent notification fails

--- a/app/backend/docker_control/health_monitor.py
+++ b/app/backend/docker_control/health_monitor.py
@@ -61,6 +61,7 @@ def _cleanup_stale_starting_records():
                     )
                     try:
                         from docker_control.docker_utils import stop_container
+
                         stop_container(dep.container_id)
                     except Exception as stop_err:
                         logger.debug(
@@ -85,7 +86,9 @@ def check_container_health():
         if not running_deployments.exists():
             return
 
-        logger.debug(f"Checking health of {running_deployments.count()} running deployments")
+        logger.debug(
+            f"Checking health of {running_deployments.count()} running deployments"
+        )
 
         # Check actual Docker container status via docker-control-service
         docker_client = get_docker_client()
@@ -94,19 +97,28 @@ def check_container_health():
             try:
                 # Get container info from docker-control-service
                 container_info = docker_client.get_container(deployment.container_id)
-                actual_status = container_info.get("status", "unknown")  # running, exited, dead, etc.
+                actual_status = container_info.get(
+                    "status", "unknown"
+                )  # running, exited, dead, etc.
 
                 # If container is not running but we didn't mark it as stopped by user
-                if actual_status not in ["running", "restarting"] and not deployment.stopped_by_user:
+                if (
+                    actual_status not in ["running", "restarting"]
+                    and not deployment.stopped_by_user
+                ):
                     # Container died unexpectedly!
-                    logger.warning(f"Container {deployment.container_name} died unexpectedly. Status: {actual_status}")
+                    logger.warning(
+                        f"Container {deployment.container_name} died unexpectedly. Status: {actual_status}"
+                    )
 
                     deployment.status = actual_status  # exited, dead, etc.
                     deployment.stopped_at = timezone.now()
                     deployment.save()
 
                     # TODO: Emit event for frontend notification
-                    logger.info(f"Updated deployment record for unexpected death: {deployment.container_name}")
+                    logger.info(
+                        f"Updated deployment record for unexpected death: {deployment.container_name}"
+                    )
 
             except Exception as e:
                 # Check if it's a 404 (container not found)
@@ -114,16 +126,22 @@ def check_container_health():
                 if "not found" in error_msg or "404" in error_msg:
                     # Container doesn't exist anymore - it died
                     if not deployment.stopped_by_user:
-                        logger.warning(f"Container {deployment.container_name} not found - marking as dead")
+                        logger.warning(
+                            f"Container {deployment.container_name} not found - marking as dead"
+                        )
                         deployment.status = "dead"
                         deployment.stopped_at = timezone.now()
                         deployment.save()
 
                         # TODO: Emit event for frontend notification
-                        logger.info(f"Updated deployment record for missing container: {deployment.container_name}")
+                        logger.info(
+                            f"Updated deployment record for missing container: {deployment.container_name}"
+                        )
                 else:
-                    logger.error(f"Error checking container {deployment.container_id}: {e}")
-                
+                    logger.error(
+                        f"Error checking container {deployment.container_id}: {e}"
+                    )
+
     except Exception as e:
         logger.error(f"Error in check_container_health: {e}")
 
@@ -135,7 +153,7 @@ def health_monitoring_loop():
     """Background thread that continuously monitors container health.
 
     Polls every _HEALTH_POLL_INTERVAL_SECONDS (5 s by default). Read-time
-    reconciliation in get_canonical_deployments now catches dead containers on the next status fetch regardless of this loop, so this thread is the persistence layer (writing status="dead" / etc. to the store) rather than the sole detection path. 
+    reconciliation in get_canonical_deployments now catches dead containers on the next status fetch regardless of this loop, so this thread is the persistence layer (writing status="dead" / etc. to the store) rather than the sole detection path.
     A 5s interval keeps the persistent store roughly current at negligible CPU cost.
     """
     global _stop_monitoring
@@ -159,11 +177,11 @@ def health_monitoring_loop():
 def start_health_monitoring():
     """Start the health monitoring background thread"""
     global _monitoring_thread, _stop_monitoring
-    
+
     if _monitoring_thread is not None and _monitoring_thread.is_alive():
         logger.info("Health monitoring is already running")
         return
-    
+
     _stop_monitoring = False
     _monitoring_thread = threading.Thread(target=health_monitoring_loop, daemon=True)
     _monitoring_thread.start()
@@ -173,9 +191,8 @@ def start_health_monitoring():
 def stop_health_monitoring():
     """Stop the health monitoring background thread"""
     global _stop_monitoring, _monitoring_thread
-    
+
     _stop_monitoring = True
     if _monitoring_thread:
         _monitoring_thread.join(timeout=5)
     logger.info("Health monitoring stopped")
-

--- a/app/backend/docker_control/image_pull.py
+++ b/app/backend/docker_control/image_pull.py
@@ -43,7 +43,7 @@ _lock = threading.Lock()
 
 _POLL_INTERVAL_SECONDS = 1.5
 _PULL_TIMEOUT_SECONDS = 2 * 60 * 60  # 2h hard cap; large multi-GB images
-_ENTRY_TTL_SECONDS = 3600            # evict finished entries after an hour
+_ENTRY_TTL_SECONDS = 3600  # evict finished entries after an hour
 # A pull can run for many minutes — longer than the canonical "starting" grace
 # window — so we periodically refresh the placeholder deployment record's
 # timestamp (via heartbeat_fn) to keep it alive and its chip slot reserved.
@@ -56,14 +56,14 @@ DeployFn = Callable[[], Tuple[Optional[str], Optional[str]]]
 def _new_entry(image_ref: str) -> dict:
     now = time.time()
     return {
-        "status": "pulling",          # pulling | success | error
+        "status": "pulling",  # pulling | success | error
         "downloaded_bytes": 0,
         "total_bytes": 0,
         "speed_bps": None,
         "eta_seconds": None,
         "layers_done": 0,
         "layers_total": 0,
-        "peak_progress": 0,           # running max of reported %, to keep progress monotonic
+        "peak_progress": 0,  # running max of reported %, to keep progress monotonic
         "message": "Preparing to pull image…",
         "image_ref": image_ref,
         "real_job_id": None,
@@ -112,7 +112,8 @@ def clamp_progress_pct(pull_id: str, pct: int) -> int:
 def _evict_stale_locked() -> None:
     now = time.time()
     stale = [
-        pid for pid, e in _image_pull_jobs.items()
+        pid
+        for pid, e in _image_pull_jobs.items()
         if e["status"] != "pulling" and now - e["updated_at"] > _ENTRY_TTL_SECONDS
     ]
     for pid in stale:
@@ -150,7 +151,9 @@ def start_prepull_and_deploy(
         name=f"prepull-{pull_id[:12]}",
     )
     thread.start()
-    logger.info(f"[image_pull] started pre-pull worker for {image_ref} (pull_id={pull_id})")
+    logger.info(
+        f"[image_pull] started pre-pull worker for {image_ref} (pull_id={pull_id})"
+    )
 
 
 def _worker(
@@ -178,7 +181,9 @@ def _worker(
             client.start_image_pull(image_name, image_tag, pull_id)
             pull_started = True
         except Exception as e:
-            logger.warning(f"[image_pull] could not start streamed pull for {pull_id}: {e}")
+            logger.warning(
+                f"[image_pull] could not start streamed pull for {pull_id}: {e}"
+            )
 
         # Mirror progress until the pull reaches a terminal state.
         if pull_started:
@@ -251,11 +256,14 @@ def _worker(
 
     except Exception as e:
         logger.error(f"[image_pull] worker crashed for {pull_id}: {e}", exc_info=True)
-        _update(pull_id, status="error", error=str(e), message=f"Deployment failed: {e}")
+        _update(
+            pull_id, status="error", error=str(e), message=f"Deployment failed: {e}"
+        )
     finally:
         # Release this thread's DB connection.
         try:
             from django.db import connection
+
             connection.close()
         except Exception:
             pass

--- a/app/backend/docker_control/serializers.py
+++ b/app/backend/docker_control/serializers.py
@@ -2,11 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-from pathlib import Path
 
 from rest_framework import serializers
 
-from shared_config.backend_config import backend_config
 from shared_config.model_config import model_implmentations
 from .docker_utils import get_model_weights_path
 
@@ -17,7 +15,9 @@ class DeploymentSerializer(serializers.Serializer):
     # device_id accepts a single integer OR a comma-separated list (e.g. "0,1") for
     # multi-chip single-card deployments where --device-id 0,1 is passed to the inference server.
     device_id = serializers.CharField(required=False, default="0", allow_blank=True)
-    host_port = serializers.IntegerField(required=False, default=None, min_value=1024, max_value=65535, allow_null=True)
+    host_port = serializers.IntegerField(
+        required=False, default=None, min_value=1024, max_value=65535, allow_null=True
+    )
     force_full_board = serializers.BooleanField(required=False, default=False)
 
     def validate_device_id(self, value):

--- a/app/backend/docker_control/test_docker_control_api.py
+++ b/app/backend/docker_control/test_docker_control_api.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import json
-import time
 
 import requests
 import jwt
@@ -14,7 +13,6 @@ from shared_config.model_config import model_implmentations
 
 from .test_docker_utils import (
     wait_for_vllm_healthy_endpoint,
-    valid_api_call,
     valid_vllm_api_call,
 )
 
@@ -78,7 +76,7 @@ def stop_model(backend_host, container_id):
     final = None
     for line in response.iter_lines():
         if line and line.startswith(b"data: "):
-            event = json.loads(line[len(b"data: "):])
+            event = json.loads(line[len(b"data: ") :])
             if event.get("type") == "complete":
                 final = event
     logger.info(f"final event:= {final}")
@@ -133,104 +131,94 @@ class ModelCatalogViewTests(APITestCase):
         # Get a valid model_id from model_implmentations
         self.model_id = list(model_implmentations.keys())[0]
         self.model = model_implmentations[self.model_id]
-        self.url = reverse('model_catalog')
-        
+        self.url = reverse("model_catalog")
+
     def test_get_catalog_status(self):
         """Test getting catalog status"""
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', response.data)
-        self.assertIn('models', response.data)
-        self.assertIn(self.model_id, response.data['models'])
-        
-        model_data = response.data['models'][self.model_id]
-        self.assertIn('model_name', model_data)
-        self.assertIn('model_type', model_data)
-        self.assertIn('image_version', model_data)
-        self.assertIn('exists', model_data)
-        self.assertIn('disk_usage', model_data)
-        
+        self.assertIn("status", response.data)
+        self.assertIn("models", response.data)
+        self.assertIn(self.model_id, response.data["models"])
+
+        model_data = response.data["models"][self.model_id]
+        self.assertIn("model_name", model_data)
+        self.assertIn("model_type", model_data)
+        self.assertIn("image_version", model_data)
+        self.assertIn("exists", model_data)
+        self.assertIn("disk_usage", model_data)
+
     def test_pull_model(self):
         """Test pulling a model"""
         response = self.client.post(
-            self.url,
-            {'model_id': self.model_id},
-            format='json'
+            self.url, {"model_id": self.model_id}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', response.data)
-        
+        self.assertIn("status", response.data)
+
     def test_pull_model_with_sse(self):
         """Test pulling a model with SSE updates"""
         response = self.client.post(
             self.url,
-            {'model_id': self.model_id},
-            format='json',
-            HTTP_ACCEPT='text/event-stream'
+            {"model_id": self.model_id},
+            format="json",
+            HTTP_ACCEPT="text/event-stream",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response['Content-Type'], 'text/event-stream')
-        
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+
     def test_pull_invalid_model(self):
         """Test pulling an invalid model"""
         response = self.client.post(
-            self.url,
-            {'model_id': 'invalid_model'},
-            format='json'
+            self.url, {"model_id": "invalid_model"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        
+
     def test_eject_model(self):
         """Test ejecting a model"""
         response = self.client.delete(
-            self.url,
-            {'model_id': self.model_id},
-            format='json'
+            self.url, {"model_id": self.model_id}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', response.data)
-        self.assertEqual(response.data['status'], 'success')
-        
+        self.assertIn("status", response.data)
+        self.assertEqual(response.data["status"], "success")
+
     def test_eject_invalid_model(self):
         """Test ejecting an invalid model"""
         response = self.client.delete(
-            self.url,
-            {'model_id': 'invalid_model'},
-            format='json'
+            self.url, {"model_id": "invalid_model"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        
+
     def test_cancel_pull(self):
         """Test cancelling a model pull"""
         response = self.client.patch(
-            self.url,
-            {'model_id': self.model_id},
-            format='json'
+            self.url, {"model_id": self.model_id}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', response.data)
-        self.assertEqual(response.data['status'], 'success')
-        
+        self.assertIn("status", response.data)
+        self.assertEqual(response.data["status"], "success")
+
     def test_cancel_invalid_pull(self):
         """Test cancelling an invalid model pull"""
         response = self.client.patch(
-            self.url,
-            {'model_id': 'invalid_model'},
-            format='json'
+            self.url, {"model_id": "invalid_model"}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class DockerPullTest(APITestCase):
     """Test suite for Docker image pull functionality with SSE streaming"""
-    
+
     def setUp(self):
         # Get a valid model_id from model_implmentations
         self.model_id = list(model_implmentations.keys())[0]
         self.model = model_implmentations[self.model_id]
-        self.pull_url = reverse('docker-pull-image')
-        self.status_url = reverse('docker-image-status', kwargs={'model_id': self.model_id})
-        
+        self.pull_url = reverse("docker-pull-image")
+        self.status_url = reverse(
+            "docker-image-status", kwargs={"model_id": self.model_id}
+        )
+
     def test_pull_image_with_sse(self):
         """Test pulling a Docker image with SSE streaming updates"""
         # First check initial image status
@@ -238,109 +226,92 @@ class DockerPullTest(APITestCase):
         self.assertEqual(status_response.status_code, status.HTTP_200_OK)
         initial_status = status_response.json()
         logger.info(f"Initial image status: {initial_status}")
-        
+
         # Start the pull with SSE
-        headers = {
-            'Accept': 'text/event-stream',
-            'Content-Type': 'application/json'
-        }
-        data = {'model_id': self.model_id}
-        
+        data = {"model_id": self.model_id}
+
         # Make the request and get the streaming response
         response = self.client.post(
-            self.pull_url,
-            data=data,
-            format='json',
-            HTTP_ACCEPT='text/event-stream'
+            self.pull_url, data=data, format="json", HTTP_ACCEPT="text/event-stream"
         )
-        
+
         # Verify response is streaming
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response['Content-Type'], 'text/event-stream')
-        
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+
         # Process the SSE stream
         events = []
-        for line in response.content.decode('utf-8').split('\n'):
-            if line.startswith('data: '):
+        for line in response.content.decode("utf-8").split("\n"):
+            if line.startswith("data: "):
                 try:
                     event_data = json.loads(line[6:])
                     events.append(event_data)
                     logger.info(f"Received SSE event: {event_data}")
-                    
+
                     # Verify event structure
-                    self.assertIn('status', event_data)
-                    self.assertIn('progress', event_data)
-                    if 'message' in event_data:
-                        self.assertIsInstance(event_data['message'], str)
+                    self.assertIn("status", event_data)
+                    self.assertIn("progress", event_data)
+                    if "message" in event_data:
+                        self.assertIsInstance(event_data["message"], str)
                 except json.JSONDecodeError:
                     logger.error(f"Failed to parse SSE data: {line}")
-        
+
         # Verify we got some events
         self.assertTrue(len(events) > 0, "No SSE events received")
-        
+
         # Verify first event is "starting"
-        self.assertEqual(events[0]['status'], 'starting')
-        self.assertEqual(events[0]['progress'], 0)
-        
+        self.assertEqual(events[0]["status"], "starting")
+        self.assertEqual(events[0]["progress"], 0)
+
         # Verify last event is "success" or "error"
         last_event = events[-1]
-        self.assertIn(last_event['status'], ['success', 'error'])
-        if last_event['status'] == 'success':
-            self.assertEqual(last_event['progress'], 100)
-        
+        self.assertIn(last_event["status"], ["success", "error"])
+        if last_event["status"] == "success":
+            self.assertEqual(last_event["progress"], 100)
+
         # Check final image status
         final_status_response = self.client.get(self.status_url)
         self.assertEqual(final_status_response.status_code, status.HTTP_200_OK)
         final_status = final_status_response.json()
         logger.info(f"Final image status: {final_status}")
-        
+
         # If pull was successful, verify image exists
-        if last_event['status'] == 'success':
-            self.assertTrue(final_status['exists'])
-            self.assertNotEqual(final_status['size'], '0MB')
-    
+        if last_event["status"] == "success":
+            self.assertTrue(final_status["exists"])
+            self.assertNotEqual(final_status["size"], "0MB")
+
     def test_pull_image_regular(self):
         """Test pulling a Docker image with regular (non-SSE) response"""
-        data = {'model_id': self.model_id}
-        response = self.client.post(self.pull_url, data=data, format='json')
-        
+        data = {"model_id": self.model_id}
+        response = self.client.post(self.pull_url, data=data, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', response.data)
-        self.assertIn('message', response.data)
-    
+        self.assertIn("status", response.data)
+        self.assertIn("message", response.data)
+
     def test_pull_invalid_model(self):
         """Test pulling an invalid model ID"""
-        data = {'model_id': 'invalid_model_id'}
+        data = {"model_id": "invalid_model_id"}
         response = self.client.post(
-            self.pull_url,
-            data=data,
-            format='json',
-            HTTP_ACCEPT='text/event-stream'
+            self.pull_url, data=data, format="json", HTTP_ACCEPT="text/event-stream"
         )
-        
+
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn('message', response.data)
-        self.assertIn('not found', response.data['message'].lower())
-    
+        self.assertIn("message", response.data)
+        self.assertIn("not found", response.data["message"].lower())
+
     def test_pull_cancellation(self):
         """Test cancelling an ongoing pull"""
         # Start a pull
-        data = {'model_id': self.model_id}
-        pull_response = self.client.post(
-            self.pull_url,
-            data=data,
-            format='json',
-            HTTP_ACCEPT='text/event-stream'
+        data = {"model_id": self.model_id}
+        self.client.post(
+            self.pull_url, data=data, format="json", HTTP_ACCEPT="text/event-stream"
         )
-        
+
         # Cancel the pull
-        cancel_url = reverse('docker-cancel-pull')
-        cancel_response = self.client.patch(
-            cancel_url,
-            data=data,
-            format='json'
-        )
-        
+        cancel_url = reverse("docker-cancel-pull")
+        cancel_response = self.client.patch(cancel_url, data=data, format="json")
+
         self.assertEqual(cancel_response.status_code, status.HTTP_200_OK)
-        self.assertIn('status', cancel_response.data)
-        self.assertEqual(cancel_response.data['status'], 'success')
+        self.assertIn("status", cancel_response.data)
+        self.assertEqual(cancel_response.data["status"], "success")

--- a/app/backend/docker_control/test_docker_utils.py
+++ b/app/backend/docker_control/test_docker_utils.py
@@ -12,7 +12,6 @@ from requests.exceptions import RequestException
 import jwt
 
 from shared_config.backend_config import backend_config
-from shared_config.device_config import DeviceConfigurations
 from shared_config.logger_config import get_logger
 from shared_config.model_config import model_implmentations
 from .docker_utils import run_container, stop_container
@@ -57,12 +56,13 @@ def test_deploy_mock_model():
     except Exception as e:
         logger.error(f"Error: {e}")
         has_error = True
+        error = e
     # 3. stop container
     logger.info(f"stop deployed container: container_id={container_id}")
     stop_status = stop_container(container_id)
     logger.info(f"status:={stop_status}")
     if has_error:
-        raise e
+        raise error
     assert stop_status["status"] == "success"
 
 
@@ -159,7 +159,6 @@ def valid_vllm_api_call(api_url, headers, vllm_model, print_output=True):
         "stream": True,
         "stop": ["<|eot_id|>"],
     }
-    req_time = time.time()
     # using requests stream=True, make sure to set a timeout
     response = requests.post(
         api_url, json=json_data, headers=headers, stream=True, timeout=35

--- a/app/backend/docker_control/tests.py
+++ b/app/backend/docker_control/tests.py
@@ -22,7 +22,9 @@ class _FakeDeployment:
 
 class ChipAllocatorDeviceIdsTests(TestCase):
     def _make_allocator(self) -> ChipSlotAllocator:
-        with patch.object(ChipSlotAllocator, "_detect_board_type", return_value="P300x2"):
+        with patch.object(
+            ChipSlotAllocator, "_detect_board_type", return_value="P300x2"
+        ):
             return ChipSlotAllocator()
 
     def test_get_chip_status_marks_all_device_ids_occupied(self):
@@ -34,7 +36,9 @@ class ChipAllocatorDeviceIdsTests(TestCase):
             device_ids=[0, 1],
             port=7000,
         )
-        with patch.object(allocator, "_get_active_deployments", return_value=[deployment]):
+        with patch.object(
+            allocator, "_get_active_deployments", return_value=[deployment]
+        ):
             with patch.object(allocator, "_get_chips_required", return_value=1):
                 chip_status = allocator.get_chip_status()
 
@@ -53,7 +57,9 @@ class ChipAllocatorDeviceIdsTests(TestCase):
             device_id=0,
             device_ids=[0, 1],
         )
-        with patch.object(allocator, "_get_active_deployments", return_value=[deployment]):
+        with patch.object(
+            allocator, "_get_active_deployments", return_value=[deployment]
+        ):
             with patch.object(allocator, "_get_chips_required", return_value=1):
                 result = allocator._validate_manual_allocation(1, 1, "Whisper")
 
@@ -69,7 +75,9 @@ class ChipAllocatorDeviceIdsTests(TestCase):
             device_ids=None,
             port=7002,
         )
-        with patch.object(allocator, "_get_active_deployments", return_value=[deployment]):
+        with patch.object(
+            allocator, "_get_active_deployments", return_value=[deployment]
+        ):
             with patch.object(allocator, "_get_chips_required", return_value=1):
                 chip_status = allocator.get_chip_status()
 

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -59,9 +59,9 @@ def resolve_deploy_image(
     from tt-studio's static catalog (impl.image_version). Pre-pulling must use this
     ref to produce a real cache hit; callers fall back to impl.image_version on None.
     """
-    fastapi_base_url = (
-        fastapi_base_url or backend_config.tt_inference_api_url
-    ).rstrip("/")
+    fastapi_base_url = (fastapi_base_url or backend_config.tt_inference_api_url).rstrip(
+        "/"
+    )
     try:
         params = {"model": model_name}
         if device:
@@ -106,8 +106,10 @@ def start_chat_deployment(
     /run/progress/<job_id> and display explicit weights download progress.
     """
     fastapi_run_url = (
-        fastapi_run_url or f"{backend_config.tt_inference_api_url}/run"
-    ).strip().rstrip("/")
+        (fastapi_run_url or f"{backend_config.tt_inference_api_url}/run")
+        .strip()
+        .rstrip("/")
+    )
     payload: Dict[str, Any] = {
         "model": model_name,
         "workflow": "server",

--- a/app/backend/docker_control/urls.py
+++ b/app/backend/docker_control/urls.py
@@ -5,55 +5,88 @@
 # docker_control/urls.py
 from django.urls import path
 from . import views
-from .views import (
-    StopStreamView,
-    ContainersView,
-    StatusView,
-    DeploymentsView,
-    ChipStatusView,
-    DeployView,
-    DeploymentProgressView,
-    DeploymentLogsView,
-    DeploymentProgressStreamView,
-    RedeployView,
-    ResetStreamView,
-    StartResetAllView,
-    ResetAllStatusView,
-    ImageStatusView,
-    ModelCatalogView,
-    BoardInfoView,
-    DockerServiceLogsView,
-    ContainerEventsView,
-    DeploymentHistoryView,
-    WorkflowLogStreamView,
-    DiscoverContainersView,
-    RegisterExternalModelView,
-    AvailableDevicesView,
-)
 
 urlpatterns = [
     path("get_containers/", views.ContainersView.as_view()),
     path("deploy/", views.DeployView.as_view()),
-    path("deploy/progress/<str:job_id>/", views.DeploymentProgressView.as_view(), name="deployment-progress"),
-    path("deploy/logs/<str:job_id>/", views.DeploymentLogsView.as_view(), name="deployment-logs"),
-    path("deploy/progress/stream/<str:job_id>/", views.DeploymentProgressStreamView.as_view(), name="deployment-progress-stream"),
-    path("stop/stream/<str:container_id>/", views.StopStreamView.as_view(), name="stop-stream"),
+    path(
+        "deploy/progress/<str:job_id>/",
+        views.DeploymentProgressView.as_view(),
+        name="deployment-progress",
+    ),
+    path(
+        "deploy/logs/<str:job_id>/",
+        views.DeploymentLogsView.as_view(),
+        name="deployment-logs",
+    ),
+    path(
+        "deploy/progress/stream/<str:job_id>/",
+        views.DeploymentProgressStreamView.as_view(),
+        name="deployment-progress-stream",
+    ),
+    path(
+        "stop/stream/<str:container_id>/",
+        views.StopStreamView.as_view(),
+        name="stop-stream",
+    ),
     path("status/", views.StatusView.as_view()),
     path("deployments/", views.DeploymentsView.as_view(), name="deployments"),
     path("chip-status/", views.ChipStatusView.as_view(), name="chip-status"),
     path("redeploy/", views.RedeployView.as_view()),
-    path("reset_board/stream/", views.ResetStreamView.as_view(), name="reset-board-stream"),
-    path("reset_device/stream/<int:device_id>/", views.ResetStreamView.as_view(), name="reset-device-stream"),
+    path(
+        "reset_board/stream/",
+        views.ResetStreamView.as_view(),
+        name="reset-board-stream",
+    ),
+    path(
+        "reset_device/stream/<int:device_id>/",
+        views.ResetStreamView.as_view(),
+        name="reset-device-stream",
+    ),
     path("reset_all/", views.StartResetAllView.as_view(), name="reset-all-start"),
-    path("reset_all/status/", views.ResetAllStatusView.as_view(), name="reset-all-status"),
-    path("docker/image_status/<str:model_id>/", views.ImageStatusView.as_view(), name="docker-image-status"),
+    path(
+        "reset_all/status/", views.ResetAllStatusView.as_view(), name="reset-all-status"
+    ),
+    path(
+        "docker/image_status/<str:model_id>/",
+        views.ImageStatusView.as_view(),
+        name="docker-image-status",
+    ),
     path("catalog/", views.ModelCatalogView.as_view(), name="model_catalog"),
     path("board-info/", views.BoardInfoView.as_view(), name="board-info"),
-    path("service-logs/", views.DockerServiceLogsView.as_view(), name="docker-service-logs"),
-    path("container-events/", views.ContainerEventsView.as_view(), name="container-events"),
-    path("deployment-history/", views.DeploymentHistoryView.as_view(), name="deployment-history"),
-    path("workflow-logs/<int:deployment_id>/", views.WorkflowLogStreamView.as_view(), name="workflow-logs"),
-    path("discover-containers/", views.DiscoverContainersView.as_view(), name="discover-containers"),
-    path("register-external/", views.RegisterExternalModelView.as_view(), name="register-external"),
-    path("available-devices/", views.AvailableDevicesView.as_view(), name="available-devices"),
+    path(
+        "service-logs/",
+        views.DockerServiceLogsView.as_view(),
+        name="docker-service-logs",
+    ),
+    path(
+        "container-events/",
+        views.ContainerEventsView.as_view(),
+        name="container-events",
+    ),
+    path(
+        "deployment-history/",
+        views.DeploymentHistoryView.as_view(),
+        name="deployment-history",
+    ),
+    path(
+        "workflow-logs/<int:deployment_id>/",
+        views.WorkflowLogStreamView.as_view(),
+        name="workflow-logs",
+    ),
+    path(
+        "discover-containers/",
+        views.DiscoverContainersView.as_view(),
+        name="discover-containers",
+    ),
+    path(
+        "register-external/",
+        views.RegisterExternalModelView.as_view(),
+        name="register-external",
+    ),
+    path(
+        "available-devices/",
+        views.AvailableDevicesView.as_view(),
+        name="available-devices",
+    ),
 ]

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2,7 +2,6 @@
 #
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-from django.shortcuts import render
 from django.http import StreamingHttpResponse, JsonResponse
 from django.views import View
 from rest_framework import status
@@ -13,19 +12,14 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 import json
 import shutil
-import subprocess
-import signal
 import os
 from pathlib import Path
 
 import re
-import os
 import asyncio
 import threading
 import concurrent.futures
 import requests
-import json
-from .forms import DockerForm
 from .docker_utils import (
     run_container,
     get_container_status,
@@ -41,7 +35,11 @@ from .docker_utils import (
     update_deploy_cache,
     DEPLOYMENT_TIMEOUT_SECONDS,
 )
-from .tt_inference_client import start_chat_deployment, tool_call_parser_for, resolve_deploy_image
+from .tt_inference_client import (
+    start_chat_deployment,
+    tool_call_parser_for,
+    resolve_deploy_image,
+)
 from shared_config.coding_agent_config import get_reasoning_parser
 from .docker_control_client import get_docker_client
 from .image_pull import start_prepull_and_deploy, get_pull_job, clamp_progress_pct
@@ -75,19 +73,28 @@ def _split_image_version(image_version: str):
         return name, tag
     return image_version, "latest"
 
+
 # Build model_name → status lookup from catalog JSON
-_CATALOG_PATH = Path(__file__).parent.parent / "shared_config/models_from_inference_server.json"
+_CATALOG_PATH = (
+    Path(__file__).parent.parent / "shared_config/models_from_inference_server.json"
+)
 try:
     _catalog = json.loads(_CATALOG_PATH.read_text())
-    _status_lookup: dict[str, str | None] = {m["model_name"]: m.get("status") for m in _catalog["models"]}
+    _status_lookup: dict[str, str | None] = {
+        m["model_name"]: m.get("status") for m in _catalog["models"]
+    }
 except Exception:
-    logger.warning(f"Could not load model catalog from {_CATALOG_PATH}; status will be null for all models")
+    logger.warning(
+        f"Could not load model catalog from {_CATALOG_PATH}; status will be null for all models"
+    )
     _status_lookup = {}
 
 # Manual compatibility overrides: model names always shown as compatible regardless of board.
 # HARDCODED: whisper-large-v3 and speecht5_tts are intentionally NOT listed here for P300x2
 # until proper board support is confirmed. Edit model_compatibility_overrides.json to re-enable.
-_OVERRIDE_PATH = Path(__file__).parent.parent / "shared_config/model_compatibility_overrides.json"
+_OVERRIDE_PATH = (
+    Path(__file__).parent.parent / "shared_config/model_compatibility_overrides.json"
+)
 try:
     _override_data = json.loads(_OVERRIDE_PATH.read_text())
     _compatibility_override_names: set[str] = set(_override_data.get("model_names", []))
@@ -102,10 +109,12 @@ def _is_llama31_8b_model(model_name: str) -> bool:
     token = (model_name or "").lower().replace("_", "").replace(" ", "")
     return "llama-3.1-8b" in token or "llama3.18b" in token
 
+
 def _lookup_deployment_device_ids(container_id):
     """Return the list of device slot ids associated with a deployment, or []."""
     try:
         from docker_control.models import ModelDeployment
+
         deployment = ModelDeployment.objects.filter(container_id=container_id).first()
         if not deployment:
             return []
@@ -126,93 +135,136 @@ def _lookup_deployment_device_ids(container_id):
                 return []
         return []
     except Exception as e:
-        logger.warning(f"Failed to look up device_ids for container {container_id}: {e}")
+        logger.warning(
+            f"Failed to look up device_ids for container {container_id}: {e}"
+        )
         return []
+
 
 class ContainersView(APIView):
     def get(self, request, *args, **kwargs):
         # Detect current board type using tt-smi command
         current_board = detect_board_type()
         logger.info(f"Detected board type: {current_board}")
-        
+
         # Map board types to their corresponding device configurations
         board_to_device_map = {
             # Wormhole single devices
-            'N150': [DeviceConfigurations.N150, DeviceConfigurations.N150_WH_ARCH_YAML],
-            'N300': [DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
-            'E150': [DeviceConfigurations.E150],
-            
+            "N150": [DeviceConfigurations.N150, DeviceConfigurations.N150_WH_ARCH_YAML],
+            "N300": [DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
+            "E150": [DeviceConfigurations.E150],
             # Wormhole multi-device
-            'N150X4': [DeviceConfigurations.N150X4, DeviceConfigurations.N150, DeviceConfigurations.N150_WH_ARCH_YAML],
-            'T3000': [DeviceConfigurations.N300x4, DeviceConfigurations.N300x4_WH_ARCH_YAML, DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
-            'T3K': [DeviceConfigurations.T3K, DeviceConfigurations.N300x4, DeviceConfigurations.N300x4_WH_ARCH_YAML, DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
-            
+            "N150X4": [
+                DeviceConfigurations.N150X4,
+                DeviceConfigurations.N150,
+                DeviceConfigurations.N150_WH_ARCH_YAML,
+            ],
+            "T3000": [
+                DeviceConfigurations.N300x4,
+                DeviceConfigurations.N300x4_WH_ARCH_YAML,
+                DeviceConfigurations.N300,
+                DeviceConfigurations.N300_WH_ARCH_YAML,
+            ],
+            "T3K": [
+                DeviceConfigurations.T3K,
+                DeviceConfigurations.N300x4,
+                DeviceConfigurations.N300x4_WH_ARCH_YAML,
+                DeviceConfigurations.N300,
+                DeviceConfigurations.N300_WH_ARCH_YAML,
+            ],
             # Blackhole single devices
-            'P100': [DeviceConfigurations.P100],
-            'P150': [DeviceConfigurations.P150],
-            'P300': [DeviceConfigurations.P300],
-
+            "P100": [DeviceConfigurations.P100],
+            "P150": [DeviceConfigurations.P150],
+            "P300": [DeviceConfigurations.P300],
             # Blackhole multi-device
-            'P150X4': [DeviceConfigurations.P150X4, DeviceConfigurations.P150],
-            'P150X8': [DeviceConfigurations.P150X8, DeviceConfigurations.P150],
+            "P150X4": [DeviceConfigurations.P150X4, DeviceConfigurations.P150],
+            "P150X8": [DeviceConfigurations.P150X8, DeviceConfigurations.P150],
             # P300x2/P300Cx4: include P150 so single-chip models (--tt-device p150) show as compatible
-            'P300x2': [DeviceConfigurations.P300x2, DeviceConfigurations.P150, DeviceConfigurations.P300],
-            'P300Cx4': [DeviceConfigurations.P300Cx4, DeviceConfigurations.P150, DeviceConfigurations.P300],
-            
+            "P300x2": [
+                DeviceConfigurations.P300x2,
+                DeviceConfigurations.P150,
+                DeviceConfigurations.P300,
+            ],
+            "P300Cx4": [
+                DeviceConfigurations.P300Cx4,
+                DeviceConfigurations.P150,
+                DeviceConfigurations.P300,
+            ],
             # Galaxy systems
-            'GALAXY': [DeviceConfigurations.GALAXY, DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
-            'GALAXY_T3K': [DeviceConfigurations.GALAXY_T3K, DeviceConfigurations.N300, DeviceConfigurations.N300_WH_ARCH_YAML],
-            
-            'unknown': []  # Empty list for unknown board type
+            "GALAXY": [
+                DeviceConfigurations.GALAXY,
+                DeviceConfigurations.N300,
+                DeviceConfigurations.N300_WH_ARCH_YAML,
+            ],
+            "GALAXY_T3K": [
+                DeviceConfigurations.GALAXY_T3K,
+                DeviceConfigurations.N300,
+                DeviceConfigurations.N300_WH_ARCH_YAML,
+            ],
+            "unknown": [],  # Empty list for unknown board type
         }
-        
+
         # Get the device configurations for current board
         current_board_devices = set(board_to_device_map.get(current_board, []))
         logger.info(f"Current board devices: {current_board_devices}")
-        
+
         data = []
         for impl_id, impl in model_implmentations.items():
             # Calculate compatibility
             is_compatible = False
-            if current_board == 'unknown':
+            if current_board == "unknown":
                 # If board type is unknown, show all models but mark them as potentially incompatible
                 is_compatible = None
             else:
                 # Check if any of the current board's device configurations are in the model's configurations
-                is_compatible = bool(current_board_devices.intersection(impl.device_configurations))
+                is_compatible = bool(
+                    current_board_devices.intersection(impl.device_configurations)
+                )
                 logger.info(f"Model {impl.model_name}: is_compatible={is_compatible}")
-            
+
             # Get all boards this model can run on
             compatible_boards = []
             for board, devices in board_to_device_map.items():
-                if board != 'unknown' and bool(set(devices).intersection(impl.device_configurations)):
+                if board != "unknown" and bool(
+                    set(devices).intersection(impl.device_configurations)
+                ):
                     compatible_boards.append(board)
 
             # Manual override: always show certain models as compatible (e.g. whisper when sync JSON is incomplete)
             if impl.model_name in _compatibility_override_names:
                 is_compatible = True
-                if current_board != 'unknown' and current_board not in compatible_boards:
+                if (
+                    current_board != "unknown"
+                    and current_board not in compatible_boards
+                ):
                     compatible_boards = list(compatible_boards) + [current_board]
-                logger.info(f"Model {impl.model_name}: compatibility overridden to True")
-            
-            logger.info(f"Model {impl.model_name}: compatible={is_compatible}, boards={compatible_boards}")
+                logger.info(
+                    f"Model {impl.model_name}: compatibility overridden to True"
+                )
+
+            logger.info(
+                f"Model {impl.model_name}: compatible={is_compatible}, boards={compatible_boards}"
+            )
 
             # Infer chip requirements for this model
             from shared_config.model_config import infer_chips_required
+
             chips_required = infer_chips_required(impl.device_configurations)
 
-            data.append({
-                "id": impl_id,
-                "name": impl.model_name,
-                "is_compatible": is_compatible,
-                "compatible_boards": compatible_boards,
-                "model_type": impl.model_type.value,
-                "display_model_type": impl.display_model_type,
-                "current_board": current_board,
-                "status": _status_lookup.get(impl.model_name),
-                "chips_required": chips_required,
-            })
-        
+            data.append(
+                {
+                    "id": impl_id,
+                    "name": impl.model_name,
+                    "is_compatible": is_compatible,
+                    "compatible_boards": compatible_boards,
+                    "model_type": impl.model_type.value,
+                    "display_model_type": impl.display_model_type,
+                    "current_board": current_board,
+                    "status": _status_lookup.get(impl.model_name),
+                    "chips_required": chips_required,
+                }
+            )
+
         return Response(data, status=status.HTTP_200_OK)
 
 
@@ -255,8 +307,8 @@ class StatusView(APIView):
 
 
 class DeploymentsView(APIView):
-    """Canonical endpoint — the single source of truth. 
-    Returns a dict keyed by Docker container_id (or a pending-<id> key for placeholder records during the CHAT-model job_id window). 
+    """Canonical endpoint — the single source of truth.
+    Returns a dict keyed by Docker container_id (or a pending-<id> key for placeholder records during the CHAT-model job_id window).
     Each entry includes Docker container fields, deployment_store fields, a serialized model_impl, plus is_pending and source markers so callers can distinguish fully-deployed models from in-flight starts and from discovered-but-unregistered containers.
 
     Other endpoints (/docker-api/status/, /models-api/deployed/, /docker-api/chip-status/) are now thin shims over this view. Their response shapes are preserved for backwards compatibility.
@@ -273,7 +325,10 @@ class DeploymentsView(APIView):
             )
 
         return Response(
-            {con_id: serialize_canonical_entry_for_http(entry) for con_id, entry in canonical.items()},
+            {
+                con_id: serialize_canonical_entry_for_http(entry)
+                for con_id, entry in canonical.items()
+            },
             status=status.HTTP_200_OK,
         )
 
@@ -302,13 +357,9 @@ class ChipStatusView(APIView):
         except Exception as e:
             logger.error(f"Error getting chip status: {str(e)}")
             return Response(
-                {
-                    "error": "Failed to get chip status",
-                    "message": str(e)
-                },
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {"error": "Failed to get chip status", "message": str(e)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-
 
 
 class DeployView(APIView):
@@ -317,17 +368,25 @@ class DeployView(APIView):
         # mid-reset conflicts with the hardware re-init and model teardown.
         if SystemResourceService.is_reset_in_progress():
             return Response(
-                {"error": "A board reset is in progress. Wait for it to finish before deploying a model."},
+                {
+                    "error": "A board reset is in progress. Wait for it to finish before deploying a model."
+                },
                 status=status.HTTP_409_CONFLICT,
             )
         serializer = DeploymentSerializer(data=request.data)
         if serializer.is_valid():
-            from docker_control.chip_allocator import ChipSlotAllocator, AllocationError, MultiChipConflictError
+            from docker_control.chip_allocator import (
+                ChipSlotAllocator,
+                AllocationError,
+                MultiChipConflictError,
+            )
 
             impl_id = request.data.get("model_id")
             weights_id = request.data.get("weights_id")
             use_image_override = request.data.get("use_image_override", True)
-            force_full_board_requested = serializer.validated_data.get("force_full_board", False)
+            force_full_board_requested = serializer.validated_data.get(
+                "force_full_board", False
+            )
 
             # Get manual override if in advanced mode (optional).
             # device_id may be a single integer or a comma-separated list (e.g. "0,1")
@@ -335,11 +394,15 @@ class DeployView(APIView):
             raw_device_id = request.data.get("device_id")
             if raw_device_id is not None:
                 requested_device_ids = [
-                    int(x.strip()) for x in str(raw_device_id).split(",") if str(x).strip() != ""
+                    int(x.strip())
+                    for x in str(raw_device_id).split(",")
+                    if str(x).strip() != ""
                 ]
                 if not requested_device_ids:
                     requested_device_ids = [0]
-                manual_device_id = requested_device_ids[0]  # primary slot for allocation
+                manual_device_id = requested_device_ids[
+                    0
+                ]  # primary slot for allocation
             else:
                 requested_device_ids = []
                 manual_device_id = None
@@ -390,7 +453,11 @@ class DeployView(APIView):
             # are always set correctly (port = 7000 + device_id).
             try:
                 allocator = ChipSlotAllocator()
-                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+                if (
+                    should_force_full_board_llama
+                    or use_whole_board_deploy
+                    or mesh_whole_board
+                ):
                     # Whole-board deploy (forced QB2 Llama, a single-chip model on a
                     # Wormhole mesh board, or a media model like FLUX with no single-chip
                     # spec) takes over the entire board — reserve all slots.
@@ -410,8 +477,7 @@ class DeployView(APIView):
                     device_ids = list(range(min(4, allocator.total_slots)))
                 else:
                     device_id = allocator.allocate_chip_slot(
-                        impl.model_name,
-                        manual_override=manual_device_id
+                        impl.model_name, manual_override=manual_device_id
                     )
                     # If multiple device IDs were requested, validate every slot and pass
                     # them all to the inference server call; otherwise use the allocated slot.
@@ -450,7 +516,11 @@ class DeployView(APIView):
                         device_ids = [device_id]
                 device_ids_str = ",".join(str(d) for d in device_ids)
                 # Full set of chip slots this model actually occupies, even though only the primary slot is passed to the inference server via device_ids_str
-                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+                if (
+                    should_force_full_board_llama
+                    or use_whole_board_deploy
+                    or mesh_whole_board
+                ):
                     # Whole-board deploy takes over every slot on the board.
                     occupied_device_ids = list(range(allocator.total_slots))
                 elif chips_required > 1:
@@ -468,23 +538,33 @@ class DeployView(APIView):
 
             except MultiChipConflictError as e:
                 logger.warning(f"Multi-chip conflict for {impl.model_name}: {str(e)}")
-                return Response({
-                    "status": "error",
-                    "error_type": "multi_chip_conflict",
-                    "message": str(e),
-                    "conflicts": e.conflicts  # List of conflicting deployments
-                }, status=status.HTTP_409_CONFLICT)
+                return Response(
+                    {
+                        "status": "error",
+                        "error_type": "multi_chip_conflict",
+                        "message": str(e),
+                        "conflicts": e.conflicts,  # List of conflicting deployments
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
 
             except AllocationError as e:
                 logger.warning(f"Allocation failed for {impl.model_name}: {str(e)}")
-                return Response({
-                    "status": "error",
-                    "error_type": "allocation_failed",
-                    "message": str(e)
-                }, status=status.HTTP_409_CONFLICT)
+                return Response(
+                    {
+                        "status": "error",
+                        "error_type": "allocation_failed",
+                        "message": str(e),
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
 
             BASE_SERVICE_PORT = 7000
-            if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+            if (
+                should_force_full_board_llama
+                or use_whole_board_deploy
+                or mesh_whole_board
+            ):
                 service_port = BASE_SERVICE_PORT
             else:
                 service_port = BASE_SERVICE_PORT + device_id
@@ -518,12 +598,16 @@ class DeployView(APIView):
                     # omit device_id. Single-board devices (n300/n150/p150) and slot-pinned
                     # constituent chips keep device_id so each model lands on its slot(s).
                     whole_board_device = map_board_type_to_device_name(board_type)
-                    single_chip_device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
+                    single_chip_device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(
+                        board_type, "cpu"
+                    )
                     is_multi_chip_board = whole_board_device != single_chip_device
                     if device == whole_board_device and is_multi_chip_board:
                         inference_device_id = None
                     else:
-                        inference_device_id = ",".join(str(d) for d in occupied_device_ids)
+                        inference_device_id = ",".join(
+                            str(d) for d in occupied_device_ids
+                        )
                 # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
                 override_tt_config = None
                 qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
@@ -574,7 +658,11 @@ class DeployView(APIView):
 
                 # If the image isn't cached yet, pull it here first so the UI can show real byte-level progress, then trigger the deployment
                 # Resolve the real ref from inference-api so the pre-pull produces a genuine cache hit.
-                deploy_image = override_docker_image or resolve_deploy_image(impl.model_name, device) or impl.image_version
+                deploy_image = (
+                    override_docker_image
+                    or resolve_deploy_image(impl.model_name, device)
+                    or impl.image_version
+                )
                 if deploy_image != impl.image_version:
                     logger.info(
                         f"Pre-pull image for {impl.model_name}: resolved {deploy_image} "
@@ -584,9 +672,13 @@ class DeployView(APIView):
                 need_pull = False
                 if image_name:
                     try:
-                        need_pull = not get_docker_client().image_exists(image_name, image_tag)
+                        need_pull = not get_docker_client().image_exists(
+                            image_name, image_tag
+                        )
                     except Exception as e:
-                        logger.warning(f"image_exists check failed for {deploy_image}: {e}")
+                        logger.warning(
+                            f"image_exists check failed for {deploy_image}: {e}"
+                        )
                         need_pull = False
 
                 if need_pull:
@@ -594,6 +686,7 @@ class DeployView(APIView):
                     # Create temporary ModelDeployment record now (placeholder container_id = pull_id) so the chip slot reads IN USE during the pull.
                     try:
                         from docker_control.models import ModelDeployment
+
                         ModelDeployment.objects.create(
                             container_id=pull_id,
                             container_name=impl.model_name,
@@ -605,13 +698,18 @@ class DeployView(APIView):
                             port=service_port,
                         )
                     except Exception as e:
-                        logger.warning(f"Could not create placeholder ModelDeployment for {pull_id}: {e}")
+                        logger.warning(
+                            f"Could not create placeholder ModelDeployment for {pull_id}: {e}"
+                        )
 
                     def _refresh_placeholder(_pull_id=pull_id):
                         # Keep the placeholder record's grace window fresh during the pull so get_canonical_deployments doesn't reconcile it to 'stopped' and free its chip slot.
                         from datetime import datetime, timezone
                         from docker_control.models import ModelDeployment
-                        dep = ModelDeployment.objects.filter(container_id=_pull_id).first()
+
+                        dep = ModelDeployment.objects.filter(
+                            container_id=_pull_id
+                        ).first()
                         if dep and dep.status == "starting":
                             dep.deployed_at = datetime.now(timezone.utc)
                             dep.save()
@@ -620,31 +718,43 @@ class DeployView(APIView):
                         from datetime import datetime, timezone
                         from docker_control.models import ModelDeployment
                         from docker_control.deployment_sync import start_deployment_sync
+
                         result = start_chat_deployment(**_kwargs)
                         if result.status != "success" or not result.job_id:
                             # Free the chip slot: mark the placeholder stopped.
                             try:
-                                dep = ModelDeployment.objects.filter(container_id=_pull_id).first()
+                                dep = ModelDeployment.objects.filter(
+                                    container_id=_pull_id
+                                ).first()
                                 if dep:
                                     dep.status = "stopped"
                                     dep.save()
                             except Exception:
                                 pass
-                            return None, (result.message or "TT Inference Server did not return a job_id")
+                            return None, (
+                                result.message
+                                or "TT Inference Server did not return a job_id"
+                            )
                         # Repoint the placeholder record at the real inference job_id so the record is equivalent to a fresh non-pre-pull deploy from here on.
                         try:
-                            dep = ModelDeployment.objects.filter(container_id=_pull_id).first()
+                            dep = ModelDeployment.objects.filter(
+                                container_id=_pull_id
+                            ).first()
                             if dep:
                                 dep.container_id = result.job_id
                                 dep.status = "starting"
                                 dep.deployed_at = datetime.now(timezone.utc)
                                 dep.save()
                         except Exception as e:
-                            logger.warning(f"Could not repoint ModelDeployment {_pull_id} -> {result.job_id}: {e}")
+                            logger.warning(
+                                f"Could not repoint ModelDeployment {_pull_id} -> {result.job_id}: {e}"
+                            )
                         try:
                             start_deployment_sync(result.job_id)
                         except Exception as e:
-                            logger.warning(f"Could not start deployment sync for job {result.job_id}: {e}")
+                            logger.warning(
+                                f"Could not start deployment sync for job {result.job_id}: {e}"
+                            )
                         return result.job_id, None
 
                     start_prepull_and_deploy(
@@ -690,6 +800,7 @@ class DeployView(APIView):
                 # container_id is known (updated in DeploymentProgressView on completion).
                 try:
                     from docker_control.models import ModelDeployment
+
                     ModelDeployment.objects.create(
                         container_id=result.job_id,
                         container_name=impl.model_name,
@@ -701,7 +812,9 @@ class DeployView(APIView):
                         port=service_port,
                     )
                 except Exception as e:
-                    logger.warning(f"Could not create ModelDeployment for chat job {result.job_id}: {e}")
+                    logger.warning(
+                        f"Could not create ModelDeployment for chat job {result.job_id}: {e}"
+                    )
                 # Spawn a background thread to poll FastAPI and transition the
                 # 'starting' record to 'running' (or 'stopped' on failure).
                 # This makes the lifecycle backend-owned so frontends that do
@@ -709,9 +822,12 @@ class DeployView(APIView):
                 # correct records.
                 try:
                     from docker_control.deployment_sync import start_deployment_sync
+
                     start_deployment_sync(result.job_id)
                 except Exception as e:
-                    logger.warning(f"Could not start deployment sync for job {result.job_id}: {e}")
+                    logger.warning(
+                        f"Could not start deployment sync for job {result.job_id}: {e}"
+                    )
                 response = {
                     "status": "success",
                     "job_id": result.job_id,
@@ -726,22 +842,39 @@ class DeployView(APIView):
 
                 # Pre-pull the media image first so the UI shows real progress.
                 media_device = infer_inference_server_device(impl)
-                deploy_image = resolve_deploy_image(impl.model_name, media_device) or impl.image_version
+                deploy_image = (
+                    resolve_deploy_image(impl.model_name, media_device)
+                    or impl.image_version
+                )
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False
                 if image_name:
                     try:
-                        need_pull = not get_docker_client().image_exists(image_name, image_tag)
+                        need_pull = not get_docker_client().image_exists(
+                            image_name, image_tag
+                        )
                     except Exception as e:
-                        logger.warning(f"image_exists check failed for {deploy_image}: {e}")
+                        logger.warning(
+                            f"image_exists check failed for {deploy_image}: {e}"
+                        )
                         need_pull = False
 
                 if need_pull:
                     pull_id = f"imgpull_{uuid4().hex}"
 
                     def deploy_fn(_host_port=host_port):
-                        resp = run_container(impl, weights_id, device_id=device_ids_str, host_port=_host_port, use_image_override=use_image_override)
-                        job_id = resp.get("job_id") or resp.get("container_id") or resp.get("container_name")
+                        resp = run_container(
+                            impl,
+                            weights_id,
+                            device_id=device_ids_str,
+                            host_port=_host_port,
+                            use_image_override=use_image_override,
+                        )
+                        job_id = (
+                            resp.get("job_id")
+                            or resp.get("container_id")
+                            or resp.get("container_name")
+                        )
                         if resp.get("status") == "error" or not job_id:
                             return None, resp.get("message", "Deployment failed")
                         try:
@@ -758,12 +891,23 @@ class DeployView(APIView):
                         deploy_fn=deploy_fn,
                     )
                     return Response(
-                        {"status": "success", "job_id": pull_id, "message": "Pulling Docker Image…", "allocated_device_id": device_id},
+                        {
+                            "status": "success",
+                            "job_id": pull_id,
+                            "message": "Pulling Docker Image…",
+                            "allocated_device_id": device_id,
+                        },
                         status=status.HTTP_201_CREATED,
                     )
 
                 # Image already cached → deploy inline (existing path, unchanged).
-                response = run_container(impl, weights_id, device_id=device_ids_str, host_port=host_port, use_image_override=use_image_override)
+                response = run_container(
+                    impl,
+                    weights_id,
+                    device_id=device_ids_str,
+                    host_port=host_port,
+                    use_image_override=use_image_override,
+                )
 
                 # Add allocated_device_id to response
                 response["allocated_device_id"] = device_id
@@ -771,14 +915,17 @@ class DeployView(APIView):
                 # Ensure job_id is set for progress tracking
                 # Use job_id from API response, or fallback to container_id or container_name
                 if not response.get("job_id"):
-                    response["job_id"] = response.get("container_id") or response.get("container_name")
+                    response["job_id"] = response.get("container_id") or response.get(
+                        "container_name"
+                    )
 
                 # Check if deployment failed
                 if response.get("status") == "error":
-                    logger.error(f"Deployment failed: {response.get('message', 'Unknown error')}")
+                    logger.error(
+                        f"Deployment failed: {response.get('message', 'Unknown error')}"
+                    )
                     return Response(
-                        response,
-                        status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                        response, status=status.HTTP_500_INTERNAL_SERVER_ERROR
                     )
 
                 # Refresh tt-smi cache after successful deployment
@@ -786,7 +933,9 @@ class DeployView(APIView):
                     try:
                         SystemResourceService.force_refresh_tt_smi_cache()
                     except Exception as e:
-                        logger.warning(f"Failed to refresh tt-smi cache after deployment: {e}")
+                        logger.warning(
+                            f"Failed to refresh tt-smi cache after deployment: {e}"
+                        )
 
                 return Response(response, status=status.HTTP_201_CREATED)
         else:
@@ -820,8 +969,15 @@ def _find_workflow_log_for_deployment(deployment) -> str | None:
 
     tt_studio_root = backend_config.host_tt_studio_root
     candidate_dirs = [
-        Path(tt_studio_root) / ".artifacts" / "tt-inference-server" / "workflow_logs" / "docker_server",
-        Path(tt_studio_root) / "tt-inference-server" / "workflow_logs" / "docker_server",
+        Path(tt_studio_root)
+        / ".artifacts"
+        / "tt-inference-server"
+        / "workflow_logs"
+        / "docker_server",
+        Path(tt_studio_root)
+        / "tt-inference-server"
+        / "workflow_logs"
+        / "docker_server",
     ]
 
     # Pass 1: exact timestamp match — try common prefixes (vllm, media, and bare model name)
@@ -830,7 +986,9 @@ def _find_workflow_log_for_deployment(deployment) -> str | None:
         for base in candidate_dirs:
             candidate = base / filename
             if candidate.exists():
-                logger.debug(f"Found exact log match for deployment {deployment.id}: {candidate}")
+                logger.debug(
+                    f"Found exact log match for deployment {deployment.id}: {candidate}"
+                )
                 return str(candidate)
 
     # Pass 2: fuzzy timestamp match — scan all *_server.log files for model+device,
@@ -850,7 +1008,9 @@ def _find_workflow_log_for_deployment(deployment) -> str | None:
                 parts = f.name.split("_")
                 # filename: prefix_YYYY-MM-DD_HH-MM-SS_...
                 file_ts_str = f"{parts[1]}_{parts[2]}"
-                file_dt = datetime.strptime(file_ts_str, "%Y-%m-%d_%H-%M-%S").replace(tzinfo=timezone.utc)
+                file_dt = datetime.strptime(file_ts_str, "%Y-%m-%d_%H-%M-%S").replace(
+                    tzinfo=timezone.utc
+                )
                 delta = abs((file_dt - dt).total_seconds())
                 if delta <= 300 and (best_delta is None or delta < best_delta):
                     best = f
@@ -870,7 +1030,8 @@ def _find_workflow_log_for_deployment(deployment) -> str | None:
         if not base.is_dir():
             continue
         matches = [
-            f for f in base.iterdir()
+            f
+            for f in base.iterdir()
             if f.name.endswith("_server.log") and model in f.name and device in f.name
         ]
         if matches:
@@ -901,6 +1062,7 @@ def _sync_chat_deployment_record(job_id: str, progress_data: dict) -> None:
     job_status = progress_data.get("status")
     try:
         from docker_control.models import ModelDeployment
+
         dep = ModelDeployment.objects.filter(container_id=job_id).first()
         if dep is None:
             return
@@ -914,9 +1076,12 @@ def _sync_chat_deployment_record(job_id: str, progress_data: dict) -> None:
                 if real_container_id:
                     try:
                         from docker_control.docker_utils import stop_container
+
                         stop_container(real_container_id)
                     except Exception as e:
-                        logger.warning(f"Cleanup of user-stopped job {job_id} failed: {e}")
+                        logger.warning(
+                            f"Cleanup of user-stopped job {job_id} failed: {e}"
+                        )
                 dep.status = "stopped"
                 dep.save()
                 logger.info(f"Job {job_id} completed but was user-stopped; cleaned up")
@@ -939,7 +1104,9 @@ def _sync_chat_deployment_record(job_id: str, progress_data: dict) -> None:
                 try:
                     update_deploy_cache()
                 except Exception as e:
-                    logger.warning(f"Could not refresh deploy cache after chat deployment: {e}")
+                    logger.warning(
+                        f"Could not refresh deploy cache after chat deployment: {e}"
+                    )
 
         elif job_status in ("error", "failed", "cancelled", "timeout"):
             dep.status = "stopped"
@@ -982,7 +1149,9 @@ class DeploymentProgressView(APIView):
                     downloaded = pull_job.get("downloaded_bytes") or 0
                     total = pull_job.get("total_bytes") or 0
                     pct = int(round(downloaded / total * 100)) if total > 0 else 0
-                    pct = max(0, min(99, pct))  # reserve 100% for the actual deploy handoff
+                    pct = max(
+                        0, min(99, pct)
+                    )  # reserve 100% for the actual deploy handoff
                     # Docker reveals layers incrementally, so `total` grows mid-pull and the
                     # raw ratio can dip. Clamp to the running peak so the % never regresses.
                     pct = clamp_progress_pct(job_id, pct)
@@ -1037,26 +1206,37 @@ class DeploymentProgressView(APIView):
                         # Check if we've exceeded the 5-hour timeout
                         if elapsed_time > DEPLOYMENT_TIMEOUT_SECONDS:
                             progress_data["status"] = "timeout"
-                            progress_data["message"] = f"Deployment timeout after {int(elapsed_time/60)} minutes"
+                            progress_data["message"] = (
+                                f"Deployment timeout after {int(elapsed_time/60)} minutes"
+                            )
                             # Clean up start time tracking
                             if job_id in deployment_start_times:
                                 del deployment_start_times[job_id]
                         else:
                             # Still within timeout - treat as running with descriptive message
                             progress_data["status"] = "running"
-                            progress_data["message"] = "Downloading model weights... (this may take several hours for large models)"
+                            progress_data["message"] = (
+                                "Downloading model weights... (this may take several hours for large models)"
+                            )
 
                     # Check timeout for other running statuses
                     elif progress_data.get("status") in ["starting", "running"]:
                         if elapsed_time > DEPLOYMENT_TIMEOUT_SECONDS:
                             progress_data["status"] = "timeout"
-                            progress_data["message"] = f"Deployment timeout after {int(elapsed_time/60)} minutes"
+                            progress_data["message"] = (
+                                f"Deployment timeout after {int(elapsed_time/60)} minutes"
+                            )
                             # Clean up start time tracking
                             if job_id in deployment_start_times:
                                 del deployment_start_times[job_id]
 
                     # Clean up start time tracking on terminal statuses
-                    elif progress_data.get("status") in ["completed", "error", "failed", "cancelled"]:
+                    elif progress_data.get("status") in [
+                        "completed",
+                        "error",
+                        "failed",
+                        "cancelled",
+                    ]:
                         if job_id in deployment_start_times:
                             del deployment_start_times[job_id]
 
@@ -1066,17 +1246,30 @@ class DeploymentProgressView(APIView):
                     # Add support for new status types
                     # Note: "not_found" is intentionally excluded here so direct-deploy models
                     # (e.g. face-recognition) fall through to container-based tracking below.
-                    if progress_data.get("status") in ["starting", "running", "completed", "error", "failed", "timeout", "cancelled", "retrying"]:
+                    if progress_data.get("status") in [
+                        "starting",
+                        "running",
+                        "completed",
+                        "error",
+                        "failed",
+                        "timeout",
+                        "cancelled",
+                        "retrying",
+                    ]:
                         return Response(progress_data, status=status.HTTP_200_OK)
 
-                logger.info(f"FastAPI progress not available (status: {response.status_code}), falling back to container-based progress")
+                logger.info(
+                    f"FastAPI progress not available (status: {response.status_code}), falling back to container-based progress"
+                )
 
             except requests.exceptions.RequestException as e:
-                logger.info(f"FastAPI not available ({str(e)}), falling back to container-based progress")
-            
+                logger.info(
+                    f"FastAPI not available ({str(e)}), falling back to container-based progress"
+                )
+
             # Fallback: existing container-based progress tracking
             # elapsed_time already calculated above
-            
+
             # job_id is container_id or container_name
             # Try to get container by ID first, then by name
             container = None
@@ -1094,6 +1287,7 @@ class DeploymentProgressView(APIView):
                             self.name = data.get("name")
                             self.status = data.get("status")
                             self.attrs = data.get("attrs", {})
+
                     container = ContainerWrapper(container_data)
             except Exception as e:
                 logger.warning(f"Error getting container {job_id}: {str(e)}")
@@ -1101,7 +1295,9 @@ class DeploymentProgressView(APIView):
             # Container not found - deployment in early stages
             # Map to actual FastAPI log stages with realistic timing
             if not container:
-                logger.info(f"Container {job_id} not found yet - deployment in progress (elapsed: {elapsed_time:.1f}s)")
+                logger.info(
+                    f"Container {job_id} not found yet - deployment in progress (elapsed: {elapsed_time:.1f}s)"
+                )
 
                 # Check for timeout
                 if elapsed_time > DEPLOYMENT_TIMEOUT_SECONDS:
@@ -1113,9 +1309,9 @@ class DeploymentProgressView(APIView):
                             "status": "timeout",
                             "stage": "error",
                             "progress": 0,
-                            "message": f"Deployment timeout after {int(elapsed_time/60)} minutes"
+                            "message": f"Deployment timeout after {int(elapsed_time/60)} minutes",
                         },
-                        status=status.HTTP_200_OK
+                        status=status.HTTP_200_OK,
                     )
 
                 # Based on model run logs - realistic timing for each stage
@@ -1126,11 +1322,15 @@ class DeploymentProgressView(APIView):
                 elif elapsed_time < 8:
                     progress = 15
                     stage = "setup"
-                    message = "Running workflow configuration..."  # model_run.log (19-27)
+                    message = (
+                        "Running workflow configuration..."  # model_run.log (19-27)
+                    )
                 elif elapsed_time < 15:
                     progress = 25
                     stage = "model_preparation"
-                    message = "Checking model setup and weights..."  # model_run.log (83-91)
+                    message = (
+                        "Checking model setup and weights..."  # model_run.log (83-91)
+                    )
                 elif elapsed_time < 25:
                     progress = 40
                     stage = "model_preparation"
@@ -1138,7 +1338,9 @@ class DeploymentProgressView(APIView):
                 elif elapsed_time < 35:
                     progress = 55
                     stage = "container_setup"
-                    message = "Preparing Docker configuration..."  # model_run.log (100-113)
+                    message = (
+                        "Preparing Docker configuration..."  # model_run.log (100-113)
+                    )
                 elif elapsed_time < 45:
                     progress = 70
                     stage = "container_setup"
@@ -1148,7 +1350,9 @@ class DeploymentProgressView(APIView):
                     # For very long operations (hours), show a more informative message
                     progress = min(75, 70 + int((elapsed_time - 45) / 10 * 5))
                     stage = "model_preparation"
-                    if elapsed_time > 300:  # After 5 minutes, assume downloading weights
+                    if (
+                        elapsed_time > 300
+                    ):  # After 5 minutes, assume downloading weights
                         message = "Downloading model weights... (this may take several hours for large models)"
                     else:
                         message = "Waiting for container to initialize..."
@@ -1158,23 +1362,23 @@ class DeploymentProgressView(APIView):
                         "status": "running",
                         "stage": stage,
                         "progress": progress,
-                        "message": message
+                        "message": message,
                     },
-                    status=status.HTTP_200_OK
+                    status=status.HTTP_200_OK,
                 )
-            
+
             # Container found - check its status and network connectivity
             container_status = container.status
             container_attrs = container.attrs
             networks = container_attrs.get("NetworkSettings", {}).get("Networks", {})
             container_name = container.name
-            
+
             # Determine progress based on container state
             progress = 0
             stage = "container_setup"
             message = "Container found..."
             status_value = "running"
-            
+
             if container_status == "created":
                 # Container created but not running yet
                 progress = 80
@@ -1195,15 +1399,21 @@ class DeploymentProgressView(APIView):
                     is_direct_deploy_by_id = (
                         job_id == container_id_str
                         or container_id_str.startswith(job_id)
-                        or (len(job_id) >= 12 and container_id_str.startswith(job_id[:12]))
+                        or (
+                            len(job_id) >= 12
+                            and container_id_str.startswith(job_id[:12])
+                        )
                     )
 
                     # FastAPI-deployed LLM containers start with a random Docker name
                     # (e.g. "romantic_khorana") and get renamed to the model name as the
                     # final step. The name-based check detects that rename for those models.
                     is_fastapi_deploy_complete = (
-                        any(part in container_name.lower() for part in ['llama', 'instruct', 'model'])
-                        or '-' not in container_name
+                        any(
+                            part in container_name.lower()
+                            for part in ["llama", "instruct", "model"]
+                        )
+                        or "-" not in container_name
                     )
 
                     if is_direct_deploy_by_id or is_fastapi_deploy_complete:
@@ -1256,25 +1466,27 @@ class DeploymentProgressView(APIView):
                 # Clean up start time tracking
                 if job_id in deployment_start_times:
                     del deployment_start_times[job_id]
-            
+
             progress_data = {
                 "status": status_value,
                 "stage": stage,
                 "progress": progress,
                 "message": message,
                 "container_status": container_status,
-                "container_name": container_name
+                "container_name": container_name,
             }
-            
-            logger.info(f"Progress data: {progress_data} (elapsed: {elapsed_time:.1f}s, networks: {list(networks.keys())})")
+
+            logger.info(
+                f"Progress data: {progress_data} (elapsed: {elapsed_time:.1f}s, networks: {list(networks.keys())})"
+            )
             return Response(progress_data, status=status.HTTP_200_OK)
 
-        except Exception as e:
+        except Exception:
             # Container not found or error - use time-based progress for early stages
             elapsed_time = time.time() - deployment_start_times.get(job_id, time.time())
             if elapsed_time < 0:
                 elapsed_time = 0
-            
+
             # Map to actual log stages
             if elapsed_time < 3:
                 progress = 5
@@ -1292,28 +1504,32 @@ class DeploymentProgressView(APIView):
                 progress = min(55, 25 + int((elapsed_time - 15) / 20 * 30))
                 stage = "container_setup"
                 message = "Preparing Docker container..."
-            
-            logger.info(f"Container {job_id} not found - deployment in progress (elapsed: {elapsed_time:.1f}s)")
+
+            logger.info(
+                f"Container {job_id} not found - deployment in progress (elapsed: {elapsed_time:.1f}s)"
+            )
             return Response(
                 {
                     "status": "running",
                     "stage": stage,
                     "progress": progress,
-                    "message": message
+                    "message": message,
                 },
-                status=status.HTTP_200_OK
+                status=status.HTTP_200_OK,
             )
         except Exception as e:
             logger.error(f"Error fetching progress: {str(e)}")
             return Response(
-                {"status": "error", "message": f"Docker API error: {str(e)}"}, 
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {"status": "error", "message": f"Docker API error: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         except Exception as e:
-            logger.error(f"Unexpected error in DeploymentProgressView: {str(e)}", exc_info=True)
+            logger.error(
+                f"Unexpected error in DeploymentProgressView: {str(e)}", exc_info=True
+            )
             return Response(
-                {"status": "error", "message": f"Internal server error: {str(e)}"}, 
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {"status": "error", "message": f"Internal server error: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
@@ -1322,109 +1538,137 @@ class DeploymentLogsView(APIView):
         """Get deployment logs from FastAPI inference server"""
         try:
             logger.info(f"Fetching deployment logs for job_id: {job_id}")
-            
+
             # Try to get logs from FastAPI inference server
             try:
                 fastapi_url = _build_fastapi_url(f"run/logs/{job_id}")
                 response = requests.get(fastapi_url, timeout=5)
-                
+
                 if response.status_code == 200:
                     logs_data = response.json()
-                    logger.info(f"Got logs from FastAPI: {logs_data.get('total_messages', 0)} messages")
+                    logger.info(
+                        f"Got logs from FastAPI: {logs_data.get('total_messages', 0)} messages"
+                    )
                     return Response(logs_data, status=status.HTTP_200_OK)
-                
-                logger.warning(f"FastAPI logs not available (status: {response.status_code})")
-                return Response(
-                    {"job_id": job_id, "logs": [], "total_messages": 0, "error": "Logs not available"},
-                    status=status.HTTP_404_NOT_FOUND
+
+                logger.warning(
+                    f"FastAPI logs not available (status: {response.status_code})"
                 )
-                
+                return Response(
+                    {
+                        "job_id": job_id,
+                        "logs": [],
+                        "total_messages": 0,
+                        "error": "Logs not available",
+                    },
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
             except requests.exceptions.RequestException as e:
                 logger.error(f"Error fetching logs from FastAPI: {str(e)}")
                 return Response(
-                    {"job_id": job_id, "logs": [], "total_messages": 0, "error": f"Failed to fetch logs: {str(e)}"},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    {
+                        "job_id": job_id,
+                        "logs": [],
+                        "total_messages": 0,
+                        "error": f"Failed to fetch logs: {str(e)}",
+                    },
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-                
+
         except Exception as e:
-            logger.error(f"Unexpected error in DeploymentLogsView: {str(e)}", exc_info=True)
+            logger.error(
+                f"Unexpected error in DeploymentLogsView: {str(e)}", exc_info=True
+            )
             return Response(
-                {"job_id": job_id, "logs": [], "total_messages": 0, "error": f"Internal server error: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {
+                    "job_id": job_id,
+                    "logs": [],
+                    "total_messages": 0,
+                    "error": f"Internal server error: {str(e)}",
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
 class DeploymentProgressStreamView(APIView):
     """Stream deployment progress updates from FastAPI inference server via SSE"""
-    
+
     def get(self, request, job_id, *args, **kwargs):
         """Proxy SSE stream from FastAPI inference server"""
-        
+
         def event_stream():
             """Generator that forwards SSE events from FastAPI to frontend"""
             try:
                 # Connect to FastAPI inference server SSE endpoint
                 fastapi_url = _build_fastapi_url(f"run/stream/{job_id}")
                 logger.info(f"Connecting to FastAPI SSE endpoint: {fastapi_url}")
-                
+
                 # Stream the response
                 response = requests.get(fastapi_url, stream=True, timeout=300)
-                
+
                 if response.status_code != 200:
-                    logger.error(f"FastAPI SSE endpoint returned status {response.status_code}")
+                    logger.error(
+                        f"FastAPI SSE endpoint returned status {response.status_code}"
+                    )
                     error_data = {
                         "status": "error",
-                        "message": f"SSE endpoint not available (status: {response.status_code})"
+                        "message": f"SSE endpoint not available (status: {response.status_code})",
                     }
                     yield f"data: {json.dumps(error_data)}\n\n"
                     return
-                
+
                 logger.info(f"Successfully connected to FastAPI SSE for job {job_id}")
-                
+
                 # Forward all SSE events from FastAPI to frontend
                 for line in response.iter_lines():
                     if line:
-                        line_str = line.decode('utf-8')
+                        line_str = line.decode("utf-8")
                         # Forward the line as-is
                         yield f"{line_str}\n"
-                        
+
                         # Check if this is the end of the stream
-                        if line_str.startswith('data: '):
+                        if line_str.startswith("data: "):
                             try:
-                                data = json.loads(line_str[6:])  # Remove 'data: ' prefix
-                                if data.get('status') in ['completed', 'error', 'failed', 'cancelled']:
-                                    logger.info(f"Stream ended for job {job_id} with status {data.get('status')}")
+                                data = json.loads(
+                                    line_str[6:]
+                                )  # Remove 'data: ' prefix
+                                if data.get("status") in [
+                                    "completed",
+                                    "error",
+                                    "failed",
+                                    "cancelled",
+                                ]:
+                                    logger.info(
+                                        f"Stream ended for job {job_id} with status {data.get('status')}"
+                                    )
                                     break
                             except json.JSONDecodeError:
                                 pass
                     else:
                         # Empty line - part of SSE format
                         yield "\n"
-                        
+
             except requests.exceptions.RequestException as e:
                 logger.error(f"Error connecting to FastAPI SSE endpoint: {str(e)}")
                 error_data = {
                     "status": "error",
-                    "message": f"Connection error: {str(e)}"
+                    "message": f"Connection error: {str(e)}",
                 }
                 yield f"data: {json.dumps(error_data)}\n\n"
             except Exception as e:
                 logger.error(f"Unexpected error in SSE stream: {str(e)}", exc_info=True)
-                error_data = {
-                    "status": "error",
-                    "message": f"Stream error: {str(e)}"
-                }
+                error_data = {"status": "error", "message": f"Stream error: {str(e)}"}
                 yield f"data: {json.dumps(error_data)}\n\n"
-        
+
         # Return streaming response with proper SSE headers
         response = StreamingHttpResponse(
-            event_stream(),
-            content_type='text/event-stream'
+            event_stream(), content_type="text/event-stream"
         )
-        response['Cache-Control'] = 'no-cache'
-        response['Connection'] = 'keep-alive'
-        response['X-Accel-Buffering'] = 'no'
-        
+        response["Cache-Control"] = "no-cache"
+        response["Connection"] = "keep-alive"
+        response["X-Accel-Buffering"] = "no"
+
         return response
 
 
@@ -1437,14 +1681,16 @@ class RedeployView(APIView):
             weights_id = request.data.get("weights_id")
             impl = model_implmentations[impl_id]
             response = run_container(impl, weights_id)
-            
+
             # Refresh tt-smi cache after successful redeployment
             if response.get("status") == "success":
                 try:
                     SystemResourceService.force_refresh_tt_smi_cache()
                 except Exception as e:
-                    logger.warning(f"Failed to refresh tt-smi cache after redeployment: {e}")
-                    
+                    logger.warning(
+                        f"Failed to refresh tt-smi cache after redeployment: {e}"
+                    )
+
             return Response(response, status=status.HTTP_201_CREATED)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -1455,27 +1701,27 @@ class ImageStatusView(APIView):
         try:
             logger.info(f"Checking image status for model_id: {model_id}")
             impl = model_implmentations[model_id]
-            image_name, image_tag = impl.image_version.split(':')
+            image_name, image_tag = impl.image_version.split(":")
             logger.info(f"Checking status for image: {image_name}:{image_tag}")
             image_status = check_image_exists(image_name, image_tag)
             logger.info(f"Image status result: {image_status}")
-            image_status['pull_in_progress'] = False
+            image_status["pull_in_progress"] = False
             return Response(image_status, status=status.HTTP_200_OK)
         except KeyError:
             logger.warning(f"Model {model_id} not found in model_implementations")
             return Response(
                 {"status": "error", "message": f"Model {model_id} not found"},
-                status=status.HTTP_404_NOT_FOUND
+                status=status.HTTP_404_NOT_FOUND,
             )
         except Exception as e:
             logger.error(f"Error checking image status: {str(e)}")
             return Response(
                 {"status": "error", "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class ModelCatalogView(APIView):
     """
     Model catalog management API that handles:
@@ -1486,17 +1732,20 @@ class ModelCatalogView(APIView):
     Note: Docker image pulling is now handled automatically by TT Inference Server
     during deployment via ensure_docker_image() function.
     """
-    renderer_classes = [JSONRenderer]  # Allow JSON renderer to prevent content negotiation issues
-    
+
+    renderer_classes = [
+        JSONRenderer
+    ]  # Allow JSON renderer to prevent content negotiation issues
+
     def options(self, request, *args, **kwargs):
         """Handle preflight requests for CORS"""
         response = Response(status=status.HTTP_200_OK)
-        response['Access-Control-Allow-Origin'] = '*'
-        response['Access-Control-Allow-Methods'] = 'GET, DELETE, OPTIONS'
-        response['Access-Control-Allow-Headers'] = 'Content-Type, Accept, Authorization'
-        response['Access-Control-Max-Age'] = '86400'
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "GET, DELETE, OPTIONS"
+        response["Access-Control-Allow-Headers"] = "Content-Type, Accept, Authorization"
+        response["Access-Control-Max-Age"] = "86400"
         return response
-    
+
     def get(self, request, *args, **kwargs):
         """Get catalog status including available models, disk space, and pull status"""
         try:
@@ -1510,15 +1759,17 @@ class ModelCatalogView(APIView):
                     disk_usage[impl_id] = {
                         "total_gb": total / (1024**3),
                         "used_gb": used / (1024**3),
-                        "free_gb": free / (1024**3)
+                        "free_gb": free / (1024**3),
                     }
                     logger.info(f"Disk usage for {impl_id}: {disk_usage[impl_id]}")
-            
+
             # Get model status
             model_status = {}
             for impl_id, impl in model_implmentations.items():
-                image_name, image_tag = impl.image_version.split(':')
-                logger.info(f"Checking status for model {impl_id}: {image_name}:{image_tag}")
+                image_name, image_tag = impl.image_version.split(":")
+                logger.info(
+                    f"Checking status for model {impl_id}: {image_name}:{image_tag}"
+                )
                 image_status = check_image_exists(image_name, image_tag)
                 model_status[impl_id] = {
                     "model_name": impl.model_name,
@@ -1527,21 +1778,20 @@ class ModelCatalogView(APIView):
                     "exists": image_status["exists"],
                     "size": image_status["size"],
                     "status": image_status["status"],
-                    "disk_usage": disk_usage.get(impl_id, None)
+                    "disk_usage": disk_usage.get(impl_id, None),
                 }
                 logger.info(f"Status for model {impl_id}: {model_status[impl_id]}")
-            
+
             logger.info("Successfully retrieved catalog status")
-            return Response({
-                "status": "success",
-                "models": model_status
-            }, status=status.HTTP_200_OK)
+            return Response(
+                {"status": "success", "models": model_status}, status=status.HTTP_200_OK
+            )
 
         except Exception as e:
             logger.error(f"Error getting catalog status: {str(e)}")
             return Response(
                 {"status": "error", "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     def delete(self, request, *args, **kwargs):
@@ -1549,16 +1799,16 @@ class ModelCatalogView(APIView):
         try:
             model_id = request.data.get("model_id")
             logger.info(f"Received request to eject model: {model_id}")
-            
+
             if not model_id or model_id not in model_implmentations:
                 logger.warning(f"Invalid model_id provided: {model_id}")
                 return Response(
                     {"status": "error", "message": f"Invalid model_id: {model_id}"},
-                    status=status.HTTP_400_BAD_REQUEST
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
 
             impl = model_implmentations[model_id]
-            image_name, image_tag = impl.image_version.split(':')
+            image_name, image_tag = impl.image_version.split(":")
             logger.info(f"Attempting to remove image: {image_name}:{image_tag}")
 
             # Remove the image via docker-control-service
@@ -1570,105 +1820,113 @@ class ModelCatalogView(APIView):
                 else:
                     raise Exception(result.get("message", "Unknown error"))
                 logger.info(f"Successfully removed image: {image_name}:{image_tag}")
-                
+
                 # Remove volume if it exists
                 volume_path = impl.volume_path
                 if volume_path.exists():
                     logger.info(f"Removing volume at path: {volume_path}")
                     shutil.rmtree(volume_path)
                     logger.info(f"Successfully removed volume for model {model_id}")
-                
-                return Response({
-                    "status": "success",
-                    "message": f"Successfully removed model {model_id}"
-                }, status=status.HTTP_200_OK)
+
+                return Response(
+                    {
+                        "status": "success",
+                        "message": f"Successfully removed model {model_id}",
+                    },
+                    status=status.HTTP_200_OK,
+                )
 
             except Exception as e:
                 logger.warning(f"Image {image_name}:{image_tag} not found: {str(e)}")
-                return Response({
-                    "status": "error",
-                    "message": f"Image {image_name}:{image_tag} not found"
-                }, status=status.HTTP_404_NOT_FOUND)
-                
+                return Response(
+                    {
+                        "status": "error",
+                        "message": f"Image {image_name}:{image_tag} not found",
+                    },
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
         except Exception as e:
             logger.error(f"Error ejecting model: {str(e)}")
             return Response(
                 {"status": "error", "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-@method_decorator(csrf_exempt, name='dispatch')
+
+@method_decorator(csrf_exempt, name="dispatch")
 class BoardInfoView(APIView):
     """
     API endpoint to provide board information to the frontend.
     This helps the frontend filter models based on board compatibility.
     """
+
     def get(self, request, *args, **kwargs):
         try:
             # Detect board type using tt-smi command
             board_type = detect_board_type()
             logger.info(f"BoardInfoView detected board type: {board_type}")
-            
+
             # Map board types to friendly names
             board_name_map = {
                 # Wormhole devices
-                'N150': 'Tenstorrent N150',
-                'N300': 'Tenstorrent N300',
-                'E150': 'Tenstorrent E150',
-                
+                "N150": "Tenstorrent N150",
+                "N300": "Tenstorrent N300",
+                "E150": "Tenstorrent E150",
                 # Wormhole multi-device
-                'N150X4': 'Tenstorrent N150x4',
-                'T3000': 'Tenstorrent T3000',
-                'T3K': 'Tenstorrent T3K',
-                
+                "N150X4": "Tenstorrent N150x4",
+                "T3000": "Tenstorrent T3000",
+                "T3K": "Tenstorrent T3K",
                 # Blackhole devices
-                'P100': 'Tenstorrent P100',
-                'P150': 'Tenstorrent P150',
-                'P300': 'Tenstorrent P300',
-
+                "P100": "Tenstorrent P100",
+                "P150": "Tenstorrent P150",
+                "P300": "Tenstorrent P300",
                 # Blackhole multi-device
-                'P150X4': 'Tenstorrent P150x4',
-                'P150X8': 'Tenstorrent P150x8',
-                'P300x2': 'Tenstorrent P300x2',    # 2 cards (4 chips)
-                'P300Cx4': 'Tenstorrent P300Cx4',  # 4 cards (8 chips)
-                
+                "P150X4": "Tenstorrent P150x4",
+                "P150X8": "Tenstorrent P150x8",
+                "P300x2": "Tenstorrent P300x2",  # 2 cards (4 chips)
+                "P300Cx4": "Tenstorrent P300Cx4",  # 4 cards (8 chips)
                 # Galaxy systems
-                'GALAXY': 'Tenstorrent Galaxy',
-                'GALAXY_T3K': 'Tenstorrent Galaxy T3K',
-                
-                'unknown': 'Unknown Board'
+                "GALAXY": "Tenstorrent Galaxy",
+                "GALAXY_T3K": "Tenstorrent Galaxy T3K",
+                "unknown": "Unknown Board",
             }
-            board_name = board_name_map.get(board_type, 'Unknown Board')
-            
-            return Response({
-                'type': board_type,
-                'name': board_name
-            }, status=status.HTTP_200_OK)
-            
+            board_name = board_name_map.get(board_type, "Unknown Board")
+
+            return Response(
+                {"type": board_type, "name": board_name}, status=status.HTTP_200_OK
+            )
+
         except Exception as e:
             logger.error(f"Error getting board info: {str(e)}")
             return Response(
                 {"status": "error", "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
-@method_decorator(csrf_exempt, name='dispatch')
+
+@method_decorator(csrf_exempt, name="dispatch")
 class DockerServiceLogsView(APIView):
     """Get recent logs from Docker services for bug reporting"""
-    
+
     def get(self, request, *args, **kwargs):
         try:
             logger.info("Fetching Docker service logs for bug report")
-            
+
             # Build logs for all TT Studio containers dynamically (backend, frontend, agent, chroma)
             # and include any that look like part of the stack, regardless of exact name
             logs_data = {}
             docker_logs_found = False
 
             try:
+
                 def classify_service(container) -> str:
                     name = (container.name or "").lower()
-                    image = (container.image.tags[0] if container.image.tags else container.image.short_id).lower()
+                    image = (
+                        container.image.tags[0]
+                        if container.image.tags
+                        else container.image.short_id
+                    ).lower()
                     candidates = name + " " + image
                     if "backend" in candidates:
                         return "tt_studio_backend"
@@ -1693,14 +1951,17 @@ class DockerServiceLogsView(APIView):
                         self.name = data.get("name")
                         self.status = data.get("status")
                         self.attrs = data.get("attrs", {})
-                        self.image = type('obj', (object,), {
-                            'tags': data.get("image_tags", [])
-                        })()
+                        self.image = type(
+                            "obj", (object,), {"tags": data.get("image_tags", [])}
+                        )()
+
                     def logs(self, tail=200, timestamps=False):
                         # This is a stub - docker-control-service doesn't support logs yet
                         return b"Logs not available via docker-control-service"
 
-                containers = [ContainerWrapper(c) for c in containers_data.get("containers", [])]
+                containers = [
+                    ContainerWrapper(c) for c in containers_data.get("containers", [])
+                ]
 
                 service_to_containers = {}
                 for c in containers:
@@ -1712,7 +1973,7 @@ class DockerServiceLogsView(APIView):
                 def fetch_logs_for_container(container) -> str:
                     try:
                         raw = container.logs(tail=200, timestamps=False)
-                        txt = raw.decode('utf-8', errors='replace').strip()
+                        txt = raw.decode("utf-8", errors="replace").strip()
                         if len(txt) > 2000:
                             txt = txt[-2000:] + "\n\n... (truncated)"
                         header = f"Container {container.name} ({container.id[:12]})\n"
@@ -1724,7 +1985,10 @@ class DockerServiceLogsView(APIView):
                     futures = {}
                     for service, conts in service_to_containers.items():
                         for c in conts:
-                            futures[executor.submit(fetch_logs_for_container, c)] = (service, c.name)
+                            futures[executor.submit(fetch_logs_for_container, c)] = (
+                                service,
+                                c.name,
+                            )
 
                     combined: dict[str, list[str]] = {}
                     for future in concurrent.futures.as_completed(futures):
@@ -1732,10 +1996,16 @@ class DockerServiceLogsView(APIView):
                         try:
                             content = future.result()
                             combined.setdefault(service, []).append(content)
-                            if content and "Failed to fetch" not in content and "No logs" not in content:
+                            if (
+                                content
+                                and "Failed to fetch" not in content
+                                and "No logs" not in content
+                            ):
                                 docker_logs_found = True
                         except Exception as e:
-                            combined.setdefault(service, []).append(f"Unexpected error: {str(e)[:500]}")
+                            combined.setdefault(service, []).append(
+                                f"Unexpected error: {str(e)[:500]}"
+                            )
 
                 # Flatten combined results to string blocks
                 for service, blocks in combined.items():
@@ -1745,21 +2015,27 @@ class DockerServiceLogsView(APIView):
             except Exception as e:
                 logger.error(f"Error initializing or fetching Docker logs: {str(e)}")
                 logs_data["docker"] = f"Docker client error: {str(e)[:500]}"
-            
+
             if not docker_logs_found:
                 if not logs_data:
                     logs_data["docker"] = "Docker logs not accessible from container"
-            
+
             # Also try to get system logs if available
             try:
                 # Check if model_run.log exists in multiple possible locations using relative paths
                 possible_model_run_logs = [
-                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "model_run.log"),  # Consolidated logs/ dir (current location)
+                    os.path.join(
+                        os.getenv("TT_STUDIO_ROOT", ""), "logs", "model_run.log"
+                    ),  # Consolidated logs/ dir (current location)
                     "logs/model_run.log",  # Relative to current directory
-                    os.path.join(os.getcwd(), "model_run.log"),  # Current working directory
+                    os.path.join(
+                        os.getcwd(), "model_run.log"
+                    ),  # Current working directory
                     "/app/model_run.log",  # Container path as fallback
                     # Legacy fastapi.log locations (pre-rename) kept for backward compatibility
-                    os.path.join(os.getenv("TT_STUDIO_ROOT", ""), "logs", "fastapi.log"),
+                    os.path.join(
+                        os.getenv("TT_STUDIO_ROOT", ""), "logs", "fastapi.log"
+                    ),
                     "logs/fastapi.log",
                     "fastapi.log",
                     "/app/fastapi.log",
@@ -1769,149 +2045,187 @@ class DockerServiceLogsView(APIView):
                 for model_run_log_path in possible_model_run_logs:
                     if os.path.exists(model_run_log_path):
                         try:
-                            with open(model_run_log_path, 'r') as f:
+                            with open(model_run_log_path, "r") as f:
                                 lines = f.readlines()
                                 # Get last 8 lines and limit size
-                                log_content = ''.join(lines[-8:])
+                                log_content = "".join(lines[-8:])
                                 if len(log_content) > 800:
-                                    log_content = log_content[-800:] + "\n\n... (truncated)"
+                                    log_content = (
+                                        log_content[-800:] + "\n\n... (truncated)"
+                                    )
                                 logs_data["model_run"] = log_content
                             model_run_log_found = True
                             break
                         except Exception as read_error:
-                            logger.error(f"Error reading {model_run_log_path}: {str(read_error)}")
+                            logger.error(
+                                f"Error reading {model_run_log_path}: {str(read_error)}"
+                            )
                             continue
 
                 if not model_run_log_found:
-                    logs_data["model_run"] = "model_run.log not accessible from container (logs available from Docker containers above)"
+                    logs_data["model_run"] = (
+                        "model_run.log not accessible from container (logs available from Docker containers above)"
+                    )
 
             except Exception as e:
                 logger.error(f"Error reading model_run.log: {str(e)}")
                 logs_data["model_run"] = f"Error reading model_run.log: {str(e)[:500]}"
-            
+
             # Try to get backend log file if available
             try:
                 # Try multiple possible paths for backend logs
                 possible_backend_log_paths = [
-                    os.path.join(os.getenv("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/path/to/fallback"), "backend_volume", "python_logs"),
-                    os.path.join(os.getenv("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/path/to/fallback"), "python_logs"),
+                    os.path.join(
+                        os.getenv(
+                            "INTERNAL_PERSISTENT_STORAGE_VOLUME", "/path/to/fallback"
+                        ),
+                        "backend_volume",
+                        "python_logs",
+                    ),
+                    os.path.join(
+                        os.getenv(
+                            "INTERNAL_PERSISTENT_STORAGE_VOLUME", "/path/to/fallback"
+                        ),
+                        "python_logs",
+                    ),
                     "/tt_studio_persistent_volume/backend_volume/python_logs",
-                    "/tt_studio_persistent_volume/python_logs"
+                    "/tt_studio_persistent_volume/python_logs",
                 ]
-                
+
                 backend_log_found = False
                 for backend_log_path in possible_backend_log_paths:
                     if os.path.exists(backend_log_path):
                         try:
                             # Get the most recent log file
-                            log_files = [f for f in os.listdir(backend_log_path) if f.endswith('.log')]
+                            log_files = [
+                                f
+                                for f in os.listdir(backend_log_path)
+                                if f.endswith(".log")
+                            ]
                             if log_files:
-                                latest_log = max(log_files, key=lambda x: os.path.getctime(os.path.join(backend_log_path, x)))
-                                latest_log_path = os.path.join(backend_log_path, latest_log)
-                                with open(latest_log_path, 'r') as f:
+                                latest_log = max(
+                                    log_files,
+                                    key=lambda x: os.path.getctime(
+                                        os.path.join(backend_log_path, x)
+                                    ),
+                                )
+                                latest_log_path = os.path.join(
+                                    backend_log_path, latest_log
+                                )
+                                with open(latest_log_path, "r") as f:
                                     lines = f.readlines()
                                     # Get last 8 lines and limit size
-                                    log_content = ''.join(lines[-8:])
+                                    log_content = "".join(lines[-8:])
                                     if len(log_content) > 800:
-                                        log_content = log_content[-800:] + "\n\n... (truncated)"
+                                        log_content = (
+                                            log_content[-800:] + "\n\n... (truncated)"
+                                        )
                                     logs_data["backend_log"] = log_content
                                 backend_log_found = True
                                 break
                         except Exception as read_error:
-                            logger.error(f"Error reading from {backend_log_path}: {str(read_error)}")
+                            logger.error(
+                                f"Error reading from {backend_log_path}: {str(read_error)}"
+                            )
                             continue
-                
+
                 if not backend_log_found:
-                    logs_data["backend_log"] = "Backend logs directory not found in any expected location"
-                    
+                    logs_data["backend_log"] = (
+                        "Backend logs directory not found in any expected location"
+                    )
+
             except Exception as e:
                 logger.error(f"Error reading backend logs: {str(e)}")
                 logs_data["backend_log"] = f"Error reading backend logs: {str(e)[:500]}"
-            
+
             # Add a summary of total log size
             total_size = sum(len(str(logs)) for logs in logs_data.values())
             logs_data["_summary"] = f"Total log size: {total_size} characters"
-            
+
             return Response(logs_data, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error fetching Docker service logs: {str(e)}")
             return Response(
                 {"error": "Failed to fetch Docker service logs", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
 class ContainerEventsView(APIView):
     """Server-Sent Events stream for container death notifications"""
-    
+
     def get(self, request):
         """Stream container death events to frontend"""
         import time
         from docker_control.models import ModelDeployment
-        
+
         def event_stream():
             """Generator that yields SSE-formatted events"""
             # Keep track of last check time
             last_check = {}
-            
+
             # Send initial connection message
             yield f"data: {json.dumps({'event': 'connected', 'message': 'Container events stream connected'})}\n\n"
-            
+
             while True:
                 try:
                     # Check for containers that died since last check
                     recent_deaths = ModelDeployment.objects.filter(
-                        status__in=['exited', 'dead'],
-                        stopped_by_user=False
-                    ).order_by('-stopped_at')[:10]  # Get last 10 unexpected deaths
-                    
+                        status__in=["exited", "dead"], stopped_by_user=False
+                    ).order_by("-stopped_at")[:10]  # Get last 10 unexpected deaths
+
                     for deployment in recent_deaths:
                         # Only send if we haven't sent this one before
-                        if deployment.container_id not in last_check or last_check[deployment.container_id] != deployment.stopped_at:
+                        if (
+                            deployment.container_id not in last_check
+                            or last_check[deployment.container_id]
+                            != deployment.stopped_at
+                        ):
                             event_data = {
-                                'event': 'container_died',
-                                'container_id': deployment.container_id,
-                                'container_name': deployment.container_name,
-                                'model_name': deployment.model_name,
-                                'device': deployment.device,
-                                'status': deployment.status,
-                                'stopped_at': deployment.stopped_at.isoformat() if deployment.stopped_at else None
+                                "event": "container_died",
+                                "container_id": deployment.container_id,
+                                "container_name": deployment.container_name,
+                                "model_name": deployment.model_name,
+                                "device": deployment.device,
+                                "status": deployment.status,
+                                "stopped_at": deployment.stopped_at.isoformat()
+                                if deployment.stopped_at
+                                else None,
                             }
                             yield f"data: {json.dumps(event_data)}\n\n"
                             last_check[deployment.container_id] = deployment.stopped_at
-                    
+
                     # Send heartbeat every 30 seconds
                     yield f"data: {json.dumps({'event': 'heartbeat', 'timestamp': time.time()})}\n\n"
-                    
+
                     # Wait before next check
                     time.sleep(30)
-                    
+
                 except Exception as e:
                     logger.error(f"Error in SSE stream: {e}")
                     yield f"data: {json.dumps({'event': 'error', 'message': str(e)})}\n\n"
                     break
-        
+
         response = StreamingHttpResponse(
-            event_stream(),
-            content_type='text/event-stream'
+            event_stream(), content_type="text/event-stream"
         )
-        response['Cache-Control'] = 'no-cache'
-        response['X-Accel-Buffering'] = 'no'
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
         return response
 
 
 class DeploymentHistoryView(APIView):
     """Get deployment history from database"""
-    
+
     def get(self, request):
         """Return all deployments ordered by most recent first"""
         try:
             from docker_control.models import ModelDeployment
-            
+
             # Get all deployments, ordered by most recent first
-            deployments = ModelDeployment.objects.all().order_by('-deployed_at')
-            
+            deployments = ModelDeployment.objects.all().order_by("-deployed_at")
+
             # Serialize the data, lazily backfilling workflow_log_path when missing
             deployment_data = []
             for deployment in deployments:
@@ -1929,34 +2243,45 @@ class DeploymentHistoryView(APIView):
                         try:
                             deployment.save()
                         except Exception as save_err:
-                            logger.warning(f"Could not save workflow_log_path for deployment {deployment.id}: {save_err}")
+                            logger.warning(
+                                f"Could not save workflow_log_path for deployment {deployment.id}: {save_err}"
+                            )
 
-                deployment_data.append({
-                    'id': deployment.id,
-                    'container_id': deployment.container_id,
-                    'container_name': deployment.container_name,
-                    'model_name': deployment.model_name,
-                    'device': deployment.device,
-                    'device_id': deployment.device_id,
-                    'deployed_at': deployment.deployed_at.isoformat() if deployment.deployed_at else None,
-                    'stopped_at': deployment.stopped_at.isoformat() if deployment.stopped_at else None,
-                    'status': deployment.status,
-                    'stopped_by_user': deployment.stopped_by_user,
-                    'port': deployment.port,
-                    'workflow_log_path': deployment.workflow_log_path,
-                })
-            
-            return Response({
-                'status': 'success',
-                'deployments': deployment_data,
-                'count': len(deployment_data)
-            }, status=status.HTTP_200_OK)
-            
+                deployment_data.append(
+                    {
+                        "id": deployment.id,
+                        "container_id": deployment.container_id,
+                        "container_name": deployment.container_name,
+                        "model_name": deployment.model_name,
+                        "device": deployment.device,
+                        "device_id": deployment.device_id,
+                        "deployed_at": deployment.deployed_at.isoformat()
+                        if deployment.deployed_at
+                        else None,
+                        "stopped_at": deployment.stopped_at.isoformat()
+                        if deployment.stopped_at
+                        else None,
+                        "status": deployment.status,
+                        "stopped_by_user": deployment.stopped_by_user,
+                        "port": deployment.port,
+                        "workflow_log_path": deployment.workflow_log_path,
+                    }
+                )
+
+            return Response(
+                {
+                    "status": "success",
+                    "deployments": deployment_data,
+                    "count": len(deployment_data),
+                },
+                status=status.HTTP_200_OK,
+            )
+
         except Exception as e:
             logger.error(f"Error fetching deployment history: {e}")
             return Response(
-                {'status': 'error', 'message': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {"status": "error", "message": str(e)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
@@ -1970,7 +2295,9 @@ class DiscoverContainersView(APIView):
         try:
             docker_client = get_docker_client()
             response = docker_client.list_containers(all=False)
-            containers_list = response.get("containers", []) if isinstance(response, dict) else []
+            containers_list = (
+                response.get("containers", []) if isinstance(response, dict) else []
+            )
 
             network_name = backend_config.docker_bridge_network_name
             results = []
@@ -1978,7 +2305,10 @@ class DiscoverContainersView(APIView):
             for c in containers_list:
                 name = c.get("name", "")
                 # Skip TT Studio infrastructure containers
-                if any(name.startswith(p) or name.lower().startswith(p) for p in self._INFRA_PREFIXES):
+                if any(
+                    name.startswith(p) or name.lower().startswith(p)
+                    for p in self._INFRA_PREFIXES
+                ):
                     continue
 
                 # Skip containers already on tt_studio_network
@@ -1993,13 +2323,15 @@ class DiscoverContainersView(APIView):
                 if not port_bindings:
                     port_bindings = c.get("port_bindings", {})
 
-                results.append({
-                    "id": c.get("id", ""),
-                    "name": name,
-                    "image": c.get("Config", {}).get("Image", c.get("image", "")),
-                    "status": c.get("status", ""),
-                    "port_bindings": port_bindings or {},
-                })
+                results.append(
+                    {
+                        "id": c.get("id", ""),
+                        "name": name,
+                        "image": c.get("Config", {}).get("Image", c.get("image", "")),
+                        "status": c.get("status", ""),
+                        "port_bindings": port_bindings or {},
+                    }
+                )
 
             return Response(results, status=status.HTTP_200_OK)
 
@@ -2053,20 +2385,26 @@ class RegisterExternalModelView(APIView):
             # --- Validate required fields ---
             if not container_id or not model_type or not model_name:
                 return Response(
-                    {"status": "error", "message": "container_id, model_type, and model_name are required."},
+                    {
+                        "status": "error",
+                        "message": "container_id, model_type, and model_name are required.",
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
             if model_type not in self._DEFAULT_ROUTES and model_type != "mock":
                 valid_types = ", ".join(sorted(self._DEFAULT_ROUTES.keys()))
                 return Response(
-                    {"status": "error", "message": f"Invalid model_type '{model_type}'. Valid types: {valid_types}"},
+                    {
+                        "status": "error",
+                        "message": f"Invalid model_type '{model_type}'. Valid types: {valid_types}",
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
             # --- Validate device_id against chip slot availability ---
             try:
-                from docker_control.chip_allocator import ChipSlotAllocator, AllocationError, MultiChipConflictError
+                from docker_control.chip_allocator import ChipSlotAllocator
 
                 allocator = ChipSlotAllocator()
                 chip_status = allocator.get_chip_status()
@@ -2075,7 +2413,9 @@ class RegisterExternalModelView(APIView):
                 if chips_required >= 4:
                     # Multi-chip: all slots (0-3) must be free
                     occupied_slots = [
-                        s for s in chip_status.get("slots", []) if s.get("status") == "occupied"
+                        s
+                        for s in chip_status.get("slots", [])
+                        if s.get("status") == "occupied"
                     ]
                     if occupied_slots:
                         occupied_names = ", ".join(
@@ -2101,7 +2441,11 @@ class RegisterExternalModelView(APIView):
                             status=status.HTTP_400_BAD_REQUEST,
                         )
                     slot_info = next(
-                        (s for s in chip_status.get("slots", []) if s.get("slot_id") == device_id),
+                        (
+                            s
+                            for s in chip_status.get("slots", [])
+                            if s.get("slot_id") == device_id
+                        ),
                         None,
                     )
                     if slot_info and slot_info.get("status") == "occupied":
@@ -2114,7 +2458,9 @@ class RegisterExternalModelView(APIView):
                             status=status.HTTP_400_BAD_REQUEST,
                         )
             except ImportError:
-                logger.warning("ChipSlotAllocator not available; skipping device_id validation")
+                logger.warning(
+                    "ChipSlotAllocator not available; skipping device_id validation"
+                )
 
             corrections = []
 
@@ -2124,14 +2470,20 @@ class RegisterExternalModelView(APIView):
                 container_info = docker_client.get_container(container_id)
             except Exception:
                 return Response(
-                    {"status": "error", "message": f"Container '{container_id}' not found or not accessible."},
+                    {
+                        "status": "error",
+                        "message": f"Container '{container_id}' not found or not accessible.",
+                    },
                     status=status.HTTP_404_NOT_FOUND,
                 )
 
             container_status = container_info.get("status", "")
             if "running" not in container_status.lower():
                 return Response(
-                    {"status": "error", "message": f"Container '{container_id}' is not running (status: {container_status})."},
+                    {
+                        "status": "error",
+                        "message": f"Container '{container_id}' is not running (status: {container_status}).",
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
@@ -2147,7 +2499,11 @@ class RegisterExternalModelView(APIView):
                     except (ValueError, IndexError):
                         pass
 
-            if service_port and exposed_ports and int(service_port) not in exposed_ports:
+            if (
+                service_port
+                and exposed_ports
+                and int(service_port) not in exposed_ports
+            ):
                 return Response(
                     {
                         "status": "error",
@@ -2161,13 +2517,20 @@ class RegisterExternalModelView(APIView):
                 try:
                     catalog_data = json.loads(_CATALOG_PATH.read_text())
                     for catalog_model in catalog_data.get("models", []):
-                        if catalog_model.get("hf_model_id", "").lower() == hf_model_id.lower():
+                        if (
+                            catalog_model.get("hf_model_id", "").lower()
+                            == hf_model_id.lower()
+                        ):
                             # Found a catalog match — use its authoritative routes
                             catalog_route = catalog_model.get("service_route")
                             catalog_health = catalog_model.get("health_route")
                             catalog_type = catalog_model.get("model_type", "").lower()
 
-                            if catalog_route and service_route and service_route != catalog_route:
+                            if (
+                                catalog_route
+                                and service_route
+                                and service_route != catalog_route
+                            ):
                                 corrections.append(
                                     f"Service route corrected from '{service_route}' to '{catalog_route}' based on catalog entry for {catalog_model.get('model_name')}"
                                 )
@@ -2193,7 +2556,9 @@ class RegisterExternalModelView(APIView):
 
             # --- Apply default route if still unset ---
             if not service_route:
-                service_route = self._DEFAULT_ROUTES.get(model_type, "/v1/chat/completions")
+                service_route = self._DEFAULT_ROUTES.get(
+                    model_type, "/v1/chat/completions"
+                )
 
             # --- Rename container based on model name ---
             current_name = container_info.get("name", container_id)
@@ -2209,9 +2574,13 @@ class RegisterExternalModelView(APIView):
             if desired_name and current_name != desired_name:
                 try:
                     docker_client.rename_container(container_id, desired_name)
-                    corrections.append(f"Container renamed from '{current_name}' to '{desired_name}'")
+                    corrections.append(
+                        f"Container renamed from '{current_name}' to '{desired_name}'"
+                    )
                     container_name = desired_name
-                    logger.info(f"Renamed container '{current_name}' to '{desired_name}'")
+                    logger.info(
+                        f"Renamed container '{current_name}' to '{desired_name}'"
+                    )
                 except Exception as e:
                     logger.warning(f"Could not rename container: {e}")
                     container_name = current_name
@@ -2224,21 +2593,33 @@ class RegisterExternalModelView(APIView):
 
             if network_name not in networks:
                 try:
-                    docker_client.connect_container_to_network(network_name, container_id)
-                    logger.info(f"Connected container '{container_id}' to network '{network_name}'")
+                    docker_client.connect_container_to_network(
+                        network_name, container_id
+                    )
+                    logger.info(
+                        f"Connected container '{container_id}' to network '{network_name}'"
+                    )
                 except requests.exceptions.HTTPError as e:
                     if e.response is not None and e.response.status_code in (409, 500):
                         # Already connected or similar — treat as non-fatal
-                        corrections.append(f"Container may already be on {network_name}")
+                        corrections.append(
+                            f"Container may already be on {network_name}"
+                        )
                         logger.warning(f"Non-fatal error connecting to network: {e}")
                     else:
                         return Response(
-                            {"status": "error", "message": f"Failed to connect container to {network_name}: {e}"},
+                            {
+                                "status": "error",
+                                "message": f"Failed to connect container to {network_name}: {e}",
+                            },
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                         )
                 except Exception as e:
                     return Response(
-                        {"status": "error", "message": f"Failed to connect container to {network_name}: {e}"},
+                        {
+                            "status": "error",
+                            "message": f"Failed to connect container to {network_name}: {e}",
+                        },
                         status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     )
             else:
@@ -2265,7 +2646,9 @@ class RegisterExternalModelView(APIView):
                         stopped_by_user=False,
                         port=int(service_port) if service_port else 7000,
                     )
-                    logger.info(f"Created deployment record for external container '{container_name}' on device_id={device_id}")
+                    logger.info(
+                        f"Created deployment record for external container '{container_name}' on device_id={device_id}"
+                    )
             except Exception as e:
                 logger.error(f"Failed to create deployment record: {e}")
                 # Continue — the network connection is the critical part
@@ -2294,85 +2677,81 @@ class RegisterExternalModelView(APIView):
             )
 
 
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class WorkflowLogStreamView(View):
     """Stream workflow logs from file using Server-Sent Events"""
-    
+
     def get(self, request, deployment_id, *args, **kwargs):
         """Stream workflow log file for a specific deployment"""
         try:
             from docker_control.models import ModelDeployment
             from django.http import HttpResponse
-            
+
             # Get deployment record
             logger.info(f"Fetching workflow logs for deployment_id: {deployment_id}")
             deployment = ModelDeployment.objects.get(id=deployment_id)
-            logger.info(f"Found deployment: {deployment.model_name}, workflow_log_path: {deployment.workflow_log_path}")
-            
+            logger.info(
+                f"Found deployment: {deployment.model_name}, workflow_log_path: {deployment.workflow_log_path}"
+            )
+
             if not deployment.workflow_log_path:
                 logger.warning(f"No workflow log path for deployment {deployment_id}")
                 return HttpResponse(
                     status=404,
-                    content="No workflow log file available for this deployment"
+                    content="No workflow log file available for this deployment",
                 )
-            
+
             log_file_path = deployment.workflow_log_path
-            
+
             # Check if file exists
             if not os.path.exists(log_file_path):
                 logger.error(f"Log file not found at path: {log_file_path}")
                 return HttpResponse(
-                    status=404,
-                    content=f"Log file not found: {log_file_path}"
+                    status=404, content=f"Log file not found: {log_file_path}"
                 )
-            
+
             def generate_log_data():
                 try:
                     yield "retry: 1000\n\n"
-                    
-                    with open(log_file_path, 'r') as f:
+
+                    with open(log_file_path, "r") as f:
                         for line in f:
-                            line = line.rstrip('\n\r')
+                            line = line.rstrip("\n\r")
                             if line:
-                                event_data = {
-                                    "type": "log",
-                                    "message": line
-                                }
+                                event_data = {"type": "log", "message": line}
                                 yield f"data: {json.dumps(event_data)}\n\n"
-                    
+
                     # Send completion event
                     yield f"data: {json.dumps({'type': 'complete', 'message': 'End of log file'})}\n\n"
-                    
+
                 except Exception as e:
                     logger.error(f"Error streaming log file: {str(e)}")
                     error_data = {
                         "type": "error",
-                        "message": f"Error reading log file: {str(e)}"
+                        "message": f"Error reading log file: {str(e)}",
                     }
                     yield f"data: {json.dumps(error_data)}\n\n"
-            
+
             response = StreamingHttpResponse(
-                generate_log_data(),
-                content_type='text/event-stream'
+                generate_log_data(), content_type="text/event-stream"
             )
-            response['Cache-Control'] = 'no-cache, no-transform'
-            response['X-Accel-Buffering'] = 'no'
-            
+            response["Cache-Control"] = "no-cache, no-transform"
+            response["X-Accel-Buffering"] = "no"
+
             return response
-            
+
         except ModelDeployment.DoesNotExist:
             logger.warning(f"Deployment {deployment_id} not found in database")
             return HttpResponse(
-                status=404,
-                content=f"Deployment {deployment_id} not found"
+                status=404, content=f"Deployment {deployment_id} not found"
             )
         except Exception as e:
             import traceback
-            logger.error(f"Error in WorkflowLogStreamView: {str(e)}\n{traceback.format_exc()}")
-            return HttpResponse(
-                status=500,
-                content=str(e)
+
+            logger.error(
+                f"Error in WorkflowLogStreamView: {str(e)}\n{traceback.format_exc()}"
             )
+            return HttpResponse(status=500, content=str(e))
 
 
 # --- Server-Sent Events helpers -------------------------------------------------
@@ -2406,9 +2785,11 @@ async def _astream_stop_remove_container(container_id, truncated):
 
     Raises _StopFailed if the container could not be stopped.
     """
+
     def _mark_stopped():
         from docker_control.models import ModelDeployment
         from django.utils import timezone
+
         deployment = ModelDeployment.objects.filter(container_id=container_id).first()
         if not deployment:
             return "No deployment record found — continuing"
@@ -2443,7 +2824,9 @@ async def _astream_stop_remove_container(container_id, truncated):
     docker_client = get_docker_client()
     container_gone = False
     try:
-        stop_result = await asyncio.to_thread(docker_client.stop_container, container_id)
+        stop_result = await asyncio.to_thread(
+            docker_client.stop_container, container_id
+        )
     except Exception as e:
         # 404 / "Not Found" means the container is already gone — not an error.
         error_str = str(e)
@@ -2485,7 +2868,7 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
     line, then ("ok", succeeded) once. Marks the resetting cache state before and
     clears it after; refreshes the tt-smi cache on success only when force_refresh.
     """
-    ansi_re = re.compile(r'\x1b\[[0-9;]*m|\|[0-9;]*m')
+    ansi_re = re.compile(r"\x1b\[[0-9;]*m|\|[0-9;]*m")
     id_args = [str(d) for d in device_ids]
     label = ", ".join(id_args) if id_args else "board"
     command = " ".join(["tt-smi", "-r", *id_args])
@@ -2499,17 +2882,23 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
         yield ("log", f"Running {command} (attempt {attempt}/{MAX_ATTEMPTS})…")
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tt-smi", "-r", *id_args,
+                "tt-smi",
+                "-r",
+                *id_args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 stdin=asyncio.subprocess.DEVNULL,
             )
             try:
                 while True:
-                    raw = await asyncio.wait_for(proc.stdout.readline(), timeout=line_timeout)
+                    raw = await asyncio.wait_for(
+                        proc.stdout.readline(), timeout=line_timeout
+                    )
                     if not raw:
                         break
-                    line = ansi_re.sub("", raw.decode("utf-8", errors="replace")).strip()
+                    line = ansi_re.sub(
+                        "", raw.decode("utf-8", errors="replace")
+                    ).strip()
                     if line:
                         yield ("log", line)
                 await asyncio.wait_for(proc.wait(), timeout=10)
@@ -2530,7 +2919,10 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
             reset_ok = True
             yield ("log", f"Device(s) {label} reset succeeded on attempt {attempt}")
             break
-        yield ("log", f"Reset of {label} attempt {attempt} failed (exit code {returncode})")
+        yield (
+            "log",
+            f"Reset of {label} attempt {attempt} failed (exit code {returncode})",
+        )
 
     await asyncio.to_thread(SystemResourceService.clear_device_state_cache)
     if reset_ok and force_refresh:
@@ -2546,16 +2938,20 @@ async def _astream_tt_smi_reset(device_ids, *, force_refresh):
 async def _astream_reset_phase(device_ids, *, force_refresh, success_msg, partial_msg):
     """Stream a reset as SSE `resetting` logs followed by a `complete` event."""
     reset_ok = False
-    async for kind, payload in _astream_tt_smi_reset(device_ids, force_refresh=force_refresh):
+    async for kind, payload in _astream_tt_smi_reset(
+        device_ids, force_refresh=force_refresh
+    ):
         if kind == "log":
             yield _sse_event({"type": "log", "step": "resetting", "message": payload})
         else:
             reset_ok = payload
-    yield _sse_event({
-        "type": "complete",
-        "status": "success" if reset_ok else "partial",
-        "message": success_msg if reset_ok else partial_msg,
-    })
+    yield _sse_event(
+        {
+            "type": "complete",
+            "status": "success" if reset_ok else "partial",
+            "message": success_msg if reset_ok else partial_msg,
+        }
+    )
 
 
 class StopStreamView(View):
@@ -2568,36 +2964,78 @@ class StopStreamView(View):
     """
 
     async def get(self, request, container_id, *args, **kwargs):
-        skip_device_reset = request.GET.get("skip_device_reset", "false").lower() == "true"
+        skip_device_reset = (
+            request.GET.get("skip_device_reset", "false").lower() == "true"
+        )
 
         async def generate():
             yield "retry: 1000\n\n"
             truncated = container_id[:12]
             try:
                 # Step 1: stop and remove the container.
-                yield _sse_event({"type": "step", "step": "deleting", "message": f"Stopping model {truncated}…"})
+                yield _sse_event(
+                    {
+                        "type": "step",
+                        "step": "deleting",
+                        "message": f"Stopping model {truncated}…",
+                    }
+                )
                 try:
-                    async for msg in _astream_stop_remove_container(container_id, truncated):
-                        yield _sse_event({"type": "log", "step": "deleting", "message": msg})
+                    async for msg in _astream_stop_remove_container(
+                        container_id, truncated
+                    ):
+                        yield _sse_event(
+                            {"type": "log", "step": "deleting", "message": msg}
+                        )
                 except _StopFailed as e:
-                    yield _sse_event({"type": "complete", "status": "error", "message": str(e)})
+                    yield _sse_event(
+                        {"type": "complete", "status": "error", "message": str(e)}
+                    )
                     return
 
                 # Stop-only: leave the chips for a later whole-board reset.
                 if skip_device_reset:
-                    await asyncio.to_thread(SystemResourceService.force_refresh_tt_smi_cache)
-                    yield _sse_event({"type": "complete", "status": "success", "message": f"Model {truncated} stopped"})
+                    await asyncio.to_thread(
+                        SystemResourceService.force_refresh_tt_smi_cache
+                    )
+                    yield _sse_event(
+                        {
+                            "type": "complete",
+                            "status": "success",
+                            "message": f"Model {truncated} stopped",
+                        }
+                    )
                     return
 
                 # Step 2: reset the chips this model occupied.
-                device_ids = await asyncio.to_thread(_lookup_deployment_device_ids, container_id)
+                device_ids = await asyncio.to_thread(
+                    _lookup_deployment_device_ids, container_id
+                )
                 if not device_ids:
-                    yield _sse_event({"type": "step", "step": "resetting", "message": "Skipping device reset (no device_ids on record)"})
-                    yield _sse_event({"type": "complete", "status": "success", "message": "Model deleted (no device reset performed)"})
+                    yield _sse_event(
+                        {
+                            "type": "step",
+                            "step": "resetting",
+                            "message": "Skipping device reset (no device_ids on record)",
+                        }
+                    )
+                    yield _sse_event(
+                        {
+                            "type": "complete",
+                            "status": "success",
+                            "message": "Model deleted (no device reset performed)",
+                        }
+                    )
                     return
 
                 label = ", ".join(str(d) for d in device_ids)
-                yield _sse_event({"type": "step", "step": "resetting", "message": f"Resetting device(s) {label}…"})
+                yield _sse_event(
+                    {
+                        "type": "step",
+                        "step": "resetting",
+                        "message": f"Resetting device(s) {label}…",
+                    }
+                )
                 async for event in _astream_reset_phase(
                     device_ids,
                     force_refresh=True,
@@ -2612,7 +3050,13 @@ class StopStreamView(View):
                 # Never let the stream die without a terminal event; the client
                 # treats an abrupt close as "Connection to stream lost".
                 logger.error(f"Stop stream for {truncated} failed: {e}", exc_info=True)
-                yield _sse_event({"type": "complete", "status": "error", "message": f"Stop failed: {e}"})
+                yield _sse_event(
+                    {
+                        "type": "complete",
+                        "status": "error",
+                        "message": f"Stop failed: {e}",
+                    }
+                )
 
         return _sse_response(generate())
 
@@ -2630,7 +3074,13 @@ class ResetStreamView(View):
         async def generate():
             yield "retry: 1000\n\n"
             try:
-                yield _sse_event({"type": "step", "step": "resetting", "message": f"Resetting {label}…"})
+                yield _sse_event(
+                    {
+                        "type": "step",
+                        "step": "resetting",
+                        "message": f"Resetting {label}…",
+                    }
+                )
                 async for event in _astream_reset_phase(
                     device_ids,
                     force_refresh=False,
@@ -2642,7 +3092,13 @@ class ResetStreamView(View):
                 # Always emit a terminal event so the client never sees an abrupt
                 # close ("Connection to stream lost") on an unexpected failure.
                 logger.error(f"Reset stream for {label} failed: {e}", exc_info=True)
-                yield _sse_event({"type": "complete", "status": "error", "message": f"Reset failed: {e}"})
+                yield _sse_event(
+                    {
+                        "type": "complete",
+                        "status": "error",
+                        "message": f"Reset failed: {e}",
+                    }
+                )
 
         return _sse_response(generate())
 
@@ -2657,7 +3113,9 @@ class ResetStreamView(View):
 # Progress is persisted to a small JSON file on the shared backend volume so a
 # status poll served by any uvicorn worker observes the same state.
 
-_RESET_ALL_STATE_PATH = Path(backend_config.backend_cache_root) / "reset_all_status.json"
+_RESET_ALL_STATE_PATH = (
+    Path(backend_config.backend_cache_root) / "reset_all_status.json"
+)
 _reset_all_write_lock = threading.Lock()
 _reset_all_task = None  # holds a reference so the detached task isn't garbage-collected
 
@@ -2672,6 +3130,7 @@ def _reset_all_read_state():
 
 def _reset_all_write_state(state):
     from django.utils import timezone
+
     state["updated_at"] = timezone.now().isoformat()
     tmp = _RESET_ALL_STATE_PATH.with_name(_RESET_ALL_STATE_PATH.name + ".tmp")
     with _reset_all_write_lock:
@@ -2687,6 +3146,7 @@ async def _run_reset_all_job():
     progress to the shared state file after each step.
     """
     from django.utils import timezone
+
     state = {
         "step": "deleting",
         "logs": [],
@@ -2721,7 +3181,9 @@ async def _run_reset_all_job():
         for round_no in range(1, MAX_ROUNDS + 1):
             if not remaining:
                 break
-            _log(f"{len(remaining)} model(s) still present; retry {round_no}/{MAX_ROUNDS}…")
+            _log(
+                f"{len(remaining)} model(s) still present; retry {round_no}/{MAX_ROUNDS}…"
+            )
             for cid in list(remaining):
                 names.setdefault(cid, remaining[cid].get("name", cid[:12]))
                 try:
@@ -2731,7 +3193,9 @@ async def _run_reset_all_job():
                     _log(f"{names.get(cid, cid[:12])}: {e}")
             remaining = await asyncio.to_thread(get_container_status)
 
-        state["remaining"] = [info.get("name", cid[:12]) for cid, info in remaining.items()]
+        state["remaining"] = [
+            info.get("name", cid[:12]) for cid, info in remaining.items()
+        ]
         state["deleted"] = [n for cid, n in names.items() if cid not in remaining]
         if remaining:
             state["step"] = "done"
@@ -2755,7 +3219,9 @@ async def _run_reset_all_job():
         state["done"] = True
         state["ok"] = reset_ok
         if not reset_ok:
-            state["error"] = "Board reset did not complete successfully. Manual intervention may be required."
+            state["error"] = (
+                "Board reset did not complete successfully. Manual intervention may be required."
+            )
         _reset_all_write_state(state)
     except Exception as e:
         logger.exception("reset_all job failed")
@@ -2779,6 +3245,7 @@ class StartResetAllView(View):
         if existing is not None and not existing.get("done"):
             from django.utils import timezone
             from django.utils.dateparse import parse_datetime
+
             updated = parse_datetime(existing.get("updated_at") or "")
             if updated is not None and (timezone.now() - updated).total_seconds() < 120:
                 return JsonResponse({"status": "already_running"}, status=202)
@@ -2792,10 +3259,17 @@ class ResetAllStatusView(View):
     def get(self, request, *args, **kwargs):
         state = _reset_all_read_state()
         if state is None:
-            return JsonResponse({
-                "step": "idle", "logs": [], "done": True, "ok": True,
-                "error": None, "deleted": [], "remaining": [],
-            })
+            return JsonResponse(
+                {
+                    "step": "idle",
+                    "logs": [],
+                    "done": True,
+                    "ok": True,
+                    "error": None,
+                    "deleted": [],
+                    "remaining": [],
+                }
+            )
         return JsonResponse(state)
 
 
@@ -2813,15 +3287,16 @@ class AvailableDevicesView(APIView):
         for device_path in device_paths:
             try:
                 device_id = int(os.path.basename(device_path))
-                devices.append({
-                    "id": device_id,
-                    "path": device_path,
-                    "available": os.access(device_path, os.R_OK | os.W_OK)
-                })
+                devices.append(
+                    {
+                        "id": device_id,
+                        "path": device_path,
+                        "available": os.access(device_path, os.R_OK | os.W_OK),
+                    }
+                )
             except (ValueError, OSError) as e:
                 logger.warning(f"Error checking device {device_path}: {e}")
 
-        return Response({
-            "devices": devices,
-            "count": len(devices)
-        }, status=status.HTTP_200_OK)
+        return Response(
+            {"devices": devices, "count": len(devices)}, status=status.HTTP_200_OK
+        )

--- a/app/backend/logs_control/urls.py
+++ b/app/backend/logs_control/urls.py
@@ -17,7 +17,11 @@ urlpatterns = [
     path("fastapi/", FastAPILogsView.as_view(), name="fastapi_logs"),
     path("tt-inference/", TtInferenceLogsView.as_view(), name="tt_inference_logs"),
     path("bug-report/", BugReportDataView.as_view(), name="bug_report_data"),
-    path("bug-report/download/", BugReportDownloadView.as_view(), name="bug_report_download"),
+    path(
+        "bug-report/download/",
+        BugReportDownloadView.as_view(),
+        name="bug_report_download",
+    ),
     path("github-issue/", GitHubIssueView.as_view(), name="github_issue"),
     path("", ListLogsView.as_view(), name="list_logs"),
     path("<path:filename>/", GetLogView.as_view(), name="get_log"),  # catch-all

--- a/app/backend/logs_control/views.py
+++ b/app/backend/logs_control/views.py
@@ -5,13 +5,12 @@ import io
 import json
 import os
 import glob
-import subprocess
 import urllib.request
 import urllib.error
 import zipfile
 import docker
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import unquote, urlencode
 from django.http import JsonResponse, HttpResponse, Http404
 from rest_framework.views import APIView
@@ -32,18 +31,58 @@ TT_STUDIO_ROOT = os.getenv("TT_STUDIO_ROOT", "/workspace")
 BUG_REPORT_MANIFEST = [
     # key in data dict         zip path                         how it's fetched
     # ─────────────────────── ──────────────────────────────── ───────────────────────────────────────────
-    ("backend_log",           "backend.log",                   "persistent volume: backend_volume/python_logs/"),
-    ("model_run_log",         "model_run.log",                 "docker-control-service HTTP /api/v1/logs/fastapi"),
-    ("model_run_deployment_logs","model_run_logs/<name>.log (×5)", "volume mount: TT_STUDIO_ROOT/logs/model_run_logs/ (ro)"),
-    ("docker_control_log",    "docker-control-service.log",    "docker-control-service HTTP /api/v1/logs/service"),
-    ("startup_log",           "startup.log",                   "docker-control-service HTTP /api/v1/logs/startup"),
-    ("agent_log",             "agent.log",                     "docker-control-service HTTP /api/v1/containers/<id>/logs"),
-    ("inference_run_logs",    "inference_artifacts/run_logs/ (×5)",         "volume mount: TT_STUDIO_ROOT/.artifacts/tt-inference-server/workflow_logs/run_logs/"),
-    ("inference_docker_server_logs", "inference_artifacts/docker_server/ (×5)", "volume mount: …/workflow_logs/docker_server/"),
-    ("inference_run_specs",   "inference_artifacts/run_specs/ (×5)",        "volume mount: …/workflow_logs/run_specs/"),
-    ("tt_smi",                "tt_smi.json",                   "in-container: board_control.services.SystemResourceService"),
-    ("deployments",           "deployments.json",              "persistent volume: backend_volume/deployments.json"),
-    ("current_models",        "current_models.json",           "docker-control list_containers + model_control deploy cache summary"),
+    ("backend_log", "backend.log", "persistent volume: backend_volume/python_logs/"),
+    (
+        "model_run_log",
+        "model_run.log",
+        "docker-control-service HTTP /api/v1/logs/fastapi",
+    ),
+    (
+        "model_run_deployment_logs",
+        "model_run_logs/<name>.log (×5)",
+        "volume mount: TT_STUDIO_ROOT/logs/model_run_logs/ (ro)",
+    ),
+    (
+        "docker_control_log",
+        "docker-control-service.log",
+        "docker-control-service HTTP /api/v1/logs/service",
+    ),
+    ("startup_log", "startup.log", "docker-control-service HTTP /api/v1/logs/startup"),
+    (
+        "agent_log",
+        "agent.log",
+        "docker-control-service HTTP /api/v1/containers/<id>/logs",
+    ),
+    (
+        "inference_run_logs",
+        "inference_artifacts/run_logs/ (×5)",
+        "volume mount: TT_STUDIO_ROOT/.artifacts/tt-inference-server/workflow_logs/run_logs/",
+    ),
+    (
+        "inference_docker_server_logs",
+        "inference_artifacts/docker_server/ (×5)",
+        "volume mount: …/workflow_logs/docker_server/",
+    ),
+    (
+        "inference_run_specs",
+        "inference_artifacts/run_specs/ (×5)",
+        "volume mount: …/workflow_logs/run_specs/",
+    ),
+    (
+        "tt_smi",
+        "tt_smi.json",
+        "in-container: board_control.services.SystemResourceService",
+    ),
+    (
+        "deployments",
+        "deployments.json",
+        "persistent volume: backend_volume/deployments.json",
+    ),
+    (
+        "current_models",
+        "current_models.json",
+        "docker-control list_containers + model_control deploy cache summary",
+    ),
 ]
 
 
@@ -122,10 +161,12 @@ class FastAPILogsView(APIView):
 
     def get(self, request, *args, **kwargs):
         logger.info("FastAPILogsView endpoint hit")
-        
+
         # Check if model_run.log exists in multiple possible locations using relative paths
         possible_model_run_logs = [
-            os.path.join(TT_STUDIO_ROOT, "logs", "model_run.log"),  # Consolidated logs/ dir (current location)
+            os.path.join(
+                TT_STUDIO_ROOT, "logs", "model_run.log"
+            ),  # Consolidated logs/ dir (current location)
             "logs/model_run.log",  # Relative to current directory
             os.path.join(LOGS_ROOT, "model_run.log"),  # Try in logs directory
             "/app/model_run.log",  # Container path as fallback
@@ -142,28 +183,37 @@ class FastAPILogsView(APIView):
         for model_run_log_path in possible_model_run_logs:
             if os.path.exists(model_run_log_path):
                 try:
-                    with open(model_run_log_path, 'r') as f:
+                    with open(model_run_log_path, "r") as f:
                         lines = f.readlines()
                         # Get last 20 lines and limit size
-                        log_content = ''.join(lines[-20:])
+                        log_content = "".join(lines[-20:])
                         if len(log_content) > 2000:
                             log_content = log_content[-2000:] + "\n\n... (truncated)"
                     model_run_log_found = True
-                    logger.info(f"Successfully read model run logs from: {model_run_log_path}")
+                    logger.info(
+                        f"Successfully read model run logs from: {model_run_log_path}"
+                    )
                     break
                 except Exception as read_error:
-                    logger.error(f"Error reading {model_run_log_path}: {str(read_error)}")
+                    logger.error(
+                        f"Error reading {model_run_log_path}: {str(read_error)}"
+                    )
                     continue
 
         if not model_run_log_found:
             log_content = "model_run.log not accessible from container (logs available from Docker containers above)"
             logger.warning("Model run log file not found in any expected location")
 
-        return JsonResponse({
-            "fastapi_logs": log_content,
-            "found": model_run_log_found,
-            "timestamp": os.path.getmtime(model_run_log_path) if model_run_log_found else None
-        }, status=200)
+        return JsonResponse(
+            {
+                "fastapi_logs": log_content,
+                "found": model_run_log_found,
+                "timestamp": os.path.getmtime(model_run_log_path)
+                if model_run_log_found
+                else None,
+            },
+            status=200,
+        )
 
 
 class TtInferenceLogsView(APIView):
@@ -176,7 +226,9 @@ class TtInferenceLogsView(APIView):
       - max_lines: optional int for how many tail lines to return (default 200)
     """
 
-    def _find_latest_file(self, directory: str, pattern_contains: Optional[str]) -> Optional[str]:
+    def _find_latest_file(
+        self, directory: str, pattern_contains: Optional[str]
+    ) -> Optional[str]:
         if not os.path.isdir(directory):
             return None
 
@@ -185,7 +237,9 @@ class TtInferenceLogsView(APIView):
         candidates = glob.glob(search_pattern)
         if pattern_contains:
             needle = pattern_contains.lower()
-            candidates = [p for p in candidates if needle in os.path.basename(p).lower()]
+            candidates = [
+                p for p in candidates if needle in os.path.basename(p).lower()
+            ]
 
         if not candidates:
             return None
@@ -196,9 +250,9 @@ class TtInferenceLogsView(APIView):
 
     def _tail_file(self, file_path: str, max_lines: int) -> str:
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 lines = f.readlines()
-                tail = ''.join(lines[-max_lines:])
+                tail = "".join(lines[-max_lines:])
                 # safety truncate
                 if len(tail) > 5000:
                     return tail[-5000:] + "\n\n... (truncated)"
@@ -207,14 +261,17 @@ class TtInferenceLogsView(APIView):
             logger.error(f"Error reading log file {file_path}: {e}")
             return f"Failed to read log file: {str(e)}"
 
-    def _extract_container_id_from_run_log(self, run_log_path: Optional[str]) -> Optional[str]:
+    def _extract_container_id_from_run_log(
+        self, run_log_path: Optional[str]
+    ) -> Optional[str]:
         if not run_log_path or not os.path.isfile(run_log_path):
             return None
         try:
-            with open(run_log_path, 'r') as f:
+            with open(run_log_path, "r") as f:
                 text = f.read()
                 # Common line in run logs: "Created Docker container ID: <id>"
                 import re
+
                 m = re.search(r"Created Docker container ID:\s*([0-9a-f]{6,64})", text)
                 if m:
                     return m.group(1)
@@ -226,24 +283,39 @@ class TtInferenceLogsView(APIView):
         try:
             client = docker.from_env()
             containers = client.containers.list(all=True)
+
             # Prefer running containers first
             def sort_key(c):
-                return (c.status != 'running', -c.attrs.get('Created', 0))
+                return (c.status != "running", -c.attrs.get("Created", 0))
+
             containers = sorted(containers, key=sort_key)
 
             def name_or_image_contains(c, needle: str) -> bool:
                 needle = needle.lower()
-                name_ok = any(needle in nm.lower() for nm in ([c.name] + [a for a in c.attrs.get('Name', '') if a]))
-                image_ok = needle in (c.image.tags[0].lower() if c.image.tags else c.image.short_id.lower())
+                name_ok = any(
+                    needle in nm.lower()
+                    for nm in ([c.name] + [a for a in c.attrs.get("Name", "") if a])
+                )
+                image_ok = needle in (
+                    c.image.tags[0].lower()
+                    if c.image.tags
+                    else c.image.short_id.lower()
+                )
                 return name_ok or image_ok
 
             # Heuristic: container likely from tt-inference-server/vllm image
             candidates = [
-                c for c in containers
-                if any(sub in (c.image.tags[0] if c.image.tags else '') for sub in ['tt-inference-server', 'vllm'])
+                c
+                for c in containers
+                if any(
+                    sub in (c.image.tags[0] if c.image.tags else "")
+                    for sub in ["tt-inference-server", "vllm"]
+                )
             ]
             if model_query:
-                candidates = [c for c in candidates if name_or_image_contains(c, model_query)] or candidates
+                candidates = [
+                    c for c in candidates if name_or_image_contains(c, model_query)
+                ] or candidates
 
             if candidates:
                 return candidates[0].id
@@ -256,37 +328,53 @@ class TtInferenceLogsView(APIView):
             client = docker.from_env()
             container = client.containers.get(container_id)
             log_bytes = container.logs(tail=max_lines, timestamps=False)
-            text = log_bytes.decode('utf-8', errors='replace').strip()
+            text = log_bytes.decode("utf-8", errors="replace").strip()
             if len(text) > 5000:
                 text = text[-5000:] + "\n\n... (truncated)"
             return text
         except Exception as e:
-            logger.error(f"Error fetching docker container logs for {container_id}: {e}")
+            logger.error(
+                f"Error fetching docker container logs for {container_id}: {e}"
+            )
             return None
 
     def get(self, request, *args, **kwargs):
-        model_query = request.GET.get('model', '').strip()
+        model_query = request.GET.get("model", "").strip()
         try:
-            max_lines = int(request.GET.get('max_lines', '200'))
+            max_lines = int(request.GET.get("max_lines", "200"))
         except ValueError:
             max_lines = 200
 
         # Base path to tt-inference-server workflow logs inside repo root
-        workflow_root = os.path.join(TT_STUDIO_ROOT, 'tt-inference-server', 'workflow_logs')
-        run_logs_dir = os.path.join(workflow_root, 'run_logs')
-        docker_server_dir = os.path.join(workflow_root, 'docker_server')
+        workflow_root = os.path.join(
+            TT_STUDIO_ROOT, "tt-inference-server", "workflow_logs"
+        )
+        run_logs_dir = os.path.join(workflow_root, "run_logs")
+        docker_server_dir = os.path.join(workflow_root, "docker_server")
 
         latest_run_log = self._find_latest_file(run_logs_dir, model_query or None)
-        latest_docker_log = self._find_latest_file(docker_server_dir, model_query or None)
+        latest_docker_log = self._find_latest_file(
+            docker_server_dir, model_query or None
+        )
 
-        run_log_content = self._tail_file(latest_run_log, max_lines) if latest_run_log else "No matching run logs found"
-        file_docker_log_content = self._tail_file(latest_docker_log, max_lines) if latest_docker_log else None
+        run_log_content = (
+            self._tail_file(latest_run_log, max_lines)
+            if latest_run_log
+            else "No matching run logs found"
+        )
+        file_docker_log_content = (
+            self._tail_file(latest_docker_log, max_lines) if latest_docker_log else None
+        )
 
         # Try to fetch docker container logs using Docker SDK (more reliable inside container)
         container_id = self._extract_container_id_from_run_log(latest_run_log)
         if not container_id:
             container_id = self._find_candidate_container_id(model_query or None)
-        docker_container_log = self._fetch_container_logs(container_id, max_lines) if container_id else None
+        docker_container_log = (
+            self._fetch_container_logs(container_id, max_lines)
+            if container_id
+            else None
+        )
 
         response = {
             "model_query": model_query or None,
@@ -304,6 +392,7 @@ class TtInferenceLogsView(APIView):
 # ---------------------------------------------------------------------------
 # Bug Report helpers and views
 # ---------------------------------------------------------------------------
+
 
 def _read_log_tail(file_path: str, max_lines: int = 500) -> str:
     """Read the last max_lines from a log file, with safe UTF-8 decoding."""
@@ -369,7 +458,9 @@ def _collect_current_models_snapshot() -> dict:
                 mi_summary = {
                     "model_name": getattr(model_impl, "model_name", None),
                     "hf_model_id": getattr(model_impl, "hf_model_id", None),
-                    "model_type": getattr(mt, "value", str(mt)) if mt is not None else None,
+                    "model_type": getattr(mt, "value", str(mt))
+                    if mt is not None
+                    else None,
                 }
             pb = entry.get("port_bindings") or {}
             port_hints = []
@@ -422,19 +513,37 @@ def _collect_bug_report_data() -> dict:
             reverse=True,
         )
         if log_files:
-            data["backend_log"] = {"file": log_files[0], "content": _read_log_tail(log_files[0], 500)}
+            data["backend_log"] = {
+                "file": log_files[0],
+                "content": _read_log_tail(log_files[0], 500),
+            }
         else:
-            data["backend_log"] = {"file": None, "content": "No backend log files found"}
+            data["backend_log"] = {
+                "file": None,
+                "content": "No backend log files found",
+            }
     else:
-        data["backend_log"] = {"file": None, "content": f"python_logs directory not found: {python_logs_dir}"}
+        data["backend_log"] = {
+            "file": None,
+            "content": f"python_logs directory not found: {python_logs_dir}",
+        }
 
     # 2. Model run main log — fetched from docker-control-service running on host
     try:
-        from docker_control.docker_control_client import DockerControlClient as _DCSClient0
+        from docker_control.docker_control_client import (
+            DockerControlClient as _DCSClient0,
+        )
+
         _model_run_result = _DCSClient0().get_model_run_log(tail=500)
-        data["model_run_log"] = {"file": _model_run_result.get("file"), "content": _model_run_result.get("content", "")}
+        data["model_run_log"] = {
+            "file": _model_run_result.get("file"),
+            "content": _model_run_result.get("content", ""),
+        }
     except Exception as _e0:
-        data["model_run_log"] = {"file": None, "content": f"model_run.log not accessible: {_e0}"}
+        data["model_run_log"] = {
+            "file": None,
+            "content": f"model_run.log not accessible: {_e0}",
+        }
 
     # 3. Per-deployment model run logs (logs/model_run_logs/ directory, newest 5).
     # Fall back to the legacy fastapi_logs/ locations so bundles captured before
@@ -469,15 +578,30 @@ def _collect_bug_report_data() -> dict:
 
     # 4 & 5. Docker control service log + startup log — fetched from docker-control-service on host
     try:
-        from docker_control.docker_control_client import DockerControlClient as _DCSClient
+        from docker_control.docker_control_client import (
+            DockerControlClient as _DCSClient,
+        )
+
         _dcs = _DCSClient()
         _dcs_result = _dcs.get_service_log(tail=500)
-        data["docker_control_log"] = {"file": _dcs_result.get("file"), "content": _dcs_result.get("content", "")}
+        data["docker_control_log"] = {
+            "file": _dcs_result.get("file"),
+            "content": _dcs_result.get("content", ""),
+        }
         _startup_result = _dcs.get_startup_log(tail=200)
-        data["startup_log"] = {"file": _startup_result.get("file"), "content": _startup_result.get("content", "")}
+        data["startup_log"] = {
+            "file": _startup_result.get("file"),
+            "content": _startup_result.get("content", ""),
+        }
     except Exception as _e:
-        data["docker_control_log"] = {"file": None, "content": f"docker-control-service.log not accessible: {_e}"}
-        data["startup_log"] = {"file": None, "content": f"startup.log not accessible: {_e}"}
+        data["docker_control_log"] = {
+            "file": None,
+            "content": f"docker-control-service.log not accessible: {_e}",
+        }
+        data["startup_log"] = {
+            "file": None,
+            "content": f"startup.log not accessible: {_e}",
+        }
 
     # 6. Agent Docker logs — fetched via docker-control-service (runs on host, has docker socket)
     try:
@@ -488,7 +612,11 @@ def _collect_bug_report_data() -> dict:
         client = DockerControlClient()
         containers_resp = client.list_containers(all=True)
         # Response is a dict with a "containers" key or directly a list depending on version
-        container_list = containers_resp if isinstance(containers_resp, list) else containers_resp.get("containers", [])
+        container_list = (
+            containers_resp
+            if isinstance(containers_resp, list)
+            else containers_resp.get("containers", [])
+        )
         agent_container = next(
             (c for c in container_list if "agent" in c.get("name", "").lower()),
             None,
@@ -496,7 +624,9 @@ def _collect_bug_report_data() -> dict:
         if agent_container:
             container_id = agent_container["id"]
             jwt_secret = os.getenv("DOCKER_CONTROL_JWT_SECRET", "")
-            dcs_url = os.getenv("DOCKER_CONTROL_SERVICE_URL", "http://host.docker.internal:8002")
+            dcs_url = os.getenv(
+                "DOCKER_CONTROL_SERVICE_URL", "http://host.docker.internal:8002"
+            )
             token = _jwt.encode({"service": "backend"}, jwt_secret, algorithm="HS256")
             resp = _req.get(
                 f"{dcs_url}/api/v1/containers/{container_id}/logs",
@@ -507,22 +637,36 @@ def _collect_bug_report_data() -> dict:
             )
             data["agent_log"] = {"content": resp.text.strip() or "No agent logs"}
         else:
-            data["agent_log"] = {"content": "Agent container not found via docker-control-service"}
+            data["agent_log"] = {
+                "content": "Agent container not found via docker-control-service"
+            }
     except Exception as e:
         data["agent_log"] = {"content": f"Could not fetch agent logs: {e}"}
 
     # 7. Inference server artifact workflow logs
     #    Check .artifacts/ path first (artifact-mode), then plain path
-    artifact_workflow_root = os.path.join(TT_STUDIO_ROOT, ".artifacts", "tt-inference-server", "workflow_logs")
-    plain_workflow_root = os.path.join(TT_STUDIO_ROOT, "tt-inference-server", "workflow_logs")
-    workflow_root = artifact_workflow_root if os.path.isdir(artifact_workflow_root) else plain_workflow_root
+    artifact_workflow_root = os.path.join(
+        TT_STUDIO_ROOT, ".artifacts", "tt-inference-server", "workflow_logs"
+    )
+    plain_workflow_root = os.path.join(
+        TT_STUDIO_ROOT, "tt-inference-server", "workflow_logs"
+    )
+    workflow_root = (
+        artifact_workflow_root
+        if os.path.isdir(artifact_workflow_root)
+        else plain_workflow_root
+    )
 
     def _collect_workflow_subdir(subdir_name: str):
         d = os.path.join(workflow_root, subdir_name)
         if not os.path.isdir(d):
             return []
         files = sorted(
-            [os.path.join(d, f) for f in os.listdir(d) if os.path.isfile(os.path.join(d, f))],
+            [
+                os.path.join(d, f)
+                for f in os.listdir(d)
+                if os.path.isfile(os.path.join(d, f))
+            ],
             key=os.path.getmtime,
             reverse=True,
         )[:5]
@@ -535,8 +679,11 @@ def _collect_bug_report_data() -> dict:
     # 8. tt-smi hardware telemetry
     try:
         from board_control.services import SystemResourceService
+
         tt_smi = SystemResourceService.get_tt_smi_data(timeout=15)
-        data["tt_smi"] = tt_smi if tt_smi is not None else {"error": "tt-smi returned no data"}
+        data["tt_smi"] = (
+            tt_smi if tt_smi is not None else {"error": "tt-smi returned no data"}
+        )
     except Exception as e:
         data["tt_smi"] = {"error": f"Failed to get tt-smi data: {e}"}
 
@@ -587,7 +734,9 @@ class BugReportDownloadView(APIView):
             with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
                 zf.writestr("backend.log", data["backend_log"]["content"])
                 zf.writestr("model_run.log", data["model_run_log"]["content"])
-                zf.writestr("docker-control-service.log", data["docker_control_log"]["content"])
+                zf.writestr(
+                    "docker-control-service.log", data["docker_control_log"]["content"]
+                )
                 zf.writestr("startup.log", data["startup_log"]["content"])
                 zf.writestr("agent.log", data["agent_log"]["content"])
 
@@ -597,18 +746,27 @@ class BugReportDownloadView(APIView):
 
                 for entry in data["inference_run_logs"]:
                     fname = os.path.basename(entry["file"])
-                    zf.writestr(f"inference_artifacts/run_logs/{fname}", entry["content"])
+                    zf.writestr(
+                        f"inference_artifacts/run_logs/{fname}", entry["content"]
+                    )
 
                 for entry in data["inference_docker_server_logs"]:
                     fname = os.path.basename(entry["file"])
-                    zf.writestr(f"inference_artifacts/docker_server/{fname}", entry["content"])
+                    zf.writestr(
+                        f"inference_artifacts/docker_server/{fname}", entry["content"]
+                    )
 
                 for entry in data["inference_run_specs"]:
                     fname = os.path.basename(entry["file"])
-                    zf.writestr(f"inference_artifacts/run_specs/{fname}", entry["content"])
+                    zf.writestr(
+                        f"inference_artifacts/run_specs/{fname}", entry["content"]
+                    )
 
                 zf.writestr("tt_smi.json", json.dumps(data["tt_smi"], indent=2))
-                zf.writestr("deployments.json", json.dumps(data["deployments"], indent=2, default=str))
+                zf.writestr(
+                    "deployments.json",
+                    json.dumps(data["deployments"], indent=2, default=str),
+                )
                 zf.writestr(
                     "current_models.json",
                     json.dumps(data["current_models"], indent=2, default=str),
@@ -657,12 +815,16 @@ class GitHubIssueView(APIView):
         pat = backend_config.github_pat
         if not pat:
             # Graceful fallback: return a pre-built browser URL (body truncated for URL safety)
-            params = urlencode({"title": title, "body": body[:8000], "labels": ",".join(labels)})
+            params = urlencode(
+                {"title": title, "body": body[:8000], "labels": ",".join(labels)}
+            )
             url = f"{self.GITHUB_NEW_ISSUE_URL}?{params}"
             return JsonResponse({"url": url, "created_via_api": False}, status=200)
 
         # Create the issue via GitHub REST API
-        payload = json.dumps({"title": title, "body": body, "labels": labels}).encode("utf-8")
+        payload = json.dumps({"title": title, "body": body, "labels": labels}).encode(
+            "utf-8"
+        )
         req = urllib.request.Request(
             self.GITHUB_API_URL,
             data=payload,
@@ -689,7 +851,10 @@ class GitHubIssueView(APIView):
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8", errors="replace")
             logger.error(f"GitHub API error {e.code}: {error_body}")
-            return JsonResponse({"error": f"GitHub API error: {e.code}", "detail": error_body}, status=502)
+            return JsonResponse(
+                {"error": f"GitHub API error: {e.code}", "detail": error_body},
+                status=502,
+            )
         except Exception as e:
             logger.error(f"Failed to create GitHub issue: {e}")
             return JsonResponse({"error": str(e)}, status=500)

--- a/app/backend/manage.py
+++ b/app/backend/manage.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 
-
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 

--- a/app/backend/model_control/admin.py
+++ b/app/backend/model_control/admin.py
@@ -2,6 +2,5 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-from django.contrib import admin
 
 # Register your models here.

--- a/app/backend/model_control/apps.py
+++ b/app/backend/model_control/apps.py
@@ -22,4 +22,5 @@ class ModelControlConfig(AppConfig):
             impl.setup()
 
         from model_control.connection_warmer import start_connection_warmer
+
         start_connection_warmer()

--- a/app/backend/model_control/connection_warmer.py
+++ b/app/backend/model_control/connection_warmer.py
@@ -55,6 +55,7 @@ def note_inference_loop() -> None:
 
 async def _ping_all() -> None:
     from model_control.model_utils import _vllm_client, encoded_jwt, get_deploy_cache
+
     try:
         entries = get_deploy_cache()
     except Exception as e:
@@ -79,6 +80,7 @@ async def _warmup_inference_all() -> None:
     """Send a max_tokens=1 inference to each deployed model to warm vLLM's
     scheduler / allocator / kernel state, not just the TCP socket."""
     from model_control.model_utils import _vllm_client, encoded_jwt, get_deploy_cache
+
     try:
         entries = get_deploy_cache()
     except Exception as e:

--- a/app/backend/model_control/download_progress.py
+++ b/app/backend/model_control/download_progress.py
@@ -38,11 +38,11 @@ _total_bytes_cache: Dict[str, Optional[int]] = {}
 _total_bytes_lock = threading.Lock()
 
 # Tunables — keep in sync with inference-api/api.py:_weights_progress_monitor.
-_MIN_SPEED_BPS = 64 * 1024          # ignore jitter under 64 KB/s when updating EMA
-_EMA_ALPHA_INITIAL = 0.35           # faster convergence on first sample
+_MIN_SPEED_BPS = 64 * 1024  # ignore jitter under 64 KB/s when updating EMA
+_EMA_ALPHA_INITIAL = 0.35  # faster convergence on first sample
 _EMA_ALPHA_LATER = 0.15
-_ETA_SMOOTH_ALPHA = 0.3             # how much new raw ETA influences smoothed ETA
-_EXEC_TIMEOUT_SECONDS = 4           # bound how long du can run before we give up
+_ETA_SMOOTH_ALPHA = 0.3  # how much new raw ETA influences smoothed ETA
+_EXEC_TIMEOUT_SECONDS = 4  # bound how long du can run before we give up
 
 # Media (tt-media-inference-server) logs only the repo, not a target path.
 # Weights land in the HF hub cache under HF_HOME, which is set to
@@ -60,6 +60,7 @@ def _media_container_path(repo: Optional[str]) -> Optional[str]:
         return None
     return _MEDIA_HF_CACHE_PREFIX + repo.replace("/", "--")
 
+
 def _container_dir_size(deploy_id: str, container_path: str) -> Optional[int]:
     """Return recursive byte count of `container_path` inside the running deploy.
 
@@ -71,6 +72,7 @@ def _container_dir_size(deploy_id: str, container_path: str) -> Optional[int]:
         return None
     try:
         from docker_control.docker_control_client import get_docker_client
+
         client = get_docker_client()
     except Exception as exc:
         logger.debug("download_progress: get_docker_client failed: %s", exc)
@@ -237,7 +239,8 @@ def compute_download_progress(
             smoothed = (
                 raw_eta
                 if st["eta_smoothed"] <= 0
-                else (1 - _ETA_SMOOTH_ALPHA) * st["eta_smoothed"] + _ETA_SMOOTH_ALPHA * raw_eta
+                else (1 - _ETA_SMOOTH_ALPHA) * st["eta_smoothed"]
+                + _ETA_SMOOTH_ALPHA * raw_eta
             )
             st["eta_smoothed"] = smoothed
             out["eta_seconds"] = float(smoothed)

--- a/app/backend/model_control/log_classifier.py
+++ b/app/backend/model_control/log_classifier.py
@@ -45,73 +45,71 @@ LLM_PHASES = [
 ]
 
 LLM_PHASE_LABELS = {
-    "container_starting":  "Starting container",
-    "vllm_importing":      "Loading vLLM runtime",
+    "container_starting": "Starting container",
+    "vllm_importing": "Loading vLLM runtime",
     "downloading_weights": "Downloading model weights",
     "engine_initializing": "Initializing inference engine",
-    "device_init":         "Opening Tenstorrent device",
-    "model_config":        "Loading model configuration",
-    "loading_weights":     "Loading model weights",
-    "compiling_model":     "Compiling inference graph",
-    "engine_ready":        "Allocating KV cache",
-    "server_starting":     "Starting API server",
-    "ready":               "Ready",
+    "device_init": "Opening Tenstorrent device",
+    "model_config": "Loading model configuration",
+    "loading_weights": "Loading model weights",
+    "compiling_model": "Compiling inference graph",
+    "engine_ready": "Allocating KV cache",
+    "server_starting": "Starting API server",
+    "ready": "Ready",
 }
 
 # Weighted by typical phase duration. compile + download together account for
 # >90% of total warmup; everything else is short.
 LLM_PHASE_BASE_PCT = {
-    "container_starting":  2,
-    "vllm_importing":      5,
+    "container_starting": 2,
+    "vllm_importing": 5,
     "downloading_weights": 8,
     "engine_initializing": 27,
-    "device_init":         28,
-    "model_config":        30,
-    "loading_weights":     32,
-    "compiling_model":     35,
-    "engine_ready":        90,
-    "server_starting":     95,
-    "ready":               100,
+    "device_init": 28,
+    "model_config": 30,
+    "loading_weights": 32,
+    "compiling_model": 35,
+    "engine_ready": 90,
+    "server_starting": 95,
+    "ready": 100,
 }
 
 # Markers chosen from real warmup logs
 _LLM_SUBSTRING_MARKERS: list[tuple[str, str]] = [
-    ("USING CACHE_ROOT",                  "container_starting"),
-    ("MOUNTED VOLUME PERMISSIONS",        "container_starting"),
-    ("AUTOMATICALLY DETECTED PLATFORM",   "vllm_importing"),
-    ("SETTING ENV VAR:",                  "vllm_importing"),
-    ("DOWNLOADING WEIGHTS FROM",          "downloading_weights"),
-    ("WEIGHTS ALREADY EXIST AT",          "downloading_weights"),
-    ("INITIALIZING A V0 LLM ENGINE",      "engine_initializing"),
-    ("INITIALIZING A V1 LLM ENGINE",      "engine_initializing"),
-    ("TTMODELRUNNER:",                    "engine_initializing"),
-    ("OPENING USER MODE DEVICE DRIVER",   "device_init"),
-    ("MAPPED HUGEPAGE",                   "device_init"),
-    ("FABRIC INITIALIZED ON DEVICE",      "device_init"),
-    ("MULTIDEVICE WITH",                  "device_init"),
-    ("INFERRING DEVICE NAME",             "model_config"),
-    ("CHECKPOINT DIRECTORY:",             "model_config"),
-    ("SUCCESSFULLY LOADED TOKENIZER",     "model_config"),
-    ("SUCCESSFULLY LOADED PROCESSOR",     "model_config"),
-    ("LOADING CHECKPOINT SHARDS",         "loading_weights"),
-    ("LOADING SAFETENSORS CHECKPOINT",    "loading_weights"),
-    ("WARMING UP PREFILL FOR SEQUENCE",   "compiling_model"),
-    ("DONE COMPILING MODEL",              "compiling_model"),
-    ("DONE CAPTURING PREFILL TRACE",      "compiling_model"),
-    ("DONE CAPTURING DECODE TRACE",       "compiling_model"),
-    ("SAMPLING PARAMS USED FOR DECODE",   "compiling_model"),
-    ("INIT ENGINE (PROFILE, CREATE KV",   "engine_ready"),
-    ("STARTED SERVER PROCESS",            "server_starting"),
-    ("APPLICATION STARTUP COMPLETE",      "server_starting"),
+    ("USING CACHE_ROOT", "container_starting"),
+    ("MOUNTED VOLUME PERMISSIONS", "container_starting"),
+    ("AUTOMATICALLY DETECTED PLATFORM", "vllm_importing"),
+    ("SETTING ENV VAR:", "vllm_importing"),
+    ("DOWNLOADING WEIGHTS FROM", "downloading_weights"),
+    ("WEIGHTS ALREADY EXIST AT", "downloading_weights"),
+    ("INITIALIZING A V0 LLM ENGINE", "engine_initializing"),
+    ("INITIALIZING A V1 LLM ENGINE", "engine_initializing"),
+    ("TTMODELRUNNER:", "engine_initializing"),
+    ("OPENING USER MODE DEVICE DRIVER", "device_init"),
+    ("MAPPED HUGEPAGE", "device_init"),
+    ("FABRIC INITIALIZED ON DEVICE", "device_init"),
+    ("MULTIDEVICE WITH", "device_init"),
+    ("INFERRING DEVICE NAME", "model_config"),
+    ("CHECKPOINT DIRECTORY:", "model_config"),
+    ("SUCCESSFULLY LOADED TOKENIZER", "model_config"),
+    ("SUCCESSFULLY LOADED PROCESSOR", "model_config"),
+    ("LOADING CHECKPOINT SHARDS", "loading_weights"),
+    ("LOADING SAFETENSORS CHECKPOINT", "loading_weights"),
+    ("WARMING UP PREFILL FOR SEQUENCE", "compiling_model"),
+    ("DONE COMPILING MODEL", "compiling_model"),
+    ("DONE CAPTURING PREFILL TRACE", "compiling_model"),
+    ("DONE CAPTURING DECODE TRACE", "compiling_model"),
+    ("SAMPLING PARAMS USED FOR DECODE", "compiling_model"),
+    ("INIT ENGINE (PROFILE, CREATE KV", "engine_ready"),
+    ("STARTED SERVER PROCESS", "server_starting"),
+    ("APPLICATION STARTUP COMPLETE", "server_starting"),
 ]
 
 # vLLM-emitted download log lines
 _DOWNLOAD_START_RE = re.compile(
     r"Downloading weights from\s+(?P<repo>\S+)\s+to\s+(?P<path>\S+)"
 )
-_DOWNLOAD_CACHED_RE = re.compile(
-    r"Weights already exist at\s+(?P<path>\S+)"
-)
+_DOWNLOAD_CACHED_RE = re.compile(r"Weights already exist at\s+(?P<path>\S+)")
 
 # MEDIA template — trimmed and verified against real distil-large-v3 and
 # speecht5_tts logs at .artifacts/tt-inference-server/workflow_logs/docker_server/.
@@ -139,24 +137,24 @@ MEDIA_PHASES = [
 ]
 
 MEDIA_PHASE_LABELS = {
-    "container_starting":  "Starting container",
-    "device_init":         "Opening Tenstorrent device",
+    "container_starting": "Starting container",
+    "device_init": "Opening Tenstorrent device",
     "downloading_weights": "Downloading model weights",
-    "loading_weights":     "Loading model weights",
-    "warming_up":          "Warming up runner",
-    "ready":               "Ready",
+    "loading_weights": "Loading model weights",
+    "warming_up": "Warming up runner",
+    "ready": "Ready",
 }
 
 # loading_weights dominates real wall-clock (~70% on speecht5_tts), so its band
 # is the widest. Sub-step counting inside the band (see MEDIA_LOAD_TOTAL) lets
 # the bar advance smoothly during the otherwise-silent HF model load.
 MEDIA_PHASE_BASE_PCT = {
-    "container_starting":  2,
-    "device_init":         8,
+    "container_starting": 2,
+    "device_init": 8,
     "downloading_weights": 14,
-    "loading_weights":     24,
-    "warming_up":          80,
-    "ready":               100,
+    "loading_weights": 24,
+    "warming_up": 80,
+    "ready": 100,
 }
 
 # Substring markers for tt-media-inference-server containers. Strings here are
@@ -172,31 +170,30 @@ _MEDIA_SUBSTRING_MARKERS: list[tuple[str, str]] = [
     # fire before the frontend has even started polling, so the user only ever
     # sees the *result* of these events (the pill is "done" by the time they
     # see it). No point in giving them dedicated phases.
-    ("USING CACHE_ROOT",                       "container_starting"),
-    ("MOUNTED VOLUME PERMISSIONS",             "container_starting"),
-    ("SETTINGS INIT: MODEL=",                  "container_starting"),
-    ("CONFIG LOOKUP: RUNNER=",                 "container_starting"),
-    ("SETTINGS RESOLVED:",                     "container_starting"),
-    ("SETTING UP PROMETHEUS METRICS",          "container_starting"),
-    ("PROMETHEUS METRICS AVAILABLE",           "container_starting"),
-    ("CREATING NEW AUDIO SERVICE",             "container_starting"),
-    ("CREATING NEW VIDEO SERVICE",             "container_starting"),
-    ("CREATING NEW IMAGE SERVICE",             "container_starting"),
-    ("CREATING NEW TEXT_TO_SPEECH SERVICE",    "container_starting"),
-    ("CREATING NEW TTS SERVICE",               "container_starting"),
-    ("STARTED SERVER PROCESS",                 "container_starting"),
-    ("WAITING FOR APPLICATION STARTUP",        "container_starting"),
-    ("AUDIOPREPROCESSING WORKER",              "container_starting"),
-    ("VIDEOPREPROCESSING WORKER",              "container_starting"),
-    ("VIDEOPOSTPROCESSING WORKER",             "container_starting"),
-    ("TTSPOSTPROCESSING WORKER",               "container_starting"),
-    ("IMAGE POSTPROCESSING WORKER",            "container_starting"),
-    ("STARTING WORKER ",                       "container_starting"),
-    ("STARTED WORKER ",                        "container_starting"),
-    ("ALL WORKERS STARTED IN SEQUENCE",        "container_starting"),
-    ("APPLICATION STARTUP COMPLETE",           "container_starting"),
-    ("UVICORN RUNNING ON",                     "container_starting"),
-
+    ("USING CACHE_ROOT", "container_starting"),
+    ("MOUNTED VOLUME PERMISSIONS", "container_starting"),
+    ("SETTINGS INIT: MODEL=", "container_starting"),
+    ("CONFIG LOOKUP: RUNNER=", "container_starting"),
+    ("SETTINGS RESOLVED:", "container_starting"),
+    ("SETTING UP PROMETHEUS METRICS", "container_starting"),
+    ("PROMETHEUS METRICS AVAILABLE", "container_starting"),
+    ("CREATING NEW AUDIO SERVICE", "container_starting"),
+    ("CREATING NEW VIDEO SERVICE", "container_starting"),
+    ("CREATING NEW IMAGE SERVICE", "container_starting"),
+    ("CREATING NEW TEXT_TO_SPEECH SERVICE", "container_starting"),
+    ("CREATING NEW TTS SERVICE", "container_starting"),
+    ("STARTED SERVER PROCESS", "container_starting"),
+    ("WAITING FOR APPLICATION STARTUP", "container_starting"),
+    ("AUDIOPREPROCESSING WORKER", "container_starting"),
+    ("VIDEOPREPROCESSING WORKER", "container_starting"),
+    ("VIDEOPOSTPROCESSING WORKER", "container_starting"),
+    ("TTSPOSTPROCESSING WORKER", "container_starting"),
+    ("IMAGE POSTPROCESSING WORKER", "container_starting"),
+    ("STARTING WORKER ", "container_starting"),
+    ("STARTED WORKER ", "container_starting"),
+    ("ALL WORKERS STARTED IN SEQUENCE", "container_starting"),
+    ("APPLICATION STARTUP COMPLETE", "container_starting"),
+    ("UVICORN RUNNING ON", "container_starting"),
     # ── downloading_weights ─────────────────────────────────────────────────
     # Two trigger families:
     # 1. The wrapper at tt-media-server/utils/hugging_face_utils.py emits the
@@ -207,70 +204,67 @@ _MEDIA_SUBSTRING_MARKERS: list[tuple[str, str]] = [
     #    Whisper and SpeechT5. We treat it as a download trigger because:
     #    (a) it's the closest thing to a download event in those logs, and
     #    (b) byte tracking via du -sb tells us if it's already cached or not.
-    ("DOWNLOADING WEIGHTS FOR MODEL:",         "downloading_weights"),
-    ("ALREADY CACHED, SKIPPING DOWNLOAD",      "downloading_weights"),
-    ("USING CACHED MODEL AT:",                 "downloading_weights"),
-    ("MODEL ALREADY EXISTS LOCALLY AT:",       "downloading_weights"),
-    ("LOADING HUGGINGFACE MODEL:",             "downloading_weights"),
-
+    ("DOWNLOADING WEIGHTS FOR MODEL:", "downloading_weights"),
+    ("ALREADY CACHED, SKIPPING DOWNLOAD", "downloading_weights"),
+    ("USING CACHED MODEL AT:", "downloading_weights"),
+    ("MODEL ALREADY EXISTS LOCALLY AT:", "downloading_weights"),
+    ("LOADING HUGGINGFACE MODEL:", "downloading_weights"),
     # ── device_init: UMD opens + device runner created ──────────────────────
-    ("SETUP_RUNNER_ENVIRONMENT",               "device_init"),
-    ("TT_VISIBLE_DEVICES",                     "device_init"),
-    ("CREATING TOPOLOGYDISCOVERY",             "device_init"),
-    ("ESTABLISHED FIRMWARE BUNDLE VERSION",    "device_init"),
-    ("OPENING USER MODE DEVICE DRIVER",        "device_init"),
-    ("TTWHISPERRUNNER",                        "device_init"),       # "created TTWhisperRunner for worker 0"
-    ("TTSPEECHT5RUNNER",                       "device_init"),       # "created TTSpeechT5Runner for worker 0"
-
+    ("SETUP_RUNNER_ENVIRONMENT", "device_init"),
+    ("TT_VISIBLE_DEVICES", "device_init"),
+    ("CREATING TOPOLOGYDISCOVERY", "device_init"),
+    ("ESTABLISHED FIRMWARE BUNDLE VERSION", "device_init"),
+    ("OPENING USER MODE DEVICE DRIVER", "device_init"),
+    ("TTWHISPERRUNNER", "device_init"),  # "created TTWhisperRunner for worker 0"
+    ("TTSPEECHT5RUNNER", "device_init"),  # "created TTSpeechT5Runner for worker 0"
     # ── loading_weights: the dominant phase (~70% of total time for TTS) ────
     # Whisper-specific (audio preprocessing)
-    ("LOADING SPEAKER DIARIZATION",            "loading_weights"),
-    ("LOADING VAD MODEL",                      "loading_weights"),
-    ("VAD MODEL LOADED",                       "loading_weights"),
+    ("LOADING SPEAKER DIARIZATION", "loading_weights"),
+    ("LOADING VAD MODEL", "loading_weights"),
+    ("VAD MODEL LOADED", "loading_weights"),
     # Mesh device + HF model load completion (both whisper and TTS)
-    ("CREATED MESH DEVICE",                    "loading_weights"),
-    ("CREATING INFERENCE PIPELINE",            "loading_weights"),
-    ("LOADING WHISPER MODEL",                  "loading_weights"),
-    ("LOADING SPEECHT5 MODEL",                 "loading_weights"),
-    ("SUCCESSFULLY LOADED HUGGINGFACE MODEL",  "loading_weights"),
-    ("INITIALIZING TTNN MODEL COMPONENTS",     "loading_weights"),
-    ("MODEL PARAMETERS PREPROCESSED",          "loading_weights"),
-    ("INITIALIZING KV CACHE",                  "loading_weights"),
-    ("SUCCESSFULLY INITIALIZED TTNN",          "loading_weights"),
-    ("SUCCESSFULLY CREATED INFERENCE PIPELINE","loading_weights"),
-    ("MODEL PIPELINE CREATED",                 "loading_weights"),
-    ("MODEL LOADED AND PIPELINE READY",        "loading_weights"),
+    ("CREATED MESH DEVICE", "loading_weights"),
+    ("CREATING INFERENCE PIPELINE", "loading_weights"),
+    ("LOADING WHISPER MODEL", "loading_weights"),
+    ("LOADING SPEECHT5 MODEL", "loading_weights"),
+    ("SUCCESSFULLY LOADED HUGGINGFACE MODEL", "loading_weights"),
+    ("INITIALIZING TTNN MODEL COMPONENTS", "loading_weights"),
+    ("MODEL PARAMETERS PREPROCESSED", "loading_weights"),
+    ("INITIALIZING KV CACHE", "loading_weights"),
+    ("SUCCESSFULLY INITIALIZED TTNN", "loading_weights"),
+    ("SUCCESSFULLY CREATED INFERENCE PIPELINE", "loading_weights"),
+    ("MODEL PIPELINE CREATED", "loading_weights"),
+    ("MODEL LOADED AND PIPELINE READY", "loading_weights"),
     # TTS-specific: speaker embeddings + TTNN model construction
-    ("LOADING DEFAULT SPEAKER EMBEDDINGS",     "loading_weights"),
-    ("DEFAULT SPEAKER EMBEDDINGS",             "loading_weights"),
-    ("CREATING TTNN ENCODER",                  "loading_weights"),
-    ("CREATING TTNN DECODER",                  "loading_weights"),
-    ("CREATING TTNN POSTNET",                  "loading_weights"),
-    ("SPEECHT5GENERATOR INITIALIZED",          "loading_weights"),
-    ("TRACE GENERATOR INITIALIZED",            "loading_weights"),
-    ("ALL SPEECHT5 MODELS INITIALIZED",        "loading_weights"),
-    ("MODEL INITIALIZATION COMPLETED",         "loading_weights"),
+    ("LOADING DEFAULT SPEAKER EMBEDDINGS", "loading_weights"),
+    ("DEFAULT SPEAKER EMBEDDINGS", "loading_weights"),
+    ("CREATING TTNN ENCODER", "loading_weights"),
+    ("CREATING TTNN DECODER", "loading_weights"),
+    ("CREATING TTNN POSTNET", "loading_weights"),
+    ("SPEECHT5GENERATOR INITIALIZED", "loading_weights"),
+    ("TRACE GENERATOR INITIALIZED", "loading_weights"),
+    ("ALL SPEECHT5 MODELS INITIALIZED", "loading_weights"),
+    ("MODEL INITIALIZATION COMPLETED", "loading_weights"),
     # Speculative — not seen in our logs but documented in diffusers/transformers
-    ("LOADING VAE",                            "loading_weights"),
-    ("LOADING UNET",                           "loading_weights"),
-    ("LOADING TEXT ENCODER",                   "loading_weights"),
-    ("LOADING TRANSFORMER",                    "loading_weights"),
-    ("PIPELINE LOADED",                        "loading_weights"),
-
+    ("LOADING VAE", "loading_weights"),
+    ("LOADING UNET", "loading_weights"),
+    ("LOADING TEXT ENCODER", "loading_weights"),
+    ("LOADING TRANSFORMER", "loading_weights"),
+    ("PIPELINE LOADED", "loading_weights"),
     # ── warming_up: model warmup loop (encoder sizes for TTS, decode for whisper)
-    ("ENCODER WARM-UP DONE",                   "warming_up"),
-    ("POSTNET WARM-UP DONE",                   "warming_up"),
-    ("WARM-UP DONE FOR ENCODER_SIZE",          "warming_up"),
-    ("MODEL WARMUP COMPLETED",                 "warming_up"),
-    ("[WARMUP] ASYNC EXECUTED",                "warming_up"),
-    ("STARTED WITH DEVICE RUNNER",             "warming_up"),
-    ("FIRST DEVICE WARMED UP",                 "warming_up"),
-    ("IS WARMED UP",                           "warming_up"),
-    ("ALL DEVICES ARE WARMED UP AND READY",    "warming_up"),
-    ("STARTING MODEL WARMUP",                  "warming_up"),
-    ("RUNNING MODEL ON BATCH",                 "warming_up"),
-    ("TIME TO ENCODER STATES",                 "warming_up"),
-    ("ON-DEVICE SAMPLING TRACE",               "warming_up"),
+    ("ENCODER WARM-UP DONE", "warming_up"),
+    ("POSTNET WARM-UP DONE", "warming_up"),
+    ("WARM-UP DONE FOR ENCODER_SIZE", "warming_up"),
+    ("MODEL WARMUP COMPLETED", "warming_up"),
+    ("[WARMUP] ASYNC EXECUTED", "warming_up"),
+    ("STARTED WITH DEVICE RUNNER", "warming_up"),
+    ("FIRST DEVICE WARMED UP", "warming_up"),
+    ("IS WARMED UP", "warming_up"),
+    ("ALL DEVICES ARE WARMED UP AND READY", "warming_up"),
+    ("STARTING MODEL WARMUP", "warming_up"),
+    ("RUNNING MODEL ON BATCH", "warming_up"),
+    ("TIME TO ENCODER STATES", "warming_up"),
+    ("ON-DEVICE SAMPLING TRACE", "warming_up"),
     ("GENERATION SUCCESSFUL WITH TEMPERATURE", "warming_up"),
 ]
 
@@ -281,15 +275,9 @@ _MEDIA_SUBSTRING_MARKERS: list[tuple[str, str]] = [
 # and speecht5 runners DON'T — they call transformers.from_pretrained() which
 # emits `Device 0: Loading HuggingFace model: <repo>` instead. We treat that
 # as a download trigger too; byte tracking decides cached vs in-progress.
-_DOWNLOAD_MEDIA_RE = re.compile(
-    r"Downloading weights for model:\s+(?P<repo>\S+)"
-)
-_DOWNLOAD_MEDIA_CACHED_RE = re.compile(
-    r"Model\s+(?P<repo>\S+)\s+already cached"
-)
-_DOWNLOAD_MEDIA_HF_LOAD_RE = re.compile(
-    r"Loading HuggingFace model:\s+(?P<repo>\S+)"
-)
+_DOWNLOAD_MEDIA_RE = re.compile(r"Downloading weights for model:\s+(?P<repo>\S+)")
+_DOWNLOAD_MEDIA_CACHED_RE = re.compile(r"Model\s+(?P<repo>\S+)\s+already cached")
+_DOWNLOAD_MEDIA_HF_LOAD_RE = re.compile(r"Loading HuggingFace model:\s+(?P<repo>\S+)")
 
 # ---------------------------------------------------------------------------
 # Shared regexes / model-type routing
@@ -327,10 +315,9 @@ def _is_noise_line(line: str) -> bool:
     """Return True for log lines we want to ignore in phase classification."""
     return bool(_UVICORN_ACCESS_LOG_RE.match(line))
 
+
 # LLM compile-trace count.
-_DONE_CAPTURE_RE = re.compile(
-    r"Done Capturing (?:Prefill|Decode) Trace", re.IGNORECASE
-)
+_DONE_CAPTURE_RE = re.compile(r"Done Capturing (?:Prefill|Decode) Trace", re.IGNORECASE)
 COMPILE_TRACE_TOTAL = 5  # 4 prefill seq_lens + 1 decode capture.
 
 # MEDIA sub-step counters for the long phases (loading_weights, warming_up). Verified against real distil-large-v3 / speecht5_tts logs.
@@ -365,40 +352,44 @@ MEDIA_WARMUP_TOTAL = 8
 
 # tt-studio ModelTypes (mirror of shared_config.model_type_config.ModelTypes)
 # that should be classified as MEDIA. Everything else → LLM.
-_MEDIA_MODEL_TYPES = frozenset({
-    "speech_recognition",
-    "tts",
-    "image_generation",
-    "video_generation",
-    "object_detection",
-    "cnn",
-    "face_recognition",
-})
+_MEDIA_MODEL_TYPES = frozenset(
+    {
+        "speech_recognition",
+        "tts",
+        "image_generation",
+        "video_generation",
+        "object_detection",
+        "cnn",
+        "face_recognition",
+    }
+)
 
 # Backstop name patterns — used when the caller doesn't pass a model_type
 # hint and we have to guess from the model name.
 _MEDIA_NAME_PATTERNS = [
-    re.compile(r"whisper",                 re.IGNORECASE),
-    re.compile(r"distil-large",            re.IGNORECASE),
-    re.compile(r"^speecht5",               re.IGNORECASE),
-    re.compile(r"^stable-diffusion",       re.IGNORECASE),
-    re.compile(r"^flux\.",                 re.IGNORECASE),
-    re.compile(r"^qwen-image",             re.IGNORECASE),
-    re.compile(r"^motif-image",            re.IGNORECASE),
-    re.compile(r"^wan2",                   re.IGNORECASE),
-    re.compile(r"^mochi",                  re.IGNORECASE),
-    re.compile(r"^yolo",                   re.IGNORECASE),
-    re.compile(r"^resnet",                 re.IGNORECASE),
-    re.compile(r"^efficientnet",           re.IGNORECASE),
-    re.compile(r"^mobilenetv2",            re.IGNORECASE),
-    re.compile(r"^vit$",                   re.IGNORECASE),
-    re.compile(r"^vovnet",                 re.IGNORECASE),
-    re.compile(r"^unet$",                  re.IGNORECASE),
-    re.compile(r"^segformer",              re.IGNORECASE),
+    re.compile(r"whisper", re.IGNORECASE),
+    re.compile(r"distil-large", re.IGNORECASE),
+    re.compile(r"^speecht5", re.IGNORECASE),
+    re.compile(r"^stable-diffusion", re.IGNORECASE),
+    re.compile(r"^flux\.", re.IGNORECASE),
+    re.compile(r"^qwen-image", re.IGNORECASE),
+    re.compile(r"^motif-image", re.IGNORECASE),
+    re.compile(r"^wan2", re.IGNORECASE),
+    re.compile(r"^mochi", re.IGNORECASE),
+    re.compile(r"^yolo", re.IGNORECASE),
+    re.compile(r"^resnet", re.IGNORECASE),
+    re.compile(r"^efficientnet", re.IGNORECASE),
+    re.compile(r"^mobilenetv2", re.IGNORECASE),
+    re.compile(r"^vit$", re.IGNORECASE),
+    re.compile(r"^vovnet", re.IGNORECASE),
+    re.compile(r"^unet$", re.IGNORECASE),
+    re.compile(r"^segformer", re.IGNORECASE),
 ]
 
 
-def category_for_model(model_type: Optional[str] = None, model_name: Optional[str] = None) -> str:
+def category_for_model(
+    model_type: Optional[str] = None, model_name: Optional[str] = None
+) -> str:
     """Return 'media' or 'llm' for the given model identifiers.
 
     Resolution order:
@@ -417,12 +408,17 @@ def category_for_model(model_type: Optional[str] = None, model_name: Optional[st
     return "llm"
 
 
-def _template_for(category: str) -> tuple[
-    list[str], dict[str, str], dict[str, int], list[tuple[str, str]]
-]:
+def _template_for(
+    category: str,
+) -> tuple[list[str], dict[str, str], dict[str, int], list[tuple[str, str]]]:
     """Return (phases, phase_labels, phase_base_pct, substring_markers)."""
     if category == "media":
-        return (MEDIA_PHASES, MEDIA_PHASE_LABELS, MEDIA_PHASE_BASE_PCT, _MEDIA_SUBSTRING_MARKERS)
+        return (
+            MEDIA_PHASES,
+            MEDIA_PHASE_LABELS,
+            MEDIA_PHASE_BASE_PCT,
+            _MEDIA_SUBSTRING_MARKERS,
+        )
     return (LLM_PHASES, LLM_PHASE_LABELS, LLM_PHASE_BASE_PCT, _LLM_SUBSTRING_MARKERS)
 
 
@@ -598,7 +594,9 @@ def classify_startup_phase(
         if warmup_seq_len:
             detail_parts.append(f"prefill seq_len {warmup_seq_len}")
         if trace_count > 0:
-            detail_parts.append(f"trace {min(trace_count, COMPILE_TRACE_TOTAL)}/{COMPILE_TRACE_TOTAL}")
+            detail_parts.append(
+                f"trace {min(trace_count, COMPILE_TRACE_TOTAL)}/{COMPILE_TRACE_TOTAL}"
+            )
         if detail_parts:
             message = " · ".join(detail_parts)
 

--- a/app/backend/model_control/metrics_tracker.py
+++ b/app/backend/model_control/metrics_tracker.py
@@ -24,10 +24,14 @@ class InferenceMetricsTracker:
 
     def __init__(self):
         self.start_time: float = time.perf_counter()
-        self.first_token_time: Optional[float] = None          # first token of any kind
-        self.first_content_token_time: Optional[float] = None  # first non-thinking token (true TTFT)
-        self.most_recent_token_time: Optional[float] = None    # vLLM-style: advances per content chunk
-        self.itl: List[float] = []          # inter-token latency list (seconds) — vLLM style
+        self.first_token_time: Optional[float] = None  # first token of any kind
+        self.first_content_token_time: Optional[float] = (
+            None  # first non-thinking token (true TTFT)
+        )
+        self.most_recent_token_time: Optional[float] = (
+            None  # vLLM-style: advances per content chunk
+        )
+        self.itl: List[float] = []  # inter-token latency list (seconds) — vLLM style
         self.token_times: List[float] = []  # kept for backwards compat / detailed stats
         self.num_tokens: int = 0
         self.prompt_tokens: int = 0
@@ -131,13 +135,16 @@ class InferenceMetricsTracker:
         """Get final statistics in vLLM-compatible format."""
         thinking_duration = (
             self.thinking_end_time - self.thinking_start_time
-            if (self.thinking_start_time is not None and self.thinking_end_time is not None)
+            if (
+                self.thinking_start_time is not None
+                and self.thinking_end_time is not None
+            )
             else None
         )
         return {
             "ttft": self.get_ttft(),
             "tpot": self.get_tpot(),
-            "itl": self.itl,              # list of inter-token latencies in seconds
+            "itl": self.itl,  # list of inter-token latencies in seconds
             "tokens_decoded": self.num_tokens,
             "tokens_prefilled": self.prompt_tokens,
             "context_length": self.prompt_tokens + self.num_tokens,

--- a/app/backend/model_control/model_utils.py
+++ b/app/backend/model_control/model_utils.py
@@ -11,7 +11,6 @@ import traceback
 import httpx
 import requests
 import jwt
-import json
 
 from django.core.cache import caches
 
@@ -25,7 +24,7 @@ logger.info(f"importing {__name__}")
 
 json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
 encoded_jwt = jwt.encode(json_payload, backend_config.jwt_secret, algorithm="HS256")
-AUTH_TOKEN = os.getenv('CLOUD_CHAT_UI_AUTH_TOKEN', '')
+AUTH_TOKEN = os.getenv("CLOUD_CHAT_UI_AUTH_TOKEN", "")
 
 # Shared async HTTP clients with connection pooling (one pool per target)
 _vllm_client = httpx.AsyncClient(
@@ -40,6 +39,7 @@ _cloud_client = httpx.AsyncClient(
     timeout=httpx.Timeout(connect=5.0, read=None, write=10.0, pool=5.0),
     limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
 )
+
 
 def messages_to_prompt(messages: list) -> str:
     """Convert chat messages list to a plain text prompt for base/completion models."""
@@ -133,7 +133,9 @@ def get_deploy_cache():
             if max_len is not None:
                 entry["max_model_len"] = max_len
                 cache.set(con_id, entry, timeout=None)
-                logger.info(f"Cached max_model_len={max_len} for container {con_id[:12]}")
+                logger.info(
+                    f"Cached max_model_len={max_len} for container {con_id[:12]}"
+                )
         if "cached_model_name" not in entry and entry.get("internal_url"):
             name = get_model_name_from_container(
                 entry["internal_url"], fallback=entry["model_impl"].hf_model_id
@@ -181,12 +183,18 @@ def health_check(url, json_data, timeout=5):
     try:
         body_json = response.json() if response.content else {}
         if isinstance(body_json, dict):
-            body_detail = str(body_json.get("detail", "")) or str(body_json.get("message", ""))
+            body_detail = str(body_json.get("detail", "")) or str(
+                body_json.get("message", "")
+            )
     except Exception:
         body_detail = ""
     body_text = (body_detail or response.text or "").lower()
 
-    if "not ready" in body_text or "still loading" in body_text or "starting up" in body_text:
+    if (
+        "not ready" in body_text
+        or "still loading" in body_text
+        or "starting up" in body_text
+    ):
         logger.info(
             f"Health check: model not ready yet (starting): "
             f"{response.status_code} {body_detail or response.text[:200]}"
@@ -203,8 +211,12 @@ def health_check(url, json_data, timeout=5):
     logger.error(f"Health check failed: {response.status_code} {response.text[:200]}")
     return False, response.text[:200]
 
+
 async def stream_response_from_agent_api(url: str, json_data: dict):
-    logger.info('[TRACE_FLOW_STEP_3_BACKEND_TO_AGENT] stream_response_from_agent_api called', extra={'url': url})
+    logger.info(
+        "[TRACE_FLOW_STEP_3_BACKEND_TO_AGENT] stream_response_from_agent_api called",
+        extra={"url": url},
+    )
     new_json_data = {
         "thread_id": json_data["thread_id"],
         "message": json_data["messages"][-1]["content"],
@@ -216,55 +228,58 @@ async def stream_response_from_agent_api(url: str, json_data: dict):
             async for chunk in response.aiter_text():
                 logger.debug(f"stream_response_from_agent_api chunk:={chunk}")
                 if chunk.strip() == "[DONE]":
-                    yield f"data: [DONE]\n\n"
+                    yield "data: [DONE]\n\n"
                 elif chunk.strip():
-                    json_chunk = {"choices": [{"index": 0, "delta": {"content": chunk}}]}
+                    json_chunk = {
+                        "choices": [{"index": 0, "delta": {"content": chunk}}]
+                    }
                     yield "data: " + json.dumps(json_chunk) + "\n\n"
         logger.info("stream_response_from_agent_api done")
     except httpx.HTTPStatusError as e:
-        logger.error(f"Agent HTTPStatusError {e.response.status_code}: {e.response.text[:200]}")
+        logger.error(
+            f"Agent HTTPStatusError {e.response.status_code}: {e.response.text[:200]}"
+        )
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
     except httpx.RequestError as e:
         logger.error(f"Agent RequestError: {str(e)}")
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
 
+
 def get_max_tokens_limit(param_count) -> int:
     """Return max_tokens ceiling based on model parameter count (in billions)."""
-    if param_count is None: return 32768
-    if param_count <= 8:    return 32768
-    if param_count <= 32:   return 65536
+    if param_count is None:
+        return 32768
+    if param_count <= 8:
+        return 32768
+    if param_count <= 32:
+        return 65536
     return 131072
 
 
 def validate_model_params(json_data, max_tokens_limit: int = 32768):
     """Validate and set default values for model parameters."""
     # Default values based on the working curl example
-    defaults = {
-        'temperature': 0.95,
-        'top_p': 0.9,
-        'top_k': 40,
-        'max_tokens': 1024
-    }
+    defaults = {"temperature": 0.95, "top_p": 0.9, "top_k": 40, "max_tokens": 1024}
 
     # Parameter ranges
     ranges = {
-        'temperature': (0.0, 2.0),
-        'top_p': (0.0, 1.0),
-        'top_k': (1, 100),
-        'max_tokens': (1, max_tokens_limit)  # ceiling is model-size-dependent
+        "temperature": (0.0, 2.0),
+        "top_p": (0.0, 1.0),
+        "top_k": (1, 100),
+        "max_tokens": (1, max_tokens_limit),  # ceiling is model-size-dependent
     }
-    
+
     validated_params = {}
-    
+
     for param, default in defaults.items():
         value = json_data.get(param)
-        
+
         # If value is None, 0, or not provided, use default
         if value is None or value == 0:
             logger.info(f"Using default value for {param}: {default}")
             validated_params[param] = default
             continue
-            
+
         # Validate range
         min_val, max_val = ranges[param]
         if not (min_val <= value <= max_val):
@@ -272,8 +287,9 @@ def validate_model_params(json_data, max_tokens_limit: int = 32768):
             validated_params[param] = default
         else:
             validated_params[param] = value
-            
+
     return validated_params
+
 
 async def stream_to_cloud_model(url: str, json_data: dict):
     """Stream response from cloud model (async)."""
@@ -289,14 +305,20 @@ async def stream_to_cloud_model(url: str, json_data: dict):
     json_data["top_p"] = float(top_p) if top_p is not None else 0.9
     json_data["max_tokens"] = int(max_tokens) if max_tokens is not None else 1024
     json_data["stream_options"] = {"include_usage": True}
-    logger.info(f"stream_to_cloud_model params: temperature={json_data['temperature']} top_k={json_data['top_k']} top_p={json_data['top_p']} max_tokens={json_data['max_tokens']}")
+    logger.info(
+        f"stream_to_cloud_model params: temperature={json_data['temperature']} top_k={json_data['top_k']} top_p={json_data['top_p']} max_tokens={json_data['max_tokens']}"
+    )
 
     headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
     tracker = InferenceMetricsTracker()
 
     try:
-        async with _cloud_client.stream("POST", url, json=json_data, headers=headers) as response:
-            logger.info(f"stream_to_cloud_model response status:={response.status_code}")
+        async with _cloud_client.stream(
+            "POST", url, json=json_data, headers=headers
+        ) as response:
+            logger.info(
+                f"stream_to_cloud_model response status:={response.status_code}"
+            )
             response.raise_for_status()
             te = response.headers.get("transfer-encoding", "")
             if te != "chunked":
@@ -312,7 +334,7 @@ async def stream_to_cloud_model(url: str, json_data: dict):
                     found_done = True
 
                 if chunk.startswith("data: "):
-                    new_chunk = chunk[len("data: "):].strip()
+                    new_chunk = chunk[len("data: ") :].strip()
                     if new_chunk and new_chunk != "[DONE]":
                         try:
                             chunk_dict = json.loads(new_chunk)
@@ -324,7 +346,9 @@ async def stream_to_cloud_model(url: str, json_data: dict):
                                     completion_tokens=completion_tokens,
                                     prompt_tokens=prompt_tokens,
                                 )
-                                logger.debug(f"Recorded token: completion={completion_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
+                                logger.debug(
+                                    f"Recorded token: completion={completion_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s"
+                                )
                         except json.JSONDecodeError as e:
                             logger.error(f"JSON decode error in cloud chunk: {e}")
                     yield chunk
@@ -343,17 +367,21 @@ async def stream_to_cloud_model(url: str, json_data: dict):
             logger.info(f"Cloud stream completed after {chunk_count} chunks")
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"Cloud HTTPStatusError {e.response.status_code}: {e.response.text[:200]}")
+        logger.error(
+            f"Cloud HTTPStatusError {e.response.status_code}: {e.response.text[:200]}"
+        )
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
     except Exception as e:
         logger.error(f"Cloud stream unexpected error: {e}\n{traceback.format_exc()}")
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
+
 
 async def stream_response_from_external_api(url: str, json_data: dict):
     """Async SSE streaming from vLLM — non-blocking, connection-pooled."""
     logger.info("=== Starting stream_response_from_external_api ===")
 
     from model_control.connection_warmer import note_inference_loop
+
     note_inference_loop()
 
     # Coerce and forward parameters
@@ -374,14 +402,18 @@ async def stream_response_from_external_api(url: str, json_data: dict):
     else:
         json_data.pop("seed", None)
 
-    logger.info(f"stream_response_from_external_api params: temperature={json_data['temperature']} top_k={json_data['top_k']} top_p={json_data['top_p']} max_tokens={json_data['max_tokens']} seed={json_data.get('seed', 'random')}")
+    logger.info(
+        f"stream_response_from_external_api params: temperature={json_data['temperature']} top_k={json_data['top_k']} top_p={json_data['top_p']} max_tokens={json_data['max_tokens']} seed={json_data.get('seed', 'random')}"
+    )
 
     headers = {"Authorization": f"Bearer {encoded_jwt}"}
     tracker = InferenceMetricsTracker()
     logger.info(f"Starting stream request at time: {tracker.start_time}")
 
     try:
-        async with _vllm_client.stream("POST", url, json=json_data, headers=headers) as response:
+        async with _vllm_client.stream(
+            "POST", url, json=json_data, headers=headers
+        ) as response:
             response.raise_for_status()
             te = response.headers.get("transfer-encoding", "")
             if te != "chunked":
@@ -390,7 +422,7 @@ async def stream_response_from_external_api(url: str, json_data: dict):
             async for chunk in response.aiter_text():
                 logger.debug(f"stream_response_from_external_api chunk:={chunk}")
                 if chunk.startswith("data: "):
-                    new_chunk = chunk[len("data: "):].strip()
+                    new_chunk = chunk[len("data: ") :].strip()
 
                     if new_chunk == "[DONE]":
                         yield chunk
@@ -415,10 +447,14 @@ async def stream_response_from_external_api(url: str, json_data: dict):
                                 tracker.record_thinking_token()
                             # chat completions: choices[0].delta.content
                             # base/completions:  choices[0].text
-                            delta_content = delta.get("content") or choices[0].get("text") or ""
+                            delta_content = (
+                                delta.get("content") or choices[0].get("text") or ""
+                            )
                             if delta_content:
                                 tracker.record_content_token()
-                                logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
+                                logger.debug(
+                                    f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s"
+                                )
 
                         # Capture prompt_tokens from usage chunk
                         usage = chunk_dict.get("usage") or {}
@@ -461,9 +497,10 @@ async def stream_openai_passthrough(url: str, json_data: dict):
                     yield chunk
     except httpx.HTTPStatusError as e:
         body = e.response.text if e.response is not None else "(no body)"
-        logger.error(f"stream_openai_passthrough HTTPError {e.response.status_code}: {body}")
+        logger.error(
+            f"stream_openai_passthrough HTTPError {e.response.status_code}: {body}"
+        )
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
     except httpx.RequestError as e:
         logger.error(f"stream_openai_passthrough RequestError: {str(e)}")
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
-

--- a/app/backend/model_control/models.py
+++ b/app/backend/model_control/models.py
@@ -2,6 +2,5 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-from django.db import models
 
 # Create your models here.

--- a/app/backend/model_control/pipeline_views.py
+++ b/app/backend/model_control/pipeline_views.py
@@ -48,6 +48,7 @@ class VoicePipelineView(APIView):
         if not audio_file:
             from rest_framework.response import Response
             from rest_framework import status
+
             return Response(
                 {"error": "audio_file is required"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -55,6 +56,7 @@ class VoicePipelineView(APIView):
         if not whisper_deploy_id or not llm_deploy_id:
             from rest_framework.response import Response
             from rest_framework import status
+
             return Response(
                 {"error": "whisper_deploy_id and llm_deploy_id are required"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -123,7 +125,7 @@ class VoicePipelineView(APIView):
                     for line in llm_resp.iter_lines(decode_unicode=True):
                         if not line or not line.startswith("data: "):
                             continue
-                        data = line[len("data: "):].strip()
+                        data = line[len("data: ") :].strip()
                         if data == "[DONE]":
                             break
                         try:
@@ -147,7 +149,11 @@ class VoicePipelineView(APIView):
                 return
 
             llm_end = time.time()
-            metrics["llm_ttfb_ms"] = round((llm_first_chunk_time - llm_start) * 1000) if llm_first_chunk_time else 0
+            metrics["llm_ttfb_ms"] = (
+                round((llm_first_chunk_time - llm_start) * 1000)
+                if llm_first_chunk_time
+                else 0
+            )
             metrics["llm_total_ms"] = round((llm_end - llm_start) * 1000)
             metrics["llm_tokens"] = llm_chunk_count
 
@@ -160,17 +166,25 @@ class VoicePipelineView(APIView):
                     tts_deploy = deploy_cache[tts_deploy_id]
                     tts_url = "http://" + tts_deploy["internal_url"]
                     model_impl = tts_deploy.get("model_impl")
-                    model_name = getattr(model_impl, "model_name", None) if model_impl else None
-                    
+                    model_name = (
+                        getattr(model_impl, "model_name", None) if model_impl else None
+                    )
+
                     # Determine if this is OpenAI-style or enqueue-style endpoint
                     is_openai_style = "/v1/audio/speech" in tts_url
-                    
+
                     if is_openai_style:
                         # OpenAI-style: POST directly and get audio back
-                        payload = {"model": model_name, "text": llm_full_text.strip(), "voice": "default"}
-                        tts_resp = requests.post(tts_url, json=payload, headers=headers, timeout=120)
+                        payload = {
+                            "model": model_name,
+                            "text": llm_full_text.strip(),
+                            "voice": "default",
+                        }
+                        tts_resp = requests.post(
+                            tts_url, json=payload, headers=headers, timeout=120
+                        )
                         tts_resp.raise_for_status()
-                        
+
                         audio_b64 = base64.b64encode(tts_resp.content).decode("utf-8")
                         content_type = tts_resp.headers.get("Content-Type", "audio/wav")
                         data_uri = f"data:{content_type};base64,{audio_b64}"
@@ -183,41 +197,70 @@ class VoicePipelineView(APIView):
                             headers=headers,
                             timeout=30,
                         )
-                        
+
                         # If 404 on enqueue, try fallback to /v1/audio/speech
                         if tts_resp.status_code == 404 and "/enqueue" in tts_url:
-                            logger.info(f"Pipeline TTS 404 on {tts_url}, trying /v1/audio/speech")
-                            fallback_url = tts_url.replace("/enqueue", "/v1/audio/speech")
-                            payload = {"model": model_name, "text": llm_full_text.strip(), "voice": "default"}
-                            tts_resp = requests.post(fallback_url, json=payload, headers=headers, timeout=120)
+                            logger.info(
+                                f"Pipeline TTS 404 on {tts_url}, trying /v1/audio/speech"
+                            )
+                            fallback_url = tts_url.replace(
+                                "/enqueue", "/v1/audio/speech"
+                            )
+                            payload = {
+                                "model": model_name,
+                                "text": llm_full_text.strip(),
+                                "voice": "default",
+                            }
+                            tts_resp = requests.post(
+                                fallback_url, json=payload, headers=headers, timeout=120
+                            )
                             tts_resp.raise_for_status()
-                            
-                            audio_b64 = base64.b64encode(tts_resp.content).decode("utf-8")
-                            content_type = tts_resp.headers.get("Content-Type", "audio/wav")
+
+                            audio_b64 = base64.b64encode(tts_resp.content).decode(
+                                "utf-8"
+                            )
+                            content_type = tts_resp.headers.get(
+                                "Content-Type", "audio/wav"
+                            )
                             data_uri = f"data:{content_type};base64,{audio_b64}"
                             yield f"data: {json.dumps({'type': 'audio_url', 'url': data_uri})}\n\n"
                         else:
                             tts_resp.raise_for_status()
-                            
+
                             task_id = tts_resp.json().get("task_id")
-                            status_url = tts_url.replace("/enqueue", f"/status/{task_id}")
+                            status_url = tts_url.replace(
+                                "/enqueue", f"/status/{task_id}"
+                            )
 
                             # Poll for completion
                             for _ in range(120):
-                                st = requests.get(status_url, headers=headers, timeout=10)
-                                if st.status_code != 404 and st.json().get("status") == "Completed":
+                                st = requests.get(
+                                    status_url, headers=headers, timeout=10
+                                )
+                                if (
+                                    st.status_code != 404
+                                    and st.json().get("status") == "Completed"
+                                ):
                                     break
                                 time.sleep(1)
 
-                            audio_url = tts_url.replace("/enqueue", f"/fetch_audio/{task_id}")
-                            audio_resp = requests.get(audio_url, headers=headers, timeout=30)
+                            audio_url = tts_url.replace(
+                                "/enqueue", f"/fetch_audio/{task_id}"
+                            )
+                            audio_resp = requests.get(
+                                audio_url, headers=headers, timeout=30
+                            )
                             audio_resp.raise_for_status()
 
-                            audio_b64 = base64.b64encode(audio_resp.content).decode("utf-8")
-                            content_type = audio_resp.headers.get("Content-Type", "audio/wav")
+                            audio_b64 = base64.b64encode(audio_resp.content).decode(
+                                "utf-8"
+                            )
+                            content_type = audio_resp.headers.get(
+                                "Content-Type", "audio/wav"
+                            )
                             data_uri = f"data:{content_type};base64,{audio_b64}"
                             yield f"data: {json.dumps({'type': 'audio_url', 'url': data_uri})}\n\n"
-                            
+
                     metrics["tts_latency_ms"] = round((time.time() - tts_start) * 1000)
                 except Exception as exc:
                     logger.error(f"TTS step failed: {exc}")
@@ -228,7 +271,9 @@ class VoicePipelineView(APIView):
             yield f"data: {json.dumps({'type': 'metrics', **metrics})}\n\n"
             yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
-        response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+        response = StreamingHttpResponse(
+            event_stream(), content_type="text/event-stream"
+        )
         response["Cache-Control"] = "no-cache"
         response["X-Accel-Buffering"] = "no"
         return response

--- a/app/backend/model_control/serializers.py
+++ b/app/backend/model_control/serializers.py
@@ -2,11 +2,9 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-from pathlib import Path
 
 from rest_framework import serializers
 
-from shared_config.backend_config import backend_config
 from shared_config.model_config import model_implmentations
 from model_control.model_utils import get_deploy_cache
 

--- a/app/backend/model_control/test_e2e.py
+++ b/app/backend/model_control/test_e2e.py
@@ -2,9 +2,6 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-import json
-import time
-import os
 import logging
 
 import requests

--- a/app/backend/model_control/test_model_api.py
+++ b/app/backend/model_control/test_model_api.py
@@ -7,9 +7,7 @@ import time
 
 import requests
 from requests.exceptions import RequestException
-import jwt
 
-from shared_config.backend_config import backend_config
 from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
@@ -25,8 +23,6 @@ else:
 
 
 def test_model_life_cycle():
-    json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
-    encoded_jwt = jwt.encode(json_payload, backend_config.jwt_secret, algorithm="HS256")
     test_model_id = "id_mock_vllm_modelv0.0.1"
     # 1. get list of models
     get_containers_route = f"{backend_host}docker/get_containers/"
@@ -67,7 +63,6 @@ def test_model_life_cycle():
     logger.info(f"found deployed_ids: {deployed_ids}")
     # 3. make valid API call to
     deploy_id = deployed_ids[-1]
-    deploy_data = deployed_res[deploy_id]
     json_data = {
         "model": vllm_model_name,
         "prompt": "What is Tenstorrent?",
@@ -89,6 +84,7 @@ def test_model_life_cycle():
     )
     logger.info(f'response.headers={response.headers.get("transfer-encoding")}')
     assert response.headers.get("transfer-encoding") == "chunked"
+    all_chunks = ""
     for chunk_idx, chunk in enumerate(
         response.iter_content(chunk_size=None, decode_unicode=True)
     ):
@@ -103,7 +99,7 @@ def test_model_life_cycle():
     data = response.json()
     # logger.info(f"response json:= {data}")
     assert deployed_container_id in data.keys()
-    logger.info(f"got status.")
+    logger.info("got status.")
     # 5. stop echo model (consume the SSE stop stream until its `complete` event)
     stop_route = f"{backend_host}docker/stop/stream/{deployed_container_id}/"
     logger.info(f"calling: {stop_route}")
@@ -111,7 +107,7 @@ def test_model_life_cycle():
     final = None
     for line in response.iter_lines():
         if line and line.startswith(b"data: "):
-            event = json.loads(line[len(b"data: "):])
+            event = json.loads(line[len(b"data: ") :])
             if event.get("type") == "complete":
                 final = event
     assert final is not None and final["status"] == "success"

--- a/app/backend/model_control/test_model_utils.py
+++ b/app/backend/model_control/test_model_utils.py
@@ -2,15 +2,11 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-import json
 import time
 import os
 
 import requests
-import jwt
 
-from shared_config.backend_config import backend_config
-from shared_config.device_config import DeviceConfigurations
 from shared_config.logger_config import get_logger
 from shared_config.model_config import model_implmentations
 from docker_control.docker_utils import run_container, stop_container
@@ -24,15 +20,13 @@ logger.info(f"importing {__name__}")
 
 # for test script set up Django using settings
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
-import django
+import django  # noqa: E402
 
 django.setup()
 
 
 def test_model_utils():
     impl = model_implmentations["0"]
-    json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
-    encoded_jwt = jwt.encode(json_payload, backend_config.jwt_secret, algorithm="HS256")
     # 1. run container
     logger.info(f"using impl:={impl}")
     status = run_container(impl)

--- a/app/backend/model_control/test_tts_fallback.py
+++ b/app/backend/model_control/test_tts_fallback.py
@@ -6,98 +6,99 @@ Tests for TTS inference view fallback behavior.
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from rest_framework.test import APIRequestFactory
-from rest_framework import status as http_status
 
 from model_control.views import TtsInferenceView, OpenAIAudioSpeechView
 
 
 class TestTtsInferenceFallback:
     """Test TTS inference view with fallback to /v1/audio/speech on 404."""
-    
-    @patch('model_control.views.get_deploy_cache')
-    @patch('model_control.views.requests.post')
+
+    @patch("model_control.views.get_deploy_cache")
+    @patch("model_control.views.requests.post")
     def test_tts_fallback_on_404_from_enqueue(self, mock_post, mock_cache):
         """When /enqueue returns 404 for TTS media model, should retry with /v1/audio/speech."""
         # Setup mock deploy cache
         mock_impl = Mock()
         mock_impl.model_name = "speecht5_tts"
         mock_impl.inference_engine = "media"
-        
+
         mock_cache.return_value = {
             "test_deploy_id": {
                 "internal_url": "speecht5_tts:7000/enqueue",
-                "model_impl": mock_impl
+                "model_impl": mock_impl,
             }
         }
-        
+
         # First call returns 404, second call succeeds
         mock_resp_404 = Mock()
         mock_resp_404.status_code = 404
-        
+
         mock_resp_success = Mock()
         mock_resp_success.status_code = 200
         mock_resp_success.headers = {"Content-Type": "audio/wav"}
         mock_resp_success.content = b"fake_audio_data"
-        
+
         mock_post.side_effect = [mock_resp_404, mock_resp_success]
-        
+
         # Create request
         factory = APIRequestFactory()
-        request = factory.post('/models-api/tts/', {
-            'deploy_id': 'test_deploy_id',
-            'text': 'Hello world'
-        }, format='json')
-        
+        request = factory.post(
+            "/models-api/tts/",
+            {"deploy_id": "test_deploy_id", "text": "Hello world"},
+            format="json",
+        )
+
         # Call view
         view = TtsInferenceView.as_view()
         response = view(request)
-        
+
         # Verify fallback was attempted
         assert mock_post.call_count == 2
         first_call_url = mock_post.call_args_list[0][0][0]
         second_call_url = mock_post.call_args_list[1][0][0]
-        
+
         assert "enqueue" in first_call_url
         assert "/v1/audio/speech" in second_call_url
         assert response.status_code == 200
-    
-    @patch('model_control.views.get_deploy_cache')
-    @patch('model_control.views.requests.post')
+
+    @patch("model_control.views.get_deploy_cache")
+    @patch("model_control.views.requests.post")
     def test_tts_success_without_fallback(self, mock_post, mock_cache):
         """When initial request succeeds, should not retry."""
         # Setup mock deploy cache
         mock_impl = Mock()
         mock_impl.model_name = "speecht5_tts"
         mock_impl.inference_engine = "media"
-        
+
         mock_cache.return_value = {
             "test_deploy_id": {
                 "internal_url": "speecht5_tts:7000/v1/audio/speech",
-                "model_impl": mock_impl
+                "model_impl": mock_impl,
             }
         }
-        
+
         # First call succeeds
         mock_resp_success = Mock()
         mock_resp_success.status_code = 200
         mock_resp_success.headers = {"Content-Type": "audio/wav"}
         mock_resp_success.content = b"fake_audio_data"
-        
+
         mock_post.return_value = mock_resp_success
-        
+
         # Create request
         factory = APIRequestFactory()
-        request = factory.post('/models-api/tts/', {
-            'deploy_id': 'test_deploy_id',
-            'text': 'Hello world'
-        }, format='json')
-        
+        request = factory.post(
+            "/models-api/tts/",
+            {"deploy_id": "test_deploy_id", "text": "Hello world"},
+            format="json",
+        )
+
         # Call view
         view = TtsInferenceView.as_view()
         response = view(request)
-        
+
         # Verify no fallback was needed
         assert mock_post.call_count == 1
         assert response.status_code == 200
@@ -105,45 +106,46 @@ class TestTtsInferenceFallback:
 
 class TestOpenAIAudioSpeechFallback:
     """Test OpenAI audio/speech view with fallback to /v1/audio/speech on 404."""
-    
-    @patch('model_control.views.get_deploy_cache')
-    @patch('model_control.views.requests.post')
+
+    @patch("model_control.views.get_deploy_cache")
+    @patch("model_control.views.requests.post")
     def test_openai_audio_fallback_on_404(self, mock_post, mock_cache):
         """OpenAI endpoint should also retry with /v1/audio/speech on 404."""
         # Setup mock deploy cache
         mock_impl = Mock()
         mock_impl.model_name = "speecht5_tts"
         mock_impl.inference_engine = "media"
-        
+
         mock_cache.return_value = {
             "deploy_1": {
                 "internal_url": "speecht5_tts:7000/enqueue",
-                "model_impl": mock_impl
+                "model_impl": mock_impl,
             }
         }
-        
+
         # First call returns 404, second call succeeds
         mock_resp_404 = Mock()
         mock_resp_404.status_code = 404
-        
+
         mock_resp_success = Mock()
         mock_resp_success.status_code = 200
         mock_resp_success.headers = {"Content-Type": "audio/wav"}
         mock_resp_success.content = b"fake_audio_data"
-        
+
         mock_post.side_effect = [mock_resp_404, mock_resp_success]
-        
+
         # Create request
         factory = APIRequestFactory()
-        request = factory.post('/v1/audio/speech', {
-            'model': 'speecht5_tts',
-            'input': 'Hello world'
-        }, format='json')
-        
+        request = factory.post(
+            "/v1/audio/speech",
+            {"model": "speecht5_tts", "input": "Hello world"},
+            format="json",
+        )
+
         # Call view
         view = OpenAIAudioSpeechView.as_view()
         response = view(request)
-        
+
         # Verify fallback was attempted
         assert mock_post.call_count == 2
         second_call_url = mock_post.call_args_list[1][0][0]

--- a/app/backend/model_control/tests.py
+++ b/app/backend/model_control/tests.py
@@ -2,6 +2,5 @@
 #
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
-from django.test import TestCase
 
 # Create your tests here.

--- a/app/backend/model_control/urls.py
+++ b/app/backend/model_control/urls.py
@@ -16,21 +16,35 @@ urlpatterns = [
     path("image-generation/", views.ImageGenerationInferenceView.as_view()),
     path("image-generation-cloud/", views.ImageGenerationInferenceCloudView.as_view()),
     path("video-generation/", views.VideoGenerationInferenceView.as_view()),
-    path("video-generation/status/<str:job_id>/", views.VideoGenerationStatusView.as_view()),
-    path("video-generation/download/<str:job_id>/", views.VideoGenerationDownloadView.as_view()),
+    path(
+        "video-generation/status/<str:job_id>/",
+        views.VideoGenerationStatusView.as_view(),
+    ),
+    path(
+        "video-generation/download/<str:job_id>/",
+        views.VideoGenerationDownloadView.as_view(),
+    ),
     path("object-detection/", views.ObjectDetectionInferenceView.as_view()),
     path("object-detection-cloud/", views.ObjectDetectionInferenceCloudView.as_view()),
     path("speech-recognition/", views.SpeechRecognitionInferenceView.as_view()),
-    path("speech-recognition-cloud/", views.SpeechRecognitionInferenceCloudView.as_view()),
+    path(
+        "speech-recognition-cloud/", views.SpeechRecognitionInferenceCloudView.as_view()
+    ),
     path("face-recognition/recognize/", views.FaceRecognitionRecognizeView.as_view()),
     path("face-recognition/register/", views.FaceRecognitionRegisterView.as_view()),
     path("face-recognition/faces/", views.FaceRecognitionListView.as_view()),
-    path("face-recognition/faces/<str:name>/", views.FaceRecognitionDeleteView.as_view()),
+    path(
+        "face-recognition/faces/<str:name>/", views.FaceRecognitionDeleteView.as_view()
+    ),
     path("tts/", views.TtsInferenceView.as_view()),
     path("pipeline/voice/", VoicePipelineView.as_view()),
     path("health/", views.ModelHealthView.as_view()),
     path("inference_cloud/", views.InferenceCloudView.as_view()),
-    path("logs/<str:container_id>/", views.ContainerLogsView.as_view(), name="container-logs"),
+    path(
+        "logs/<str:container_id>/",
+        views.ContainerLogsView.as_view(),
+        name="container-logs",
+    ),
     path("api-info/", views.ModelAPIInfoView.as_view()),
     # Coding-agent gateway (LiteLLM) — OpenAI-compatible upstream + UI helper
     path("openai/v1/chat/completions", views.OpenAIChatCompletionsView.as_view()),

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -4,7 +4,6 @@
 
 # model_control/views.py
 import os
-from pathlib import Path
 from typing import Optional
 import asyncio
 import base64
@@ -25,18 +24,19 @@ from django.views import View
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.renderers import JSONRenderer
-from rest_framework.parsers import JSONParser
 from rest_framework.negotiation import DefaultContentNegotiation
-from django.views import View
+
 
 # Add this renderer class for SSE support
 class PlainTextRenderer(JSONRenderer):
-    media_type = 'text/plain'
-    format = 'txt'
+    media_type = "text/plain"
+    format = "txt"
+
 
 class EventStreamRenderer(JSONRenderer):
-    media_type = 'text/event-stream'
-    format = 'txt'
+    media_type = "text/event-stream"
+    format = "txt"
+
 
 # Add this negotiation class to bypass content type checks
 class IgnoreClientContentNegotiation(DefaultContentNegotiation):
@@ -44,8 +44,9 @@ class IgnoreClientContentNegotiation(DefaultContentNegotiation):
         # Force the first renderer without checking Accept headers
         return (renderers[0], renderers[0].media_type)
 
-from .serializers import InferenceSerializer, ModelWeightsSerializer
-from .log_classifier import classify_startup_phase
+
+from .serializers import InferenceSerializer, ModelWeightsSerializer  # noqa: E402
+from .log_classifier import classify_startup_phase  # noqa: E402
 
 
 # Module-level latch: tracks the highest phase + cached state we've ever seen
@@ -95,7 +96,9 @@ def _apply_phase_latch(deploy_id: str, phase_dict: dict) -> dict:
         cur_progress = int(phase_dict.get("progress", 0) or 0)
         if cur_progress < prev_max_progress:
             phase_dict["progress"] = prev_max_progress
-        new_max_progress = max(prev_max_progress, int(phase_dict.get("progress", 0) or 0))
+        new_max_progress = max(
+            prev_max_progress, int(phase_dict.get("progress", 0) or 0)
+        )
 
         # Sticky cached/repo so the badge persists across tail rotations.
         if prev.get("weights_cached") and not phase_dict.get("weights_cached"):
@@ -106,7 +109,9 @@ def _apply_phase_latch(deploy_id: str, phase_dict: dict) -> dict:
         _phase_latch[deploy_id] = {
             "phase": new_phase,
             "max_progress": new_max_progress,
-            "weights_cached": bool(phase_dict.get("weights_cached") or prev.get("weights_cached")),
+            "weights_cached": bool(
+                phase_dict.get("weights_cached") or prev.get("weights_cached")
+            ),
             "weights_repo": phase_dict.get("weights_repo") or prev.get("weights_repo"),
         }
     return phase_dict
@@ -116,7 +121,9 @@ def _drop_phase_latch(deploy_id: str) -> None:
     """Forget latched state for a deploy (e.g. when it becomes healthy or is removed)."""
     with _phase_latch_lock:
         _phase_latch.pop(deploy_id, None)
-from model_control.model_utils import (
+
+
+from model_control.model_utils import (  # noqa: E402
     encoded_jwt,
     _vllm_client,
     get_deploy_cache,
@@ -129,26 +136,29 @@ from model_control.model_utils import (
     health_check,
     stream_to_cloud_model,
 )
-from shared_config.model_config import model_implmentations
-from shared_config.logger_config import get_logger
-from shared_config.backend_config import backend_config
+from shared_config.model_config import model_implmentations  # noqa: E402
+from shared_config.logger_config import get_logger  # noqa: E402
+from shared_config.backend_config import backend_config  # noqa: E402
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
 
 
-
-
 TTS_API_KEY = os.environ.get("TTS_API_KEY", "")
-CLOUD_CHAT_UI_URL =os.environ.get("CLOUD_CHAT_UI_URL")
+CLOUD_CHAT_UI_URL = os.environ.get("CLOUD_CHAT_UI_URL")
 CLOUD_YOLOV4_API_URL = os.environ.get("CLOUD_YOLOV4_API_URL")
 CLOUD_YOLOV4_API_AUTH_TOKEN = os.environ.get("CLOUD_YOLOV4_API_AUTH_TOKEN")
 CLOUD_SPEECH_RECOGNITION_URL = os.environ.get("CLOUD_SPEECH_RECOGNITION_URL")
-CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get("CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN")
+CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get(
+    "CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN"
+)
 CLOUD_STABLE_DIFFUSION_URL = os.environ.get("CLOUD_STABLE_DIFFUSION_URL")
 CLOUD_STABLE_DIFFUSION_AUTH_TOKEN = os.environ.get("CLOUD_STABLE_DIFFUSION_AUTH_TOKEN")
 CLOUD_SPEECH_RECOGNITION_URL = os.environ.get("CLOUD_SPEECH_RECOGNITION_URL")
-CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get("CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN")
+CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get(
+    "CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN"
+)
+
 
 @method_decorator(csrf_exempt, name="dispatch")
 class InferenceCloudView(View):
@@ -165,6 +175,7 @@ class InferenceCloudView(View):
         response["X-Accel-Buffering"] = "no"
         return response
 
+
 @method_decorator(csrf_exempt, name="dispatch")
 class InferenceView(View):
     async def post(self, request, *args, **kwargs):
@@ -179,14 +190,18 @@ class InferenceView(View):
         internal_url = "http://" + deploy["internal_url"]
         logger.info(f"internal_url:= {internal_url}")
         logger.info(f"using vllm model:= {deploy['model_impl'].model_name}")
-        data["model"] = deploy.get("cached_model_name") or get_model_name_from_container(
+        data["model"] = deploy.get(
+            "cached_model_name"
+        ) or get_model_name_from_container(
             deploy["internal_url"], fallback=deploy["model_impl"].hf_model_id
         )
 
         # Clamp max_tokens to 75% of the model's context window so there is
         # always headroom for input tokens (conversation history, system prompt, etc).
         # Falls back to a param_count-based estimate when max_model_len is not yet cached.
-        raw_limit = deploy.get("max_model_len") or get_max_tokens_limit(deploy["model_impl"].param_count)
+        raw_limit = deploy.get("max_model_len") or get_max_tokens_limit(
+            deploy["model_impl"].param_count
+        )
         max_tokens_limit = max(1, raw_limit * 3 // 4)
         if data.get("max_tokens"):
             data["max_tokens"] = min(int(data["max_tokens"]), max_tokens_limit)
@@ -201,7 +216,9 @@ class InferenceView(View):
 
         async def generate():
             try:
-                async for chunk in stream_response_from_external_api(internal_url, data):
+                async for chunk in stream_response_from_external_api(
+                    internal_url, data
+                ):
                     yield chunk
             except Exception as e:
                 logger.error(f"Error in stream: {str(e)}")
@@ -212,10 +229,11 @@ class InferenceView(View):
         response["X-Accel-Buffering"] = "no"
         return response
 
+
 @method_decorator(csrf_exempt, name="dispatch")
 class AgentView(View):
     async def post(self, request, *args, **kwargs):
-        logger.info('[TRACE_FLOW_STEP_2_BACKEND_AGENT_ENTRY] AgentView.post called')
+        logger.info("[TRACE_FLOW_STEP_2_BACKEND_AGENT_ENTRY] AgentView.post called")
         data = json.loads(request.body)
         logger.info(f"AgentView data:={data}")
 
@@ -226,11 +244,15 @@ class AgentView(View):
         if deploy_id and deploy_id in deploy_cache:
             deploy = deploy_cache[deploy_id]
             logger.info(f"using vllm model:= {deploy['model_impl'].model_name}")
-            data["model"] = deploy.get("cached_model_name") or get_model_name_from_container(
+            data["model"] = deploy.get(
+                "cached_model_name"
+            ) or get_model_name_from_container(
                 deploy["internal_url"], fallback=deploy["model_impl"].hf_model_id
             )
         else:
-            logger.info("No valid deployment found, proceeding with agent-only mode (cloud LLM)")
+            logger.info(
+                "No valid deployment found, proceeding with agent-only mode (cloud LLM)"
+            )
             data.pop("deploy_id", None)
 
         agent_url = "http://tt_studio_agent:8080/poll_requests"
@@ -255,46 +277,50 @@ class AgentStatusView(APIView):
         """Get agent status and discovery information"""
         try:
             import time
+
             # Get agent status directly from the agent service
             agent_status_url = "http://tt_studio_agent:8080/status"
             response = requests.get(agent_status_url, timeout=10)
-            
+
             if response.status_code == 200:
                 agent_status = response.json()
-                
+
                 # Add backend-specific information
                 backend_info = {
                     "backend_status": "running",
                     "deployed_models_count": len(get_deploy_cache()),
                     "agent_integration": "enhanced",
-                    "discovery_enabled": True
+                    "discovery_enabled": True,
                 }
-                
+
                 # Merge agent and backend status
                 full_status = {
                     "agent": agent_status,
                     "backend": backend_info,
-                    "timestamp": time.time()
+                    "timestamp": time.time(),
                 }
-                
+
                 return Response(full_status, status=status.HTTP_200_OK)
             else:
                 return Response(
-                    {"error": "Agent service unavailable", "status_code": response.status_code},
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE
+                    {
+                        "error": "Agent service unavailable",
+                        "status_code": response.status_code,
+                    },
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
-                
+
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to get agent status: {e}")
             return Response(
                 {"error": "Failed to connect to agent service", "details": str(e)},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except Exception as e:
             logger.error(f"Unexpected error in AgentStatusView: {e}")
             return Response(
                 {"error": "Internal server error", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 
@@ -398,6 +424,7 @@ def _get_startup_phase(deploy_id: str) -> dict | None:
 
     try:
         from docker_control.docker_control_client import get_docker_client
+
         client = get_docker_client()
         lines = client.tail_logs(deploy_id, tail=200, timeout=3.0)
         # Even if `lines` is empty (container hasn't logged yet, or the tail
@@ -405,7 +432,9 @@ def _get_startup_phase(deploy_id: str) -> dict | None:
         # phases[0], and `_apply_phase_latch` promotes that to the previously
         # latched maximum so the bar never reports null mid-warmup.
         phase_dict = classify_startup_phase(
-            lines or [], model_type=model_type, model_name=model_name,
+            lines or [],
+            model_type=model_type,
+            model_name=model_name,
         )
         phase_dict = _apply_phase_latch(deploy_id, phase_dict)
     except Exception as e:
@@ -415,6 +444,7 @@ def _get_startup_phase(deploy_id: str) -> dict | None:
     try:
         if phase_dict.get("phase") == "downloading_weights":
             from .download_progress import compute_download_progress
+
             dl = compute_download_progress(
                 deploy_id=deploy_id,
                 repo=phase_dict.get("weights_repo"),
@@ -429,7 +459,8 @@ def _get_startup_phase(deploy_id: str) -> dict | None:
             total = dl.get("total_bytes")
             if dl.get("weights_cached"):
                 phase_dict["message"] = (
-                    f"Weights cached — skipping download ({repo})" if repo
+                    f"Weights cached — skipping download ({repo})"
+                    if repo
                     else "Weights cached — skipping download"
                 )
             elif repo:
@@ -538,9 +569,11 @@ class ObjectDetectionInferenceView(APIView):
             file = {"file": byte_im}
             try:
                 headers = {"Authorization": f"Bearer {encoded_jwt}"}
-                inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
+                inference_data = requests.post(
+                    internal_url, files=file, headers=headers, timeout=5
+                )
                 inference_data.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
+            except requests.exceptions.HTTPError:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                     return Response(status=status.HTTP_401_UNAUTHORIZED)
                 else:
@@ -556,14 +589,16 @@ class ObjectDetectionInferenceCloudView(APIView):
         """special inference view that performs special handling"""
         data = request.data
         logger.info(f"{self.__class__.__name__} data:={data}")
-        
+
         # Get image directly instead of using serializer
         image = data.get("image")
         if not image:
-            return Response({"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
+            return Response(
+                {"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         image = image.file  # we should only receive 1 file
-        
+
         # Get deploy_id and handle the case where it's the string "null" or empty
         deploy_id = data.get("deploy_id")
         if deploy_id == "null" or not deploy_id:
@@ -576,7 +611,7 @@ class ObjectDetectionInferenceCloudView(APIView):
             deploy = get_deploy_cache()[deploy_id]
             internal_url = "http://" + deploy["internal_url"]
             headers = {"Authorization": f"Bearer {CLOUD_YOLOV4_API_AUTH_TOKEN}"}
-            
+
         # construct file to send
         pil_image = Image.open(image)
         pil_image = pil_image.resize((320, 320))  # Resize to target dimensions
@@ -587,15 +622,17 @@ class ObjectDetectionInferenceCloudView(APIView):
         )
         byte_im = buf.getvalue()
         file = {"file": byte_im}
-        
+
         try:
             # log request
             logger.info(f"internal_url:={internal_url}")
             logger.info(f"headers:={headers}")
             # logger.info(f"file:={file}")
-            inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
+            inference_data = requests.post(
+                internal_url, files=file, headers=headers, timeout=5
+            )
             inference_data.raise_for_status()
-        except requests.exceptions.HTTPError as http_err:
+        except requests.exceptions.HTTPError:
             if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
             else:
@@ -633,19 +670,28 @@ class ImageGenerationInferenceView(APIView):
                     else:
                         b64_image = resp_json["data"][0]["b64_json"]
                     image_bytes = base64.b64decode(b64_image)
-                    django_response = HttpResponse(image_bytes, content_type="image/jpeg")
-                    django_response["Content-Disposition"] = "attachment; filename=image.jpg"
+                    django_response = HttpResponse(
+                        image_bytes, content_type="image/jpeg"
+                    )
+                    django_response["Content-Disposition"] = (
+                        "attachment; filename=image.jpg"
+                    )
                     return django_response
                 else:
                     # Legacy enqueue/poll/fetch API
                     inference_data = requests.post(
-                        internal_url, json={"prompt": prompt}, headers=headers, timeout=5
+                        internal_url,
+                        json={"prompt": prompt},
+                        headers=headers,
+                        timeout=5,
                     )
                     inference_data.raise_for_status()
 
                     ready_latest = False
                     task_id = inference_data.json().get("task_id")
-                    get_status_url = internal_url.replace("/enqueue", f"/status/{task_id}")
+                    get_status_url = internal_url.replace(
+                        "/enqueue", f"/status/{task_id}"
+                    )
                     while not ready_latest:
                         latest_prompt = requests.get(get_status_url, headers=headers)
                         if latest_prompt.status_code != status.HTTP_404_NOT_FOUND:
@@ -654,15 +700,25 @@ class ImageGenerationInferenceView(APIView):
                                 ready_latest = True
                         time.sleep(1)
 
-                    get_image_url = internal_url.replace("/enqueue", f"/fetch_image/{task_id}")
-                    latest_image = requests.get(get_image_url, headers=headers, stream=True)
+                    get_image_url = internal_url.replace(
+                        "/enqueue", f"/fetch_image/{task_id}"
+                    )
+                    latest_image = requests.get(
+                        get_image_url, headers=headers, stream=True
+                    )
                     latest_image.raise_for_status()
-                    content_type = latest_image.headers.get("Content-Type", "application/octet-stream")
-                    django_response = HttpResponse(latest_image.content, content_type=content_type)
-                    django_response["Content-Disposition"] = "attachment; filename=image.png"
+                    content_type = latest_image.headers.get(
+                        "Content-Type", "application/octet-stream"
+                    )
+                    django_response = HttpResponse(
+                        latest_image.content, content_type=content_type
+                    )
+                    django_response["Content-Disposition"] = (
+                        "attachment; filename=image.png"
+                    )
                     return django_response
 
-            except requests.exceptions.HTTPError as http_err:
+            except requests.exceptions.HTTPError:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                     return Response(status=status.HTTP_401_UNAUTHORIZED)
                 elif inference_data.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
@@ -686,7 +742,9 @@ class VideoGenerationInferenceView(APIView):
         deploy_id = data.get("deploy_id")
         prompt = data.get("prompt")
         if not prompt:
-            return Response({"error": "prompt is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "prompt is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         deploy = get_deploy_cache()[deploy_id]
         internal_url = "http://" + deploy["internal_url"]
@@ -705,14 +763,20 @@ class VideoGenerationInferenceView(APIView):
                 pass
 
         try:
-            init_resp = requests.post(internal_url, json=payload, headers=headers, timeout=30)
+            init_resp = requests.post(
+                internal_url, json=payload, headers=headers, timeout=30
+            )
             init_resp.raise_for_status()
 
             # Sync mode: server returned video bytes directly (use_async_video=False)
             if init_resp.status_code == status.HTTP_200_OK:
                 content_type = init_resp.headers.get("Content-Type", "video/mp4")
-                django_response = HttpResponse(init_resp.content, content_type=content_type)
-                django_response["Content-Disposition"] = "attachment; filename=video.mp4"
+                django_response = HttpResponse(
+                    init_resp.content, content_type=content_type
+                )
+                django_response["Content-Disposition"] = (
+                    "attachment; filename=video.mp4"
+                )
                 return django_response
 
             # Async mode: server returned 202 with job_id — return it immediately so the
@@ -722,7 +786,10 @@ class VideoGenerationInferenceView(APIView):
             job_id = job_data.get("job_id") or job_data.get("id")
             if not job_id:
                 logger.error(f"No job_id in async response: {job_data}")
-                return Response({"error": "No job_id in response"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                return Response(
+                    {"error": "No job_id in response"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
 
             return Response({"job_id": job_id}, status=status.HTTP_202_ACCEPTED)
 
@@ -739,7 +806,9 @@ class VideoGenerationInferenceView(APIView):
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as exc:
             logger.error(f"VideoGenerationInferenceView unexpected error: {exc}")
-            return Response({"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 def _video_base_url(deploy_id):
@@ -769,7 +838,9 @@ class VideoGenerationStatusView(APIView):
     def get(self, request, job_id, *args, **kwargs):
         deploy_id = request.query_params.get("deploy_id")
         if not deploy_id:
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             base_url = _video_base_url(deploy_id)
@@ -790,7 +861,9 @@ class VideoGenerationStatusView(APIView):
             return Response(status=err_status or status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as exc:
             logger.error(f"VideoGenerationStatusView unexpected error: {exc}")
-            return Response({"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class VideoGenerationDownloadView(APIView):
@@ -799,7 +872,9 @@ class VideoGenerationDownloadView(APIView):
     def get(self, request, job_id, *args, **kwargs):
         deploy_id = request.query_params.get("deploy_id")
         if not deploy_id:
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             base_url = _video_base_url(deploy_id)
@@ -822,92 +897,14 @@ class VideoGenerationDownloadView(APIView):
             return Response(status=err_status or status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as exc:
             logger.error(f"VideoGenerationDownloadView unexpected error: {exc}")
-            return Response({"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-
-class SpeechRecognitionInferenceView(APIView):
-    def post(self, request, *args, **kwargs):
-        """special automatic speec recognition inference view"""
-        data = request.data
-        logger.info(f"{self.__class__.__name__} data:={data}")
-        serializer = InferenceSerializer(data=data)
-        if serializer.is_valid():
-            deploy_id = data.get("deploy_id")
-            audio_file = data.get("file")  # we should only receive 1 file
-            deploy = get_deploy_cache()[deploy_id]
-            internal_url = "http://" + deploy["internal_url"]
-            model_impl = deploy.get("model_impl")
-            inference_engine = getattr(model_impl, "inference_engine", None)
-            if inference_engine == "media":
-                headers = {"Authorization": f"Bearer {TTS_API_KEY}"}
-            else:
-                headers = {"Authorization": f"Bearer {encoded_jwt}"}
-            file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-            try:
-                inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-                inference_data.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
-                if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                    return Response(status=status.HTTP_401_UNAUTHORIZED)
-                else:
-                    return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-            return Response(inference_data.json(), status=status.HTTP_200_OK)
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-class SpeechRecognitionInferenceCloudView(APIView):
-    def post(self, request, *args, **kwargs):
-        """special inference view that performs special handling for cloud speech recognition"""
-        data = request.data
-        logger.info(f"{self.__class__.__name__} data:={data}")
-        
-        # Get audio file directly instead of using serializer
-        audio_file = data.get("file")
-        if not audio_file:
-            return Response({"error": "file is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
-        # Get deploy_id and handle the case where it's the string "null"
-        deploy_id = data.get("deploy_id")
-        if deploy_id == "null" or not deploy_id:
-            # Use cloud URL when deploy_id is "null" or empty
-            internal_url = CLOUD_SPEECH_RECOGNITION_URL
-            if not internal_url:
-                return Response(
-                    {"error": "Cloud speech recognition URL not configured"}, 
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE
-                )
-            logger.info(f"Using cloud URL: {internal_url}")
-            headers = {"Authorization": f"Bearer {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}"}
-            logger.info(f"Using cloud auth token: {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}")
-        else:
-            deploy = get_deploy_cache()[deploy_id]
-            internal_url = "http://" + deploy["internal_url"]
-            model_impl = deploy.get("model_impl")
-            inference_engine = getattr(model_impl, "inference_engine", None)
-            if inference_engine == "media":
-                headers = {"Authorization": f"Bearer {TTS_API_KEY}"}
-            else:
-                headers = {"Authorization": f"Bearer {encoded_jwt}"}
-            
-        file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-        
-        try:
-            # log request
-            logger.info(f"internal_url:={internal_url}")
-            logger.info(f"headers:={headers}")
-            inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-            inference_data.raise_for_status()
-        except requests.exceptions.HTTPError as http_err:
-            if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                return Response(status=status.HTTP_401_UNAUTHORIZED)
-            else:
-                return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 class FaceRecognitionRecognizeView(APIView):
     """Proxy view for face recognition - recognize faces in an image"""
+
     def post(self, request, *args, **kwargs):
         data = request.data
         logger.info(f"{self.__class__.__name__} data:={data}")
@@ -915,40 +912,57 @@ class FaceRecognitionRecognizeView(APIView):
         deploy_id = data.get("deploy_id")
         image = data.get("image")
         if not image:
-            return Response({"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
         if not deploy_id or deploy_id == "null":
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             deploy = get_deploy_cache()[deploy_id]
-            base_url = "http://" + deploy["internal_url"].rsplit('/', 1)[0]
+            base_url = "http://" + deploy["internal_url"].rsplit("/", 1)[0]
             internal_url = f"{base_url}/recognize-face"
         except KeyError:
-            return Response({"error": f"No deployment found for {deploy_id}"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"No deployment found for {deploy_id}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         try:
             headers = {"Authorization": f"Bearer {encoded_jwt}"}
             files = {"image": (image.name, image.file, image.content_type)}
-            inference_data = requests.post(internal_url, files=files, headers=headers, timeout=30)
+            inference_data = requests.post(
+                internal_url, files=files, headers=headers, timeout=30
+            )
             inference_data.raise_for_status()
         except requests.exceptions.Timeout:
-            return Response({"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT)
+            return Response(
+                {"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT
+            )
         except requests.exceptions.HTTPError:
             if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
             elif inference_data.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
-                return Response({"error": "Models not loaded"}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+                return Response(
+                    {"error": "Models not loaded"},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
             else:
                 return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
             logger.error(f"Face recognition error: {e}")
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 
 class FaceRecognitionRegisterView(APIView):
     """Proxy view for face recognition - register a new face"""
+
     def post(self, request, *args, **kwargs):
         data = request.data
         logger.info(f"{self.__class__.__name__} data:={data}")
@@ -958,105 +972,151 @@ class FaceRecognitionRegisterView(APIView):
         name = data.get("name")
 
         if not image:
-            return Response({"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "image is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
         if not name:
-            return Response({"error": "name is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "name is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
         if not deploy_id or deploy_id == "null":
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             deploy = get_deploy_cache()[deploy_id]
-            base_url = "http://" + deploy["internal_url"].rsplit('/', 1)[0]
+            base_url = "http://" + deploy["internal_url"].rsplit("/", 1)[0]
             internal_url = f"{base_url}/register-face"
         except KeyError:
-            return Response({"error": f"No deployment found for {deploy_id}"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"No deployment found for {deploy_id}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         try:
             headers = {"Authorization": f"Bearer {encoded_jwt}"}
             files = {"image": (image.name, image.file, image.content_type)}
             form_data = {"name": name}
-            inference_data = requests.post(internal_url, files=files, data=form_data, headers=headers, timeout=30)
+            inference_data = requests.post(
+                internal_url, files=files, data=form_data, headers=headers, timeout=30
+            )
             inference_data.raise_for_status()
         except requests.exceptions.Timeout:
-            return Response({"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT)
+            return Response(
+                {"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT
+            )
         except requests.exceptions.HTTPError:
             if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
             elif inference_data.status_code == status.HTTP_409_CONFLICT:
-                return Response({"error": "Identity already exists"}, status=status.HTTP_409_CONFLICT)
+                return Response(
+                    {"error": "Identity already exists"},
+                    status=status.HTTP_409_CONFLICT,
+                )
             elif inference_data.status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
-                return Response({"error": "Models not loaded"}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+                return Response(
+                    {"error": "Models not loaded"},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                )
             else:
                 return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
             logger.error(f"Face registration error: {e}")
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 
 class FaceRecognitionListView(APIView):
     """Proxy view for face recognition - list registered faces"""
+
     def get(self, request, *args, **kwargs):
         deploy_id = request.query_params.get("deploy_id")
         logger.info(f"{self.__class__.__name__} deploy_id:={deploy_id}")
 
         if not deploy_id or deploy_id == "null":
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             deploy = get_deploy_cache()[deploy_id]
-            base_url = "http://" + deploy["internal_url"].rsplit('/', 1)[0]
+            base_url = "http://" + deploy["internal_url"].rsplit("/", 1)[0]
             internal_url = f"{base_url}/registered-faces"
         except KeyError:
-            return Response({"error": f"No deployment found for {deploy_id}"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"No deployment found for {deploy_id}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         try:
             headers = {"Authorization": f"Bearer {encoded_jwt}"}
             response = requests.get(internal_url, headers=headers, timeout=10)
             response.raise_for_status()
         except requests.exceptions.Timeout:
-            return Response({"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT)
+            return Response(
+                {"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT
+            )
         except requests.exceptions.HTTPError:
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
             logger.error(f"Face list error: {e}")
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         return Response(response.json(), status=status.HTTP_200_OK)
 
 
 class FaceRecognitionDeleteView(APIView):
     """Proxy view for face recognition - delete a registered face"""
+
     def delete(self, request, name, *args, **kwargs):
         deploy_id = request.query_params.get("deploy_id")
         logger.info(f"{self.__class__.__name__} deploy_id:={deploy_id} name:={name}")
 
         if not deploy_id or deploy_id == "null":
-            return Response({"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "deploy_id is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
         if not name:
-            return Response({"error": "name is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "name is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         try:
             deploy = get_deploy_cache()[deploy_id]
-            base_url = "http://" + deploy["internal_url"].rsplit('/', 1)[0]
+            base_url = "http://" + deploy["internal_url"].rsplit("/", 1)[0]
             internal_url = f"{base_url}/registered-faces/{name}"
         except KeyError:
-            return Response({"error": f"No deployment found for {deploy_id}"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": f"No deployment found for {deploy_id}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         try:
             headers = {"Authorization": f"Bearer {encoded_jwt}"}
             response = requests.delete(internal_url, headers=headers, timeout=10)
             response.raise_for_status()
         except requests.exceptions.Timeout:
-            return Response({"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT)
+            return Response(
+                {"error": "Request timeout"}, status=status.HTTP_504_GATEWAY_TIMEOUT
+            )
         except requests.exceptions.HTTPError:
             if response.status_code == status.HTTP_404_NOT_FOUND:
-                return Response({"error": f"Identity '{name}' not found"}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"error": f"Identity '{name}' not found"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
             logger.error(f"Face delete error: {e}")
-            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
         return Response(response.json(), status=status.HTTP_200_OK)
 
@@ -1066,34 +1126,40 @@ class ImageGenerationInferenceCloudView(APIView):
         """special image generation inference view that performs special file handling"""
         data = request.data
         logger.info(f"{self.__class__.__name__} received request data: {data}")
-        
+
         # Get prompt directly since we don't need deploy_id validation for cloud
         prompt = data.get("prompt")
         if not prompt:
             logger.error("No prompt provided in request")
-            return Response({"error": "prompt is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
+            return Response(
+                {"error": "prompt is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         logger.info(f"Processing prompt: {prompt}")
         base_url = CLOUD_STABLE_DIFFUSION_URL
         if not base_url:
             logger.error("Cloud stable diffusion URL not configured")
             return Response(
-                {"error": "Cloud stable diffusion URL not configured"}, 
-                status=status.HTTP_503_SERVICE_UNAVAILABLE
+                {"error": "Cloud stable diffusion URL not configured"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         try:
             headers = {"Authorization": f"Bearer {CLOUD_STABLE_DIFFUSION_AUTH_TOKEN}"}
             data = {"prompt": prompt}
-            
+
             # Use /enqueue endpoint for initial request
             enqueue_url = f"{base_url}/enqueue"
             logger.info(f"Making request to cloud endpoint: {enqueue_url}")
             logger.info(f"Request headers: {headers}")
             logger.info(f"Request data: {data}")
-            
-            inference_data = requests.post(enqueue_url, json=data, headers=headers, timeout=5)
+
+            inference_data = requests.post(
+                enqueue_url, json=data, headers=headers, timeout=5
+            )
             inference_data.raise_for_status()
-            logger.info(f"Initial request successful, response: {inference_data.json()}")
+            logger.info(
+                f"Initial request successful, response: {inference_data.json()}"
+            )
 
             # begin fetch status loop
             ready_latest = False
@@ -1101,8 +1167,8 @@ class ImageGenerationInferenceCloudView(APIView):
             logger.info(f"Got task_id: {task_id}")
             status_url = f"{base_url}/status/{task_id}"
             logger.info(f"Status check URL: {status_url}")
-            
-            while (not ready_latest):
+
+            while not ready_latest:
                 logger.info(f"Checking status for task {task_id}")
                 latest_prompt = requests.get(status_url, headers=headers)
                 if latest_prompt.status_code != status.HTTP_404_NOT_FOUND:
@@ -1120,13 +1186,17 @@ class ImageGenerationInferenceCloudView(APIView):
             latest_image = requests.get(image_url, headers=headers, stream=True)
             latest_image.raise_for_status()
             logger.info("Successfully retrieved image")
-            
-            content_type = latest_image.headers.get('Content-Type', 'application/octet-stream')
-            content_disposition = f'attachment; filename=image.png'
-            
+
+            content_type = latest_image.headers.get(
+                "Content-Type", "application/octet-stream"
+            )
+            content_disposition = "attachment; filename=image.png"
+
             # Create a Django HttpResponse with the content of the file from Flask
-            django_response = HttpResponse(latest_image.content, content_type=content_type)
-            django_response['Content-Disposition'] = content_disposition
+            django_response = HttpResponse(
+                latest_image.content, content_type=content_type
+            )
+            django_response["Content-Disposition"] = content_disposition
             logger.info("Returning image response")
             return django_response
 
@@ -1141,7 +1211,6 @@ class ImageGenerationInferenceCloudView(APIView):
             else:
                 logger.error(f"Unexpected error: {str(http_err)}")
                 return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
 
 
 class SpeechRecognitionInferenceView(APIView):
@@ -1163,9 +1232,11 @@ class SpeechRecognitionInferenceView(APIView):
                 headers = {"Authorization": f"Bearer {encoded_jwt}"}
             file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
             try:
-                inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
+                inference_data = requests.post(
+                    internal_url, files=file, headers=headers, timeout=5
+                )
                 inference_data.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
+            except requests.exceptions.HTTPError:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                     return Response(status=status.HTTP_401_UNAUTHORIZED)
                 else:
@@ -1175,17 +1246,20 @@ class SpeechRecognitionInferenceView(APIView):
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
 class SpeechRecognitionInferenceCloudView(APIView):
     def post(self, request, *args, **kwargs):
         """special inference view that performs special handling for cloud speech recognition"""
         data = request.data
         logger.info(f"{self.__class__.__name__} data:={data}")
-        
+
         # Get audio file directly instead of using serializer
         audio_file = data.get("file")
         if not audio_file:
-            return Response({"error": "file is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
+            return Response(
+                {"error": "file is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         # Get deploy_id and handle the case where it's the string "null"
         deploy_id = data.get("deploy_id")
         if deploy_id == "null" or not deploy_id:
@@ -1193,12 +1267,14 @@ class SpeechRecognitionInferenceCloudView(APIView):
             internal_url = CLOUD_SPEECH_RECOGNITION_URL
             if not internal_url:
                 return Response(
-                    {"error": "Cloud speech recognition URL not configured"}, 
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE
+                    {"error": "Cloud speech recognition URL not configured"},
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
             logger.info(f"Using cloud URL: {internal_url}")
             headers = {"Authorization": f"Bearer {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}"}
-            logger.info(f"Using cloud auth token: {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}")
+            logger.info(
+                f"Using cloud auth token: {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}"
+            )
         else:
             deploy = get_deploy_cache()[deploy_id]
             internal_url = "http://" + deploy["internal_url"]
@@ -1208,16 +1284,18 @@ class SpeechRecognitionInferenceCloudView(APIView):
                 headers = {"Authorization": f"Bearer {TTS_API_KEY}"}
             else:
                 headers = {"Authorization": f"Bearer {encoded_jwt}"}
-            
+
         file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-        
+
         try:
             # log request
             logger.info(f"internal_url:={internal_url}")
             logger.info(f"headers:={headers}")
-            inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
+            inference_data = requests.post(
+                internal_url, files=file, headers=headers, timeout=5
+            )
             inference_data.raise_for_status()
-        except requests.exceptions.HTTPError as http_err:
+        except requests.exceptions.HTTPError:
             if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
             else:
@@ -1225,8 +1303,10 @@ class SpeechRecognitionInferenceCloudView(APIView):
 
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
+
 class TtsInferenceView(APIView):
     """Text-to-speech inference: supports both OpenAI-style and enqueue-style endpoints."""
+
     def post(self, request, *args, **kwargs):
         data = request.data
         logger.info(f"{self.__class__.__name__} data:={data}")
@@ -1235,34 +1315,52 @@ class TtsInferenceView(APIView):
             deploy_id = data.get("deploy_id")
             text = data.get("text") or data.get("prompt")
             if not text:
-                return Response({"error": "text is required"}, status=status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {"error": "text is required"}, status=status.HTTP_400_BAD_REQUEST
+                )
             deploy = get_deploy_cache()[deploy_id]
             internal_url = "http://" + deploy["internal_url"]
             try:
                 model_impl = deploy.get("model_impl")
-                model_name = getattr(model_impl, "model_name", None) if model_impl else None
+                model_name = (
+                    getattr(model_impl, "model_name", None) if model_impl else None
+                )
                 inference_engine = getattr(model_impl, "inference_engine", None)
-                
+
                 if inference_engine == "media":
                     headers = {"Authorization": f"Bearer {TTS_API_KEY}"}
                     payload = {"model": model_name, "text": text, "voice": "default"}
                 else:
                     headers = {"Authorization": f"Bearer {encoded_jwt}"}
                     payload = {"model": model_name, "input": text, "voice": "default"}
-                
-                audio_resp = requests.post(internal_url, json=payload, headers=headers, timeout=120)
-                
+
+                audio_resp = requests.post(
+                    internal_url, json=payload, headers=headers, timeout=120
+                )
+
                 # If 404 on /enqueue for TTS media model, retry with /v1/audio/speech
-                if audio_resp.status_code == 404 and inference_engine == "media" and "/enqueue" in internal_url:
-                    logger.info(f"TTS 404 on {internal_url}, retrying with /v1/audio/speech")
+                if (
+                    audio_resp.status_code == 404
+                    and inference_engine == "media"
+                    and "/enqueue" in internal_url
+                ):
+                    logger.info(
+                        f"TTS 404 on {internal_url}, retrying with /v1/audio/speech"
+                    )
                     fallback_url = internal_url.replace("/enqueue", "/v1/audio/speech")
-                    audio_resp = requests.post(fallback_url, json=payload, headers=headers, timeout=120)
-                
+                    audio_resp = requests.post(
+                        fallback_url, json=payload, headers=headers, timeout=120
+                    )
+
                 audio_resp.raise_for_status()
 
                 content_type = audio_resp.headers.get("Content-Type", "audio/wav")
-                django_response = HttpResponse(audio_resp.content, content_type=content_type)
-                django_response["Content-Disposition"] = "attachment; filename=tts_output.wav"
+                django_response = HttpResponse(
+                    audio_resp.content, content_type=content_type
+                )
+                django_response["Content-Disposition"] = (
+                    "attachment; filename=tts_output.wav"
+                )
                 django_response["Cache-Control"] = "no-cache, no-store, must-revalidate"
                 return django_response
 
@@ -1275,14 +1373,19 @@ class TtsInferenceView(APIView):
 
 class OpenAIAudioSpeechView(APIView):
     """OpenAI-compatible POST /v1/audio/speech — looks up deployed TTS model by name."""
+
     def post(self, request, *args, **kwargs):
         data = request.data
         model_name = data.get("model")
         text = data.get("input") or data.get("text")
         if not model_name:
-            return Response({"error": "model is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "model is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
         if not text:
-            return Response({"error": "input is required"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "input is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         # Find a running TTS deployment matching the requested model name
         deploy = None
@@ -1301,26 +1404,46 @@ class OpenAIAudioSpeechView(APIView):
         try:
             model_impl = deploy.get("model_impl")
             inference_engine = getattr(model_impl, "inference_engine", None)
-            
+
             if inference_engine == "media":
                 headers = {"Authorization": f"Bearer {TTS_API_KEY}"}
-                payload = {"model": model_name, "text": text, "voice": data.get("voice", "default")}
+                payload = {
+                    "model": model_name,
+                    "text": text,
+                    "voice": data.get("voice", "default"),
+                }
             else:
                 headers = {"Authorization": f"Bearer {encoded_jwt}"}
-                payload = {"model": model_name, "input": text, "voice": data.get("voice", "default")}
-            
-            audio_resp = requests.post(internal_url, json=payload, headers=headers, timeout=120)
-            
+                payload = {
+                    "model": model_name,
+                    "input": text,
+                    "voice": data.get("voice", "default"),
+                }
+
+            audio_resp = requests.post(
+                internal_url, json=payload, headers=headers, timeout=120
+            )
+
             # If 404 on /enqueue for TTS media model, retry with /v1/audio/speech
-            if audio_resp.status_code == 404 and inference_engine == "media" and "/enqueue" in internal_url:
-                logger.info(f"OpenAI audio/speech 404 on {internal_url}, retrying with /v1/audio/speech")
+            if (
+                audio_resp.status_code == 404
+                and inference_engine == "media"
+                and "/enqueue" in internal_url
+            ):
+                logger.info(
+                    f"OpenAI audio/speech 404 on {internal_url}, retrying with /v1/audio/speech"
+                )
                 fallback_url = internal_url.replace("/enqueue", "/v1/audio/speech")
-                audio_resp = requests.post(fallback_url, json=payload, headers=headers, timeout=120)
-            
+                audio_resp = requests.post(
+                    fallback_url, json=payload, headers=headers, timeout=120
+                )
+
             audio_resp.raise_for_status()
 
             content_type = audio_resp.headers.get("Content-Type", "audio/wav")
-            django_response = HttpResponse(audio_resp.content, content_type=content_type)
+            django_response = HttpResponse(
+                audio_resp.content, content_type=content_type
+            )
             django_response["Cache-Control"] = "no-cache, no-store, must-revalidate"
             return django_response
 
@@ -1332,79 +1455,89 @@ class OpenAIAudioSpeechView(APIView):
 class ContainerLogsView(View):
     # Define event detection configuration before the get method
     SIMPLE_EVENT_KEYWORDS = [
-        '[ERROR]', '[FATAL]', '[CRITICAL]',
-        '[WARN]', '[WARNING]',
-        'RESPONSE_Q OUT OF SYNC',
-        'ABORTED', 'CORE DUMPED',
-        'TERMINATED', 'EXCEPTION',
-        'DESTINATION UNREACHABLE',
-        'CLUSTER GENERATION FAILED',
-        'APPLICATION STARTUP COMPLETE',
-        'UVICORN RUNNING ON',
-        'STARTED SERVER PROCESS',
-        'WAITING FOR APPLICATION STARTUP',
-        'WH_ARCH_YAML:',
-        'PLATFORM LINUX',
-        'PYTEST-',
-        'ROOTDIR:',
-        'PLUGINS:'
+        "[ERROR]",
+        "[FATAL]",
+        "[CRITICAL]",
+        "[WARN]",
+        "[WARNING]",
+        "RESPONSE_Q OUT OF SYNC",
+        "ABORTED",
+        "CORE DUMPED",
+        "TERMINATED",
+        "EXCEPTION",
+        "DESTINATION UNREACHABLE",
+        "CLUSTER GENERATION FAILED",
+        "APPLICATION STARTUP COMPLETE",
+        "UVICORN RUNNING ON",
+        "STARTED SERVER PROCESS",
+        "WAITING FOR APPLICATION STARTUP",
+        "WH_ARCH_YAML:",
+        "PLATFORM LINUX",
+        "PYTEST-",
+        "ROOTDIR:",
+        "PLUGINS:",
     ]
-    
+
     @staticmethod
     def _is_complex_event(line_upper):
         """
         Check for event patterns that require multiple keyword combinations.
-        
+
         Args:
             line_upper: Uppercase version of the log line
-            
+
         Returns:
             bool: True if line matches a complex event pattern
         """
-        if 'DEVICE |' in line_upper and 'OPENING USER MODE DEVICE DRIVER' in line_upper:
+        if "DEVICE |" in line_upper and "OPENING USER MODE DEVICE DRIVER" in line_upper:
             return True
 
-        if 'SILICONDRIVER' in line_upper and ('OPENED PCI DEVICE' in line_upper or 'DETECTED PCI' in line_upper):
+        if "SILICONDRIVER" in line_upper and (
+            "OPENED PCI DEVICE" in line_upper or "DETECTED PCI" in line_upper
+        ):
             return True
-        
-        if 'SOFTWARE VERSION' in line_upper and 'ETHERNET FW VERSION' in line_upper:
+
+        if "SOFTWARE VERSION" in line_upper and "ETHERNET FW VERSION" in line_upper:
             return True
-        
-        if 'COLLECTED' in line_upper and 'ITEM' in line_upper:
+
+        if "COLLECTED" in line_upper and "ITEM" in line_upper:
             return True
-        
+
         return False
-    
+
     @classmethod
     def _determine_message_type(cls, line):
         """
         Determine if a log line should be classified as an event or regular log.
-        
+
         Args:
             line: The log line to classify
-            
+
         Returns:
             str: Either "event" or "log"
         """
         line_upper = line.upper()
-        
+
         # Check simple keyword patterns
         if any(keyword in line_upper for keyword in cls.SIMPLE_EVENT_KEYWORDS):
             return "event"
-        
+
         # Check complex multi-keyword patterns
         if cls._is_complex_event(line_upper):
             return "event"
-        
+
         return "log"
-    
+
     async def get(self, request, container_id, *args, **kwargs):
         """Stream logs from a Docker container using Server-Sent Events via docker-control-service"""
-        logger.info(f"ContainerLogsView received request for container_id: {container_id}")
+        logger.info(
+            f"ContainerLogsView received request for container_id: {container_id}"
+        )
 
         try:
             logger.info("Getting docker-control-service client")
             from docker_control.docker_control_client import get_docker_client
+
             client = get_docker_client()
 
             logger.info(f"Setting up log stream for container: {container_id}")
@@ -1415,7 +1548,9 @@ class ContainerLogsView(View):
 
                 def sync_stream():
                     try:
-                        for log_line in client.get_logs_stream(container_id, follow=True, tail=100):
+                        for log_line in client.get_logs_stream(
+                            container_id, follow=True, tail=100
+                        ):
                             loop.call_soon_threadsafe(queue.put_nowait, log_line)
 
                     except requests.exceptions.ConnectionError as e:
@@ -1423,11 +1558,13 @@ class ContainerLogsView(View):
                         error_data = {
                             "type": "service_unavailable",
                             "message": "Cannot reach the docker-control-service (port 8002). Make sure it is running on the host.",
-                            "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                            "timestamp": datetime.datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            ),
                         }
                         loop.call_soon_threadsafe(
                             queue.put_nowait,
-                            f"data: {json.dumps(error_data)}\n\n".encode('utf-8')
+                            f"data: {json.dumps(error_data)}\n\n".encode("utf-8"),
                         )
 
                     except Exception as e:
@@ -1435,11 +1572,13 @@ class ContainerLogsView(View):
                         error_data = {
                             "type": "error",
                             "message": f"Error streaming data: {str(e)}",
-                            "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                            "timestamp": datetime.datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            ),
                         }
                         loop.call_soon_threadsafe(
                             queue.put_nowait,
-                            f"data: {json.dumps(error_data)}\n\n".encode('utf-8')
+                            f"data: {json.dumps(error_data)}\n\n".encode("utf-8"),
                         )
 
                     finally:
@@ -1455,71 +1594,86 @@ class ContainerLogsView(View):
                     yield chunk
 
             response = StreamingHttpResponse(
-                generate_container_data(),
-                content_type='text/event-stream'
+                generate_container_data(), content_type="text/event-stream"
             )
 
             # Set required headers for SSE
-            response['Cache-Control'] = 'no-cache, no-transform'
-            response['X-Accel-Buffering'] = 'no'
+            response["Cache-Control"] = "no-cache, no-transform"
+            response["X-Accel-Buffering"] = "no"
 
             return response
 
         except Exception as e:
             logger.error(f"Error streaming container data: {str(e)}")
+            error_detail = str(e)
 
             async def error_stream():
                 error_data = {
                     "type": "service_unavailable",
-                    "message": f"Failed to initialize log stream: {str(e)}",
-                    "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                    "message": f"Failed to initialize log stream: {error_detail}",
+                    "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 }
-                yield f"data: {json.dumps(error_data)}\n\n".encode('utf-8')
+                yield f"data: {json.dumps(error_data)}\n\n".encode("utf-8")
 
-            response = StreamingHttpResponse(error_stream(), content_type='text/event-stream')
-            response['Cache-Control'] = 'no-cache, no-transform'
-            response['X-Accel-Buffering'] = 'no'
+            response = StreamingHttpResponse(
+                error_stream(), content_type="text/event-stream"
+            )
+            response["Cache-Control"] = "no-cache, no-transform"
+            response["X-Accel-Buffering"] = "no"
             return response
 
 
 class ModelAPIInfoView(APIView):
     """Get API endpoint information for deployed models"""
+
     def get(self, request, *args, **kwargs):
         """Return API endpoint details for all deployed models"""
         try:
             deployed_data = get_deploy_cache()
             api_info = {}
-            
+
             for deploy_id, deploy_info in deployed_data.items():
                 # Get the base URL from the request
-                base_url = request.build_absolute_uri('/').rstrip('/')
-                
+                base_url = request.build_absolute_uri("/").rstrip("/")
+
                 # Extract model information
                 model_impl = deploy_info.get("model_impl", {})
-                model_name = getattr(model_impl, "model_name", "Unknown") if model_impl else "Unknown"
-                model_type_obj = getattr(model_impl, "model_type", None) if model_impl else None
-                model_type = getattr(model_type_obj, "value", "ChatModel") if model_type_obj else "ChatModel"
-                
+                model_name = (
+                    getattr(model_impl, "model_name", "Unknown")
+                    if model_impl
+                    else "Unknown"
+                )
+                model_type_obj = (
+                    getattr(model_impl, "model_type", None) if model_impl else None
+                )
+                model_type = (
+                    getattr(model_type_obj, "value", "ChatModel")
+                    if model_type_obj
+                    else "ChatModel"
+                )
+
                 # Get internal URL and port bindings for external URL construction
                 internal_url = deploy_info.get("internal_url", "")
                 health_url = deploy_info.get("health_url", "")
                 port_bindings = deploy_info.get("port_bindings", {})
-                
+
                 # Construct external URLs using port bindings
                 chat_completions_url = ""
                 completions_url = ""
                 health_endpoint_url = ""
-                
+
                 if internal_url and port_bindings:
                     # Extract the service port from internal_url (e.g., "container_name:7000/v1/chat/completions" -> "7000")
                     service_port = None
                     if ":" in internal_url:
                         service_port = internal_url.split(":")[1].split("/")[0]
-                    
+
                     # Find the external port mapping for this service port
-                    external_host = "localhost"  # Default to localhost for external access
+                    external_host = (
+                        "localhost"  # Default to localhost for external access
+                    )
                     external_port = None
-                    
+
                     # Look for the port binding that matches the service port
                     for container_port, host_bindings in port_bindings.items():
                         if container_port and host_bindings:
@@ -1536,42 +1690,62 @@ class ModelAPIInfoView(APIView):
                                     else:
                                         external_host = host_ip
                                 break
-                    
+
                     # Construct external URLs if we found the port mapping
                     if external_port:
                         base_external_url = f"http://{external_host}:{external_port}"
-                        chat_completions_url = f"{base_external_url}/v1/chat/completions"
+                        chat_completions_url = (
+                            f"{base_external_url}/v1/chat/completions"
+                        )
                         completions_url = f"{base_external_url}/v1/completions"
                         health_endpoint_url = f"{base_external_url}/health"
                     else:
                         # Fallback to internal URL if no port mapping found
-                        logger.warning(f"No port mapping found for service port {service_port} in {deploy_id}")
+                        logger.warning(
+                            f"No port mapping found for service port {service_port} in {deploy_id}"
+                        )
                         if internal_url:
                             # Extract hostname:port from internal_url
                             if "/v1/chat/completions" in internal_url:
-                                base_internal_url = internal_url.replace("/v1/chat/completions", "")
+                                base_internal_url = internal_url.replace(
+                                    "/v1/chat/completions", ""
+                                )
                             elif "/v1/completions" in internal_url:
-                                base_internal_url = internal_url.replace("/v1/completions", "")
+                                base_internal_url = internal_url.replace(
+                                    "/v1/completions", ""
+                                )
                             else:
                                 base_internal_url = internal_url
-                            
-                            chat_completions_url = f"http://{base_internal_url}/v1/chat/completions"
-                            completions_url = f"http://{base_internal_url}/v1/completions"
-                            health_endpoint_url = f"http://{health_url}" if health_url else f"http://{base_internal_url}/health"
-                
+
+                            chat_completions_url = (
+                                f"http://{base_internal_url}/v1/chat/completions"
+                            )
+                            completions_url = (
+                                f"http://{base_internal_url}/v1/completions"
+                            )
+                            health_endpoint_url = (
+                                f"http://{health_url}"
+                                if health_url
+                                else f"http://{base_internal_url}/health"
+                            )
+
                 # Generate JWT token for this model
                 team_id = os.getenv("TEAM_ID", "tenstorrent")
                 token_id = os.getenv("TOKEN_ID", "debug-test")
                 json_payload = {"team_id": team_id, "token_id": token_id}
                 jwt_secret = backend_config.jwt_secret
                 encoded_jwt = jwt.encode(json_payload, jwt_secret, algorithm="HS256")
-                
+
                 # Create example payload based on model type
                 example_payload = self._get_example_payload(model_type, deploy_info)
-                
+
                 # Create curl examples for both chat completions and completions APIs
-                chat_curl_example = self._get_chat_curl_example(chat_completions_url, encoded_jwt, deploy_info)
-                completions_curl_example = self._get_completions_curl_example(completions_url, encoded_jwt, deploy_info)
+                chat_curl_example = self._get_chat_curl_example(
+                    chat_completions_url, encoded_jwt, deploy_info
+                )
+                completions_curl_example = self._get_completions_curl_example(
+                    completions_url, encoded_jwt, deploy_info
+                )
 
                 # For non-LLM models the container does not serve /v1/chat/completions,
                 # so expose the matching TT-Studio backend proxy route instead. The route
@@ -1583,7 +1757,9 @@ class ModelAPIInfoView(APIView):
                 api_info[deploy_id] = {
                     "model_name": model_name,
                     "model_type": model_type,
-                    "hf_model_id": getattr(model_impl, "hf_model_id", None) if model_impl else None,
+                    "hf_model_id": getattr(model_impl, "hf_model_id", None)
+                    if model_impl
+                    else None,
                     "jwt_secret": jwt_secret,
                     "jwt_token": encoded_jwt,
                     "example_payload": example_payload,
@@ -1595,29 +1771,35 @@ class ModelAPIInfoView(APIView):
                         "chat_completions": chat_completions_url,
                         "completions": completions_url,
                         "health": health_endpoint_url,
-                        "tt_studio_backend": f"{base_url}/models-api/inference/"
+                        "tt_studio_backend": f"{base_url}/models-api/inference/",
                     },
                     "inference_route": inference_route,
                     "deploy_info": {
                         "model_impl": {
-                            "model_name": getattr(model_impl, "model_name", None) if model_impl else None,
-                            "hf_model_id": getattr(model_impl, "hf_model_id", None) if model_impl else None,
+                            "model_name": getattr(model_impl, "model_name", None)
+                            if model_impl
+                            else None,
+                            "hf_model_id": getattr(model_impl, "hf_model_id", None)
+                            if model_impl
+                            else None,
                             "model_type": model_type,  # Use the string value instead of the enum object
-                        } if model_impl else {},
+                        }
+                        if model_impl
+                        else {},
                         "internal_url": internal_url,
-                        "health_url": health_url
-                    }
+                        "health_url": health_url,
+                    },
                 }
-            
+
             return Response(api_info, status=status.HTTP_200_OK)
-            
+
         except Exception as e:
             logger.error(f"Error getting API info: {str(e)}")
             return Response(
                 {"error": "Failed to get API information", "details": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-    
+
     def _get_endpoint_path(self, model_type):
         """Get the backend proxy route for a non-LLM model type.
 
@@ -1637,48 +1819,57 @@ class ModelAPIInfoView(APIView):
         # Get the actual deploy_id for this specific model
         deploy_id = None
         current_model_impl = deploy_info.get("model_impl", {})
-        current_model_name = getattr(current_model_impl, "model_name", None) if current_model_impl else None
-        
+        current_model_name = (
+            getattr(current_model_impl, "model_name", None)
+            if current_model_impl
+            else None
+        )
+
         for did, dinfo in get_deploy_cache().items():
             dinfo_model_impl = dinfo.get("model_impl", {})
-            dinfo_model_name = getattr(dinfo_model_impl, "model_name", None) if dinfo_model_impl else None
+            dinfo_model_name = (
+                getattr(dinfo_model_impl, "model_name", None)
+                if dinfo_model_impl
+                else None
+            )
             if dinfo_model_name == current_model_name:
                 deploy_id = did
                 break
-        
+
         # Get the HF model ID for the model
-        hf_model_id = getattr(current_model_impl, "hf_model_id", "meta-llama/Llama-3.2-1B-Instruct") if current_model_impl else "meta-llama/Llama-3.2-1B-Instruct"
-        
+        hf_model_id = (
+            getattr(
+                current_model_impl, "hf_model_id", "meta-llama/Llama-3.2-1B-Instruct"
+            )
+            if current_model_impl
+            else "meta-llama/Llama-3.2-1B-Instruct"
+        )
+
         if model_type == "ChatModel":
             # Return OpenAI-compatible format for direct model testing
             return {
                 "model": hf_model_id,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": "What is Tenstorrent?"
-                    }
-                ],
+                "messages": [{"role": "user", "content": "What is Tenstorrent?"}],
                 "temperature": 0.7,
                 "max_tokens": 100,
-                "stream": False
+                "stream": False,
             }
         elif model_type == "ImageGeneration":
             return {
                 "deploy_id": deploy_id or "your_deploy_id",
-                "prompt": "A beautiful sunset over mountains"
+                "prompt": "A beautiful sunset over mountains",
             }
         elif model_type == "ObjectDetectionModel":
             return {
                 "deploy_id": deploy_id or "your_deploy_id",
-                "image": "base64_encoded_image_or_file_upload"
+                "image": "base64_encoded_image_or_file_upload",
             }
         elif model_type == "SpeechRecognitionModel":
             return {
                 "deploy_id": deploy_id or "your_deploy_id",
-                "file": "audio_file_upload"
+                "file": "audio_file_upload",
             }
-        
+
         # Fallback for unknown model types
         return {
             "deploy_id": deploy_id or "your_deploy_id",
@@ -1688,17 +1879,21 @@ class ModelAPIInfoView(APIView):
             "top_p": 0.9,
             "max_tokens": 128,
             "stream": True,
-            "stop": ["<|eot_id|>"]
+            "stop": ["<|eot_id|>"],
         }
-    
+
     def _get_chat_curl_example(self, chat_url, jwt_token, deploy_info):
         """Generate curl example for chat completions API"""
         if not chat_url:
             return "# Chat completions endpoint not available"
-        
+
         model_impl = deploy_info.get("model_impl", {})
-        hf_model_id = getattr(model_impl, "hf_model_id", "your-model-name") if model_impl else "your-model-name"
-        
+        hf_model_id = (
+            getattr(model_impl, "hf_model_id", "your-model-name")
+            if model_impl
+            else "your-model-name"
+        )
+
         return f"""curl -X POST "{chat_url}" \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer {jwt_token}" \\
@@ -1714,15 +1909,19 @@ class ModelAPIInfoView(APIView):
     "max_tokens": 100,
     "stream": false
   }}'"""
-    
+
     def _get_completions_curl_example(self, completions_url, jwt_token, deploy_info):
         """Generate curl example for completions API"""
         if not completions_url:
             return "# Completions endpoint not available"
-        
+
         model_impl = deploy_info.get("model_impl", {})
-        hf_model_id = getattr(model_impl, "hf_model_id", "your-model-name") if model_impl else "your-model-name"
-        
+        hf_model_id = (
+            getattr(model_impl, "hf_model_id", "your-model-name")
+            if model_impl
+            else "your-model-name"
+        )
+
         return f"""curl -X POST "{completions_url}" \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer {jwt_token}" \\
@@ -1736,7 +1935,7 @@ class ModelAPIInfoView(APIView):
     "stream": false,
     "stop": ["<|eot_id|>"]
   }}'"""
-    
+
     def _get_curl_example(self, api_url, jwt_token, payload, model_type):
         """Generate curl example for the API endpoint (legacy method)"""
         if model_type == "ObjectDetectionModel":
@@ -1774,7 +1973,9 @@ from shared_config.coding_agent_config import (  # noqa: E402
 LITELLM_UPSTREAM_KEY = os.environ.get("LITELLM_UPSTREAM_KEY", "")
 LITELLM_MASTER_KEY = os.environ.get("LITELLM_MASTER_KEY", "")
 LITELLM_PORT = int(os.environ.get("LITELLM_PORT", "4000"))
-LITELLM_INTERNAL_URL = os.environ.get("LITELLM_INTERNAL_URL", "http://tt-studio-litellm:4000")
+LITELLM_INTERNAL_URL = os.environ.get(
+    "LITELLM_INTERNAL_URL", "http://tt-studio-litellm:4000"
+)
 
 # Round-robin cursor per model_name for multi-chip / duplicate deployments
 _rr_lock = threading.Lock()
@@ -1834,7 +2035,7 @@ def _check_upstream_auth(request) -> bool:
     if not LITELLM_UPSTREAM_KEY:
         return True
     auth = request.headers.get("Authorization", "")
-    token = auth[len("Bearer "):].strip() if auth.startswith("Bearer ") else ""
+    token = auth[len("Bearer ") :].strip() if auth.startswith("Bearer ") else ""
     return token == LITELLM_UPSTREAM_KEY
 
 
@@ -1862,8 +2063,12 @@ class OpenAIChatCompletionsView(View):
         deploy = await asyncio.to_thread(_resolve_deploy_by_model_name, base_model)
         if deploy is None:
             return JsonResponse(
-                {"error": {"message": f"No running model named '{base_model}'.",
-                           "type": "model_not_found"}},
+                {
+                    "error": {
+                        "message": f"No running model named '{base_model}'.",
+                        "type": "model_not_found",
+                    }
+                },
                 status=404,
             )
         if enable_thinking is not None:
@@ -1873,7 +2078,9 @@ class OpenAIChatCompletionsView(View):
             data["chat_template_kwargs"] = ctk
 
         internal_url = "http://" + deploy["internal_url"]
-        data["model"] = deploy.get("cached_model_name") or get_model_name_from_container(
+        data["model"] = deploy.get(
+            "cached_model_name"
+        ) or get_model_name_from_container(
             deploy["internal_url"], fallback=deploy["model_impl"].hf_model_id
         )
 
@@ -1895,6 +2102,7 @@ class OpenAIChatCompletionsView(View):
         stream = bool(data.get("stream", False))
 
         if stream:
+
             async def generate():
                 try:
                     # Clean OpenAI SSE passthrough (no injected stream_options /
@@ -1905,7 +2113,9 @@ class OpenAIChatCompletionsView(View):
                     logger.error(f"OpenAIChatCompletionsView stream error: {e}")
                     yield f"data: {json.dumps({'error': str(e)})}\n\n"
 
-            response = StreamingHttpResponse(generate(), content_type="text/event-stream")
+            response = StreamingHttpResponse(
+                generate(), content_type="text/event-stream"
+            )
             response["Cache-Control"] = "no-cache"
             response["X-Accel-Buffering"] = "no"
             return response
@@ -1915,7 +2125,9 @@ class OpenAIChatCompletionsView(View):
         headers = {"Authorization": f"Bearer {encoded_jwt}"}
         try:
             upstream = await _vllm_client.post(internal_url, json=data, headers=headers)
-            return JsonResponse(upstream.json(), status=upstream.status_code, safe=False)
+            return JsonResponse(
+                upstream.json(), status=upstream.status_code, safe=False
+            )
         except Exception as e:
             logger.error(f"OpenAIChatCompletionsView non-stream error: {e}")
             return JsonResponse({"error": {"message": str(e)}}, status=502)
@@ -1930,8 +2142,10 @@ class OpenAIModelsView(APIView):
 
     def get(self, request, *args, **kwargs):
         if not _check_upstream_auth(request):
-            return Response({"error": {"message": "Unauthorized"}},
-                            status=status.HTTP_401_UNAUTHORIZED)
+            return Response(
+                {"error": {"message": "Unauthorized"}},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
         seen = set()
         data = []
         for _, entry in _running_coding_agent_deploys():
@@ -1957,7 +2171,9 @@ class CodingAgentsView(APIView):
         health = "disabled"
         if LITELLM_MASTER_KEY:
             try:
-                resp = requests.get(f"{LITELLM_INTERNAL_URL}/health/liveliness", timeout=2)
+                resp = requests.get(
+                    f"{LITELLM_INTERNAL_URL}/health/liveliness", timeout=2
+                )
                 health = "healthy" if resp.status_code == 200 else "unreachable"
             except requests.RequestException:
                 health = "unreachable"

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -51,8 +51,8 @@ def get_reasoning_parser(model_name) -> str | None:
 
 def get_gateway_model_names(model_name) -> list[str]:
     """
-        Return the names a model is exposed under to coding agents: the plain name, plus a
-        "-thinking" variant for reasoning models.
+    Return the names a model is exposed under to coding agents: the plain name, plus a
+    "-thinking" variant for reasoning models.
     """
     if model_name in REASONING_MODELS:
         return [model_name, model_name + THINKING_SUFFIX]

--- a/app/backend/shared_config/device_config.py
+++ b/app/backend/shared_config/device_config.py
@@ -7,15 +7,16 @@ from enum import Enum, auto
 
 class DeviceConfigurations(Enum):
     """The *WH_ARCH_YAML enumerations signal to use the wormhole_b0_80_arch_eth_dispatch.yaml"""
+
     CPU = auto()
-    
+
     # Wormhole devices
     E150 = auto()
     N150 = auto()
     N300 = auto()
     N150_WH_ARCH_YAML = auto()
     N300_WH_ARCH_YAML = auto()
-    
+
     # Wormhole multi-device
     N150X4 = auto()
     N300x4 = auto()
@@ -23,7 +24,7 @@ class DeviceConfigurations(Enum):
     T3K = auto()
     T3K_RING = auto()
     T3K_LINE = auto()
-    
+
     # Blackhole devices
     P100 = auto()
     P150 = auto()
@@ -32,9 +33,9 @@ class DeviceConfigurations(Enum):
     # Blackhole multi-device
     P150X4 = auto()
     P150X8 = auto()
-    P300x2 = auto()   # 2 cards (4 chips)
+    P300x2 = auto()  # 2 cards (4 chips)
     P300Cx4 = auto()  # 4 cards (8 chips)
-    
+
     # Galaxy systems
     GALAXY = auto()
     GALAXY_T3K = auto()

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import json
-import os
 from dataclasses import dataclass, asdict
 from typing import Set, Dict, Any, Union, Optional
 from pathlib import Path
@@ -32,8 +31,8 @@ def load_dotenv_dict(env_path: Union[str, Path]) -> Dict[str, str]:
     with open(env_path) as f:
         lines = f.readlines()
     for line in lines:
-        if line.strip() and not line.startswith('#'):
-            key, value = line.strip().split('=', 1)
+        if line.strip() and not line.startswith("#"):
+            key, value = line.strip().split("=", 1)
             # expand any $VAR or ${VAR} and ~
             if key not in exluded_keys:
                 env_dict[key] = value
@@ -54,8 +53,8 @@ class ModelImpl:
     setup_type: SetupTypes
     model_type: ModelTypes
     hf_model_id: str = None
-    model_name: str = None     # uses defaults based on hf_model_id
-    model_id: str = None       # uses defaults based on hf_model_id
+    model_name: str = None  # uses defaults based on hf_model_id
+    model_id: str = None  # uses defaults based on hf_model_id
     impl_id: str = "tt-metal"  # implementation ID
     version: str = "0.0.1"
     shm_size: str = "32G"
@@ -69,14 +68,14 @@ class ModelImpl:
     def __post_init__(self):
         # _init methods compute values that are dependent on other values
         self._init_model_name()
-        
+
         self.docker_config.update({"volumes": self.get_volume_mounts()})
         self.docker_config["shm_size"] = self.shm_size
         self.docker_config["environment"]["HF_MODEL_PATH"] = self.hf_model_id
         self.docker_config["environment"]["HF_HOME"] = Path(
             backend_config.model_container_cache_root
         ).joinpath("huggingface")
-        
+
         # Set environment variable if N150_WH_ARCH_YAML, N300_WH_ARCH_YAML, or N300x4_WH_ARCH_YAML is in the device configurations
         if (
             DeviceConfigurations.N150_WH_ARCH_YAML in self.device_configurations
@@ -140,31 +139,41 @@ class ModelImpl:
     def _init_model_name(self):
         # Note: ONLY run this in __post_init__
         # need to use __setattr__ because instance is frozen
-        assert self.hf_model_id or self.model_name, "either hf_model_id or model_name must be set."
+        assert (
+            self.hf_model_id or self.model_name
+        ), "either hf_model_id or model_name must be set."
         if not self.model_name:
             # use basename of HF model ID to use same format as tt-transformers
-            object.__setattr__(self, 'model_name', Path(self.hf_model_id).name)
+            object.__setattr__(self, "model_name", Path(self.hf_model_id).name)
         if not self.model_id:
-            object.__setattr__(self, 'model_id', self.get_default_model_id())
+            object.__setattr__(self, "model_id", self.get_default_model_id())
         if not self.hf_model_id:
-            logger.info(f"model_name:={self.model_name} does not have a hf_model_id set")
+            logger.info(
+                f"model_name:={self.model_name} does not have a hf_model_id set"
+            )
 
     def get_default_model_id(self):
         return f"id_{self.impl_id}-{self.model_name}-v{self.version}"
-        
+
     def get_model_env_file(self):
         ret_env_file = None
         model_env_dir_name = "model_envs"
-        model_env_dir = Path(backend_config.persistent_storage_volume).joinpath(model_env_dir_name)
+        model_env_dir = Path(backend_config.persistent_storage_volume).joinpath(
+            model_env_dir_name
+        )
         if model_env_dir.exists():
             env_fname = f"{self.model_name}.env"
             model_env_fpath = model_env_dir.joinpath(env_fname)
             if model_env_fpath.exists():
                 ret_env_file = model_env_fpath
             else:
-                logger.warning(f"for model {self.model_name} env file: {model_env_fpath} does not exist, have you run tt-inference-server setup.sh for the model?")
+                logger.warning(
+                    f"for model {self.model_name} env file: {model_env_fpath} does not exist, have you run tt-inference-server setup.sh for the model?"
+                )
         else:
-            logger.warning(f"{model_env_dir} does not exist, have you run tt-inference-server setup.sh?")
+            logger.warning(
+                f"{model_env_dir} does not exist, have you run tt-inference-server setup.sh?"
+            )
         return ret_env_file
 
     def get_volume_mounts(self):
@@ -187,7 +196,7 @@ class ModelImpl:
         return volume_mounts
 
     def setup(self):
-        # verify model setup and runtime setup 
+        # verify model setup and runtime setup
         self.init_volumes()
 
     def init_volumes(self):
@@ -247,7 +256,7 @@ _CATALOG_DEVICE_MAP = {
     # Blackhole P300 family
     "P300": "P300",
     "P300x2": "P300x2",
-    "P300Cx2": "P300x2",   # stale name from older catalog syncs
+    "P300Cx2": "P300x2",  # stale name from older catalog syncs
 }
 
 
@@ -383,8 +392,15 @@ for impl in _json_impls + _hardcoded_impls:
 # Board type classifications for chip allocation
 SINGLE_CHIP_BOARDS_STR = {"N150", "N300", "E150", "P100", "P150", "P300"}
 MULTI_CHIP_ONLY_BOARDS_STR = {
-    "T3K", "GALAXY", "GALAXY_T3K", "P150X4", "P150X8",
-    "N150X4", "N300x4", "P300x2", "P300Cx4"
+    "T3K",
+    "GALAXY",
+    "GALAXY_T3K",
+    "P150X4",
+    "P150X8",
+    "N150X4",
+    "N300x4",
+    "P300x2",
+    "P300Cx4",
 }
 
 
@@ -445,5 +461,7 @@ def get_model_chip_requirement(model_name: str) -> int:
             return infer_chips_required(impl.device_configurations)
 
     # Model not found, default to 1 chip
-    logger.warning(f"Model {model_name} not found in model_implmentations, defaulting to 1 chip")
+    logger.warning(
+        f"Model {model_name} not found in model_implmentations, defaulting to 1 chip"
+    )
     return 1

--- a/app/backend/shared_config/model_type_config.py
+++ b/app/backend/shared_config/model_type_config.py
@@ -4,6 +4,7 @@
 
 from enum import Enum
 
+
 class ModelTypes(Enum):
     MOCK = "mock"
     CHAT = "chat"

--- a/app/backend/shared_config/setup_config.py
+++ b/app/backend/shared_config/setup_config.py
@@ -4,6 +4,7 @@
 
 from enum import IntEnum, auto
 
+
 class SetupTypes(IntEnum):
     NO_SETUP = auto()  # 1
     MAKE_VOLUMES = auto()  # 2

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -60,6 +60,7 @@ def resolve_source_json(override: str | None = None) -> Path:
         + "\n".join(f"  {c.resolve()}" for c in _CANDIDATE_SOURCES)
     )
 
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -114,9 +115,17 @@ def map_model_type(raw_model_type: str, inference_engine: str) -> str:
 
 
 CHAT_CAPABLE_PATTERNS = [
-    "instruct", "-chat", "chat-", "-it-", "-it", "assistant",
+    "instruct",
+    "-chat",
+    "chat-",
+    "-it-",
+    "-it",
+    "assistant",
     # Reasoning / thinking models that do have chat templates
-    "deepseek-r1", "qwq", "qwen3", "gpt-oss",
+    "deepseek-r1",
+    "qwq",
+    "qwen3",
+    "gpt-oss",
 ]
 
 
@@ -125,16 +134,22 @@ def is_chat_capable(hf_model_id: str) -> bool:
     return any(p in lower for p in CHAT_CAPABLE_PATTERNS)
 
 
-def map_service_route(inference_engine: str, hf_model_id: str = "", raw_model_type: str = "") -> str:
+def map_service_route(
+    inference_engine: str, hf_model_id: str = "", raw_model_type: str = ""
+) -> str:
     """Derive service_route from inference_engine, model type, and model id.
-    
+
     Args:
         inference_engine: Engine type (vLLM, media, forge)
         hf_model_id: HuggingFace model ID (for vLLM chat detection)
         raw_model_type: Raw model type from inference server (TEXT_TO_SPEECH, TTS, etc.)
     """
     if inference_engine == "vLLM":
-        return "/v1/chat/completions" if is_chat_capable(hf_model_id) else "/v1/completions"
+        return (
+            "/v1/chat/completions"
+            if is_chat_capable(hf_model_id)
+            else "/v1/completions"
+        )
     if inference_engine == "media":
         # TTS models use OpenAI-compatible /v1/audio/speech endpoint
         if raw_model_type in ("TEXT_TO_SPEECH", "TTS"):
@@ -159,11 +174,11 @@ def map_service_route(inference_engine: str, hf_model_id: str = "", raw_model_ty
 
 def map_health_route(inference_engine: str, service_route: str) -> str:
     """Derive health_route from inference_engine and service_route.
-    
+
     Args:
         inference_engine: Engine type (vLLM, media, forge)
         service_route: The service route (e.g., /enqueue, /v1/audio/speech)
-    
+
     Returns:
         The appropriate health check endpoint
     """
@@ -179,18 +194,18 @@ def filter_env_vars(env_vars: dict) -> dict:
     must be strings. The artifact emits int-valued vars (e.g.
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1) that would otherwise break.
     """
-    return {
-        k: str(v)
-        for k, v in env_vars.items()
-        if k not in DEVICE_SPECIFIC_ENV_KEYS
-    }
+    return {k: str(v) for k, v in env_vars.items() if k not in DEVICE_SPECIFIC_ENV_KEYS}
 
 
 def pick_higher_status(current: str | None, candidate: str) -> str:
     """Return whichever status is higher priority."""
     if current is None:
         return candidate
-    return current if STATUS_ORDER.get(current, 0) >= STATUS_ORDER.get(candidate, 0) else candidate
+    return (
+        current
+        if STATUS_ORDER.get(current, 0) >= STATUS_ORDER.get(candidate, 0)
+        else candidate
+    )
 
 
 def _version_key(entry: dict) -> tuple[int, tuple[int, ...]]:
@@ -284,33 +299,48 @@ def normalize(source_path: Path) -> list[dict]:
 
         inference_engine = first.get("inference_engine", "vLLM")
         raw_model_type = first.get("model_type", "LLM")
-        service_route = map_service_route(inference_engine, hf_model_id=first.get("hf_model_repo", ""), raw_model_type=raw_model_type)
+        service_route = map_service_route(
+            inference_engine,
+            hf_model_id=first.get("hf_model_repo", ""),
+            raw_model_type=raw_model_type,
+        )
 
-        models.append({
-            "model_name": model_name,
-            "model_type": map_model_type(raw_model_type, inference_engine),
-            "display_model_type": raw_model_type,
-            "device_configurations": device_configurations,
-            "hf_model_id": first.get("hf_model_repo"),
-            "inference_engine": inference_engine,
-            "status": status,
-            "version": canonical.get("version", "0.0.0"),
-            "docker_image": canonical.get("docker_image"),
-            "service_route": service_route,
-            "health_route": map_health_route(inference_engine, service_route),
-            "env_vars": env_vars,
-            "param_count": first.get("param_count"),
-        })
+        models.append(
+            {
+                "model_name": model_name,
+                "model_type": map_model_type(raw_model_type, inference_engine),
+                "display_model_type": raw_model_type,
+                "device_configurations": device_configurations,
+                "hf_model_id": first.get("hf_model_repo"),
+                "inference_engine": inference_engine,
+                "status": status,
+                "version": canonical.get("version", "0.0.0"),
+                "docker_image": canonical.get("docker_image"),
+                "service_route": service_route,
+                "health_route": map_health_route(inference_engine, service_route),
+                "env_vars": env_vars,
+                "param_count": first.get("param_count"),
+            }
+        )
 
     # Sort: by status (highest first), then alphabetically by model_name
-    models.sort(key=lambda m: (-STATUS_ORDER.get(m["status"], 0), m["model_name"].lower()))
+    models.sort(
+        key=lambda m: (-STATUS_ORDER.get(m["status"], 0), m["model_name"].lower())
+    )
     return models
 
 
 def main():
     import argparse
-    parser = argparse.ArgumentParser(description="Sync model catalog from tt-inference-server")
-    parser.add_argument("--source", default=None, help="Path to model_specs_output.json (overrides auto-detection)")
+
+    parser = argparse.ArgumentParser(
+        description="Sync model catalog from tt-inference-server"
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Path to model_specs_output.json (overrides auto-detection)",
+    )
     args = parser.parse_args()
 
     source_path = resolve_source_json(args.source)
@@ -351,6 +381,7 @@ def main():
 
     # Print a summary
     from collections import Counter
+
     status_counts = Counter(m["status"] for m in models)
     type_counts = Counter(m["model_type"] for m in models)
     display_type_counts = Counter(m["display_model_type"] for m in models)

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -11,27 +11,42 @@ from sync_models_from_inference_server import map_service_route
 
 class TestServiceRouteMapping:
     """Test that service routes are correctly derived for different model types."""
-    
+
     def test_vllm_chat_capable_models(self):
         """vLLM chat-capable models should use /v1/chat/completions."""
-        assert map_service_route("vLLM", "meta-llama/Llama-3.1-8B-Instruct", "") == "/v1/chat/completions"
-        assert map_service_route("vLLM", "mistralai/Mistral-7B-Instruct-v0.3", "") == "/v1/chat/completions"
+        assert (
+            map_service_route("vLLM", "meta-llama/Llama-3.1-8B-Instruct", "")
+            == "/v1/chat/completions"
+        )
+        assert (
+            map_service_route("vLLM", "mistralai/Mistral-7B-Instruct-v0.3", "")
+            == "/v1/chat/completions"
+        )
         assert map_service_route("vLLM", "Qwen/QwQ-32B", "") == "/v1/chat/completions"
-    
+
     def test_vllm_base_models(self):
         """vLLM base models should use /v1/completions."""
-        assert map_service_route("vLLM", "meta-llama/Llama-3.1-70B", "") == "/v1/completions"
-        assert map_service_route("vLLM", "meta-llama/Llama-3.2-1B", "") == "/v1/completions"
-    
+        assert (
+            map_service_route("vLLM", "meta-llama/Llama-3.1-70B", "")
+            == "/v1/completions"
+        )
+        assert (
+            map_service_route("vLLM", "meta-llama/Llama-3.2-1B", "")
+            == "/v1/completions"
+        )
+
     def test_tts_media_models_use_openai_endpoint(self):
         """TTS media models should use /v1/audio/speech (OpenAI-compatible)."""
         assert map_service_route("media", "", "TEXT_TO_SPEECH") == "/v1/audio/speech"
         assert map_service_route("media", "", "TTS") == "/v1/audio/speech"
-    
+
     def test_image_gen_media_models_use_v1_images_generations(self):
         """Image generation media models should use /v1/images/generations."""
         assert map_service_route("media", "", "IMAGE") == "/v1/images/generations"
-        assert map_service_route("media", "", "IMAGE_GENERATION") == "/v1/images/generations"
+        assert (
+            map_service_route("media", "", "IMAGE_GENERATION")
+            == "/v1/images/generations"
+        )
 
     def test_non_image_media_models_use_enqueue(self):
         """Non-image/non-audio/non-video media models should use /enqueue."""
@@ -40,10 +55,19 @@ class TestServiceRouteMapping:
 
     def test_video_gen_media_models_use_v1_videos_generations(self):
         """T2V video generation media models should use /v1/videos/generations."""
-        assert map_service_route("media", "Wan-AI/Wan2.2-T2V-A14B-Diffusers", "VIDEO") == "/v1/videos/generations"
-        assert map_service_route("media", "Wan-AI/Wan2.2-I2V-A14B-Diffusers", "VIDEO") == "/v1/videos/generations/i2v"
-        assert map_service_route("media", "some-org/some-T2V-model", "VIDEO") == "/v1/videos/generations"
-    
+        assert (
+            map_service_route("media", "Wan-AI/Wan2.2-T2V-A14B-Diffusers", "VIDEO")
+            == "/v1/videos/generations"
+        )
+        assert (
+            map_service_route("media", "Wan-AI/Wan2.2-I2V-A14B-Diffusers", "VIDEO")
+            == "/v1/videos/generations/i2v"
+        )
+        assert (
+            map_service_route("media", "some-org/some-T2V-model", "VIDEO")
+            == "/v1/videos/generations"
+        )
+
     def test_forge_models_use_chat_completions(self):
         """Forge models should use /v1/chat/completions."""
         assert map_service_route("forge", "", "") == "/v1/chat/completions"

--- a/app/backend/vector_db_control/apps.py
+++ b/app/backend/vector_db_control/apps.py
@@ -7,7 +7,10 @@ from django.apps import AppConfig
 from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
-from vector_db_control.singletons import ChromaClient, get_embedding_function
+from vector_db_control.singletons import (  # noqa: E402
+    ChromaClient,
+    get_embedding_function,
+)
 
 
 class VectorDbConfig(AppConfig):
@@ -28,35 +31,39 @@ class VectorDbConfig(AppConfig):
         # Preload the singleton to initialize the model at startup
         get_embedding_function(model_name=settings.CHROMA_DB_EMBED_MODEL)
         ChromaClient(host=settings.CHROMA_DB_HOST, port=settings.CHROMA_DB_PORT)
-        
+
         # Create default internal knowledge collection if it doesn't exist
         try:
             collections = list_collections()
             internal_collection_name = "tenstorrent_internal_knowledge"
-            
+
             # Check if internal knowledge collection already exists
             existing_internal = next(
-                (col for col in collections if col.name == internal_collection_name), 
-                None
+                (col for col in collections if col.name == internal_collection_name),
+                None,
             )
-            
+
             if not existing_internal:
-                logger.info(f"Creating default internal knowledge collection: {internal_collection_name}")
-                
+                logger.info(
+                    f"Creating default internal knowledge collection: {internal_collection_name}"
+                )
+
                 # Create collection with special metadata to mark it as internal
-                collection = create_collection(
+                create_collection(
                     collection_name=internal_collection_name,
                     metadata={
                         "type": "internal_knowledge",
                         "description": "Tenstorrent internal documentation and knowledge base",
-                        "created_by": "system"
+                        "created_by": "system",
                     },
                     embedding_func_name=settings.CHROMA_DB_EMBED_MODEL,
                 )
-                
+
                 # Chunk before loading: the embedding model truncates long inputs,
                 # so the large documentation corpus must be split to be searchable.
-                logger.info(f"Loading internal knowledge into {internal_collection_name}")
+                logger.info(
+                    f"Loading internal knowledge into {internal_collection_name}"
+                )
                 chunks = chunk_texts(
                     INTERNAL_KNOWLEDGE,
                     metadatas=[
@@ -76,10 +83,16 @@ class VectorDbConfig(AppConfig):
                     metadatas=[chunk.metadata for chunk in chunks],
                     embedding_func_name=settings.CHROMA_DB_EMBED_MODEL,
                 )
-                
-                logger.info(f"Successfully created internal knowledge collection: {internal_collection_name}")
+
+                logger.info(
+                    f"Successfully created internal knowledge collection: {internal_collection_name}"
+                )
             else:
-                logger.info(f"Internal knowledge collection already exists: {internal_collection_name}")
-                
+                logger.info(
+                    f"Internal knowledge collection already exists: {internal_collection_name}"
+                )
+
         except Exception as e:
-            logger.error(f"Error creating internal knowledge collection: {str(e)}", exc_info=True)
+            logger.error(
+                f"Error creating internal knowledge collection: {str(e)}", exc_info=True
+            )

--- a/app/backend/vector_db_control/chroma.py
+++ b/app/backend/vector_db_control/chroma.py
@@ -12,7 +12,10 @@ from chromadb.types import Collection
 from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
-from vector_db_control.singletons import ChromaClient, get_embedding_function
+from vector_db_control.singletons import (  # noqa: E402
+    ChromaClient,
+    get_embedding_function,
+)
 
 
 def list_collections(filter_func=None):
@@ -20,10 +23,6 @@ def list_collections(filter_func=None):
     if filter_func:
         return filter(filter_func, chroma_collections)
     return chroma_collections
-
-
-def delete_collection(collection_name: str):
-    ChromaClient().delete_collection(name=collection_name)
 
 
 def get_collection(collection_name: str, embedding_func_name: str):
@@ -59,7 +58,10 @@ def delete_collection(collection_name: str):
 
 
 def query_collection(
-    collection_name: str, embedding_func_name: str, query_texts: List[str], n_results: int = 10
+    collection_name: str,
+    embedding_func_name: str,
+    query_texts: List[str],
+    n_results: int = 10,
 ):
     embedding_func = get_embedding_function(model_name=embedding_func_name)
     target_collection = ChromaClient().get_collection(

--- a/app/backend/vector_db_control/data.py
+++ b/app/backend/vector_db_control/data.py
@@ -266,7 +266,7 @@ Tenstorrent is a hardware company that designs and produces AI accelerators. The
 designed for efficient AI and machine learning workloads. The company focuses on creating scalable solutions for AI computation.
 """
 
-TT_METAL="""
+TT_METAL = """
 # Install
 
 These instructions will guide you through the installation of Tenstorrent system tools and drivers, followed by the installation of TT-Metalium and TT-NN.
@@ -631,7 +631,6 @@ User-supplied: keyboard, mouse, certified HDMI cable, and a monitor.
 # Generated from docs.tenstorrent.com and the tt-inference-server / tt-studio
 # repositories. Each entry is one source page. Rebuild with build_data.py.
 _SCRAPED_DOCS = [
-
     # === section: guides ===
     """# Installing the Tenstorrent Software Stack
 
@@ -1353,7 +1352,6 @@ Now that your model endpoint is running:
 
 If you encounter any issues, or have a question that isn’t covered in the documentation, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
 """,
-
     # === section: hardware ===
     """# Add-In Boards and Accessories
 
@@ -4327,7 +4325,6 @@ For BIOS updates, non-Tenstorrent drivers, and other hardware support, visit the
 
 For support with the Tenstorrent add-in boards and related Tenstorrent software, you can visit the Tenstorrent [Discord](https://discord.gg/tvhGzHQwaj) server or contact [support@tenstorrent.com](mailto:support%40tenstorrent.com) with additional questions.
 """,
-
     # === section: syseng ===
     """# Systems Tools Developer Documentation
 
@@ -4450,7 +4447,6 @@ Now that your Tenstorrent Tensix Processor(s) up and running, there are two SDKs
 
 * [First 5 Things](https://tenstorrent.github.io/tt-metalium/latest/get_started/get_started.html) for **TT-Metalium**, our open source, low level SDK
 """,
-
     # === section: forge ===
     """# TT-Forge™ Backend Compiler
 
@@ -4521,7 +4517,6 @@ Tools
 
 * [TT-NPE](https://docs.tenstorrent.com/tt-npe/)
 """,
-
     # === section: tools ===
     """# Tools
 
@@ -4588,7 +4583,6 @@ For tools specific to individual components of the Tenstorrent software stack, s
 * TT-Metalium tools: <https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tools/index.html>
 * TT-NN tools: <https://docs.tenstorrent.com/tt-metal/latest/ttnn/tools/index.html>
 """,
-
     # === section: support ===
     """# Support & FAQ
 
@@ -4600,7 +4594,6 @@ If you encounter any issues, or have questions that are not covered by the docum
 
 For forums and community discussions, visit Tenstorrent’s [Discord channel](https://discord.gg/tvhGzHQwaj).
 """,
-
     # === section: misc ===
     """# Home
 
@@ -4913,7 +4906,6 @@ A Quick Note on Usage: To keep things transparent, please acknowledge the follow
 
 Any questions? Reach out on [Discord](https://discord.gg/tvhGzHQwaj).
 """,
-
     # === section: tt-metalium ===
     """# Getting Started
 
@@ -21901,7 +21893,6 @@ Source: https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tt_metal/progra
 
 Please find our architecture and programming model guide [here](https://github.com/tenstorrent/tt-metal/blob/main/METALIUM_GUIDE.md).
 """,
-
     # === section: tt-nn ===
     """# Welcome to TT-NN documentation!
 
@@ -53101,7 +53092,6 @@ To summarize:
 
 TT-NN Visualizer gives you everything you need to deeply understand your model’s interaction with the hardware — and where it can be improved.
 """,
-
     # === section: tt-lang ===
     """# Build System
 
@@ -57882,7 +57872,6 @@ x, y, z = ttl.node(dims=3)  # x in [0, 8), y in [0, 8), z = 0
 
 Both functions can be used inside operation functions and kernel functions.
 """,
-
     # === section: tt-blacksmith ===
     """# Welcome to TT-Blacksmith documentation!
 
@@ -58488,7 +58477,6 @@ The main goal of this project are:
 
 * **Demonstrations:** Practical examples and workflows showcasing how to train various ML models on Tenstorrent hardware.
 """,
-
     # === section: ttnn-visualizer ===
     """# Welcome to TT-NN Visualizer documentation!
 
@@ -59117,7 +59105,6 @@ The app is available to [install via PyPi](installing.html#installing-from-pypi)
 
 For the latest updates see [releases](https://github.com/tenstorrent/ttnn-visualizer/releases).
 """,
-
     # === section: tt-toplike ===
     """# Watchinferencehappen.
 
@@ -59506,7 +59493,6 @@ Keyboard shortcuts:
 `q` / `ESC` quit
 `r` force refresh
 """,
-
     # === section: tt-vscode-toolkit ===
     """# TTDeveloperToolkit
 
@@ -59801,7 +59787,6 @@ Copy
 Re-running the same command updates to the latest version
 (use `--clobber` to overwrite the existing `.vsix`).
 """,
-
     # === section: tt-inference-server ===
     """# tt-inference-server/.devcontainer/README.md
 
@@ -80333,7 +80318,6 @@ helm template charts/tt-inference-server \\
   --set hfCacheDir=/data/weights
 ```
 """,
-
     # === section: tt-studio ===
     """# tt-studio/CODE_OF_CONDUCT.md
 

--- a/app/backend/vector_db_control/document_processor.py
+++ b/app/backend/vector_db_control/document_processor.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 import os
-import mimetypes
 from typing import List, Optional, Dict, Any
 import pypdf
 import docx
@@ -15,18 +14,19 @@ from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
 
+
 class DocumentProcessor:
     SUPPORTED_EXTENSIONS = {
-        '.pdf': 'application/pdf',
-        '.txt': 'text/plain',
-        '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        '.md': 'text/markdown',
-        '.html': 'text/html',
-        '.py': 'text/x-python',
-        '.js': 'application/javascript',
-        '.ts': 'application/typescript',
-        '.tsx': 'application/typescript',
-        '.jsx': 'application/javascript',
+        ".pdf": "application/pdf",
+        ".txt": "text/plain",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".md": "text/markdown",
+        ".html": "text/html",
+        ".py": "text/x-python",
+        ".js": "application/javascript",
+        ".ts": "application/typescript",
+        ".tsx": "application/typescript",
+        ".jsx": "application/javascript",
     }
 
     @staticmethod
@@ -41,15 +41,12 @@ class DocumentProcessor:
     def process_pdf(file_path: str, metadata: Dict[str, Any]) -> List[Document]:
         """Process PDF files."""
         try:
-            with open(file_path, 'rb') as file:
+            with open(file_path, "rb") as file:
                 pdf_reader = pypdf.PdfReader(file)
                 documents = []
                 for page in pdf_reader.pages:
                     documents.append(
-                        Document(
-                            page_content=page.extract_text(),
-                            metadata=metadata
-                        )
+                        Document(page_content=page.extract_text(), metadata=metadata)
                     )
                 return documents
         except Exception as e:
@@ -60,12 +57,12 @@ class DocumentProcessor:
     def process_text(file_path: str, metadata: Dict[str, Any]) -> List[Document]:
         """Process text files."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 content = file.read()
                 return [Document(page_content=content, metadata=metadata)]
         except UnicodeDecodeError:
             # Try with different encoding if UTF-8 fails
-            with open(file_path, 'r', encoding='latin-1') as file:
+            with open(file_path, "r", encoding="latin-1") as file:
                 content = file.read()
                 return [Document(page_content=content, metadata=metadata)]
 
@@ -74,7 +71,7 @@ class DocumentProcessor:
         """Process Word documents."""
         try:
             doc = docx.Document(file_path)
-            content = '\n'.join([paragraph.text for paragraph in doc.paragraphs])
+            content = "\n".join([paragraph.text for paragraph in doc.paragraphs])
             return [Document(page_content=content, metadata=metadata)]
         except Exception as e:
             logger.error(f"Error processing DOCX file {file_path}: {str(e)}")
@@ -84,11 +81,11 @@ class DocumentProcessor:
     def process_markdown(file_path: str, metadata: Dict[str, Any]) -> List[Document]:
         """Process Markdown files."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 content = file.read()
                 # Convert markdown to plain text
                 html = markdown.markdown(content)
-                soup = BeautifulSoup(html, 'html.parser')
+                soup = BeautifulSoup(html, "html.parser")
                 text = soup.get_text()
                 return [Document(page_content=text, metadata=metadata)]
         except Exception as e:
@@ -99,13 +96,13 @@ class DocumentProcessor:
     def process_html(file_path: str, metadata: Dict[str, Any]) -> List[Document]:
         """Process HTML files."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 content = file.read()
-                soup = BeautifulSoup(content, 'html.parser')
+                soup = BeautifulSoup(content, "html.parser")
                 # Remove script and style elements
                 for script in soup(["script", "style"]):
                     script.decompose()
-                text = soup.get_text(separator='\n')
+                text = soup.get_text(separator="\n")
                 return [Document(page_content=text, metadata=metadata)]
         except Exception as e:
             logger.error(f"Error processing HTML file {file_path}: {str(e)}")
@@ -115,7 +112,7 @@ class DocumentProcessor:
     def process_code(file_path: str, metadata: Dict[str, Any]) -> List[Document]:
         """Process code files."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 content = file.read()
                 return [Document(page_content=content, metadata=metadata)]
         except Exception as e:
@@ -123,23 +120,25 @@ class DocumentProcessor:
             raise
 
     @classmethod
-    def process_document(cls, file_path: str, metadata: Dict[str, Any]) -> List[Document]:
+    def process_document(
+        cls, file_path: str, metadata: Dict[str, Any]
+    ) -> List[Document]:
         """Process document based on file type."""
         file_type = cls.get_file_type(file_path)
         if not file_type:
             raise ValueError(f"Unsupported file type: {file_path}")
 
         processors = {
-            'application/pdf': cls.process_pdf,
-            'text/plain': cls.process_text,
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document': cls.process_docx,
-            'text/markdown': cls.process_markdown,
-            'text/html': cls.process_html,
+            "application/pdf": cls.process_pdf,
+            "text/plain": cls.process_text,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document": cls.process_docx,
+            "text/markdown": cls.process_markdown,
+            "text/html": cls.process_html,
         }
 
         # Handle code files
-        if file_type.startswith('text/x-') or file_type.startswith('application/'):
-            if file_type in ['application/javascript', 'application/typescript']:
+        if file_type.startswith("text/x-") or file_type.startswith("application/"):
+            if file_type in ["application/javascript", "application/typescript"]:
                 return cls.process_code(file_path, metadata)
 
         if file_type not in processors:
@@ -148,10 +147,11 @@ class DocumentProcessor:
         return processors[file_type](file_path, metadata)
 
     @staticmethod
-    def chunk_documents(documents: List[Document], chunk_size: int = 1000, chunk_overlap: int = 100) -> List[Document]:
+    def chunk_documents(
+        documents: List[Document], chunk_size: int = 1000, chunk_overlap: int = 100
+    ) -> List[Document]:
         """Split documents into chunks."""
         text_splitter = RecursiveCharacterTextSplitter(
-            chunk_size=chunk_size,
-            chunk_overlap=chunk_overlap
+            chunk_size=chunk_size, chunk_overlap=chunk_overlap
         )
-        return text_splitter.split_documents(documents) 
+        return text_splitter.split_documents(documents)

--- a/app/backend/vector_db_control/documents.py
+++ b/app/backend/vector_db_control/documents.py
@@ -3,24 +3,21 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 from langchain_core.documents import Document
-from langchain_text_splitters import RecursiveCharacterTextSplitter
 from .document_processor import DocumentProcessor
 
+
 def chunk_document(
-    file_path: str,
-    metadata: dict,
-    chunk_size: int = 1000,
-    chunk_overlap: int = 100
+    file_path: str, metadata: dict, chunk_size: int = 1000, chunk_overlap: int = 100
 ):
     """
     Process and chunk a document based on its file type.
-    
+
     Args:
         file_path (str): Path to the document file
         metadata (dict): Metadata to attach to the document
         chunk_size (int): Size of each chunk
         chunk_overlap (int): Overlap between chunks
-        
+
     Returns:
         List[Document]: List of chunked documents
     """
@@ -29,17 +26,12 @@ def chunk_document(
 
     # Chunk the processed documents
     return DocumentProcessor.chunk_documents(
-        documents,
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap
+        documents, chunk_size=chunk_size, chunk_overlap=chunk_overlap
     )
 
 
 def chunk_texts(
-    texts,
-    metadatas=None,
-    chunk_size: int = 1000,
-    chunk_overlap: int = 100
+    texts, metadatas=None, chunk_size: int = 1000, chunk_overlap: int = 100
 ):
     """
     Chunk a list of in-memory text strings (e.g. INTERNAL_KNOWLEDGE) into Documents
@@ -63,7 +55,5 @@ def chunk_texts(
         for i, text in enumerate(texts)
     ]
     return DocumentProcessor.chunk_documents(
-        documents,
-        chunk_size=chunk_size,
-        chunk_overlap=chunk_overlap
+        documents, chunk_size=chunk_size, chunk_overlap=chunk_overlap
     )

--- a/app/backend/vector_db_control/urls.py
+++ b/app/backend/vector_db_control/urls.py
@@ -4,7 +4,12 @@
 
 from django.urls import path
 from rest_framework import routers
-from .views import VectorCollectionsAPIView, rag_admin_authenticate, rag_admin_list_all_collections, rag_admin_delete_collection
+from .views import (
+    VectorCollectionsAPIView,
+    rag_admin_authenticate,
+    rag_admin_list_all_collections,
+    rag_admin_delete_collection,
+)
 
 
 app_name = "rag"
@@ -17,7 +22,15 @@ router_urls = router.urls
 
 # Add admin endpoints
 urlpatterns = [
-    path('admin/authenticate', rag_admin_authenticate, name='admin-authenticate'),
-    path('admin/collections', rag_admin_list_all_collections, name='admin-list-collections'),
-    path('admin/delete-collection', rag_admin_delete_collection, name='admin-delete-collection'),
+    path("admin/authenticate", rag_admin_authenticate, name="admin-authenticate"),
+    path(
+        "admin/collections",
+        rag_admin_list_all_collections,
+        name="admin-list-collections",
+    ),
+    path(
+        "admin/delete-collection",
+        rag_admin_delete_collection,
+        name="admin-delete-collection",
+    ),
 ] + router_urls

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -4,11 +4,9 @@
 
 import os
 import uuid
-import json
 from typing import List
 from datetime import datetime
 from shared_config.logger_config import get_logger
-import pypdf
 from chromadb.types import Collection
 from django.conf import settings
 from rest_framework import status
@@ -49,8 +47,16 @@ def _merge_query_results(primary, secondary, limit):
             continue
         documents = result["documents"][0]
         ids = result["ids"][0]
-        metadatas = result["metadatas"][0] if result.get("metadatas") else [None] * len(documents)
-        distances = result["distances"][0] if result.get("distances") else [None] * len(documents)
+        metadatas = (
+            result["metadatas"][0]
+            if result.get("metadatas")
+            else [None] * len(documents)
+        )
+        distances = (
+            result["distances"][0]
+            if result.get("distances")
+            else [None] * len(documents)
+        )
         for i in range(len(documents)):
             combined.append((distances[i], ids[i], documents[i], metadatas[i]))
 
@@ -63,6 +69,7 @@ def _merge_query_results(primary, secondary, limit):
         "distances": [[item[0] for item in combined]],
     }
 
+
 class VectorCollectionsAPIView(ViewSet):
     EMBED_MODEL = None
     chromadb_client = None
@@ -72,21 +79,25 @@ class VectorCollectionsAPIView(ViewSet):
         super().__init__(**kwargs)
         if hasattr(settings, "CHROMA_DB_EMBED_MODEL"):
             self.EMBED_MODEL = settings.CHROMA_DB_EMBED_MODEL
-            
+
     def get_user_identifier(self, request):
         """Get a unique identifier for the current user/session"""
         # Check if user is authenticated (with proper None check)
-        if hasattr(request, 'user') and request.user is not None and request.user.is_authenticated:
+        if (
+            hasattr(request, "user")
+            and request.user is not None
+            and request.user.is_authenticated
+        ):
             logger.info(f"Using authenticated user ID: {request.user.id}")
             return f"user_{request.user.id}"
-        
+
         # Check for browser ID in header
-        browser_id = request.headers.get('X-Browser-ID')
+        browser_id = request.headers.get("X-Browser-ID")
         logger.info(f"Browser ID from headers: {browser_id}")
         if not browser_id:
             browser_id = str(uuid.uuid4())
             logger.info(f"Generated new browser ID: {browser_id}")
-        
+
         return f"session_{browser_id}"
 
     def list(self, request):
@@ -95,90 +106,116 @@ class VectorCollectionsAPIView(ViewSet):
         user_id = self.get_user_identifier(request)
         logger.info(f"User identifier for list: {user_id}")
         logger.info(f"Total collections before filtering: {len(collections)}")
-        
+
         # Filter collections by user identifier
         filtered_collections = [
-            col for col in collections 
-            if not col.metadata or not col.metadata.get('user_id') or col.metadata.get('user_id') == user_id
+            col
+            for col in collections
+            if not col.metadata
+            or not col.metadata.get("user_id")
+            or col.metadata.get("user_id") == user_id
         ]
-        
+
         logger.info(f"Filtered collections: {len(filtered_collections)}")
         for col in filtered_collections:
             logger.info(f"Collection: {col.name}, Metadata: {col.metadata}")
-        
+
         # Serialize collections and add fallback for missing document names
         serialized_collections = []
         for collection in filtered_collections:
             serialized_collection = serialize_collection(collection)
-            
-            # If last_uploaded_document is missing from collection metadata, 
+
+            # If last_uploaded_document is missing from collection metadata,
             # try to get it from the individual document chunks as a fallback
-            if not serialized_collection.get('metadata', {}).get('last_uploaded_document'):
+            if not serialized_collection.get("metadata", {}).get(
+                "last_uploaded_document"
+            ):
                 try:
                     results = collection.get(include=["metadatas"])
                     if results and results.get("metadatas"):
                         # Find the most recent document based on upload_date
                         latest_document = None
                         latest_date = None
-                        
+
                         for metadata in results["metadatas"]:
-                            if metadata and metadata.get("source") and metadata.get("source") != "internal_knowledge":
+                            if (
+                                metadata
+                                and metadata.get("source")
+                                and metadata.get("source") != "internal_knowledge"
+                            ):
                                 upload_date = metadata.get("upload_date")
-                                if upload_date and (not latest_date or upload_date > latest_date):
+                                if upload_date and (
+                                    not latest_date or upload_date > latest_date
+                                ):
                                     latest_date = upload_date
                                     latest_document = metadata.get("source")
-                        
+
                         # Update the serialized collection with the fallback document name
                         if latest_document:
-                            if 'metadata' not in serialized_collection:
-                                serialized_collection['metadata'] = {}
-                            serialized_collection['metadata']['last_uploaded_document'] = latest_document
-                            logger.info(f"Fallback: Found document name '{latest_document}' for collection {collection.name}")
+                            if "metadata" not in serialized_collection:
+                                serialized_collection["metadata"] = {}
+                            serialized_collection["metadata"][
+                                "last_uploaded_document"
+                            ] = latest_document
+                            logger.info(
+                                f"Fallback: Found document name '{latest_document}' for collection {collection.name}"
+                            )
                 except Exception as e:
-                    logger.error(f"Error getting fallback document name for collection {collection.name}: {str(e)}")
-            
+                    logger.error(
+                        f"Error getting fallback document name for collection {collection.name}: {str(e)}"
+                    )
+
             serialized_collections.append(serialized_collection)
-        
+
         return Response(data=serialized_collections)
 
     def post(self, request):
         logger.info(f"Post request received. Headers: {request.headers}")
         logger.info(f"Request data: {request.data}")
-        
+
         try:
             name = request.data["name"]
             metadata = request.data.get("metadata", dict())
             logger.info(f"Creating collection {name} with metadata {metadata}")
-            
+
             # Add user identifier to collection metadata
             user_id = self.get_user_identifier(request)
             logger.info(f"User identifier for post: {user_id}")
-            
+
             # Check if collection with this name already exists
             collections: List[Collection] = list_collections()
-            existing_collection = next((col for col in collections if col.name == name), None)
-            
+            existing_collection = next(
+                (col for col in collections if col.name == name), None
+            )
+
             if existing_collection:
                 logger.warning(f"Collection with name {name} already exists")
                 # Check if the collection is owned by the current user
-                if existing_collection.metadata and existing_collection.metadata.get('user_id') == user_id:
+                if (
+                    existing_collection.metadata
+                    and existing_collection.metadata.get("user_id") == user_id
+                ):
                     return Response(
                         status=status.HTTP_400_BAD_REQUEST,
-                        data={"error": f"A collection with name '{name}' already exists and is owned by you."}
+                        data={
+                            "error": f"A collection with name '{name}' already exists and is owned by you."
+                        },
                     )
                 else:
                     return Response(
                         status=status.HTTP_400_BAD_REQUEST,
-                        data={"error": f"A collection with name '{name}' already exists and is owned by another user."}
+                        data={
+                            "error": f"A collection with name '{name}' already exists and is owned by another user."
+                        },
                     )
-            
+
             metadata.update({"user_id": user_id})
-            
+
             logger.info(f"Final metadata for creation: {metadata}")
-            
+
             # Debug the EMBED_MODEL
             logger.info(f"Using EMBED_MODEL: {self.EMBED_MODEL}")
-            
+
             collection = create_collection(
                 collection_name=name,
                 metadata=metadata,
@@ -191,61 +228,79 @@ class VectorCollectionsAPIView(ViewSet):
             logger.info(f"Collection created successfully: {collection.name}")
             serialized = serialize_collection(collection)
             logger.info(f"Serialized response: {serialized}")
-            
+
             return Response(data=serialized)
         except Exception as e:
             logger.error(f"Error creating collection: {str(e)}", exc_info=True)
             return Response(
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                data={"error": f"Failed to create collection: {str(e)}"}
+                data={"error": f"Failed to create collection: {str(e)}"},
             )
 
     def retrieve(self, request, pk=None):
         logger.info(f"Retrieve request for collection: {pk}")
         if not pk:
             return self.list(request)
-            
+
         collection = get_collection(
             collection_name=pk, embedding_func_name=self.EMBED_MODEL
         )
-        
+
         # Check if user has access to this collection
         user_id = self.get_user_identifier(request)
-        if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
-            logger.warning(f"User {user_id} attempted to access collection {pk} owned by {collection.metadata.get('user_id')}")
+        if (
+            collection.metadata
+            and collection.metadata.get("user_id")
+            and collection.metadata.get("user_id") != user_id
+        ):
+            logger.warning(
+                f"User {user_id} attempted to access collection {pk} owned by {collection.metadata.get('user_id')}"
+            )
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
-                data={"error": "You don't have access to this collection"}
+                data={"error": "You don't have access to this collection"},
             )
-        
+
         serialized_collection = serialize_collection(collection)
-        
-        # If last_uploaded_document is missing from collection metadata, 
+
+        # If last_uploaded_document is missing from collection metadata,
         # try to get it from the individual document chunks as a fallback
-        if not serialized_collection.get('metadata', {}).get('last_uploaded_document'):
+        if not serialized_collection.get("metadata", {}).get("last_uploaded_document"):
             try:
                 results = collection.get(include=["metadatas"])
                 if results and results.get("metadatas"):
                     # Find the most recent document based on upload_date
                     latest_document = None
                     latest_date = None
-                    
+
                     for metadata in results["metadatas"]:
-                        if metadata and metadata.get("source") and metadata.get("source") != "internal_knowledge":
+                        if (
+                            metadata
+                            and metadata.get("source")
+                            and metadata.get("source") != "internal_knowledge"
+                        ):
                             upload_date = metadata.get("upload_date")
-                            if upload_date and (not latest_date or upload_date > latest_date):
+                            if upload_date and (
+                                not latest_date or upload_date > latest_date
+                            ):
                                 latest_date = upload_date
                                 latest_document = metadata.get("source")
-                    
+
                     # Update the serialized collection with the fallback document name
                     if latest_document:
-                        if 'metadata' not in serialized_collection:
-                            serialized_collection['metadata'] = {}
-                        serialized_collection['metadata']['last_uploaded_document'] = latest_document
-                        logger.info(f"Fallback: Found document name '{latest_document}' for collection {pk}")
+                        if "metadata" not in serialized_collection:
+                            serialized_collection["metadata"] = {}
+                        serialized_collection["metadata"]["last_uploaded_document"] = (
+                            latest_document
+                        )
+                        logger.info(
+                            f"Fallback: Found document name '{latest_document}' for collection {pk}"
+                        )
             except Exception as e:
-                logger.error(f"Error getting fallback document name for collection {pk}: {str(e)}")
-            
+                logger.error(
+                    f"Error getting fallback document name for collection {pk}: {str(e)}"
+                )
+
         return Response(data=serialized_collection)
 
     @action(methods=["DELETE"], detail=True)
@@ -256,19 +311,25 @@ class VectorCollectionsAPIView(ViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 data={"error": "No collection name provided"},
             )
-            
+
         # Check if user has access to this collection
         collection = get_collection(
             collection_name=pk, embedding_func_name=self.EMBED_MODEL
         )
         user_id = self.get_user_identifier(request)
-        if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
-            logger.warning(f"User {user_id} attempted to delete collection {pk} owned by {collection.metadata.get('user_id')}")
+        if (
+            collection.metadata
+            and collection.metadata.get("user_id")
+            and collection.metadata.get("user_id") != user_id
+        ):
+            logger.warning(
+                f"User {user_id} attempted to delete collection {pk} owned by {collection.metadata.get('user_id')}"
+            )
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
-                data={"error": "You don't have access to this collection"}
+                data={"error": "You don't have access to this collection"},
             )
-            
+
         delete_collection(collection_name=pk)
         logger.info(f"Collection {pk} deleted successfully")
         return Response(status=200)
@@ -281,11 +342,17 @@ class VectorCollectionsAPIView(ViewSet):
             collection_name=pk, embedding_func_name=self.EMBED_MODEL
         )
         user_id = self.get_user_identifier(request)
-        if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
-            logger.warning(f"User {user_id} attempted to insert document to collection {pk} owned by {collection.metadata.get('user_id')}")
+        if (
+            collection.metadata
+            and collection.metadata.get("user_id")
+            and collection.metadata.get("user_id") != user_id
+        ):
+            logger.warning(
+                f"User {user_id} attempted to insert document to collection {pk} owned by {collection.metadata.get('user_id')}"
+            )
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
-                data={"error": "You don't have access to this collection"}
+                data={"error": "You don't have access to this collection"},
             )
 
         if "document" not in request.FILES:
@@ -295,70 +362,72 @@ class VectorCollectionsAPIView(ViewSet):
             )
 
         document = request.FILES["document"]
-        
+
         # Create a temporary file to store the uploaded document
-        temp_dir = os.path.join(settings.MEDIA_ROOT, 'temp')
+        temp_dir = os.path.join(settings.MEDIA_ROOT, "temp")
         os.makedirs(temp_dir, exist_ok=True)
-        
+
         # Sanitize filename to prevent directory traversal
         filename = os.path.basename(document.name)
         temp_file_path = os.path.join(temp_dir, filename)
 
-        with open(temp_file_path, 'wb+') as temp_file:
+        with open(temp_file_path, "wb+") as temp_file:
             for chunk in document.chunks():
                 temp_file.write(chunk)
-        
+
         try:
             # Get file extension and determine folder type
             file_extension = os.path.splitext(document.name)[1].lower()
             filename = document.name
-            
+
             # Organize by file type into virtual folders
-            if file_extension in ['.pdf']:
+            if file_extension in [".pdf"]:
                 folder_type = "pdf"
                 folder_path = f"pdf/{filename}"
-            elif file_extension in ['.doc', '.docx']:
+            elif file_extension in [".doc", ".docx"]:
                 folder_type = "docs"
                 folder_path = f"docs/{filename}"
-            elif file_extension in ['.txt']:
+            elif file_extension in [".txt"]:
                 folder_type = "text"
                 folder_path = f"text/{filename}"
-            elif file_extension in ['.ppt', '.pptx']:
+            elif file_extension in [".ppt", ".pptx"]:
                 folder_type = "presentations"
                 folder_path = f"presentations/{filename}"
-            elif file_extension in ['.xls', '.xlsx']:
+            elif file_extension in [".xls", ".xlsx"]:
                 folder_type = "spreadsheets"
                 folder_path = f"spreadsheets/{filename}"
             else:
                 folder_type = "other"
                 folder_path = f"other/{filename}"
-            
+
             # Enhanced metadata with folder structure
             upload_timestamp = datetime.now().isoformat()
             # Ensure filename is never empty, default to "Untitled" if missing
             if not filename or filename.strip() == "":
                 filename = "Untitled"
-                logger.warning(f"Document filename was empty, defaulting to 'Untitled'")
-            
+                logger.warning("Document filename was empty, defaulting to 'Untitled'")
+
             base_metadata = {
                 "source": filename,
                 "folder_type": folder_type,
                 "folder_path": folder_path,
                 "file_extension": file_extension,
                 "display_path": folder_path,  # This will be shown in the UI
-                "upload_date": upload_timestamp
+                "upload_date": upload_timestamp,
             }
-            
-            chunked_document = chunk_document(file_path=temp_file_path, metadata=base_metadata)
+
+            chunked_document = chunk_document(
+                file_path=temp_file_path, metadata=base_metadata
+            )
             documents = [d.page_content for d in chunked_document]
-            
+
             # Update each chunk's metadata to include the folder structure
             metadatas = []
             for d in chunked_document:
                 chunk_metadata = d.metadata.copy()
                 chunk_metadata.update(base_metadata)
                 metadatas.append(chunk_metadata)
-            
+
             ids = [str(uuid.uuid4()) for _ in documents]
             insert_to_chroma_collection(
                 collection_name=pk,
@@ -367,7 +436,7 @@ class VectorCollectionsAPIView(ViewSet):
                 metadatas=metadatas,
                 embedding_func_name=self.EMBED_MODEL,
             )
-            
+
             # Update collection metadata with the last uploaded document
             metadata_update_success = False
             try:
@@ -375,52 +444,73 @@ class VectorCollectionsAPIView(ViewSet):
                 collection = get_collection(
                     collection_name=pk, embedding_func_name=self.EMBED_MODEL
                 )
-                
+
                 # Update the collection metadata to include the last uploaded document
-                updated_metadata = collection.metadata.copy() if collection.metadata else {}
-                updated_metadata['last_uploaded_document'] = filename
-                
-                logger.info(f"Attempting to update collection {pk} metadata: {updated_metadata}")
-                
+                updated_metadata = (
+                    collection.metadata.copy() if collection.metadata else {}
+                )
+                updated_metadata["last_uploaded_document"] = filename
+
+                logger.info(
+                    f"Attempting to update collection {pk} metadata: {updated_metadata}"
+                )
+
                 # Modify the collection with updated metadata
                 chroma_client = ChromaClient()
-                chroma_client.modify_collection(
-                    name=pk,
-                    metadata=updated_metadata
-                )
-                
+                chroma_client.modify_collection(name=pk, metadata=updated_metadata)
+
                 # Verify the metadata was updated by re-fetching the collection
                 updated_collection = get_collection(
                     collection_name=pk, embedding_func_name=self.EMBED_MODEL
                 )
-                
-                if updated_collection.metadata and updated_collection.metadata.get('last_uploaded_document') == filename:
+
+                if (
+                    updated_collection.metadata
+                    and updated_collection.metadata.get("last_uploaded_document")
+                    == filename
+                ):
                     metadata_update_success = True
-                    logger.info(f"Successfully updated collection {pk} metadata with last_uploaded_document: {filename}")
+                    logger.info(
+                        f"Successfully updated collection {pk} metadata with last_uploaded_document: {filename}"
+                    )
                 else:
-                    logger.warning(f"Metadata update for collection {pk} may not have persisted correctly")
+                    logger.warning(
+                        f"Metadata update for collection {pk} may not have persisted correctly"
+                    )
                     # Try alternative approach: Get the collection directly and check if modify_collection worked
                     try:
-                        logger.info(f"Alternative check: Current collection metadata: {updated_collection.metadata}")
+                        logger.info(
+                            f"Alternative check: Current collection metadata: {updated_collection.metadata}"
+                        )
                         # Force a small delay to ensure consistency
                         import time
+
                         time.sleep(0.1)
-                        
+
                         # Try one more verification
                         final_collection = get_collection(
                             collection_name=pk, embedding_func_name=self.EMBED_MODEL
                         )
-                        if final_collection.metadata and final_collection.metadata.get('last_uploaded_document') == filename:
+                        if (
+                            final_collection.metadata
+                            and final_collection.metadata.get("last_uploaded_document")
+                            == filename
+                        ):
                             metadata_update_success = True
-                            logger.info(f"Metadata update verified on second check for {pk}")
+                            logger.info(
+                                f"Metadata update verified on second check for {pk}"
+                            )
                     except Exception as alt_e:
                         logger.error(f"Alternative metadata check failed: {str(alt_e)}")
-                    
+
             except Exception as e:
-                logger.error(f"Error updating collection metadata for {pk}: {str(e)}", exc_info=True)
+                logger.error(
+                    f"Error updating collection metadata for {pk}: {str(e)}",
+                    exc_info=True,
+                )
                 # Don't fail the entire operation if metadata update fails, but log it properly
                 metadata_update_success = False
-            
+
             # Return information about the uploaded document
             upload_info = {
                 "status": "success",
@@ -434,9 +524,9 @@ class VectorCollectionsAPIView(ViewSet):
                     "chunks_count": len(documents),
                 },
                 "collection": pk,
-                "metadata_updated": metadata_update_success
+                "metadata_updated": metadata_update_success,
             }
-            
+
             # Add current collection metadata to response for debugging
             try:
                 current_collection = get_collection(
@@ -444,15 +534,19 @@ class VectorCollectionsAPIView(ViewSet):
                 )
                 upload_info["collection_metadata"] = current_collection.metadata
             except Exception as meta_e:
-                logger.error(f"Error fetching collection metadata for response: {str(meta_e)}")
+                logger.error(
+                    f"Error fetching collection metadata for response: {str(meta_e)}"
+                )
                 upload_info["collection_metadata"] = None
-            
+
             if not metadata_update_success:
-                upload_info["warning"] = "Document uploaded successfully but collection metadata may not have been updated. File name might not display correctly in the UI."
-            
+                upload_info["warning"] = (
+                    "Document uploaded successfully but collection metadata may not have been updated. File name might not display correctly in the UI."
+                )
+
             logger.info(f"Document upload successful: {upload_info}")
             return Response(data=upload_info, status=status.HTTP_200_OK)
-        except ValueError as e: # Unsupported file type
+        except ValueError as e:  # Unsupported file type
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"error": str(e)},
@@ -461,7 +555,7 @@ class VectorCollectionsAPIView(ViewSet):
             logger.error(f"Error processing document: {str(e)}", exc_info=True)
             return Response(
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                data={"error": f"Failed to process document: {str(e)}"}
+                data={"error": f"Failed to process document: {str(e)}"},
             )
         finally:
             # Clean up the temporary file
@@ -482,11 +576,17 @@ class VectorCollectionsAPIView(ViewSet):
             collection_name=pk, embedding_func_name=self.EMBED_MODEL
         )
         user_id = self.get_user_identifier(request)
-        if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
-            logger.warning(f"User {user_id} attempted to query collection {pk} owned by {collection.metadata.get('user_id')}")
+        if (
+            collection.metadata
+            and collection.metadata.get("user_id")
+            and collection.metadata.get("user_id") != user_id
+        ):
+            logger.warning(
+                f"User {user_id} attempted to query collection {pk} owned by {collection.metadata.get('user_id')}"
+            )
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
-                data={"error": "You don't have access to this collection"}
+                data={"error": "You don't have access to this collection"},
             )
 
         query_text = request.GET.get("query_text")
@@ -513,9 +613,13 @@ class VectorCollectionsAPIView(ViewSet):
                     n_results=self.query_results_limit,
                     embedding_func_name=self.EMBED_MODEL,
                 )
-                results = _merge_query_results(results, internal_results, self.query_results_limit)
+                results = _merge_query_results(
+                    results, internal_results, self.query_results_limit
+                )
             except Exception as e:
-                logger.error(f"Error merging internal knowledge into query for {pk}: {e}")
+                logger.error(
+                    f"Error merging internal knowledge into query for {pk}: {e}"
+                )
 
         return Response(results)
 
@@ -533,18 +637,23 @@ class VectorCollectionsAPIView(ViewSet):
         all_collections: List[Collection] = list_collections()
         user_id = self.get_user_identifier(request)
         user_collections = [
-            col for col in all_collections 
-            if not col.metadata or not col.metadata.get('user_id') or col.metadata.get('user_id') == user_id
+            col
+            for col in all_collections
+            if not col.metadata
+            or not col.metadata.get("user_id")
+            or col.metadata.get("user_id") == user_id
         ]
-        
+
         if not user_collections:
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
-                data={"error": "No collections found for this user."}
+                data={"error": "No collections found for this user."},
             )
 
-        logger.info(f"Querying across {len(user_collections)} collections for user {user_id}")
-        
+        logger.info(
+            f"Querying across {len(user_collections)} collections for user {user_id}"
+        )
+
         all_results = {"results": []}
         for collection in user_collections:
             logger.info(f"Querying collection: {collection.name}")
@@ -562,8 +671,12 @@ class VectorCollectionsAPIView(ViewSet):
                         result_item = {
                             "collection": serialized_collection,
                             "document": results["documents"][0][i],
-                            "metadata": results["metadatas"][0][i] if results["metadatas"] else None,
-                            "distance": results["distances"][0][i] if results["distances"] else None,
+                            "metadata": results["metadatas"][0][i]
+                            if results["metadatas"]
+                            else None,
+                            "distance": results["distances"][0][i]
+                            if results["distances"]
+                            else None,
                         }
                         all_results["results"].append(result_item)
             except Exception as e:
@@ -572,7 +685,9 @@ class VectorCollectionsAPIView(ViewSet):
                 continue
 
         # Sort all aggregated results by distance (ascending)
-        all_results["results"].sort(key=lambda x: x["distance"] if x["distance"] is not None else float('inf'))
+        all_results["results"].sort(
+            key=lambda x: x["distance"] if x["distance"] is not None else float("inf")
+        )
 
         # Limit the final results to the top N
         limit = int(request.GET.get("limit", 10))
@@ -594,28 +709,30 @@ class VectorCollectionsAPIView(ViewSet):
             collection = get_collection(
                 collection_name=pk, embedding_func_name=self.EMBED_MODEL
             )
-            
+
             # Get all documents from the collection
-            results = collection.get(
-                include=["metadatas", "documents", "embeddings"]
-            )
-            
+            results = collection.get(include=["metadatas", "documents", "embeddings"])
+
             debug_info = {
                 "collection_name": pk,
                 "total_documents": len(results.get("documents", [])) if results else 0,
                 "embedding_model": self.EMBED_MODEL,
-                "sample_documents": results.get("documents", [])[:3] if results else [],  # First 3 docs
-                "sample_metadatas": results.get("metadatas", [])[:3] if results else [],  # First 3 metadatas
+                "sample_documents": results.get("documents", [])[:3]
+                if results
+                else [],  # First 3 docs
+                "sample_metadatas": results.get("metadatas", [])[:3]
+                if results
+                else [],  # First 3 metadatas
                 "has_embeddings": bool(results.get("embeddings")) if results else False,
             }
-            
+
             return Response(debug_info)
-            
+
         except Exception as e:
             logger.error(f"Error debugging collection {pk}: {str(e)}", exc_info=True)
             return Response(
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                data={"error": f"Failed to debug collection: {str(e)}"}
+                data={"error": f"Failed to debug collection: {str(e)}"},
             )
 
     @action(methods=["GET"], detail=True, url_path="documents")
@@ -633,30 +750,38 @@ class VectorCollectionsAPIView(ViewSet):
             collection_name=pk, embedding_func_name=self.EMBED_MODEL
         )
         user_id = self.get_user_identifier(request)
-        if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
-            logger.warning(f"User {user_id} attempted to list documents in collection {pk} owned by {collection.metadata.get('user_id')}")
+        if (
+            collection.metadata
+            and collection.metadata.get("user_id")
+            and collection.metadata.get("user_id") != user_id
+        ):
+            logger.warning(
+                f"User {user_id} attempted to list documents in collection {pk} owned by {collection.metadata.get('user_id')}"
+            )
             return Response(
                 status=status.HTTP_403_FORBIDDEN,
-                data={"error": "You don't have access to this collection"}
+                data={"error": "You don't have access to this collection"},
             )
 
         try:
             # Get all documents from the collection
-            results = collection.get(
-                include=["metadatas", "documents"]
-            )
-            
+            results = collection.get(include=["metadatas", "documents"])
+
             # Group documents by their source file
             documents_by_file = {}
-            
+
             if results and results.get("metadatas"):
                 for i, metadata in enumerate(results["metadatas"]):
-                    if metadata and metadata.get("source") and metadata.get("source") != "internal_knowledge":
+                    if (
+                        metadata
+                        and metadata.get("source")
+                        and metadata.get("source") != "internal_knowledge"
+                    ):
                         source = metadata.get("source")
                         folder_path = metadata.get("folder_path", source)
                         folder_type = metadata.get("folder_type", "other")
                         file_extension = metadata.get("file_extension", "")
-                        
+
                         if source not in documents_by_file:
                             documents_by_file[source] = {
                                 "filename": source,
@@ -665,30 +790,34 @@ class VectorCollectionsAPIView(ViewSet):
                                 "file_extension": file_extension,
                                 "display_path": folder_path,
                                 "chunks_count": 0,
-                                "upload_date": metadata.get("upload_date", "Unknown")
+                                "upload_date": metadata.get("upload_date", "Unknown"),
                             }
-                        
+
                         documents_by_file[source]["chunks_count"] += 1
-            
+
             # Convert to list and sort by upload date or filename
             uploaded_documents = list(documents_by_file.values())
             uploaded_documents.sort(key=lambda x: x["filename"])
-            
-            return Response({
-                "collection": pk,
-                "documents": uploaded_documents,
-                "total_files": len(uploaded_documents)
-            })
-            
+
+            return Response(
+                {
+                    "collection": pk,
+                    "documents": uploaded_documents,
+                    "total_files": len(uploaded_documents),
+                }
+            )
+
         except Exception as e:
-            logger.error(f"Error listing documents in collection {pk}: {str(e)}", exc_info=True)
+            logger.error(
+                f"Error listing documents in collection {pk}: {str(e)}", exc_info=True
+            )
             return Response(
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                data={"error": f"Failed to list documents: {str(e)}"}
+                data={"error": f"Failed to list documents: {str(e)}"},
             )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 def rag_admin_authenticate(request):
     """
     Dummy endpoint for admin authentication.
@@ -696,23 +825,20 @@ def rag_admin_authenticate(request):
     """
     logger.info("RAG Admin authentication request")
     password = request.data.get("password")
-    
+
     # Allow authentication if RAG_ADMIN_PASSWORD is not set or if it matches
     if not settings.RAG_ADMIN_PASSWORD or password == settings.RAG_ADMIN_PASSWORD:
         logger.info("RAG Admin authenticated successfully")
         # In a real app, you would return a token here
-        return Response(
-            {"status": "authenticated"},
-            status=status.HTTP_200_OK
-        )
+        return Response({"status": "authenticated"}, status=status.HTTP_200_OK)
     else:
         logger.warning("RAG Admin authentication failed")
         return Response(
-            {"error": "Invalid password"},
-            status=status.HTTP_401_UNAUTHORIZED
+            {"error": "Invalid password"}, status=status.HTTP_401_UNAUTHORIZED
         )
 
-@api_view(['POST'])
+
+@api_view(["POST"])
 @permission_classes([])
 def rag_admin_list_all_collections(request):
     """
@@ -721,7 +847,7 @@ def rag_admin_list_all_collections(request):
     """
     logger.info("RAG Admin list all collections request")
     password = request.data.get("password")
-    
+
     # Allow access if RAG_ADMIN_PASSWORD is not set or if it matches
     if not settings.RAG_ADMIN_PASSWORD or password == settings.RAG_ADMIN_PASSWORD:
         logger.info("RAG Admin authenticated for listing collections")
@@ -730,17 +856,17 @@ def rag_admin_list_all_collections(request):
         serialized_collections = []
         for col in collections:
             s_col = serialize_collection(col)
-            s_col['user_id'] = col.metadata.get('user_id') if col.metadata else None
+            s_col["user_id"] = col.metadata.get("user_id") if col.metadata else None
             serialized_collections.append(s_col)
         return Response(data=serialized_collections)
     else:
         logger.warning("RAG Admin authentication failed for listing collections")
         return Response(
-            {"error": "Invalid password"},
-            status=status.HTTP_401_UNAUTHORIZED
+            {"error": "Invalid password"}, status=status.HTTP_401_UNAUTHORIZED
         )
 
-@api_view(['POST'])
+
+@api_view(["POST"])
 def rag_admin_delete_collection(request):
     """
     An endpoint for admins to delete any collection.
@@ -753,28 +879,31 @@ def rag_admin_delete_collection(request):
     if not collection_name:
         return Response(
             {"error": "Collection name not provided"},
-            status=status.HTTP_400_BAD_REQUEST
+            status=status.HTTP_400_BAD_REQUEST,
         )
 
     # Allow access if RAG_ADMIN_PASSWORD is not set or if it matches
     if not settings.RAG_ADMIN_PASSWORD or password == settings.RAG_ADMIN_PASSWORD:
-        logger.info(f"RAG Admin authenticated for deleting collection: {collection_name}")
+        logger.info(
+            f"RAG Admin authenticated for deleting collection: {collection_name}"
+        )
         try:
             delete_collection(collection_name=collection_name)
             logger.info(f"Admin successfully deleted collection: {collection_name}")
             return Response(
                 {"status": f"Collection '{collection_name}' deleted successfully"},
-                status=status.HTTP_200_OK
+                status=status.HTTP_200_OK,
             )
         except Exception as e:
             logger.error(f"Admin failed to delete collection {collection_name}: {e}")
             return Response(
                 {"error": f"Failed to delete collection: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
     else:
-        logger.warning(f"RAG Admin authentication failed for deleting collection: {collection_name}")
+        logger.warning(
+            f"RAG Admin authentication failed for deleting collection: {collection_name}"
+        )
         return Response(
-            {"error": "Invalid password"},
-            status=status.HTTP_401_UNAUTHORIZED
+            {"error": "Invalid password"}, status=status.HTTP_401_UNAUTHORIZED
         )

--- a/app/backend/wakeword_control/apps.py
+++ b/app/backend/wakeword_control/apps.py
@@ -17,7 +17,11 @@ WAKEWORD_MODEL = os.environ.get("WAKEWORD_MODEL", "hey_quiet_box")
 WAKEWORD_THRESHOLD = float(os.environ.get("WAKEWORD_THRESHOLD", "0.3"))
 
 # When truthy, logs every per-frame top-score >= 0.1 for debugging purposes
-WAKEWORD_DEBUG_SCORES = os.environ.get("WAKEWORD_DEBUG_SCORES", "").lower() in ("1", "true", "yes")
+WAKEWORD_DEBUG_SCORES = os.environ.get("WAKEWORD_DEBUG_SCORES", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 # Repo-bundled wake-word weights. Drop `{name}.onnx` here and set
 BUNDLED_DIR = Path(__file__).resolve().parent / "bundled_models"
@@ -52,7 +56,9 @@ class WakeWordConfig(AppConfig):
         have_preprocessing = (MODELS_DIR / "melspectrogram.onnx").exists() and (
             MODELS_DIR / "embedding_model.onnx"
         ).exists()
-        have_wake_word = bundled or manual or any(MODELS_DIR.glob(f"{WAKEWORD_MODEL}_*.onnx"))
+        have_wake_word = (
+            bundled or manual or any(MODELS_DIR.glob(f"{WAKEWORD_MODEL}_*.onnx"))
+        )
         if have_preprocessing and have_wake_word:
             return  # nothing to fetch
 

--- a/app/backend/wakeword_control/consumers.py
+++ b/app/backend/wakeword_control/consumers.py
@@ -21,7 +21,9 @@ class WakeWordConsumer(AsyncWebsocketConsumer):
             # No wake-word model on disk — accept the socket so the client gets a clear reason, then close.
             logger.warning("Wake-word connection rejected: %s", exc)
             await self.accept()
-            await self.send(text_data=json.dumps({"event": "unavailable", "detail": str(exc)}))
+            await self.send(
+                text_data=json.dumps({"event": "unavailable", "detail": str(exc)})
+            )
             await self.close(code=1011)
             return
         await self.accept()

--- a/app/backend/wakeword_control/detector.py
+++ b/app/backend/wakeword_control/detector.py
@@ -8,7 +8,13 @@ import time
 import numpy as np
 from openwakeword.model import Model
 
-from .apps import BUNDLED_DIR, MODELS_DIR, WAKEWORD_DEBUG_SCORES, WAKEWORD_MODEL, WAKEWORD_THRESHOLD
+from .apps import (
+    BUNDLED_DIR,
+    MODELS_DIR,
+    WAKEWORD_DEBUG_SCORES,
+    WAKEWORD_MODEL,
+    WAKEWORD_THRESHOLD,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +35,9 @@ def _resolve_wake_model_path():
 
 
 class WakeDetector:
-    def __init__(self, threshold: float = WAKEWORD_THRESHOLD, debounce_seconds: float = 1.5):
+    def __init__(
+        self, threshold: float = WAKEWORD_THRESHOLD, debounce_seconds: float = 1.5
+    ):
         self.threshold = threshold
         self.debounce_seconds = debounce_seconds
 
@@ -56,7 +64,12 @@ class WakeDetector:
         top_model, top_score = max(scores.items(), key=lambda kv: kv[1])
 
         if WAKEWORD_DEBUG_SCORES and top_score >= 0.1:
-            logger.info("wake score=%.3f model=%s threshold=%.2f", top_score, top_model, self.threshold)
+            logger.info(
+                "wake score=%.3f model=%s threshold=%.2f",
+                top_score,
+                top_model,
+                self.threshold,
+            )
 
         now = time.monotonic()
         if now - self._last_fire < self.debounce_seconds:

--- a/docker-control-service/api.py
+++ b/docker-control-service/api.py
@@ -20,8 +20,7 @@ from routers import health, containers, images, networks, logs
 
 # Setup logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -32,7 +31,7 @@ app = FastAPI(
     version="1.0.0",
     docs_url="/api/v1/docs",
     redoc_url="/api/v1/redoc",
-    openapi_url="/api/v1/openapi.json"
+    openapi_url="/api/v1/openapi.json",
 )
 
 # CORS configuration - only allow backend
@@ -41,7 +40,7 @@ app.add_middleware(
     allow_origins=[
         "http://localhost:8000",
         "http://127.0.0.1:8000",
-        "http://tt-studio-backend-api:8000"
+        "http://tt-studio-backend-api:8000",
     ],
     allow_credentials=True,
     allow_methods=["*"],
@@ -59,7 +58,6 @@ app.include_router(networks.router, prefix="/api/v1", tags=["networks"])
 app.include_router(logs.router, prefix="/api/v1", tags=["logs"])
 
 
-
 @app.on_event("startup")
 async def startup_event():
     """Application startup event handler"""
@@ -67,7 +65,9 @@ async def startup_event():
     logger.info("Docker Control Service starting up...")
     logger.info(f"Listening on {settings.HOST}:{settings.PORT}")
     logger.info(f"Development mode: {settings.DEV_MODE}")
-    logger.info(f"API documentation: http://{settings.HOST}:{settings.PORT}/api/v1/docs")
+    logger.info(
+        f"API documentation: http://{settings.HOST}:{settings.PORT}/api/v1/docs"
+    )
     logger.info("=" * 60)
 
 
@@ -85,5 +85,5 @@ if __name__ == "__main__":
         host=settings.HOST,
         port=settings.PORT,
         reload=settings.DEV_MODE,
-        log_level="info"
+        log_level="info",
     )

--- a/docker-control-service/middleware/auth.py
+++ b/docker-control-service/middleware/auth.py
@@ -31,25 +31,22 @@ async def authenticate_request(request: Request, call_next):
     if not token:
         logger.warning(f"Missing authentication token from {request.client.host}")
         return JSONResponse(
-            status_code=401,
-            content={"error": "Missing authentication token"}
+            status_code=401, content={"error": "Missing authentication token"}
         )
 
     try:
         payload = jwt.decode(token, settings.JWT_SECRET, algorithms=["HS256"])
         request.state.auth_payload = payload
-        logger.debug(f"Authenticated request from service: {payload.get('service', 'unknown')}")
+        logger.debug(
+            f"Authenticated request from service: {payload.get('service', 'unknown')}"
+        )
     except jwt.ExpiredSignatureError:
         logger.warning(f"Expired JWT token from {request.client.host}")
-        return JSONResponse(
-            status_code=401,
-            content={"error": "Token has expired"}
-        )
+        return JSONResponse(status_code=401, content={"error": "Token has expired"})
     except jwt.InvalidTokenError as e:
         logger.warning(f"Invalid JWT token from {request.client.host}: {e}")
         return JSONResponse(
-            status_code=401,
-            content={"error": "Invalid authentication token"}
+            status_code=401, content={"error": "Invalid authentication token"}
         )
 
     return await call_next(request)

--- a/docker-control-service/models/requests.py
+++ b/docker-control-service/models/requests.py
@@ -11,12 +11,19 @@ from pydantic import BaseModel, Field
 
 class ContainerRunRequest(BaseModel):
     """Request model for running a container"""
+
     image: str = Field(..., description="Docker image name:tag")
     name: Optional[str] = Field(None, description="Container name")
     command: Optional[str] = Field(None, description="Command to run")
-    environment: Dict[str, str] = Field(default_factory=dict, description="Environment variables")
-    ports: Dict[str, int] = Field(default_factory=dict, description="Port mappings (container_port: host_port)")
-    volumes: Dict[str, str] = Field(default_factory=dict, description="Volume mounts (host_path: container_path)")
+    environment: Dict[str, str] = Field(
+        default_factory=dict, description="Environment variables"
+    )
+    ports: Dict[str, int] = Field(
+        default_factory=dict, description="Port mappings (container_port: host_port)"
+    )
+    volumes: Dict[str, str] = Field(
+        default_factory=dict, description="Volume mounts (host_path: container_path)"
+    )
     devices: List[str] = Field(default_factory=list, description="Device mounts")
     network: Optional[str] = Field(None, description="Network name")
     hostname: Optional[str] = Field(None, description="Container hostname")
@@ -24,12 +31,18 @@ class ContainerRunRequest(BaseModel):
     auto_remove: bool = Field(False, description="Remove container on exit")
     privileged: bool = Field(False, description="Run in privileged mode (NOT ALLOWED)")
     user: Optional[str] = Field(None, description="User to run as (e.g., '1000:1000')")
-    cap_add: List[str] = Field(default_factory=list, description="Linux capabilities to add (e.g., ['SYS_ADMIN', 'IPC_LOCK'])")
-    shm_size: Optional[str] = Field(None, description="Shared memory size (e.g., '32G')")
+    cap_add: List[str] = Field(
+        default_factory=list,
+        description="Linux capabilities to add (e.g., ['SYS_ADMIN', 'IPC_LOCK'])",
+    )
+    shm_size: Optional[str] = Field(
+        None, description="Shared memory size (e.g., '32G')"
+    )
 
 
 class ContainerStopRequest(BaseModel):
     """Request model for stopping a container"""
+
     timeout: int = Field(10, description="Timeout in seconds before killing")
 
 
@@ -39,12 +52,14 @@ class ContainerDirSizeRequest(BaseModel):
     Read-only: only used to report download progress to the UI. Path must be
     an absolute container path; the service refuses anything else.
     """
+
     path: str = Field(..., description="Absolute path inside the container to size")
     timeout: float = Field(4.0, description="Hard cap on the `du` exec, in seconds")
 
 
 class ImagePullRequest(BaseModel):
     """Request model for pulling an image"""
+
     image_name: str = Field(..., description="Image name")
     image_tag: str = Field("latest", description="Image tag")
     registry_auth: Optional[Dict] = Field(None, description="Registry credentials")
@@ -57,6 +72,7 @@ class ImagePullStartRequest(BaseModel):
     by `pull_id`; the caller polls GET /images/pull/progress/{pull_id} for byte-level
     progress aggregated from Docker's per-layer event stream.
     """
+
     image_name: str = Field(..., description="Image name")
     image_tag: str = Field("latest", description="Image tag")
     pull_id: str = Field(..., description="Caller-supplied id used to poll progress")
@@ -64,5 +80,6 @@ class ImagePullStartRequest(BaseModel):
 
 class NetworkCreateRequest(BaseModel):
     """Request model for creating a network"""
+
     name: str = Field(..., description="Network name")
     driver: str = Field("bridge", description="Network driver")

--- a/docker-control-service/models/responses.py
+++ b/docker-control-service/models/responses.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, ConfigDict
 
 class ContainerRunResponse(BaseModel):
     """Response model for container run operation"""
+
     status: str = Field(..., description="Operation status: 'success' or 'error'")
     container_id: Optional[str] = Field(None, description="Container ID")
     container_name: Optional[str] = Field(None, description="Container name")
@@ -20,6 +21,7 @@ class ContainerRunResponse(BaseModel):
 
 class ContainerInfo(BaseModel):
     """Container information model"""
+
     id: str
     name: str
     status: str
@@ -31,19 +33,24 @@ class ContainerInfo(BaseModel):
 
 class ContainerListResponse(BaseModel):
     """Response model for listing containers"""
+
     status: str
     containers: List[Dict[str, Any]]
 
 
 class ContainerDirSizeResponse(BaseModel):
     """Response model for a recursive byte-count of a container directory."""
+
     status: str
-    bytes: Optional[int] = Field(None, description="Total bytes (None if path missing or exec failed)")
+    bytes: Optional[int] = Field(
+        None, description="Total bytes (None if path missing or exec failed)"
+    )
     message: Optional[str] = None
 
 
 class ContainerDetailsResponse(BaseModel):
     """Response model for container details - allows extra fields so all container data passes through"""
+
     model_config = ConfigDict(extra="allow")
     status: str
     container: Optional[ContainerInfo] = None
@@ -52,13 +59,17 @@ class ContainerDetailsResponse(BaseModel):
 
 class OperationResponse(BaseModel):
     """Generic operation response"""
+
     status: str
     message: Optional[str] = None
-    exists: Optional[bool] = Field(None, description="Whether the resource exists (for existence checks)")
+    exists: Optional[bool] = Field(
+        None, description="Whether the resource exists (for existence checks)"
+    )
 
 
 class ImagePullProgress(BaseModel):
     """Progress update for image pull operation"""
+
     status: str = Field(..., description="'pulling', 'success', or 'error'")
     progress: int = Field(..., description="Progress percentage (0-100)")
     current: int = Field(0, description="Current bytes downloaded")
@@ -69,18 +80,21 @@ class ImagePullProgress(BaseModel):
 
 class ImageListResponse(BaseModel):
     """Response model for listing images"""
+
     status: str
     images: List[Dict[str, Any]]
 
 
 class NetworkListResponse(BaseModel):
     """Response model for listing networks"""
+
     status: str
     networks: List[Dict[str, Any]]
 
 
 class HealthResponse(BaseModel):
     """Health check response"""
+
     status: str
     timestamp: str
     checks: Dict[str, str]

--- a/docker-control-service/routers/containers.py
+++ b/docker-control-service/routers/containers.py
@@ -13,13 +13,17 @@ import re
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
-from models.requests import ContainerRunRequest, ContainerStopRequest, ContainerDirSizeRequest
+from models.requests import (
+    ContainerRunRequest,
+    ContainerStopRequest,
+    ContainerDirSizeRequest,
+)
 from models.responses import (
     ContainerRunResponse,
     ContainerListResponse,
     ContainerDetailsResponse,
     ContainerDirSizeResponse,
-    OperationResponse
+    OperationResponse,
 )
 from services.container_service import ContainerService
 
@@ -55,7 +59,9 @@ async def run_container(request: ContainerRunRequest):
         result = get_service().run_container(request)
 
         if result["status"] == "error":
-            raise HTTPException(status_code=400, detail=result.get("message", "Unknown error"))
+            raise HTTPException(
+                status_code=400, detail=result.get("message", "Unknown error")
+            )
 
         return result
 
@@ -70,7 +76,9 @@ async def run_container(request: ContainerRunRequest):
 
 
 @router.post("/containers/{container_id}/stop", response_model=OperationResponse)
-async def stop_container(container_id: str, request: ContainerStopRequest = ContainerStopRequest()):
+async def stop_container(
+    container_id: str, request: ContainerStopRequest = ContainerStopRequest()
+):
     """
     Stop a running container.
 
@@ -84,7 +92,9 @@ async def stop_container(container_id: str, request: ContainerStopRequest = Cont
         if result["status"] == "error":
             if "not found" in result.get("message", "").lower():
                 raise HTTPException(status_code=404, detail=result["message"])
-            raise HTTPException(status_code=400, detail=result.get("message", "Unknown error"))
+            raise HTTPException(
+                status_code=400, detail=result.get("message", "Unknown error")
+            )
 
         return result
 
@@ -104,13 +114,17 @@ async def remove_container(container_id: str, force: bool = False):
     - force: Force removal even if running
     """
     try:
-        logger.info(f"Received remove container request: {container_id} (force={force})")
+        logger.info(
+            f"Received remove container request: {container_id} (force={force})"
+        )
         result = get_service().remove_container(container_id, force=force)
 
         if result["status"] == "error":
             if "not found" in result.get("message", "").lower():
                 raise HTTPException(status_code=404, detail=result["message"])
-            raise HTTPException(status_code=400, detail=result.get("message", "Unknown error"))
+            raise HTTPException(
+                status_code=400, detail=result.get("message", "Unknown error")
+            )
 
         return result
 
@@ -152,7 +166,9 @@ async def get_container(container_id: str):
         if result["status"] == "error":
             if "not found" in result.get("message", "").lower():
                 raise HTTPException(status_code=404, detail=result["message"])
-            raise HTTPException(status_code=400, detail=result.get("message", "Unknown error"))
+            raise HTTPException(
+                status_code=400, detail=result.get("message", "Unknown error")
+            )
 
         return result
 
@@ -180,10 +196,7 @@ async def rename_container(container_id: str, new_name: str):
         container.rename(new_name)
 
         logger.info(f"Container renamed successfully: {container_id} -> {new_name}")
-        return {
-            "status": "success",
-            "message": f"Container renamed to {new_name}"
-        }
+        return {"status": "success", "message": f"Container renamed to {new_name}"}
 
     except docker.errors.NotFound:
         error_msg = f"Container {container_id} not found"
@@ -200,7 +213,9 @@ async def rename_container(container_id: str, new_name: str):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/containers/{container_id}/dir-size", response_model=ContainerDirSizeResponse)
+@router.post(
+    "/containers/{container_id}/dir-size", response_model=ContainerDirSizeResponse
+)
 async def container_dir_size(container_id: str, request: ContainerDirSizeRequest):
     """Recursive byte count of an absolute path inside a running container.
 
@@ -218,7 +233,9 @@ async def container_dir_size(container_id: str, request: ContainerDirSizeRequest
         try:
             container = client.containers.get(container_id)
         except docker.errors.NotFound:
-            raise HTTPException(status_code=404, detail=f"container {container_id} not found")
+            raise HTTPException(
+                status_code=404, detail=f"container {container_id} not found"
+            )
 
         # Single-quote escape for `sh -c`. stderr discarded so a transient ENOENT
         # (path being created mid-download) returns "" rather than erroring.
@@ -261,7 +278,9 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
     - tail: Number of lines to show from end of logs (default: 100)
     """
     try:
-        logger.info(f"Received logs stream request: {container_id} (follow={follow}, tail={tail})")
+        logger.info(
+            f"Received logs stream request: {container_id} (follow={follow}, tail={tail})"
+        )
 
         def generate_sse_logs():
             """Generate Server-Sent Events from container logs"""
@@ -271,14 +290,16 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
 
                 # Stream logs from container
                 service = get_service()
-                for log_line in service.get_logs_stream(container_id, follow=follow, tail=tail):
+                for log_line in service.get_logs_stream(
+                    container_id, follow=follow, tail=tail
+                ):
                     try:
                         # Decode log line
-                        log_text = log_line.decode('utf-8', errors='replace')
+                        log_text = log_line.decode("utf-8", errors="replace")
 
                         # Split into individual lines and process each
-                        for line in log_text.split('\n'):
-                            line = line.rstrip('\r')  # Remove carriage returns
+                        for line in log_text.split("\n"):
+                            line = line.rstrip("\r")  # Remove carriage returns
                             if not line:
                                 continue
                             # Only filter access-log noise when the caller is
@@ -290,23 +311,33 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
                             if follow and _UVICORN_ACCESS_LOG_RE.match(line):
                                 continue
                             # Create log data with timestamp
-                            timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                            timestamp = datetime.datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            )
 
                             # Determine message type (simple heuristic)
                             message_type = "log"
                             line_upper = line.upper()
-                            if any(keyword in line_upper for keyword in ["ERROR", "EXCEPTION", "FAILED", "FATAL"]):
+                            if any(
+                                keyword in line_upper
+                                for keyword in ["ERROR", "EXCEPTION", "FAILED", "FATAL"]
+                            ):
                                 message_type = "error"
-                            elif any(keyword in line_upper for keyword in ["WARNING", "WARN"]):
+                            elif any(
+                                keyword in line_upper for keyword in ["WARNING", "WARN"]
+                            ):
                                 message_type = "warning"
-                            elif any(keyword in line_upper for keyword in ["INFO", "STARTED", "LISTENING", "READY"]):
+                            elif any(
+                                keyword in line_upper
+                                for keyword in ["INFO", "STARTED", "LISTENING", "READY"]
+                            ):
                                 message_type = "event"
 
                             log_data = {
                                 "type": message_type,
                                 "message": line,
                                 "timestamp": timestamp,
-                                "raw": True
+                                "raw": True,
                             }
                             yield f"data: {json.dumps(log_data)}\n\n"
 
@@ -316,8 +347,10 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
                         log_data = {
                             "type": "log",
                             "message": error_msg,
-                            "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-                            "raw": True
+                            "timestamp": datetime.datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            ),
+                            "raw": True,
                         }
                         yield f"data: {json.dumps(log_data)}\n\n"
 
@@ -325,7 +358,7 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
                 error_data = {
                     "type": "error",
                     "message": f"Container {container_id} not found",
-                    "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                    "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 yield f"data: {json.dumps(error_data)}\n\n"
             except Exception as e:
@@ -333,18 +366,18 @@ async def get_container_logs(container_id: str, follow: bool = True, tail: int =
                 error_data = {
                     "type": "error",
                     "message": f"Error streaming logs: {str(e)}",
-                    "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                    "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 }
                 yield f"data: {json.dumps(error_data)}\n\n"
 
         # Return streaming response with SSE content type
         return StreamingResponse(
             generate_sse_logs(),
-            media_type='text/event-stream',
+            media_type="text/event-stream",
             headers={
-                'Cache-Control': 'no-cache, no-transform',
-                'X-Accel-Buffering': 'no'
-            }
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+            },
         )
 
     except Exception as e:

--- a/docker-control-service/routers/health.py
+++ b/docker-control-service/routers/health.py
@@ -25,7 +25,7 @@ async def health_check():
     health_status = {
         "status": "healthy",
         "timestamp": datetime.now().isoformat(),
-        "checks": {}
+        "checks": {},
     }
 
     # Check Docker daemon

--- a/docker-control-service/routers/images.py
+++ b/docker-control-service/routers/images.py
@@ -27,7 +27,7 @@ _PULL_ENTRY_TTL_SECONDS = 3600  # drop finished entries after an hour to bound m
 
 def _new_pull_entry() -> dict:
     return {
-        "status": "pulling",          # pulling | success | error
+        "status": "pulling",  # pulling | success | error
         "downloaded_bytes": 0,
         "total_bytes": 0,
         "layers_done": 0,
@@ -42,7 +42,8 @@ def _new_pull_entry() -> dict:
 def _evict_stale_locked() -> None:
     now = time.time()
     stale = [
-        pid for pid, e in _PULLS.items()
+        pid
+        for pid, e in _PULLS.items()
         if e["status"] != "pulling" and now - e["updated_at"] > _PULL_ENTRY_TTL_SECONDS
     ]
     for pid in stale:
@@ -66,7 +67,9 @@ def _run_pull(pull_id: str, image_name: str, image_tag: str) -> None:
     try:
         client = docker.from_env()
         logger.info(f"[pull {pull_id}] streaming pull of {image_ref}")
-        for event in client.api.pull(image_name, tag=image_tag, stream=True, decode=True):
+        for event in client.api.pull(
+            image_name, tag=image_tag, stream=True, decode=True
+        ):
             if not isinstance(event, dict):
                 continue
 
@@ -81,7 +84,9 @@ def _run_pull(pull_id: str, image_name: str, image_tag: str) -> None:
             detail = event.get("progressDetail") or {}
 
             if layer_id:
-                layer = layers.setdefault(layer_id, {"current": 0, "total": 0, "done": False})
+                layer = layers.setdefault(
+                    layer_id, {"current": 0, "total": 0, "done": False}
+                )
                 low = status_text.lower()
                 if low == "downloading":
                     if detail.get("total"):
@@ -94,10 +99,10 @@ def _run_pull(pull_id: str, image_name: str, image_tag: str) -> None:
                         layer["current"] = layer["total"]
                     layer["done"] = True
 
-            downloaded = sum(l["current"] for l in layers.values())
-            total = sum(l["total"] for l in layers.values())
+            downloaded = sum(lyr["current"] for lyr in layers.values())
+            total = sum(lyr["total"] for lyr in layers.values())
             layers_total = len(layers)
-            layers_done = sum(1 for l in layers.values() if l["done"])
+            layers_done = sum(1 for lyr in layers.values() if lyr["done"])
 
             msg = status_text or "Pulling image…"
             if layer_id and status_text:
@@ -143,7 +148,10 @@ async def start_pull_image(request: ImagePullStartRequest):
         _evict_stale_locked()
         existing = _PULLS.get(pull_id)
         if existing is not None and existing["status"] == "pulling":
-            return {"status": "success", "message": f"Pull {pull_id} already in progress"}
+            return {
+                "status": "success",
+                "message": f"Pull {pull_id} already in progress",
+            }
         _PULLS[pull_id] = _new_pull_entry()
 
     thread = threading.Thread(
@@ -162,7 +170,9 @@ async def get_pull_progress(pull_id: str):
     with _PULLS_LOCK:
         entry = _PULLS.get(pull_id)
         if entry is None:
-            raise HTTPException(status_code=404, detail=f"No pull tracked for {pull_id}")
+            raise HTTPException(
+                status_code=404, detail=f"No pull tracked for {pull_id}"
+            )
         snapshot = dict(entry)
     snapshot["pull_id"] = pull_id
     return snapshot
@@ -184,16 +194,14 @@ async def pull_image(request: ImagePullRequest):
         logger.info(f"Pulling image: {image_ref}")
 
         # Pull image with optional authentication
-        image = client.images.pull(
-            request.image_name,
-            tag=request.image_tag,
-            auth_config=request.registry_auth
+        client.images.pull(
+            request.image_name, tag=request.image_tag, auth_config=request.registry_auth
         )
 
         logger.info(f"Image pulled successfully: {image_ref}")
         return {
             "status": "success",
-            "message": f"Image {image_ref} pulled successfully"
+            "message": f"Image {image_ref} pulled successfully",
         }
 
     except docker.errors.ImageNotFound:
@@ -232,7 +240,7 @@ async def remove_image(name: str, tag: str = "latest", force: bool = False):
         logger.info(f"Image removed successfully: {image_ref}")
         return {
             "status": "success",
-            "message": f"Image {image_ref} removed successfully"
+            "message": f"Image {image_ref} removed successfully",
         }
 
     except docker.errors.ImageNotFound:
@@ -266,18 +274,17 @@ async def list_images():
             # Get tags or ID
             tags = image.tags if image.tags else [image.short_id]
 
-            image_list.append({
-                "id": image.id,
-                "tags": tags,
-                "size": image.attrs.get("Size", 0),
-                "created": image.attrs.get("Created", "")
-            })
+            image_list.append(
+                {
+                    "id": image.id,
+                    "tags": tags,
+                    "size": image.attrs.get("Size", 0),
+                    "created": image.attrs.get("Created", ""),
+                }
+            )
 
         logger.info(f"Listed {len(image_list)} images")
-        return {
-            "status": "success",
-            "images": image_list
-        }
+        return {"status": "success", "images": image_list}
 
     except docker.errors.APIError as e:
         error_msg = str(e)
@@ -310,14 +317,14 @@ async def check_image_exists(name: str, tag: str = "latest"):
             return {
                 "status": "success",
                 "message": f"Image {image_ref} exists",
-                "exists": True
+                "exists": True,
             }
         except docker.errors.ImageNotFound:
             logger.info(f"Image does not exist: {image_ref}")
             return {
                 "status": "success",
                 "message": f"Image {image_ref} does not exist",
-                "exists": False
+                "exists": False,
             }
 
     except docker.errors.APIError as e:

--- a/docker-control-service/routers/logs.py
+++ b/docker-control-service/routers/logs.py
@@ -25,7 +25,10 @@ async def get_service_log(tail: int = 500):
     if not settings.SERVICE_LOG_FILE:
         raise HTTPException(status_code=503, detail="Service log path not configured")
     logger.debug(f"Serving service log: {settings.SERVICE_LOG_FILE}")
-    return {"content": _read_tail(settings.SERVICE_LOG_FILE, tail), "file": settings.SERVICE_LOG_FILE}
+    return {
+        "content": _read_tail(settings.SERVICE_LOG_FILE, tail),
+        "file": settings.SERVICE_LOG_FILE,
+    }
 
 
 @router.get("/logs/startup")
@@ -33,7 +36,10 @@ async def get_startup_log(tail: int = 200):
     if not settings.STARTUP_LOG_FILE:
         raise HTTPException(status_code=503, detail="Startup log path not configured")
     logger.debug(f"Serving startup log: {settings.STARTUP_LOG_FILE}")
-    return {"content": _read_tail(settings.STARTUP_LOG_FILE, tail), "file": settings.STARTUP_LOG_FILE}
+    return {
+        "content": _read_tail(settings.STARTUP_LOG_FILE, tail),
+        "file": settings.STARTUP_LOG_FILE,
+    }
 
 
 @router.get("/logs/fastapi")
@@ -41,4 +47,7 @@ async def get_fastapi_log(tail: int = 500):
     if not settings.MODEL_RUN_LOG_FILE:
         raise HTTPException(status_code=503, detail="Model run log path not configured")
     logger.debug(f"Serving model run log: {settings.MODEL_RUN_LOG_FILE}")
-    return {"content": _read_tail(settings.MODEL_RUN_LOG_FILE, tail), "file": settings.MODEL_RUN_LOG_FILE}
+    return {
+        "content": _read_tail(settings.MODEL_RUN_LOG_FILE, tail),
+        "file": settings.MODEL_RUN_LOG_FILE,
+    }

--- a/docker-control-service/routers/networks.py
+++ b/docker-control-service/routers/networks.py
@@ -17,9 +17,11 @@ from models.responses import NetworkListResponse, OperationResponse
 class NetworkConnectRequest(BaseModel):
     container: str
 
+
 class NetworkDisconnectRequest(BaseModel):
     container: str
     force: bool = False
+
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -38,15 +40,12 @@ async def create_network(request: NetworkCreateRequest):
 
         logger.info(f"Creating network: {request.name} (driver={request.driver})")
 
-        network = client.networks.create(
-            name=request.name,
-            driver=request.driver
-        )
+        client.networks.create(name=request.name, driver=request.driver)
 
         logger.info(f"Network created successfully: {request.name}")
         return {
             "status": "success",
-            "message": f"Network {request.name} created successfully"
+            "message": f"Network {request.name} created successfully",
         }
 
     except docker.errors.APIError as e:
@@ -54,7 +53,9 @@ async def create_network(request: NetworkCreateRequest):
         logger.error(f"Error creating network: {error_msg}")
 
         if "already exists" in error_msg.lower():
-            raise HTTPException(status_code=409, detail=f"Network {request.name} already exists")
+            raise HTTPException(
+                status_code=409, detail=f"Network {request.name} already exists"
+            )
 
         raise HTTPException(status_code=500, detail=error_msg)
 
@@ -79,10 +80,7 @@ async def remove_network(name: str):
         network.remove()
 
         logger.info(f"Network removed successfully: {name}")
-        return {
-            "status": "success",
-            "message": f"Network {name} removed successfully"
-        }
+        return {"status": "success", "message": f"Network {name} removed successfully"}
 
     except docker.errors.NotFound:
         error_msg = f"Network {name} not found"
@@ -112,19 +110,18 @@ async def list_networks():
 
         network_list = []
         for network in networks:
-            network_list.append({
-                "id": network.id,
-                "name": network.name,
-                "driver": network.attrs.get("Driver", ""),
-                "scope": network.attrs.get("Scope", ""),
-                "created": network.attrs.get("Created", "")
-            })
+            network_list.append(
+                {
+                    "id": network.id,
+                    "name": network.name,
+                    "driver": network.attrs.get("Driver", ""),
+                    "scope": network.attrs.get("Scope", ""),
+                    "created": network.attrs.get("Created", ""),
+                }
+            )
 
         logger.info(f"Listed {len(network_list)} networks")
-        return {
-            "status": "success",
-            "networks": network_list
-        }
+        return {"status": "success", "networks": network_list}
 
     except docker.errors.APIError as e:
         error_msg = str(e)
@@ -156,7 +153,7 @@ async def connect_container_to_network(name: str, request: NetworkConnectRequest
         logger.info(f"Container connected successfully: {container_id} -> {name}")
         return {
             "status": "success",
-            "message": f"Container {container_id} connected to network {name}"
+            "message": f"Container {container_id} connected to network {name}",
         }
 
     except docker.errors.NotFound as e:
@@ -175,7 +172,9 @@ async def connect_container_to_network(name: str, request: NetworkConnectRequest
 
 
 @router.post("/networks/{name}/disconnect", response_model=OperationResponse)
-async def disconnect_container_from_network(name: str, request: NetworkDisconnectRequest):
+async def disconnect_container_from_network(
+    name: str, request: NetworkDisconnectRequest
+):
     """
     Disconnect a container from a network.
 
@@ -195,7 +194,7 @@ async def disconnect_container_from_network(name: str, request: NetworkDisconnec
         logger.info(f"Container disconnected successfully: {container_id} <- {name}")
         return {
             "status": "success",
-            "message": f"Container {container_id} disconnected from network {name}"
+            "message": f"Container {container_id} disconnected from network {name}",
         }
 
     except docker.errors.NotFound as e:

--- a/docker-control-service/services/container_service.py
+++ b/docker-control-service/services/container_service.py
@@ -7,7 +7,7 @@ Container Service - Business logic for Docker container operations
 
 import docker
 import logging
-from typing import Dict, List, Any
+from typing import Dict
 from models.requests import ContainerRunRequest
 from config import settings
 
@@ -72,7 +72,7 @@ class ContainerService:
             volumes = {}
             for host_path, container_path in request.volumes.items():
                 if isinstance(container_path, str):
-                    volumes[host_path] = {'bind': container_path, 'mode': 'rw'}
+                    volumes[host_path] = {"bind": container_path, "mode": "rw"}
                 else:
                     volumes[host_path] = container_path
             run_kwargs["volumes"] = volumes
@@ -104,7 +104,7 @@ class ContainerService:
 
             # Get port bindings from container attributes
             port_bindings = {}
-            if hasattr(container, 'attrs'):
+            if hasattr(container, "attrs"):
                 host_config = container.attrs.get("HostConfig", {})
                 port_bindings = host_config.get("PortBindings", {})
 
@@ -115,32 +115,23 @@ class ContainerService:
                 "container_id": container.id,
                 "name": container.name,  # Add 'name' for compatibility
                 "container_name": container.name,
-                "port_bindings": port_bindings
+                "port_bindings": port_bindings,
             }
 
         except docker.errors.ImageNotFound:
             error_msg = f"Image {request.image} not found"
             logger.error(error_msg)
-            return {
-                "status": "error",
-                "message": error_msg
-            }
+            return {"status": "error", "message": error_msg}
 
         except docker.errors.APIError as e:
             error_msg = str(e)
             logger.error(f"Docker API error: {error_msg}")
-            return {
-                "status": "error",
-                "message": error_msg
-            }
+            return {"status": "error", "message": error_msg}
 
         except Exception as e:
             error_msg = f"Unexpected error: {str(e)}"
             logger.error(error_msg)
-            return {
-                "status": "error",
-                "message": error_msg
-            }
+            return {"status": "error", "message": error_msg}
 
     def stop_container(self, container_id: str, timeout: int = 10) -> Dict:
         """
@@ -218,26 +209,25 @@ class ContainerService:
                 image = image_tags[0] if image_tags else container.image.short_id
 
                 # Build comprehensive container info for backend compatibility
-                container_list.append({
-                    "id": container.id,
-                    "name": container.name,
-                    "status": container.status,
-                    "image": image,
-                    "image_tags": image_tags,
-                    # Include full attrs for backend compatibility
-                    "attrs": container.attrs,
-                    # Convenience fields extracted from attrs
-                    "Config": container.attrs.get("Config", {}),
-                    "NetworkSettings": container.attrs.get("NetworkSettings", {}),
-                    "HostConfig": container.attrs.get("HostConfig", {}),
-                    "environment": container.attrs.get("Config", {}).get("Env", [])
-                })
+                container_list.append(
+                    {
+                        "id": container.id,
+                        "name": container.name,
+                        "status": container.status,
+                        "image": image,
+                        "image_tags": image_tags,
+                        # Include full attrs for backend compatibility
+                        "attrs": container.attrs,
+                        # Convenience fields extracted from attrs
+                        "Config": container.attrs.get("Config", {}),
+                        "NetworkSettings": container.attrs.get("NetworkSettings", {}),
+                        "HostConfig": container.attrs.get("HostConfig", {}),
+                        "environment": container.attrs.get("Config", {}).get("Env", []),
+                    }
+                )
 
             logger.debug(f"Listed {len(container_list)} containers (all={all})")
-            return {
-                "status": "success",
-                "containers": container_list
-            }
+            return {"status": "success", "containers": container_list}
 
         except docker.errors.APIError as e:
             error_msg = str(e)
@@ -262,7 +252,9 @@ class ContainerService:
             image = image_tags[0] if image_tags else container.image.short_id
 
             # Get network information
-            networks = list(container.attrs.get("NetworkSettings", {}).get("Networks", {}).keys())
+            networks = list(
+                container.attrs.get("NetworkSettings", {}).get("Networks", {}).keys()
+            )
 
             container_info = {
                 "id": container.id,
@@ -278,13 +270,13 @@ class ContainerService:
                 "Config": container.attrs.get("Config", {}),
                 "NetworkSettings": container.attrs.get("NetworkSettings", {}),
                 "HostConfig": container.attrs.get("HostConfig", {}),
-                "environment": container.attrs.get("Config", {}).get("Env", [])
+                "environment": container.attrs.get("Config", {}).get("Env", []),
             }
 
             logger.debug(f"Retrieved container info: {container_id[:12]}")
             return {
                 "status": "success",
-                **container_info  # Return container info directly (not nested under "container" key)
+                **container_info,  # Return container info directly (not nested under "container" key)
             }
 
         except docker.errors.NotFound:
@@ -317,7 +309,9 @@ class ContainerService:
 
         # Never allow privileged mode
         if request.privileged:
-            raise ValueError("Privileged containers are not allowed for security reasons")
+            raise ValueError(
+                "Privileged containers are not allowed for security reasons"
+            )
 
         # Validate network
         if request.network and request.network not in settings.ALLOWED_NETWORKS:

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-from fastapi import FastAPI, HTTPException, Response, status
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
-from typing import Optional, Dict, Any, Iterable, Tuple
+from typing import Optional, Dict, Any, Tuple
 import sys
 import os
 import inspect
@@ -53,6 +53,7 @@ if artifact_path is None:
 # Patch get_repo_root_path to return artifact directory when running from artifact
 # This MUST be done before importing any workflows modules that use it
 import workflows.utils as workflows_utils  # noqa: E402
+
 original_get_repo_root_path = workflows_utils.get_repo_root_path
 
 
@@ -86,7 +87,9 @@ if artifact_path:
                 continue
             _params = list(inspect.signature(_fn).parameters.values())
             # Defaults align to the trailing parameters that have defaults.
-            _defaulted = [p for p in _params if p.default is not inspect.Parameter.empty]
+            _defaulted = [
+                p for p in _params if p.default is not inspect.Parameter.empty
+            ]
             _new_defaults = list(_fn.__defaults__)
             _rebound = False
             for _idx, _param in enumerate(_defaulted):
@@ -102,16 +105,21 @@ if artifact_path:
                     _fn_name,
                 )
         except Exception as exc:  # pragma: no cover - defensive: never block import
-            logging.warning("Could not rebind default dotenv path for %s: %s", _fn_name, exc)
+            logging.warning(
+                "Could not rebind default dotenv path for %s: %s", _fn_name, exc
+            )
 
 # Patch setup_run_logger so run_log file handler is always present even when
 # other handlers were attached to run_log before run_main() executes.
 import workflows.log_setup as workflows_log_setup  # noqa: E402
+
 original_setup_run_logger = workflows_log_setup.setup_run_logger
 
 
 def _patched_setup_run_logger(logger, run_id, run_log_path, log_level=logging.DEBUG):
-    configured_logger = original_setup_run_logger(logger, run_id, run_log_path, log_level)
+    configured_logger = original_setup_run_logger(
+        logger, run_id, run_log_path, log_level
+    )
     run_logger = logging.getLogger("run_log")
     target_run_log_path = Path(run_log_path)
     target_run_log_file = target_run_log_path.expanduser()
@@ -147,6 +155,7 @@ workflows_log_setup.setup_run_logger = _patched_setup_run_logger
 # Media containers happen to survive today without this; LLM containers don't.
 # See issue #825.
 import subprocess as _subprocess  # noqa: E402
+
 _orig_popen = _subprocess.Popen
 
 
@@ -179,7 +188,10 @@ except ImportError as e:
 # Only overrides True → False (never the reverse). Fails open on any exception so a
 # permission error or unexpected path layout never blocks a valid deploy.
 import workflows.setup_host as _setup_host_module  # noqa: E402
-_orig_check_model_weights_dir = _setup_host_module.HostSetupManager.check_model_weights_dir
+
+_orig_check_model_weights_dir = (
+    _setup_host_module.HostSetupManager.check_model_weights_dir
+)
 
 
 def _patched_check_model_weights_dir(self, host_weights_dir):
@@ -206,13 +218,17 @@ def _patched_check_model_weights_dir(self, host_weights_dir):
         logging.getLogger(__name__).warning(
             "check_model_weights_dir: %d incomplete blob(s) in %s — "
             "re-download required. Files: %s",
-            len(incomplete), blobs_dir, [f.name for f in incomplete],
+            len(incomplete),
+            blobs_dir,
+            [f.name for f in incomplete],
         )
         return False
     return True
 
 
-_setup_host_module.HostSetupManager.check_model_weights_dir = _patched_check_model_weights_dir
+_setup_host_module.HostSetupManager.check_model_weights_dir = (
+    _patched_check_model_weights_dir
+)
 
 # Set up logging
 # DO NOT use basicConfig() - it interferes with file handlers
@@ -220,6 +236,7 @@ _setup_host_module.HostSetupManager.check_model_weights_dir = _patched_check_mod
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # Set level on the logger itself
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
 
 # Configure FastAPI logger to also write to file
 def setup_model_run_file_logging():
@@ -262,9 +279,9 @@ def setup_model_run_file_logging():
             ("uvicorn.access", logging.INFO),
             ("uvicorn.error", logging.INFO),
         ]:
-            l = logging.getLogger(name)
-            l.setLevel(level)
-            l.propagate = True
+            sublogger = logging.getLogger(name)
+            sublogger.setLevel(level)
+            sublogger.propagate = True
 
         logger.info(f"FastAPI file logging configured - writing to {root_log_file}")
         logger.debug(f"Root log absolute path: {root_log_file.absolute()}")
@@ -273,6 +290,7 @@ def setup_model_run_file_logging():
         error_msg = f"Failed to setup FastAPI file logging: {e}"
         print(error_msg, file=sys.stderr)
         import traceback
+
         print(traceback.format_exc(), file=sys.stderr)
 
         # Try to write error to a local fallback log
@@ -283,6 +301,7 @@ def setup_model_run_file_logging():
                 f.write(traceback.format_exc())
         except Exception:
             pass  # If even fallback fails, just continue
+
 
 # Initialize file logging
 setup_model_run_file_logging()
@@ -307,8 +326,12 @@ PULL_STALL_THRESHOLD_SECONDS = 120
 PROG_RE = re.compile(r"TT_PROGRESS stage=(\w+) pct=(\d{1,3}) msg=(.*)$")
 
 _DOCKER_RUN_NAME_RE = re.compile(r"--name\s+(?P<name>[^\s]+)")
-_RUN_LOG_PATH_RE = re.compile(r"This log file is saved on local machine at:\s*(?P<path>\S+)")
-_DOCKER_WORKFLOW_LOG_PATH_RE = re.compile(r"Running docker container with log file:\s*(?P<path>\S+)")
+_RUN_LOG_PATH_RE = re.compile(
+    r"This log file is saved on local machine at:\s*(?P<path>\S+)"
+)
+_DOCKER_WORKFLOW_LOG_PATH_RE = re.compile(
+    r"Running docker container with log file:\s*(?P<path>\S+)"
+)
 
 # Host-setup / weights download hints (from tt-inference-server logs).
 # setup_host.py emits "Downloading model to host volume: {repo}" or
@@ -318,7 +341,9 @@ _HF_DOWNLOAD_REPO_RE = re.compile(
 )
 # setup_host.py:388 emits "✅ HF_HOME set to {path}" (no "HOST_" prefix).
 _HOST_HF_HOME_RE = re.compile(r"HF_HOME set to\s*(?P<path>\S+)")
-_HOST_VOLUME_WEIGHTS_MISSING_RE = re.compile(r"Weights directory does not exist for\s*(?P<model>.+?)\.")
+_HOST_VOLUME_WEIGHTS_MISSING_RE = re.compile(
+    r"Weights directory does not exist for\s*(?P<model>.+?)\."
+)
 # setup_host.py:582 emits "Weights already exist in host volume, skipping download" on cache hit.
 _HF_CACHED_RE = re.compile(r"Weights already exist in host volume")
 _PREFERRED_HOST_VOLUME_PATH = Path("~/data/tt-cache")
@@ -648,13 +673,23 @@ def _stage_preloaded_version_symlink(model, device, impl, override_dir, root, jo
         return
     try:
         ms, _, _ = get_runtime_model_spec(model, device, impl=impl)
-        target = Path(root) / f"volume_id_{ms.impl.impl_id}-{ms.model_name}-v{ms.version}"
+        target = (
+            Path(root) / f"volume_id_{ms.impl.impl_id}-{ms.model_name}-v{ms.version}"
+        )
         if target.exists() or target.is_symlink():  # never clobber; idempotent
             return
-        os.symlink(Path(override_dir).resolve(), target)  # resolve() avoids symlink-to-symlink
-        logger.info("Job %s: linked %s -> %s", job_id, target.name, Path(override_dir).name)
+        os.symlink(
+            Path(override_dir).resolve(), target
+        )  # resolve() avoids symlink-to-symlink
+        logger.info(
+            "Job %s: linked %s -> %s", job_id, target.name, Path(override_dir).name
+        )
     except Exception as exc:
-        logger.warning("Job %s: could not stage preloaded host-volume symlink: %s", job_id, exc)
+        logger.warning(
+            "Job %s: could not stage preloaded host-volume symlink: %s", job_id, exc
+        )
+
+
 # ─── end TEMP (QB2 workaround) ────────────────────────────────────────────────
 
 
@@ -685,7 +720,7 @@ def _format_bytes(num_bytes: Optional[float]) -> str:
         return "0 B"
     units = ["B", "KB", "MB", "GB", "TB", "PB"]
     idx = min(int(math.log(num_bytes, 1024)), len(units) - 1)
-    scaled = num_bytes / (1024 ** idx)
+    scaled = num_bytes / (1024**idx)
     # Keep it compact for UI messages
     if scaled >= 100 or idx == 0:
         return f"{scaled:.0f} {units[idx]}"
@@ -707,7 +742,9 @@ def _format_eta(seconds: Optional[float]) -> str:
     return f"ETA {sec}s"
 
 
-def _extract_repo_and_hf_home_from_job_logs(job_id: str) -> Tuple[Optional[str], Optional[str]]:
+def _extract_repo_and_hf_home_from_job_logs(
+    job_id: str,
+) -> Tuple[Optional[str], Optional[str]]:
     """Best-effort extraction of HF repo id and HOST_HF_HOME from captured run.py logs."""
     with progress_lock:
         entries = list(log_store.get(job_id, []))
@@ -810,6 +847,7 @@ class WeightsLocation:
         read directly because /var/lib/docker/volumes/ is root-only).
       - "hf_cache": legacy HF-hub layout under host_path/hub/models--<repo>/.
     """
+
     read_mode: str
     host_path: Optional[Path] = None
     volume_name: Optional[str] = None
@@ -847,7 +885,10 @@ def _resolve_weights_location(
     except Exception as exc:
         logger.warning(
             "weights-monitor: could not resolve model spec for %s/%s/%s: %s",
-            model_name, device, impl, exc,
+            model_name,
+            device,
+            impl,
+            exc,
         )
         return None
     volume_name = f"volume_id_{model_spec.impl.impl_id}-{model_spec.model_name}"
@@ -895,7 +936,9 @@ def _du_bytes_in_volume(volume_name: str, subpath: str) -> int:
         first = text.splitlines()[0].strip()
         return int(first) if first.isdigit() else 0
     except docker.errors.ImageNotFound:
-        logger.debug("weights-monitor: %s missing; will be pulled at startup", _DU_HELPER_IMAGE)
+        logger.debug(
+            "weights-monitor: %s missing; will be pulled at startup", _DU_HELPER_IMAGE
+        )
         return 0
     except Exception as exc:
         logger.debug("weights-monitor: du in volume %s failed: %s", volume_name, exc)
@@ -913,7 +956,11 @@ def _downloaded_bytes_for_location(
     if location is not None:
         if location.read_mode == "host_fs" and location.host_path:
             return _dir_size_bytes_recursive(location.host_path)
-        if location.read_mode == "docker_volume" and location.volume_name and location.volume_subpath:
+        if (
+            location.read_mode == "docker_volume"
+            and location.volume_name
+            and location.volume_subpath
+        ):
             return _du_bytes_in_volume(location.volume_name, location.volume_subpath)
     # Legacy fallback (hf_home discovered via log scrape).
     if hf_home is not None and repo_id:
@@ -1016,7 +1063,8 @@ def _weights_progress_monitor(
         if weights_location:
             logger.info(
                 "Job %s: weights-monitor resolved location: %s",
-                job_id, weights_location,
+                job_id,
+                weights_location,
             )
 
     # Poll at 1s cadence; keep it lightweight (single dir scan).
@@ -1035,7 +1083,9 @@ def _weights_progress_monitor(
 
         # Discover repo + HF_HOME from logs (these appear before the download starts).
         if repo_id is None or hf_home is None:
-            discovered_repo, discovered_home = _extract_repo_and_hf_home_from_job_logs(job_id)
+            discovered_repo, discovered_home = _extract_repo_and_hf_home_from_job_logs(
+                job_id
+            )
             if repo_id is None:
                 repo_id = discovered_repo
             if hf_home is None:
@@ -1050,31 +1100,44 @@ def _weights_progress_monitor(
             cached_announced_at = time.time()
             with progress_lock:
                 cur = progress_store.get(job_id)
-                if cur and cur.get("stage") not in {"container_setup", "finalizing", "complete"}:
+                if cur and cur.get("stage") not in {
+                    "container_setup",
+                    "finalizing",
+                    "complete",
+                }:
                     progress_val = max(cur.get("progress", 0) or 0, 39)
-                    cur.update({
-                        "status": "running",
-                        "stage": "model_preparation",
-                        "progress": progress_val,
-                        "message": "Weights already cached — skipping download",
-                        "downloaded_bytes": total_bytes,
-                        "total_bytes": total_bytes,
-                        "speed_bps": None,
-                        "eta_seconds": 0,
-                        "last_updated": time.time(),
-                    })
-        if cached_announced_at is not None and (time.time() - cached_announced_at) >= CACHED_LINGER_SECONDS:
+                    cur.update(
+                        {
+                            "status": "running",
+                            "stage": "model_preparation",
+                            "progress": progress_val,
+                            "message": "Weights already cached — skipping download",
+                            "downloaded_bytes": total_bytes,
+                            "total_bytes": total_bytes,
+                            "speed_bps": None,
+                            "eta_seconds": 0,
+                            "last_updated": time.time(),
+                        }
+                    )
+        if (
+            cached_announced_at is not None
+            and (time.time() - cached_announced_at) >= CACHED_LINGER_SECONDS
+        ):
             return
 
         if repo_id:
             if not total_bytes_attempted:
                 total_bytes_attempted = True
-                total_bytes = _fetch_hf_total_bytes(repo_id, os.getenv("HF_TOKEN") or "")
-            downloaded = _downloaded_bytes_for_location(hf_home, repo_id, weights_location)
+                total_bytes = _fetch_hf_total_bytes(
+                    repo_id, os.getenv("HF_TOKEN") or ""
+                )
+            downloaded = _downloaded_bytes_for_location(
+                hf_home, repo_id, weights_location
+            )
             now = time.time()
             dt = max(1e-3, now - last_t)
             delta = downloaded - last_bytes
-           
+
             if delta > MIN_SPEED_BPS:
                 stagnant_polls = 0
 
@@ -1111,7 +1174,11 @@ def _weights_progress_monitor(
                     return
                 status = cur.get("status")
                 stage = cur.get("stage")
-                if status not in {"starting", "running"} or stage in {"container_setup", "finalizing", "complete"}:
+                if status not in {"starting", "running"} or stage in {
+                    "container_setup",
+                    "finalizing",
+                    "complete",
+                }:
                     pass
                 else:
                     base = 15  # env+setup emits 15%
@@ -1119,10 +1186,14 @@ def _weights_progress_monitor(
                     progress_val = cur.get("progress", 0) or 0
                     # Without a known total size, we can't compute % completion. Still advance
                     # slightly so users can tell we're alive (cap below host-setup completion).
-                    progress_val = max(progress_val, min(max_before_host_setup_done, base + 1))
+                    progress_val = max(
+                        progress_val, min(max_before_host_setup_done, base + 1)
+                    )
 
-                    speed_txt = _format_bytes(ema_speed_bps) + "/s" if ema_speed_bps else "—"
-                    
+                    speed_txt = (
+                        _format_bytes(ema_speed_bps) + "/s" if ema_speed_bps else "—"
+                    )
+
                     if total_bytes and downloaded >= total_bytes:
                         msg = "Finalizing model weights and cache..."
                         eta_seconds = None
@@ -1152,9 +1223,15 @@ def _weights_progress_monitor(
                             "last_updated": time.time(),
                             "weights_repo": repo_id,
                             "downloaded_bytes": int(downloaded),
-                            "total_bytes": int(total_bytes) if total_bytes is not None else None,
-                            "speed_bps": float(ema_speed_bps) if ema_speed_bps is not None else None,
-                            "eta_seconds": float(eta_seconds) if eta_seconds is not None else None,
+                            "total_bytes": int(total_bytes)
+                            if total_bytes is not None
+                            else None,
+                            "speed_bps": float(ema_speed_bps)
+                            if ema_speed_bps is not None
+                            else None,
+                            "eta_seconds": float(eta_seconds)
+                            if eta_seconds is not None
+                            else None,
                         }
                     )
 
@@ -1190,7 +1267,7 @@ def _extract_from_job_logs(job_id: str) -> Dict[str, Optional[str]]:
 
 class ProgressHandler(logging.Handler):
     """Custom logging handler to capture progress from run.py execution"""
-    
+
     def __init__(self, job_id: str):
         super().__init__()
         self.job_id = job_id
@@ -1209,23 +1286,25 @@ class ProgressHandler(logging.Handler):
         with progress_lock:
             if job_id not in log_store:
                 log_store[job_id] = deque(maxlen=MAX_LOG_MESSAGES)
-        
+
     def emit(self, record):
         # Ignore records from other job threads to prevent cross-contamination
         # of log stores when multiple models are deployed concurrently.
         if record.thread != self._owner_thread:
             return
         message = record.getMessage()
-        
+
         # Store raw log message
         with progress_lock:
             if self.job_id in log_store:
-                log_store[self.job_id].append({
-                    "timestamp": record.created,
-                    "level": record.levelname,
-                    "message": message
-                })
-        
+                log_store[self.job_id].append(
+                    {
+                        "timestamp": record.created,
+                        "level": record.levelname,
+                        "message": message,
+                    }
+                )
+
         # 1) Structured DEBUG path - prefer this when available
         structured_parsed = False
         if record.levelno <= logging.DEBUG:
@@ -1247,13 +1326,15 @@ class ProgressHandler(logging.Handler):
                         else:
                             prev = cur.get("progress", 0)
                             pct = max(prev, pct)  # monotonic clamp
-                            progress_store[self.job_id].update({
-                                "status": status,
-                                "stage": stage,
-                                "progress": pct,
-                                "message": text[:200],
-                                "last_updated": time.time(),
-                            })
+                            progress_store[self.job_id].update(
+                                {
+                                    "status": status,
+                                    "stage": stage,
+                                    "progress": pct,
+                                    "message": text[:200],
+                                    "last_updated": time.time(),
+                                }
+                            )
                     else:
                         # Initialize if not exists
                         progress_store[self.job_id] = {
@@ -1270,19 +1351,36 @@ class ProgressHandler(logging.Handler):
             stage = "unknown"
             progress = 0
             status = "running"
-        
+
             # Based on the model_run.log patterns, parse deployment stages
-            if any(keyword in message.lower() for keyword in ["validate_runtime_args", "handle_secrets", "validate_local_setup"]):
+            if any(
+                keyword in message.lower()
+                for keyword in [
+                    "validate_runtime_args",
+                    "handle_secrets",
+                    "validate_local_setup",
+                ]
+            ):
                 stage = "initialization"
                 progress = 5
-            elif any(keyword in message.lower() for keyword in ["setup_host", "setting up python venv", "loaded environment"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in [
+                    "setup_host",
+                    "setting up python venv",
+                    "loaded environment",
+                ]
+            ):
                 stage = "setup"
                 progress = 15
             elif "setup already completed" in message.lower():
                 stage = "setup"
                 progress = 16
                 message = "Environment ready..."
-            elif any(keyword in message.lower() for keyword in ["downloading model", "huggingface-cli download"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in ["downloading model", "huggingface-cli download"]
+            ):
                 stage = "model_preparation"
                 progress = 28
             # HF metadata/config file fetch (e.g. "Fetching 15 files:  47%|...")
@@ -1291,14 +1389,17 @@ class ProgressHandler(logging.Handler):
                 progress = 20
                 message = "Downloading model configuration files..."
             # Docker image layer pull (e.g. "abc123: Download complete", "Pulling from ...")
-            elif any(keyword in message.lower() for keyword in [
-                "pulling from",
-                ": pulling fs layer",
-                ": download complete",
-                ": verifying checksum",
-                ": pull complete",
-                ": already exists",
-            ]):
+            elif any(
+                keyword in message.lower()
+                for keyword in [
+                    "pulling from",
+                    ": pulling fs layer",
+                    ": download complete",
+                    ": verifying checksum",
+                    ": pull complete",
+                    ": already exists",
+                ]
+            ):
                 stage = "container_setup"
                 msg_l = message.lower()
                 if ": pulling fs layer" in msg_l:
@@ -1306,7 +1407,9 @@ class ProgressHandler(logging.Handler):
                 elif ": pull complete" in msg_l or ": already exists" in msg_l:
                     self._pull_layers_complete += 1
                 if self._pull_layers_total > 0:
-                    ratio = min(1.0, self._pull_layers_complete / self._pull_layers_total)
+                    ratio = min(
+                        1.0, self._pull_layers_complete / self._pull_layers_total
+                    )
                     progress = 20 + int(ratio * 12)  # ramp 20 -> 32 during pull
                     message = (
                         f"Pulling container image layers "
@@ -1315,11 +1418,20 @@ class ProgressHandler(logging.Handler):
                 else:
                     progress = 20
                     message = "Pulling container image layers..."
-            elif any(keyword in message.lower() for keyword in ["docker image pulled successfully", "docker image available locally"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in [
+                    "docker image pulled successfully",
+                    "docker image available locally",
+                ]
+            ):
                 stage = "image_ready"
                 progress = 34
                 message = "Container image ready."
-            elif any(keyword in message.lower() for keyword in ["docker run command", "running docker container"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in ["docker run command", "running docker container"]
+            ):
                 stage = "container_setup"
                 progress = 42
                 message = "Creating and starting the container..."
@@ -1327,11 +1439,17 @@ class ProgressHandler(logging.Handler):
                 stage = "container_started"
                 progress = 60
                 message = "Container is running..."
-            elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in ["searching for container", "looking for container"]
+            ):
                 stage = "container_started"
                 progress = 64
                 message = "Locating the container..."
-            elif any(keyword in message.lower() for keyword in ["connected container", "tt_studio_network"]):
+            elif any(
+                keyword in message.lower()
+                for keyword in ["connected container", "tt_studio_network"]
+            ):
                 stage = "network_setup"
                 progress = 84
                 message = "Connecting to the network..."
@@ -1344,11 +1462,27 @@ class ProgressHandler(logging.Handler):
                 stage = "complete"
                 progress = 100
                 status = "completed"
-            elif any(p in message.lower() for p in ["401", "403", "token invalid", "access not granted", "gated repo", "unauthorized", "hf_token"]) and any(p in message.lower() for p in ["huggingface", "hugging face", "hf_token", "token"]):
+            elif any(
+                p in message.lower()
+                for p in [
+                    "401",
+                    "403",
+                    "token invalid",
+                    "access not granted",
+                    "gated repo",
+                    "unauthorized",
+                    "hf_token",
+                ]
+            ) and any(
+                p in message.lower()
+                for p in ["huggingface", "hugging face", "hf_token", "token"]
+            ):
                 status = "error"
                 stage = "error"
                 message = "HF_TOKEN authentication failed: your Hugging Face token is invalid, expired, or does not have access to this model. Re-run 'python run.py' to update your token."
-            elif any(keyword in message for keyword in ["⛔", "Error", "Failed", "error"]):
+            elif any(
+                keyword in message for keyword in ["⛔", "Error", "Failed", "error"]
+            ):
                 false_positives = [
                     "any errors will be in the logs",
                     "if you encounter any issues",
@@ -1360,27 +1494,39 @@ class ProgressHandler(logging.Handler):
                 if not any(fp in message.lower() for fp in false_positives):
                     status = "error"
                     stage = "error"
-                
+
             # Update progress store (only if we have meaningful progress)
             if progress > 0 or status in ["error", "completed"]:
                 with progress_lock:
                     if self.job_id in progress_store:
-                        current_progress = progress_store[self.job_id].get("progress", 0)
-                        current_status = progress_store[self.job_id].get("status", "running")
+                        current_progress = progress_store[self.job_id].get(
+                            "progress", 0
+                        )
+                        current_status = progress_store[self.job_id].get(
+                            "status", "running"
+                        )
                         # Never let a log-line override a terminal status
                         if current_status in ("completed", "failed", "cancelled"):
                             pass
-                        elif progress > current_progress or status == "error" or status == "completed":
+                        elif (
+                            progress > current_progress
+                            or status == "error"
+                            or status == "completed"
+                        ):
                             update_payload = {
                                 "status": status,
                                 "stage": stage,
                                 "progress": progress,
                                 "message": message[:200],
-                                "last_updated": time.time()
+                                "last_updated": time.time(),
                             }
                             if self._pull_layers_total > 0:
-                                update_payload["pull_layers_complete"] = self._pull_layers_complete
-                                update_payload["pull_layers_total"] = self._pull_layers_total
+                                update_payload["pull_layers_complete"] = (
+                                    self._pull_layers_complete
+                                )
+                                update_payload["pull_layers_total"] = (
+                                    self._pull_layers_total
+                                )
                             progress_store[self.job_id].update(update_payload)
                     else:
                         # Initialize if not exists
@@ -1389,7 +1535,7 @@ class ProgressHandler(logging.Handler):
                             "stage": stage,
                             "progress": progress,
                             "message": message[:200],
-                            "last_updated": time.time()
+                            "last_updated": time.time(),
                         }
 
 
@@ -1403,10 +1549,11 @@ class FastAPIHandler(logging.Handler):
         for line in message.splitlines() or [""]:
             logger.info(f"[RUN.PY] {line}")
 
+
 app = FastAPI(
     title="TT Inference Server API",
     description="Fast API wrapper for the TT Inference Server run script",
-    version="1.3.0"
+    version="1.3.0",
 )
 
 # Test logging on startup
@@ -1427,7 +1574,9 @@ def _prepull_weights_monitor_helper_image() -> None:
         client = docker.from_env()
         try:
             client.images.get(_DU_HELPER_IMAGE)
-            logger.info("weights-monitor helper image already present: %s", _DU_HELPER_IMAGE)
+            logger.info(
+                "weights-monitor helper image already present: %s", _DU_HELPER_IMAGE
+            )
             return
         except docker.errors.ImageNotFound:
             pass
@@ -1437,8 +1586,10 @@ def _prepull_weights_monitor_helper_image() -> None:
     except Exception as exc:
         logger.warning(
             "weights-monitor: could not pre-pull %s (%s); the monitor will retry per poll.",
-            _DU_HELPER_IMAGE, exc,
+            _DU_HELPER_IMAGE,
+            exc,
         )
+
 
 class RunRequest(BaseModel):
     model: str
@@ -1463,6 +1614,7 @@ class RunRequest(BaseModel):
     is_retry: Optional[bool] = False
     skip_system_sw_validation: Optional[bool] = False
 
+
 def normalize_device_alias(device: str) -> str:
     """Normalize device aliases to supported device names"""
     if not device:
@@ -1474,12 +1626,14 @@ def normalize_device_alias(device: str) -> str:
     }
     return alias_map.get(device.strip().lower(), device)
 
+
 def get_model_run_logs_dir():
     """Get the per-deployment model run logs directory under TT Studio root's logs/"""
     tt_studio_root = Path(__file__).parent.parent.resolve()
     model_run_logs_dir = tt_studio_root / "logs" / "model_run_logs"
     model_run_logs_dir.mkdir(parents=True, exist_ok=True)
     return model_run_logs_dir
+
 
 def create_deployment_log_handler(job_id: str, model: str, device: str):
     """Create a per-deployment log file handler with model and device in filename"""
@@ -1489,23 +1643,24 @@ def create_deployment_log_handler(job_id: str, model: str, device: str):
     # Create log file with pattern: model_run_YYYY-MM-DD_HH-MM-SS_ModelName_device_server.log
     log_filename = f"model_run_{timestamp}_{model}_{device}_server.log"
     log_file_path = model_run_logs_dir / log_filename
-    
+
     # Create file handler
-    file_handler = logging.FileHandler(log_file_path, mode='w')
+    file_handler = logging.FileHandler(log_file_path, mode="w")
     file_handler.setLevel(logging.DEBUG)
-    
+
     # Use workflow log format
     formatter = logging.Formatter(
         "%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s: %(message)s"
     )
     file_handler.setFormatter(formatter)
-    
+
     # Store handler reference for cleanup
     with progress_lock:
         deployment_log_handlers[job_id] = file_handler
-    
+
     logger.info(f"Created per-deployment log file: {log_file_path}")
     return file_handler, log_file_path
+
 
 class _RunLogForwarder(logging.Handler):
     """Module-level singleton handler that forwards run_log records to the
@@ -1541,10 +1696,12 @@ def setup_run_logging_to_fastapi():
         logger.info("Added FastAPI logging handler to run_log logger")
     _run_log_forwarder_installed = True
 
+
 @app.get("/")
 async def root():
     logger.info("Root endpoint accessed")
     return {"message": "TT Inference Server API is running"}
+
 
 @app.get("/health")
 async def health():
@@ -1554,6 +1711,8 @@ async def health():
         "status": "ok",
         "timestamp": time.time(),
     }
+
+
 @app.get("/test-logging")
 async def test_logging():
     """Test endpoint to verify logging is working"""
@@ -1561,33 +1720,40 @@ async def test_logging():
     logger.debug("Debug level test message")
     logger.warning("Warning level test message")
     return {
-        "message": "Logging test completed", 
+        "message": "Logging test completed",
         "check": "model_run.log file for log messages",
-        "timestamp": time.time()
+        "timestamp": time.time(),
     }
+
 
 @app.get("/run/progress/{job_id}")
 async def get_run_progress(job_id: str):
     """Get progress for a running deployment job"""
     with progress_lock:
-        progress = progress_store.get(job_id, {
-            "status": "not_found",
-            "stage": "unknown",
-            "progress": 0,
-            "message": "Job not found",
-            "last_updated": time.time()
-        })
-        
+        progress = progress_store.get(
+            job_id,
+            {
+                "status": "not_found",
+                "stage": "unknown",
+                "progress": 0,
+                "message": "Job not found",
+                "last_updated": time.time(),
+            },
+        )
+
         # Add stalled detection (>120s no updates from run.py)
         if progress["status"] == "running" and "last_updated" in progress:
             time_since_update = time.time() - progress["last_updated"]
             if time_since_update > PULL_STALL_THRESHOLD_SECONDS:
                 progress = progress.copy()  # Don't modify the stored version
                 progress["status"] = "stalled"
-                progress["message"] = f"No progress updates for {int(time_since_update)}s - deployment may be stalled"
+                progress["message"] = (
+                    f"No progress updates for {int(time_since_update)}s - deployment may be stalled"
+                )
                 progress["stale_seconds"] = int(time_since_update)
-                
+
     return progress
+
 
 @app.get("/run/logs/{job_id}")
 async def get_run_logs(job_id: str, limit: int = 50):
@@ -1596,88 +1762,102 @@ async def get_run_logs(job_id: str, limit: int = 50):
         logs = log_store.get(job_id, deque())
         # Convert deque to list and get last 'limit' messages
         log_list = list(logs)[-limit:] if logs else []
-    
-    return {
-        "job_id": job_id,
-        "logs": log_list,
-        "total_messages": len(log_list)
-    }
+
+    return {"job_id": job_id, "logs": log_list, "total_messages": len(log_list)}
+
 
 @app.get("/run/stream/{job_id}")
 async def stream_run_progress(job_id: str):
     """Stream real-time progress updates via Server-Sent Events"""
-    
+
     def event_generator():
         last_progress = None
-        
+
         # Send initial progress if available
         with progress_lock:
             if job_id in progress_store:
                 last_progress = progress_store[job_id].copy()
                 yield f"data: {json.dumps(last_progress)}\n\n"
-        
+
         # Poll for updates and stream changes
         while True:
             try:
                 with progress_lock:
                     current_progress = progress_store.get(job_id)
-                    
+
                     if current_progress:
                         # Check if progress has changed
                         if not last_progress or current_progress != last_progress:
                             last_progress = current_progress.copy()
-                            
+
                             # Add stalled detection (>5 hours no updates)
                             # Changed from 120s to 5 hours to accommodate long model downloads
-                            if current_progress["status"] == "running" and "last_updated" in current_progress:
-                                time_since_update = time.time() - current_progress["last_updated"]
-                                if time_since_update > DEPLOYMENT_TIMEOUT_SECONDS:  # 5 hours
+                            if (
+                                current_progress["status"] == "running"
+                                and "last_updated" in current_progress
+                            ):
+                                time_since_update = (
+                                    time.time() - current_progress["last_updated"]
+                                )
+                                if (
+                                    time_since_update > DEPLOYMENT_TIMEOUT_SECONDS
+                                ):  # 5 hours
                                     last_progress["status"] = "stalled"
-                                    last_progress["message"] = f"No progress updates for {int(time_since_update/60)} minutes - deployment may be stalled"
-                            
+                                    last_progress["message"] = (
+                                        f"No progress updates for {int(time_since_update/60)} minutes - deployment may be stalled"
+                                    )
+
                             yield f"data: {json.dumps(last_progress)}\n\n"
-                            
+
                             # Stop streaming if deployment is complete or failed
-                            if last_progress["status"] in ["completed", "error", "failed", "cancelled"]:
+                            if last_progress["status"] in [
+                                "completed",
+                                "error",
+                                "failed",
+                                "cancelled",
+                            ]:
                                 break
                     else:
                         # Job not found
                         yield f"data: {json.dumps({'status': 'not_found', 'message': 'Job not found'})}\n\n"
                         break
-                
+
                 # Wait before next poll
                 time.sleep(1)
-                
+
             except Exception as e:
                 logger.error(f"Error in SSE stream: {str(e)}")
                 yield f"data: {json.dumps({'status': 'error', 'message': f'Stream error: {str(e)}'})}\n\n"
                 break
-    
+
     # Only enable SSE if TT_PROGRESS_SSE is set
     if os.getenv("TT_PROGRESS_SSE") != "1":
         raise HTTPException(status_code=404, detail="SSE endpoint not enabled")
-    
+
     return StreamingResponse(
         event_generator(),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "X-Accel-Buffering": "no"
-        }
+            "X-Accel-Buffering": "no",
+        },
     )
+
 
 def sync_tokens_from_tt_studio():
     """
-    Cross-check and sync JWT_SECRET and HF_TOKEN from TT Studio's .env 
+    Cross-check and sync JWT_SECRET and HF_TOKEN from TT Studio's .env
     to inference server's .env file if they differ.
     """
     from workflows.utils import load_dotenv
-    
+
     # Paths to .env files
     tt_studio_root = os.getenv("TT_STUDIO_ROOT")
     if not tt_studio_root:
-        logger.warning("TT_STUDIO_ROOT environment variable not set, cannot sync tokens")
+        logger.warning(
+            "TT_STUDIO_ROOT environment variable not set, cannot sync tokens"
+        )
         return
     tt_studio_env = Path(tt_studio_root) / ".env"
 
@@ -1686,80 +1866,87 @@ def sync_tokens_from_tt_studio():
         inference_server_env = Path(artifact_path) / ".env"
     else:
         inference_server_env = tt_studio_root / ".env"
-    
+
     # Read TT Studio .env values
     tt_studio_jwt = None
     tt_studio_hf = None
-    
+
     if tt_studio_env.exists():
-        with open(tt_studio_env, 'r') as f:
+        with open(tt_studio_env, "r") as f:
             for line in f:
                 line = line.strip()
-                if line and not line.startswith('#'):
-                    if '=' in line:
-                        key, value = line.split('=', 1)
+                if line and not line.startswith("#"):
+                    if "=" in line:
+                        key, value = line.split("=", 1)
                         key = key.strip()
                         value = value.strip().strip('"').strip("'")
-                        if key == 'JWT_SECRET':
+                        if key == "JWT_SECRET":
                             tt_studio_jwt = value
-                        elif key == 'HF_TOKEN':
+                        elif key == "HF_TOKEN":
                             tt_studio_hf = value
     else:
         logger.warning(f"TT Studio .env file not found at {tt_studio_env}")
         return
-    
+
     # Read inference server .env values
     inference_jwt = None
     inference_hf = None
     env_lines = []
-    
+
     if inference_server_env.exists():
-        with open(inference_server_env, 'r') as f:
+        with open(inference_server_env, "r") as f:
             env_lines = f.readlines()
             for line in env_lines:
                 line_stripped = line.strip()
-                if line_stripped and not line_stripped.startswith('#'):
-                    if '=' in line_stripped:
-                        key, value = line_stripped.split('=', 1)
+                if line_stripped and not line_stripped.startswith("#"):
+                    if "=" in line_stripped:
+                        key, value = line_stripped.split("=", 1)
                         key = key.strip()
                         value = value.strip().strip('"').strip("'")
-                        if key == 'JWT_SECRET':
+                        if key == "JWT_SECRET":
                             inference_jwt = value
-                        elif key == 'HF_TOKEN':
+                        elif key == "HF_TOKEN":
                             inference_hf = value
-    
+
     # Check for differences and update if needed
     updated = False
-    
+
     # Update or add JWT_SECRET
     if tt_studio_jwt and tt_studio_jwt != inference_jwt:
-        logger.info("JWT_SECRET differs between TT Studio and inference server - updating inference server .env")
+        logger.info(
+            "JWT_SECRET differs between TT Studio and inference server - updating inference server .env"
+        )
         # Remove old JWT_SECRET line if exists
-        env_lines = [line for line in env_lines 
-                    if not line.strip().startswith('JWT_SECRET=')]
+        env_lines = [
+            line for line in env_lines if not line.strip().startswith("JWT_SECRET=")
+        ]
         # Add new JWT_SECRET
         env_lines.append(f"JWT_SECRET={tt_studio_jwt}\n")
         updated = True
-    
+
     # Update or add HF_TOKEN
     if tt_studio_hf and tt_studio_hf != inference_hf:
-        logger.info("HF_TOKEN differs between TT Studio and inference server - updating inference server .env")
+        logger.info(
+            "HF_TOKEN differs between TT Studio and inference server - updating inference server .env"
+        )
         # Remove old HF_TOKEN line if exists
-        env_lines = [line for line in env_lines 
-                    if not line.strip().startswith('HF_TOKEN=')]
+        env_lines = [
+            line for line in env_lines if not line.strip().startswith("HF_TOKEN=")
+        ]
         # Add new HF_TOKEN
         env_lines.append(f"HF_TOKEN={tt_studio_hf}\n")
         updated = True
-    
+
     # Write back if updated
     if updated:
-        with open(inference_server_env, 'w') as f:
+        with open(inference_server_env, "w") as f:
             f.writelines(env_lines)
         logger.info(f"Updated inference server .env file at {inference_server_env}")
         # Reload environment variables
         load_dotenv()
     else:
         logger.info("JWT_SECRET and HF_TOKEN are already synchronized")
+
 
 @app.post("/run")
 async def run_inference(request: RunRequest):
@@ -1776,17 +1963,17 @@ async def run_inference(request: RunRequest):
             )
         # Generate a unique job ID for this deployment
         job_id = str(uuid.uuid4())[:8]
-        
+
         # Create per-deployment log file
         deployment_log_handler, deployment_log_path = create_deployment_log_handler(
             job_id, request.model, request.device
         )
-        
+
         # Attach deployment log handler to relevant loggers
         logger.addHandler(deployment_log_handler)
         run_logger = logging.getLogger("run_log")
         run_logger.addHandler(deployment_log_handler)
-        
+
         # Initialize progress tracking
         with progress_lock:
             progress_store[job_id] = {
@@ -1794,30 +1981,34 @@ async def run_inference(request: RunRequest):
                 "stage": "initialization",
                 "progress": 0,
                 "message": "Starting deployment...",
-                "last_updated": time.time()
+                "last_updated": time.time(),
             }
             log_store[job_id] = deque(maxlen=MAX_LOG_MESSAGES)
-        
+
         # Sync tokens from TT Studio before setting environment variables
         try:
             sync_tokens_from_tt_studio()
         except Exception as e:
             logger.warning(f"Failed to sync tokens from TT Studio: {e}")
             # Continue anyway - tokens might be set via request or environment
-        
+
         # Ensure we're in the correct working directory (use artifact directory if available)
         if artifact_path and os.path.exists(artifact_path):
             script_dir = Path(artifact_path).resolve()
         else:
             # Fallback: try to find artifact directory in standard location
-            default_artifact_dir = Path(__file__).parent.parent / ".artifacts" / "tt-inference-server"
+            default_artifact_dir = (
+                Path(__file__).parent.parent / ".artifacts" / "tt-inference-server"
+            )
             if default_artifact_dir.exists():
                 script_dir = default_artifact_dir.resolve()
                 logger.info(f"Using default artifact directory: {script_dir}")
             else:
                 script_dir = Path(__file__).parent.absolute()
-                logger.warning(f"Artifact directory not found, using inference-api directory: {script_dir}")
-        
+                logger.warning(
+                    f"Artifact directory not found, using inference-api directory: {script_dir}"
+                )
+
         # Set required environment variables for automatic setup
         # Note: Since the FastAPI server now runs as the actual user (not root),
         # Path.home() in get_default_hf_home_path() will correctly return the user's home directory
@@ -1825,40 +2016,43 @@ async def run_inference(request: RunRequest):
         env_vars_to_set = {
             "AUTOMATIC_HOST_SETUP": "True",
             "TT_PROGRESS_DEBUG": "1",  # Enable structured progress emission
-            "TT_PROGRESS_SSE": "1",     # Enable SSE endpoint for real-time progress
-            "SERVICE_PORT": request.service_port or "7000",  # Use requested port (per-slot)
+            "TT_PROGRESS_SSE": "1",  # Enable SSE endpoint for real-time progress
+            "SERVICE_PORT": request.service_port
+            or "7000",  # Use requested port (per-slot)
             "HF_HUB_DISABLE_XET": "1",  # force synchronous HTTPS download; XET exits 0 before blobs finish
         }
-        
+
         # Handle secrets - use from request if provided and not already in environment
         if request.jwt_secret and not os.getenv("JWT_SECRET"):
             logger.info("Setting JWT_SECRET from request")
             env_vars_to_set["JWT_SECRET"] = request.jwt_secret
         elif not os.getenv("JWT_SECRET"):
             logger.warning("JWT_SECRET not set - this may cause issues")
-            
+
         if request.hf_token and not os.getenv("HF_TOKEN"):
             logger.info("Setting HF_TOKEN from request")
             env_vars_to_set["HF_TOKEN"] = request.hf_token
         elif not os.getenv("HF_TOKEN"):
-            logger.warning("HF_TOKEN not set - this may cause issues with model downloads")
-            
+            logger.warning(
+                "HF_TOKEN not set - this may cause issues with model downloads"
+            )
+
         # Convert the request to command line arguments
         base_argv = ["run.py"]
-        
+
         # Add required arguments
         base_argv.extend(["--model", request.model])
         base_argv.extend(["--workflow", request.workflow])
         base_argv.extend(["--device", normalized_device])
         base_argv.extend(["--docker-server"])
-         # Add dev-mode if requested (used for auto-retry on failure)
+        # Add dev-mode if requested (used for auto-retry on failure)
         if request.dev_mode:
             base_argv.extend(["--dev-mode"])
         # Skip system software validation if requested (handles prerelease versions like '2.6.0-rc1')
         if request.skip_system_sw_validation:
             base_argv.extend(["--skip-system-sw-validation"])
         base_argv.extend(["--service-port", request.service_port or "7000"])
-        
+
         # Add optional arguments if they are set
         if request.impl:
             base_argv.extend(["--impl", request.impl])
@@ -1931,7 +2125,10 @@ async def run_inference(request: RunRequest):
         # Media (DiT) models reuse the host's already-downloaded HF weights via
         # --host-hf-cache. This is mutually exclusive with the Qwen --host-volume
         # path: Qwen uses host-volume, media uses hf-cache; they shouldn't combine.
-        if _model_uses_host_hf_cache(request.model) and "--host-volume" not in initial_argv:
+        if (
+            _model_uses_host_hf_cache(request.model)
+            and "--host-volume" not in initial_argv
+        ):
             host_hf_cache_path = str(_default_hf_home())
             # Ensure the HF cache dir exists. tt-inference-server's
             # validate_bind_mount_permissions() ValueErrors on a non-existent
@@ -1965,6 +2162,7 @@ async def run_inference(request: RunRequest):
                 job_id,
                 host_hf_cache_skip_reason,
             )
+
         def _run_job_in_background():
             weights_stop_event = threading.Event()
             progress_handler = None
@@ -1973,7 +2171,13 @@ async def run_inference(request: RunRequest):
                 # Start weights progress monitor (keeps progress moving during long hf downloads)
                 threading.Thread(
                     target=_weights_progress_monitor,
-                    args=(job_id, weights_stop_event, request.model, normalized_device, request.impl),
+                    args=(
+                        job_id,
+                        weights_stop_event,
+                        request.model,
+                        normalized_device,
+                        request.impl,
+                    ),
                     daemon=True,
                 ).start()
 
@@ -1992,9 +2196,13 @@ async def run_inference(request: RunRequest):
                         # Apply env vars (including secrets if provided)
                         for key, value in env_vars_to_set.items():
                             if key in ["JWT_SECRET", "HF_TOKEN"]:
-                                logger.info(f"Setting environment variable: {key}=[REDACTED]")
+                                logger.info(
+                                    f"Setting environment variable: {key}=[REDACTED]"
+                                )
                             else:
-                                logger.info(f"Setting environment variable: {key}={value}")
+                                logger.info(
+                                    f"Setting environment variable: {key}={value}"
+                                )
                             os.environ[key] = value
 
                         # Switch cwd for tt-inference-server execution
@@ -2003,9 +2211,15 @@ async def run_inference(request: RunRequest):
 
                         sys.argv = list(initial_argv)
 
-                        def _execute_run(argv_for_attempt: list[str]) -> Tuple[int, Optional[Dict[str, Any]]]:
+                        def _execute_run(
+                            argv_for_attempt: list[str],
+                        ) -> Tuple[int, Optional[Dict[str, Any]]]:
                             """Execute run_main() for one attempt and return (code, container_info)."""
-                            attempt_mode = "host-volume" if "--host-volume" in argv_for_attempt else "baseline"
+                            attempt_mode = (
+                                "host-volume"
+                                if "--host-volume" in argv_for_attempt
+                                else "baseline"
+                            )
                             sys.argv = argv_for_attempt
                             logger.info(
                                 f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}"
@@ -2022,23 +2236,42 @@ async def run_inference(request: RunRequest):
                             else:
                                 attempt_return_code = run_result
                                 attempt_container_info = None
-                            logger.info(f"Job {job_id}: run_main() return code: {attempt_return_code}")
-                            logger.info(f"Job {job_id}: container_info:= {attempt_container_info}")
+                            logger.info(
+                                f"Job {job_id}: run_main() return code: {attempt_return_code}"
+                            )
+                            logger.info(
+                                f"Job {job_id}: container_info:= {attempt_container_info}"
+                            )
                             return attempt_return_code, attempt_container_info
 
                         def _build_retry_argv_and_reason() -> Tuple[list[str], str]:
                             retry_argv = list(sys.argv)
                             retry_reason_parts: list[str] = []
                             if "--host-volume" in retry_argv:
-                                retry_argv = _strip_cli_option(retry_argv, "--host-volume")
-                                retry_reason_parts.append("baseline startup without --host-volume")
+                                retry_argv = _strip_cli_option(
+                                    retry_argv, "--host-volume"
+                                )
+                                retry_reason_parts.append(
+                                    "baseline startup without --host-volume"
+                                )
                             if "--host-hf-cache" in retry_argv:
-                                retry_argv = _strip_cli_option(retry_argv, "--host-hf-cache")
-                                retry_reason_parts.append("baseline startup without --host-hf-cache")
-                            if request.skip_system_sw_validation and "--skip-system-sw-validation" not in retry_argv:
+                                retry_argv = _strip_cli_option(
+                                    retry_argv, "--host-hf-cache"
+                                )
+                                retry_reason_parts.append(
+                                    "baseline startup without --host-hf-cache"
+                                )
+                            if (
+                                request.skip_system_sw_validation
+                                and "--skip-system-sw-validation" not in retry_argv
+                            ):
                                 retry_argv.append("--skip-system-sw-validation")
                                 retry_reason_parts.append("--skip-system-sw-validation")
-                            retry_reason = " and ".join(retry_reason_parts) if retry_reason_parts else "same options"
+                            retry_reason = (
+                                " and ".join(retry_reason_parts)
+                                if retry_reason_parts
+                                else "same options"
+                            )
                             return retry_argv, retry_reason
 
                         try:
@@ -2051,7 +2284,9 @@ async def run_inference(request: RunRequest):
                             # root-owned (leftover from a previous sudo-based startup). Retrying
                             # with different Docker args won't help — re-raise immediately so the
                             # caller gets a clear error instead of a misleading retry.
-                            if isinstance(first_attempt_error, PermissionError) and "workflow_logs" in str(first_attempt_error):
+                            if isinstance(
+                                first_attempt_error, PermissionError
+                            ) and "workflow_logs" in str(first_attempt_error):
                                 logger.error(
                                     "Job %s: PermissionError on workflow_logs directory — directory is likely "
                                     "root-owned from a previous sudo-based startup. Fix with: "
@@ -2061,7 +2296,10 @@ async def run_inference(request: RunRequest):
                                 )
                                 raise
                             retry_argv, retry_reason = _build_retry_argv_and_reason()
-                            if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
+                            if (
+                                "--host-volume" in sys.argv
+                                and _job_has_host_volume_weights_warning(job_id)
+                            ):
                                 logger.warning(
                                     "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
                                     job_id,
@@ -2076,7 +2314,9 @@ async def run_inference(request: RunRequest):
                             )
                             with progress_lock:
                                 if job_id in progress_store:
-                                    current_progress = progress_store[job_id].get("progress", 0)
+                                    current_progress = progress_store[job_id].get(
+                                        "progress", 0
+                                    )
                                     progress_store[job_id].update(
                                         {
                                             "status": "retrying",
@@ -2091,7 +2331,10 @@ async def run_inference(request: RunRequest):
                         # Retry once when the initial run fails.
                         if return_code != 0:
                             retry_argv, retry_reason = _build_retry_argv_and_reason()
-                            if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
+                            if (
+                                "--host-volume" in sys.argv
+                                and _job_has_host_volume_weights_warning(job_id)
+                            ):
                                 logger.warning(
                                     "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
                                     job_id,
@@ -2106,7 +2349,9 @@ async def run_inference(request: RunRequest):
                             )
                             with progress_lock:
                                 if job_id in progress_store:
-                                    current_progress = progress_store[job_id].get("progress", 0)
+                                    current_progress = progress_store[job_id].get(
+                                        "progress", 0
+                                    )
                                     progress_store[job_id].update(
                                         {
                                             "status": "retrying",
@@ -2146,30 +2391,46 @@ async def run_inference(request: RunRequest):
                         f"run_log_file_path={extracted.get('run_log_file_path')!r}"
                     )
 
-                    if not isinstance(container_info, dict) or not container_info.get("container_name"):
+                    if not isinstance(container_info, dict) or not container_info.get(
+                        "container_name"
+                    ):
                         inferred_name = extracted.get("container_name")
                         if inferred_name:
                             container_info = {
                                 "container_name": inferred_name,
                                 "container_id": None,
                                 "service_port": str(os.getenv("SERVICE_PORT") or ""),
-                                "docker_log_file_path": extracted.get("docker_log_file_path"),
+                                "docker_log_file_path": extracted.get(
+                                    "docker_log_file_path"
+                                ),
                                 "run_log_file_path": extracted.get("run_log_file_path"),
                             }
-                            logger.info(f"Job {job_id}: inferred container_name='{inferred_name}' from logs.")
+                            logger.info(
+                                f"Job {job_id}: inferred container_name='{inferred_name}' from logs."
+                            )
 
-                    container_name = container_info.get("container_name") if isinstance(container_info, dict) else None
-                    container_id = container_info.get("container_id") if isinstance(container_info, dict) else None
+                    container_name = (
+                        container_info.get("container_name")
+                        if isinstance(container_info, dict)
+                        else None
+                    )
+                    container_id = (
+                        container_info.get("container_id")
+                        if isinstance(container_info, dict)
+                        else None
+                    )
                     # Prefer container_info value; fall back to log-extracted value so that
                     # docker_log_file_path is never lost when container name extraction fails.
                     docker_log_file_path = (
-                        (container_info.get("docker_log_file_path") if isinstance(container_info, dict) else None)
-                        or extracted.get("docker_log_file_path")
-                    )
+                        container_info.get("docker_log_file_path")
+                        if isinstance(container_info, dict)
+                        else None
+                    ) or extracted.get("docker_log_file_path")
                     run_log_file_path = (
-                        (container_info.get("run_log_file_path") if isinstance(container_info, dict) else None)
-                        or extracted.get("run_log_file_path")
-                    )
+                        container_info.get("run_log_file_path")
+                        if isinstance(container_info, dict)
+                        else None
+                    ) or extracted.get("run_log_file_path")
 
                     response_data = {
                         "job_id": job_id,
@@ -2189,25 +2450,38 @@ async def run_inference(request: RunRequest):
                     def _advance(stage_name: str, pct: int, msg: str) -> None:
                         with progress_lock:
                             cur = progress_store.get(job_id)
-                            if not cur or cur.get("status") in ("completed", "failed", "cancelled", "error"):
+                            if not cur or cur.get("status") in (
+                                "completed",
+                                "failed",
+                                "cancelled",
+                                "error",
+                            ):
                                 return
-                            cur.update({
-                                "status": "running",
-                                "stage": stage_name,
-                                "progress": max(cur.get("progress", 0), pct),
-                                "message": msg,
-                                "last_updated": time.time(),
-                            })
+                            cur.update(
+                                {
+                                    "status": "running",
+                                    "stage": stage_name,
+                                    "progress": max(cur.get("progress", 0), pct),
+                                    "message": msg,
+                                    "last_updated": time.time(),
+                                }
+                            )
 
                     # Container process is up; we're now locating it to wire up networking.
-                    _advance("container_started", 60, "Container started, locating it...")
+                    _advance(
+                        "container_started", 60, "Container started, locating it..."
+                    )
 
                     # Best-effort: connect to tt_studio_network and rename container
                     try:
                         client = docker.from_env()
                         target_container_name = container_name
                         target_container_id = container_id
-                        service_port = (container_info or {}).get("service_port") if isinstance(container_info, dict) else None
+                        service_port = (
+                            (container_info or {}).get("service_port")
+                            if isinstance(container_info, dict)
+                            else None
+                        )
 
                         max_retries = 10
                         retry_interval = 3
@@ -2227,9 +2501,13 @@ async def run_inference(request: RunRequest):
                                         break
                             if not new_container and service_port:
                                 for c in all_containers:
-                                    container_ports = c.attrs.get("NetworkSettings", {}).get("Ports", {})
+                                    container_ports = c.attrs.get(
+                                        "NetworkSettings", {}
+                                    ).get("Ports", {})
                                     for port_config in container_ports.values():
-                                        if port_config and port_config[0].get("HostPort") == str(service_port):
+                                        if port_config and port_config[0].get(
+                                            "HostPort"
+                                        ) == str(service_port):
                                             new_container = c
                                             break
                                     if new_container:
@@ -2243,13 +2521,17 @@ async def run_inference(request: RunRequest):
                             original_name = new_container.name
                             if new_container.id:
                                 response_data["container_id"] = new_container.id
-                            _advance("network_setup", 72, "Connecting to the network...")
+                            _advance(
+                                "network_setup", 72, "Connecting to the network..."
+                            )
                             try:
                                 network = client.networks.get("tt_studio_network")
                                 network.connect(new_container)
                             except Exception:
                                 pass
-                            _advance("network_setup", 84, "Network connected, finalizing...")
+                            _advance(
+                                "network_setup", 84, "Network connected, finalizing..."
+                            )
                             # Rename for easier identification
                             model_name = request.model.replace("/", "-")
                             if original_name != model_name:
@@ -2271,19 +2553,42 @@ async def run_inference(request: RunRequest):
                                     "progress": 100,
                                     "message": "Deployment completed successfully",
                                     "last_updated": time.time(),
-                                    "container_name": response_data.get("container_name"),
+                                    "container_name": response_data.get(
+                                        "container_name"
+                                    ),
                                     "container_id": response_data.get("container_id"),
-                                    "docker_log_file_path": response_data.get("docker_log_file_path"),
-                                    "run_log_file_path": response_data.get("run_log_file_path"),
+                                    "docker_log_file_path": response_data.get(
+                                        "docker_log_file_path"
+                                    ),
+                                    "run_log_file_path": response_data.get(
+                                        "run_log_file_path"
+                                    ),
                                 }
                             )
                 else:
                     # Scan recent logs for auth errors to surface a clear message
-                    auth_patterns = ["401", "403", "token invalid", "access not granted", "gated repo", "unauthorized", "hf_token", "gatedrepoerror"]
+                    auth_patterns = [
+                        "401",
+                        "403",
+                        "token invalid",
+                        "access not granted",
+                        "gated repo",
+                        "unauthorized",
+                        "hf_token",
+                        "gatedrepoerror",
+                    ]
                     auth_error_msg = None
                     for entry in reversed(list(log_store.get(job_id, []))):
                         msg = entry.get("message", "").lower()
-                        if any(p in msg for p in auth_patterns) and any(p in msg for p in ["huggingface", "hugging face", "hf_token", "token"]):
+                        if any(p in msg for p in auth_patterns) and any(
+                            p in msg
+                            for p in [
+                                "huggingface",
+                                "hugging face",
+                                "hf_token",
+                                "token",
+                            ]
+                        ):
                             auth_error_msg = "HF_TOKEN authentication failed: your Hugging Face token is invalid, expired, or does not have access to this model. Re-run 'python run.py' to update your token."
                             break
                     with progress_lock:
@@ -2293,7 +2598,8 @@ async def run_inference(request: RunRequest):
                                     "status": "failed",
                                     "stage": "error",
                                     "progress": 0,
-                                    "message": auth_error_msg or f"Deployment failed with return code: {return_code}",
+                                    "message": auth_error_msg
+                                    or f"Deployment failed with return code: {return_code}",
                                     "last_updated": time.time(),
                                 }
                             )
@@ -2348,42 +2654,42 @@ async def run_inference(request: RunRequest):
             },
             headers={"Location": f"/run/progress/{job_id}"},
         )
-            
+
     except Exception as e:
         logger.error(f"Error in run_inference: {str(e)}", exc_info=True)
-        
+
         # Clean up per-deployment log handler if it was created
-        if 'deployment_log_handler' in locals() and deployment_log_handler:
+        if "deployment_log_handler" in locals() and deployment_log_handler:
             try:
                 logger.removeHandler(deployment_log_handler)
                 run_logger = logging.getLogger("run_log")
                 run_logger.removeHandler(deployment_log_handler)
                 deployment_log_handler.close()
-                if 'job_id' in locals():
+                if "job_id" in locals():
                     with progress_lock:
                         if job_id in deployment_log_handlers:
                             del deployment_log_handlers[job_id]
             except Exception as cleanup_error:
-                logger.error(f"Error cleaning up deployment log handler in exception handler: {cleanup_error}")
-        
+                logger.error(
+                    f"Error cleaning up deployment log handler in exception handler: {cleanup_error}"
+                )
+
         # Update progress for exception
-        if 'job_id' in locals():
+        if "job_id" in locals():
             with progress_lock:
                 if job_id in progress_store:
-                    progress_store[job_id].update({
-                        "status": "error",
-                        "stage": "error",
-                        "progress": 0,
-                        "message": f"Deployment error: {str(e)[:200]}",
-                        "last_updated": time.time()
-                    })
-        
-        # Restore working directory in case of exception
-        if 'original_cwd' in locals() and 'script_dir' in locals() and original_cwd != script_dir:
-            os.chdir(original_cwd)
-        
+                    progress_store[job_id].update(
+                        {
+                            "status": "error",
+                            "stage": "error",
+                            "progress": 0,
+                            "message": f"Deployment error: {str(e)[:200]}",
+                            "last_updated": time.time(),
+                        }
+                    )
+
         # Return JSONResponse instead of raising HTTPException to include job_id
-        if 'job_id' in locals():
+        if "job_id" in locals():
             return JSONResponse(
                 status_code=500,
                 content={
@@ -2391,12 +2697,13 @@ async def run_inference(request: RunRequest):
                     "job_id": job_id,
                     "message": f"Deployment error: {str(e)}",
                     "progress_url": f"/run/progress/{job_id}",
-                    "logs_url": f"/run/logs/{job_id}"
-                }
+                    "logs_url": f"/run/logs/{job_id}",
+                },
             )
         else:
             # If job_id wasn't created yet, raise HTTPException
             raise HTTPException(status_code=500, detail=str(e))
+
 
 @app.get("/resolve-image")
 async def resolve_image(model: str, device: str, impl: Optional[str] = None):
@@ -2408,9 +2715,17 @@ async def resolve_image(model: str, device: str, impl: Optional[str] = None):
     """
     try:
         model_spec, _, _ = get_runtime_model_spec(model, device, impl=impl)
-        return {"status": "success", "model": model, "device": device, "docker_image": model_spec.docker_image}
+        return {
+            "status": "success",
+            "model": model,
+            "device": device,
+            "docker_image": model_spec.docker_image,
+        }
     except Exception as e:
-        raise HTTPException(status_code=404, detail=f"Could not resolve image for model={model}, device={device}: {e}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Could not resolve image for model={model}, device={device}: {e}",
+        )
 
 
 @app.get("/models")
@@ -2418,12 +2733,14 @@ async def get_available_models():
     """Get list of available models"""
     return {"models": list(set(spec.model_name for _, spec in MODEL_SPECS.items()))}
 
+
 @app.get("/workflows")
 async def get_available_workflows():
     """Get list of available workflows"""
     return {"workflows": [w.name.lower() for w in WorkflowType]}
 
+
 @app.get("/devices")
 async def get_available_devices():
     """Get list of available devices"""
-    return {"devices": [d.name.lower() for d in DeviceTypes]} 
+    return {"devices": [d.name.lower() for d in DeviceTypes]}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# Ruff configuration for TT-Studio Python services. Matches the pinned
+# pre-commit hook (dev-tools/.pre-commit-config.yaml, ruff v0.7.0) which runs
+# ruff with its default rule set (pyflakes `F` + a subset of pycodestyle `E`).
+
+target-version = "py311"
+
+extend-exclude = [
+    ".artifacts",
+    "tt_studio_persistent_volume",
+    "node_modules",
+    "**/migrations/**",
+    ".venv",
+]


### PR DESCRIPTION
## Problem

The repo has no ruff config and a backlog of lint errors/unformatted files across the Python services. A backend CI lint gate can't be introduced until the tree is clean, since a full-tree `ruff check` would fail on every branch.

## Change

- Add a root `ruff.toml` (`target-version = py311`, shared excludes for `.artifacts`, the persistent volume, `node_modules`, migrations, `.venv`). It documents that ruff runs its default rule set, matching the pinned pre-commit hook (`dev-tools/.pre-commit-config.yaml`, ruff v0.7.0).
- Run `ruff check --fix` and `ruff format` across all four Python services: `app/backend`, `app/agent`, `inference-api`, `docker-control-service`.

Most of the diff is mechanical formatting and removal of unused imports/variables. The **non-mechanical correctness fixes** (worth a closer look in review):

- **`model_control/views.py`** — bind the exception message to a local before the nested `error_stream` generator. The previous code used the `except ... as e` variable *inside* the generator, but Python clears that variable on block exit, so the log-stream error path would raise `NameError` at runtime.
- **`model_control/views.py`** — remove a duplicate `SpeechRecognitionInferenceView` / `SpeechRecognitionInferenceCloudView` class pair. It was byte-identical to a later pair that shadows and wins at runtime (dead code).
- **`vector_db_control/chroma.py`** — remove a duplicate `delete_collection` shadowed by the later, validated version.
- **`docker_control/docker_utils.py`** — `run_agent_container` called an undefined `get_host_agent_port()`; switched to the existing `get_host_port()` allocator.
- **`inference-api/api.py`** — drop a dead cwd-restore block in the `run_inference` exception handler that referenced a name out of scope (its `in locals()` guard was always false, so it never executed); rename an ambiguous loop variable.
- **`board_control/services.py`, `app/agent/agent.py`** — replace bare `except:` with `except Exception:`.
- **tests** — initialize `all_chunks` before use, re-raise through a surviving local, drop unused setup.

A few `# noqa` are used where the flag is a false positive: intentional post-`django.setup()` / post-config imports (E402), and a cross-module re-export in `app/agent/health_monitor.py` (`HealthStatus` is imported by `agent.py` from that module).

## Verification

- `ruff check` and `ruff format --check` pass on all four service directories.
- All edited files parse without syntax errors.
- Static cross-reference audit of every removed name (this caught and fixed a re-export regression in `health_monitor.py`).
- `pytest shared_config/test_sync_models.py` passes; backend dependency resolution (`pip install --dry-run -r requirements.txt`) succeeds with no conflicts.
- Django-app-context tests and full-stack health checks are exercised by the follow-up backend CI PR, which adds the test bootstrap and the workflow that runs them.

## Context

First of two PRs. This one clears the lint backlog; the follow-up adds the `backend-ci.yml` GitHub Actions workflow (lint / deps / Django sanity / unit tests / compose validate / image build / boot smoke) that hard-gates the now-clean tree.