### PR TITLE
feat(workflow): implement dynamic edge styling based on execution state

### DIFF
--- a/app/frontend/src/components/workflows/WorkflowCanvas.tsx
+++ b/app/frontend/src/components/workflows/WorkflowCanvas.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useCallback, useEffect, type DragEventHandler } from "react";
+import { useCallback, useEffect, useMemo, type DragEventHandler } from "react";
 import {
   ReactFlow,
   Background,
@@ -15,6 +15,52 @@ import "./canvas-overrides.css";
 import { useWorkflowStore } from "../../store/workflowStore";
 import { nodeTypes } from "./nodes/nodeTypes";
 import type { WorkflowNodeType, WorkflowNode } from "../../types/workflow";
+import type { NodeStatus } from "../../types/workflow";
+
+/* ── Edge colours by execution state ───────────────────────────────── */
+
+const EDGE_COLOR_DEFAULT = "#7c3aed";
+const EDGE_COLOR_COMPLETED = "#10b981";
+const EDGE_COLOR_ACTIVE = "#8b5cf6";
+const EDGE_COLOR_ERROR = "#ef4444";
+const EDGE_COLOR_IDLE = "#52525b";
+
+function getEdgeStyle(
+  sourceStatus: NodeStatus,
+  targetStatus: NodeStatus,
+  isNew: boolean
+): { stroke: string; animated: boolean } {
+  // If this edge was added after the execution, it hasn't carried data yet,
+  // so it should always appear as Pending (idle).
+  if (isNew) {
+    return { stroke: EDGE_COLOR_IDLE, animated: false };
+  }
+
+  // Edge colour follows the SOURCE node — the edge represents data
+  // that flowed out of the source. If the source succeeded the edge
+  // is green, even when the target later fails. Only edges *leaving*
+  // the failed node turn red.
+
+  if (sourceStatus === "error")
+    return { stroke: EDGE_COLOR_ERROR, animated: false };
+
+  if (sourceStatus === "completed") {
+    // If the target is actively running, animate the edge to show flow
+    if (targetStatus === "running") {
+      return { stroke: EDGE_COLOR_ACTIVE, animated: true };
+    }
+    // Otherwise it's fully complete
+    return { stroke: EDGE_COLOR_COMPLETED, animated: false };
+  }
+
+  if (sourceStatus === "running")
+    return { stroke: EDGE_COLOR_ACTIVE, animated: true };
+
+  // Idle (pending) state
+  // If the run hasn't started yet, or this edge is downstream of a failure,
+  // it remains dimmed and solid.
+  return { stroke: EDGE_COLOR_IDLE, animated: false };
+}
 
 const NODE_DEFAULTS: Record<string, Record<string, unknown>> = {
   input: { label: "User Input", text: "" },
@@ -46,7 +92,26 @@ export default function WorkflowCanvas() {
     setSelectedNode,
     deleteSelected,
     selectedNodeId,
+    nodeStatuses,
+    isRunning,
   } = useWorkflowStore();
+
+  /* Derive per-edge style from execution state */
+  const styledEdges = useMemo(
+    () =>
+      edges.map((edge) => {
+        const srcStatus: NodeStatus = nodeStatuses[edge.source] || "idle";
+        const tgtStatus: NodeStatus = nodeStatuses[edge.target] || "idle";
+        const isNew = Boolean(edge.data?.isNew);
+        const { stroke, animated } = getEdgeStyle(srcStatus, tgtStatus, isNew);
+        return {
+          ...edge,
+          animated,
+          style: { ...edge.style, stroke },
+        };
+      }),
+    [edges, nodeStatuses, isRunning]
+  );
 
   const onNodeClick: NodeMouseHandler<WorkflowNode> = useCallback(
     (_event, node) => {
@@ -110,7 +175,7 @@ export default function WorkflowCanvas() {
   return (
     <ReactFlow
       nodes={nodes}
-      edges={edges}
+      edges={styledEdges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}
@@ -123,7 +188,7 @@ export default function WorkflowCanvas() {
       fitView
       defaultEdgeOptions={{
         animated: true,
-        style: { stroke: "#7c3aed" },
+        style: { stroke: EDGE_COLOR_DEFAULT },
       }}
       proOptions={{ hideAttribution: true }}
     >

--- a/app/frontend/src/store/workflowStore.ts
+++ b/app/frontend/src/store/workflowStore.ts
@@ -202,9 +202,20 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   },
 
   onConnect: (connection) => {
-    set((s) => ({
-      edges: addEdge({ ...connection, data: { isNew: true } }, s.edges),
-    }));
+    set((s) => {
+      const nextEdges = addEdge(connection, s.edges);
+      // React Flow appends the newly created edge at the end of the array.
+      // We must check if the length actually increased, because React Flow 
+      // will reject duplicate connections and return the original array.
+      if (nextEdges.length > s.edges.length) {
+        const lastIdx = nextEdges.length - 1;
+        nextEdges[lastIdx] = {
+          ...nextEdges[lastIdx],
+          data: { ...nextEdges[lastIdx].data, isNew: true },
+        };
+      }
+      return { edges: nextEdges };
+    });
   },
 
   addNode: (node) => {

--- a/app/frontend/src/store/workflowStore.ts
+++ b/app/frontend/src/store/workflowStore.ts
@@ -203,7 +203,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
 
   onConnect: (connection) => {
     set((s) => ({
-      edges: addEdge(connection, s.edges),
+      edges: addEdge({ ...connection, data: { isNew: true } }, s.edges),
     }));
   },
 
@@ -349,7 +349,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   },
 
   resetExecution: () => {
-    set({
+    set((s) => ({
       isRunning: false,
       nodeStatuses: {},
       nodeOutputs: {},
@@ -357,7 +357,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
       runProgress: 0,
       runError: null,
       abortController: null,
-    });
+      edges: s.edges.map((e) => ({ ...e, data: { ...e.data, isNew: false } })),
+    }));
   },
 
   loadExampleWorkflow: () => {


### PR DESCRIPTION
### **Description**
This PR introduces dynamic visual styling for workflow edges to reflect the real-time execution state of the graph, resolving a key UX issue where edges remained static during runs. It also includes state protections so that editing the graph after a run behaves predictably.

- Resolves #1037 

### **What was changed?**
* **Dynamic Edge Styling:** Replaced the static `defaultEdgeOptions` in `WorkflowCanvas` with a `useMemo` block that dynamically maps over edges and updates their style based on the live `nodeStatuses` from the Zustand store.
* **Execution State Mapping:** Edges now visually communicate data flow exactly as it happens:
  * 🟢 **Completed:** Solid Emerald Green (`#10b981`)
  * 🔴 **Error:** Solid Red (`#ef4444`) — applied only to edges originating directly from the failed node.
  * 🟣 **Active:** Animated (dashed) Violet (`#8b5cf6`) — shows data actively flowing when a node is processing.
  * ⚪ **Pending/Idle:** Solid Gray (`#52525b`) — seamlessly matches the idle node borders.
* **Stale State Protection:** Added logic in `workflowStore.ts` to tag newly drawn edges with an `isNew` flag. This ensures that if a user deletes and redraws a connection *after* a run has finished, the new edge correctly renders as Pending instead of instantly inheriting the success/error color of the previous execution.

### **How to test**
1. Open a workflow with a few nodes (e.g., `User Input` → `LLM` → `Output`).
2. Click **Run**.
3. Verify that the edge entering the `LLM` node turns **Violet and animates (dashed)** while the LLM is processing.
4. Verify that edges turn **Green** when data successfully flows out of a node.
5. Force an error and verify that the edge originating from the failed node turns **Red**.
6. After the run completes, delete an edge and redraw it. Verify that the new edge appears **Gray (Pending)** until you click Run again.