### PR TITLE
Fix: duplicate imported components from lucide-react causing page to not load

### DIFF
--- a/app/frontend/src/components/DeployModelStep.tsx
+++ b/app/frontend/src/components/DeployModelStep.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo, useEffect, useState } from "react";
 import { AnimatedDeployButton } from "./magicui/AnimatedDeployButton";
 import { StepperFormActions } from "./StepperFormActions";
 import { useRefresh } from "../hooks/useRefresh";
-import { Cpu, AlertTriangle, ExternalLink, Info } from "lucide-react";
 import { useIsResetting } from "../hooks/useIsResetting";
 import { DeploymentProgress } from "./ui/DeploymentProgress";
 import type { ActiveDeployment, DeploymentProgressData } from "../hooks/useActiveDeployments";


### PR DESCRIPTION
### Summary
The problem was a duplicate import in `DeployModelStep.tsx `— Cpu (and several other icons) were imported twice from lucide-react, on both line 9 and line 13. That's the` Identifier 'Cpu' has already been declared` error, which aborts the whole module and prevents the page from loading.

### Fix
Removed the redundant line 9. The line 13 import was kept since it's a superset (it also brings in CheckCircle). The page should load now.