### PR TITLE
fix(workflow): default tab and render markdown in node inspector

### DIFF
--- a/app/frontend/src/components/workflows/NodeConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/NodeConfigPanel.tsx
@@ -19,6 +19,7 @@ import InputConfigPanel from "./config/InputConfigPanel";
 import LLMConfigPanel from "./config/LLMConfigPanel";
 import RAGConfigPanel from "./config/RAGConfigPanel";
 import AgentConfigPanel from "./config/AgentConfigPanel";
+import MarkdownComponent from "../chatui/MarkdownComponent";
 
 interface SourceLink {
   title: string;
@@ -77,6 +78,16 @@ export default function NodeConfigPanel() {
 
   const [activeTab, setActiveTab] = useState<Tab>("config");
 
+  useEffect(() => {
+    if (selectedNodeId) {
+      const state = useWorkflowStore.getState();
+      const initialOutput = state.nodeOutputs[selectedNodeId];
+      const initialReasoning = state.agentReasoningLog[selectedNodeId];
+      const initHasOutput = !!initialOutput || (initialReasoning && initialReasoning.length > 0);
+      setActiveTab(initHasOutput ? "output" : "config");
+    }
+  }, [selectedNodeId]);
+
   const node = nodes.find((n) => n.id === selectedNodeId);
   if (!node) return null;
 
@@ -134,15 +145,14 @@ export default function NodeConfigPanel() {
             <AlertCircle className="w-3.5 h-3.5 text-red-400" />
           )}
           <span
-            className={`text-xs font-medium ${
-              status === "running"
+            className={`text-xs font-medium ${status === "running"
                 ? "text-violet-400"
                 : status === "completed"
                   ? "text-emerald-400"
                   : status === "error"
                     ? "text-red-400"
                     : "text-zinc-500"
-            }`}
+              }`}
           >
             {status.charAt(0).toUpperCase() + status.slice(1)}
           </span>
@@ -161,9 +171,9 @@ export default function NodeConfigPanel() {
           <div className="flex flex-col gap-1.5">
             <span className="text-xs font-medium text-zinc-400">Output</span>
             <div className="overflow-y-auto rounded border border-zinc-800 bg-zinc-950 p-4">
-              <p className="text-sm text-zinc-300 whitespace-pre-wrap break-words leading-relaxed text-left">
-                {output}
-              </p>
+              <div className="text-sm text-zinc-300 break-words leading-relaxed text-left">
+                <MarkdownComponent>{output}</MarkdownComponent>
+              </div>
             </div>
           </div>
         )}
@@ -193,29 +203,28 @@ export default function NodeConfigPanel() {
       {/* Tabs */}
       <div className="flex border-b border-zinc-800">
         <button
-          onClick={() => setActiveTab("config")}
-          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors ${
-            activeTab === "config"
-              ? "text-violet-400 border-b-2 border-violet-500"
-              : "text-zinc-500 hover:text-zinc-300"
-          }`}
-        >
-          <Settings className="w-3.5 h-3.5" />
-          Config
-        </button>
-        <button
           onClick={() => setActiveTab("output")}
-          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors relative ${
-            activeTab === "output"
+          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors relative ${activeTab === "output"
               ? "text-violet-400 border-b-2 border-violet-500"
               : "text-zinc-500 hover:text-zinc-300"
-          }`}
+            }`}
         >
           <Terminal className="w-3.5 h-3.5" />
           Output
           {hasOutput && activeTab !== "output" && (
             <span className="absolute top-1.5 right-3 w-1.5 h-1.5 rounded-full bg-emerald-400" />
           )}
+        </button>
+        <button
+          onClick={() => setActiveTab("config")}
+          className={`flex items-center gap-1.5 flex-1 px-4 py-2 text-xs font-medium transition-colors
+            ${activeTab === "config"
+              ? "text-violet-400 border-b-2 border-violet-500"
+              : "text-zinc-500 hover:text-zinc-300"
+            }`}
+        >
+          <Settings className="w-3.5 h-3.5" />
+          Config
         </button>
       </div>
 


### PR DESCRIPTION
### Description

This PR addresses the UI/UX issues in the Workflows Node Inspector by updating the tab ordering and rendering the output as formatted markdown.
 - resolves #1033 

**Changes:**
1. **Reordered Tabs:** The `Output` tab is now placed before the `Config` tab.
2. **Dynamic Default Selection:** Added a `useEffect` to `NodeConfigPanel` that intelligently checks the store when a node is selected. If the node has generated output or reasoning logs, it defaults to the `Output` tab. For fresh nodes with no output, it safely falls back to `Config`.
3. **Markdown Rendering:** Swapped the raw `<p>` text tag for the app's existing `MarkdownComponent` so that LLM outputs (tables, code blocks, lists, etc.) are correctly formatted.

### Testing
Since deploying an actual LLM requires TT hardware which I do not currently have access to locally, I validated the markdown UI rendering by directly injecting a rich markdown payload into the Zustand `workflowStore`. 

As shown in the screenshot below, the Output tab now correctly defaults to active and perfectly renders complex markdown elements including tables and code blocks.

**Screenshots:**
<img width="1470" height="840" alt="Screenshot 2026-07-13 at 3 07 31 PM" src="https://github.com/user-attachments/assets/b59bd15d-3038-48b1-ad20-5d85118c3019" />
