### PR TITLE
feat(workflows): auto-select first RAG collection on node mount (#1034)

### DIFF
--- a/app/frontend/src/components/workflows/config/RAGConfigPanel.tsx
+++ b/app/frontend/src/components/workflows/config/RAGConfigPanel.tsx
@@ -19,6 +19,8 @@ export default function RAGConfigPanel({ nodeId, data }: Props) {
   const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
   const [collections, setCollections] = useState<Collection[]>([]);
 
+  const autoSelectedName = data._autoSelectedCollection as string | undefined;
+
   useEffect(() => {
     axios
       .get("/collections-api/")
@@ -26,13 +28,80 @@ export default function RAGConfigPanel({ nodeId, data }: Props) {
         const list = Array.isArray(res.data)
           ? res.data
           : (res.data as Record<string, unknown>).results ?? [];
-        setCollections(list as Collection[]);
+        const fetched = list as Collection[];
+        setCollections(fetched);
+
+        // Auto-select the first collection when none is set
+        if (
+          fetched.length > 0 &&
+          !data.collection_name &&
+          !data._autoSelectAttempted
+        ) {
+          const defaultName = fetched[0].name;
+          updateNodeData(nodeId, {
+            collection_name: defaultName,
+            _autoSelectedCollection: defaultName,
+            _autoSelectAttempted: true,
+          });
+        }
       })
       .catch(() => setCollections([]));
-  }, []);
+
+  }, [data.collection_name, data._autoSelectAttempted, nodeId, updateNodeData]);
+
+  /** Dismiss the auto-selection banner */
+  const dismissBanner = () => {
+    updateNodeData(nodeId, { _autoSelectedCollection: undefined });
+  };
+
+  /** Manual collection change — clears the auto-select flag */
+  const handleCollectionChange = (value: string) => {
+    updateNodeData(nodeId, {
+      collection_name: value,
+      _autoSelectedCollection: undefined,
+      _autoSelectAttempted: true,
+    });
+  };
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Banner: no collections exist — guide the user to RAG setup */}
+      {collections.length === 0 && (
+        <div className="flex items-start gap-2 p-3 bg-yellow-900/50 border border-yellow-700/60 rounded-lg text-sm text-yellow-200">
+          <span className="mt-0.5">⚠️</span>
+          <p>
+            No RAG collections found.{" "}
+            <a
+              href="/rag"
+              className="underline font-semibold hover:text-yellow-100"
+            >
+              Set up a collection
+            </a>{" "}
+            to enable retrieval.
+          </p>
+        </div>
+      )}
+
+      {/* Banner: auto-selected notification (dismissible) */}
+      {autoSelectedName && collections.length > 0 && (
+        <div className="flex items-start justify-between gap-2 p-3 bg-blue-900/50 border border-blue-700/60 rounded-lg text-sm text-blue-200">
+          <p>
+            Auto-selected collection{" "}
+            <strong className="text-blue-100">
+              &apos;{autoSelectedName}&apos;
+            </strong>{" "}
+            — change it in the node config.
+          </p>
+          <button
+            onClick={dismissBanner}
+            className="shrink-0 text-blue-400 hover:text-white transition-colors"
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
       <Field label="Label">
         <input
           type="text"
@@ -45,9 +114,7 @@ export default function RAGConfigPanel({ nodeId, data }: Props) {
       <Field label="Collection">
         <select
           value={(data.collection_name as string) || ""}
-          onChange={(e) =>
-            updateNodeData(nodeId, { collection_name: e.target.value })
-          }
+          onChange={(e) => handleCollectionChange(e.target.value)}
           className="w-full px-3 py-2 bg-zinc-800 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-violet-500"
         >
           <option value="">Select a collection...</option>

--- a/app/frontend/src/components/workflows/nodes/RAGQueryNode.tsx
+++ b/app/frontend/src/components/workflows/nodes/RAGQueryNode.tsx
@@ -1,14 +1,47 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { memo } from "react";
+import { memo, useEffect } from "react";
 import { Database } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
+import axios from "axios";
 import BaseNode from "./BaseNode";
+import { useWorkflowStore } from "../../../store/workflowStore";
 
 function RAGQueryNodeComponent({ id, data }: NodeProps) {
+  const updateNodeData = useWorkflowStore((s) => s.updateNodeData);
+
   const label = (data.label as string) || "RAG Query";
   const collection = (data.collection_name as string) || "not set";
+
+  // Auto-select the first collection if not set.
+  // By checking data._autoSelectAttempted, we ensure that if a new template is loaded
+  // (which resets the data object), this effect will run again even if the React component instance is reused by React Flow.
+  useEffect(() => {
+    if (data.collection_name || data._autoSelectAttempted) return;
+
+    axios
+      .get("/collections-api/")
+      .then((res) => {
+        const list = Array.isArray(res.data)
+          ? res.data
+          : (res.data as Record<string, unknown>).results ?? [];
+
+        if (list.length > 0) {
+          const first = (list as { name: string }[])[0].name;
+          updateNodeData(id, {
+            collection_name: first,
+            _autoSelectedCollection: first,
+            _autoSelectAttempted: true,
+          });
+        } else {
+          updateNodeData(id, { _autoSelectAttempted: true });
+        }
+      })
+      .catch(() => {
+        updateNodeData(id, { _autoSelectAttempted: true });
+      });
+  }, [data.collection_name, data._autoSelectAttempted, id, updateNodeData]);
 
   return (
     <BaseNode


### PR DESCRIPTION
### Description

This PR addresses the silent failure of RAG queries by automatically selecting a default collection when a RAG Query node is added or loaded from a template.

- resolves #1034

### Changes:

1. **Node Auto-selection**: Added a `useEffect` in `RAGQueryNodeComponent` that intelligently fetches from `/collections-api/` when a node mounts. If no collection is set, it updates the `workflowStore` to automatically select the first available collection.
2. **Persistent State Flag**: Added an `_autoSelectAttempted` flag to the node data to persist the auto-selection state. This guarantees that when React Flow reuses node components between different templates, the auto-select logic correctly fires again for the newly loaded data.
3. **UI Notifications & Empty States**: Updated `RAGConfigPanel` to render a dismissible blue notice banner when a collection has been auto-selected. If the user has zero collections available, it falls back to displaying a yellow warning banner with a direct link to the `/rag` setup page.

### Testing

I validated this locally by creating a RAG collection and adding a new RAG Query node to the canvas. The node immediately displayed the auto-selected collection on the canvas card without needing to open the config panel.

Furthermore, I verified that switching between workflow templates successfully re-triggers the auto-select logic due to the new data-bound state flag.