### PR TITLE
feat(workflows): show loaded template name in toolbar header with modified indicator

### DIFF
--- a/app/frontend/src/components/workflows/WorkflowToolbar.tsx
+++ b/app/frontend/src/components/workflows/WorkflowToolbar.tsx
@@ -16,6 +16,8 @@ export default function WorkflowToolbar() {
     deleteWorkflow,
     setCurrentWorkflow,
     loadFromTemplate,
+    sourceTemplateName,
+    isTemplateModified,
   } = useWorkflowStore();
 
   const [showList, setShowList] = useState(false);
@@ -65,9 +67,20 @@ export default function WorkflowToolbar() {
   return (
     <div className="flex items-center gap-2 px-4 py-2 bg-zinc-900 border-b border-zinc-800">
       {/* Workflow name */}
-      <span className="text-sm font-medium text-zinc-300 mr-2 truncate max-w-48">
-        {currentWorkflow?.name || "New Workflow"}
-      </span>
+      <div className="flex items-center gap-1.5 mr-2 min-w-0 max-w-56 max-w-48">
+        {sourceTemplateName && !currentWorkflow && isTemplateModified && (
+          <span
+            className="w-2 h-2 rounded-full bg-amber-400 shrink-0"
+            title="Template modified"
+          />
+        )}
+        <span className="text-sm font-medium text-zinc-300 truncate">
+          {currentWorkflow?.name ||
+            (sourceTemplateName
+              ? `Template: ${sourceTemplateName}`
+              : "New Workflow")}
+        </span>
+      </div>
 
       <div className="h-4 w-px bg-zinc-700" />
 

--- a/app/frontend/src/store/workflowStore.ts
+++ b/app/frontend/src/store/workflowStore.ts
@@ -38,6 +38,10 @@ export interface WorkflowState {
   edges: WorkflowEdge[];
   selectedNodeId: string | null;
 
+  // Template tracking
+  sourceTemplateName: string | null;
+  isTemplateModified: boolean;
+
   // Execution
   isRunning: boolean;
   nodeStatuses: Record<string, NodeStatus>;
@@ -85,6 +89,9 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   edges: [],
   selectedNodeId: null,
 
+  sourceTemplateName: null,
+  isTemplateModified: false,
+
   isRunning: false,
   nodeStatuses: {},
   nodeOutputs: {},
@@ -127,6 +134,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
     set((s) => ({
       workflows: [wf, ...s.workflows],
       currentWorkflow: wf,
+      sourceTemplateName: null,
+      isTemplateModified: false,
       ...(blank ? { nodes: [], edges: [], selectedNodeId: null } : {}),
     }));
     if (blank) get().resetExecution();
@@ -163,6 +172,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
         nodes: (wf.graph_data?.nodes ?? []) as WorkflowNode[],
         edges: (wf.graph_data?.edges ?? []) as WorkflowEdge[],
         selectedNodeId: null,
+        sourceTemplateName: null,
+        isTemplateModified: false,
       });
     } else {
       set({
@@ -170,6 +181,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
         nodes: [],
         edges: [],
         selectedNodeId: null,
+        sourceTemplateName: null,
+        isTemplateModified: false,
       });
     }
     get().resetExecution();
@@ -181,6 +194,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       nodes: (template.graph_data?.nodes ?? []) as WorkflowNode[],
       edges: (template.graph_data?.edges ?? []) as WorkflowEdge[],
       selectedNodeId: null,
+      sourceTemplateName: template.name,
+      isTemplateModified: false,
     });
     get().resetExecution();
   },
@@ -190,25 +205,45 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   // -----------------------------------------------------------------------
 
   onNodesChange: (changes) => {
+    // Structural changes (position, add, remove) mark the template as modified;
+    // selection and dimension changes are not user edits.
+    const isStructural = changes.some(
+      (c) => c.type !== "select" && c.type !== "dimensions"
+    );
     set((s) => ({
       nodes: applyNodeChanges(changes, s.nodes) as WorkflowNode[],
+      ...(isStructural && s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
     }));
   },
 
   onEdgesChange: (changes) => {
+    const isStructural = changes.some((c) => c.type !== "select");
     set((s) => ({
       edges: applyEdgeChanges(changes, s.edges),
+      ...(isStructural && s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
     }));
   },
 
   onConnect: (connection) => {
     set((s) => ({
       edges: addEdge(connection, s.edges),
+      ...(s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
     }));
   },
 
   addNode: (node) => {
-    set((s) => ({ nodes: [...s.nodes, node] }));
+    set((s) => ({
+      nodes: [...s.nodes, node],
+      ...(s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
+    }));
   },
 
   setSelectedNode: (id) => {
@@ -220,6 +255,9 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       nodes: s.nodes.map((n) =>
         n.id === nodeId ? { ...n, data: { ...n.data, ...data } } : n
       ),
+      ...(s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
     }));
   },
 
@@ -232,6 +270,9 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
         (e) => e.source !== selectedNodeId && e.target !== selectedNodeId
       ),
       selectedNodeId: null,
+      ...(s.sourceTemplateName && !s.isTemplateModified
+        ? { isTemplateModified: true }
+        : {}),
     }));
   },
 
@@ -445,6 +486,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       nodes,
       edges,
       selectedNodeId: null,
+      sourceTemplateName: null,
+      isTemplateModified: false,
     });
     get().resetExecution();
   },


### PR DESCRIPTION
## Summary

After loading a template from the Templates dropdown, the toolbar now displays which template is in use and visually indicates when it has been modified.
- Resolves #1032 
## Changes

### `workflowStore.ts`
- Added `sourceTemplateName` and `isTemplateModified` state fields to track the active template
- `loadFromTemplate` now persists the template name
- Graph-editing actions (`onNodesChange`, `onEdgesChange`, `onConnect`, `addNode`, `updateNodeData`, `deleteSelected`) mark the template as modified on structural changes
- `createWorkflow`, `setCurrentWorkflow`, and `loadExampleWorkflow` clear the template state

### `WorkflowToolbar.tsx`
- Header now shows `Template: <name>` when a template is loaded
- An amber dot indicator appears before the name when the graph has been edited
- Blank canvas continues to show "New Workflow"

## How to Test

1. Navigate to `/workflows`
2. Click **Templates** → select any template → header should show `Template: <name>`
3. Move a node or add an edge → an amber dot should appear before the template name
4. Click **New** → header should revert to `New Workflow` with no template label