### PR TITLE
Make voice agent system prompt editable at runtime

### DIFF
--- a/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
@@ -7,7 +7,7 @@ import { StatusPanel } from "@/src/components/voiceAgent/StatusPanel";
 import { MetricsPanel } from "@/src/components/voiceAgent/MetricsPanel";
 import { AudioRecorderWithVisualizer, type AudioRecorderHandle } from "@/src/components/voiceAgent/AudioRecorderWithVisualizer";
 import { useWakeWord } from "@/src/components/voiceAgent/hooks/useWakeWord";
-import { Activity, BarChart3, UserCheck, X } from "lucide-react";
+import { Activity, BarChart3, Settings2, UserCheck, X } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useTheme } from "../../hooks/useTheme";
 import { useLocation } from "react-router-dom";
@@ -46,6 +46,13 @@ import type {
   DeployedModelState,
   PipelineMetrics,
 } from "./types";
+import { VoiceAgentSettings } from "./VoiceAgentSettings";
+import {
+  loadVoiceSystemPrompt,
+  saveVoiceSystemPrompt,
+  renderVoiceSystemPrompt,
+  VOICE_PROMPT_SAFETY_SUFFIX,
+} from "./lib/prompts";
 
 export type { Conversation, ConversationMessage };
 
@@ -138,6 +145,18 @@ export default function VoiceAgentApp() {
     },
     [addMemoryNote]
   );
+
+  // Editable LLM system prompt, persisted per-browser. A ref mirrors it so the
+  // inference callback reads the latest value without re-subscribing.
+  const [systemPrompt, setSystemPrompt] = useState<string>(() => loadVoiceSystemPrompt());
+  const systemPromptRef = useRef<string>(systemPrompt);
+  useEffect(() => {
+    systemPromptRef.current = systemPrompt;
+  }, [systemPrompt]);
+  const handleSaveSystemPrompt = useCallback((prompt: string) => {
+    setSystemPrompt(prompt);
+    saveVoiceSystemPrompt(prompt);
+  }, []);
 
   useEffect(() => {
     chatHistoryRef.current = chatHistory;
@@ -332,13 +351,10 @@ export default function VoiceAgentApp() {
           false,
           0,
           undefined,
-          `${userContext}${memoryBlock}Role: You are a helpful, friendly voice assistant having a real spoken conversation with the user. \
-          Style: Talk like a person — warm, natural, and conversational. Use contractions, light filler ("sure", "got it", "hmm"), and vary your phrasing so you don't sound scripted. \
-          Engagement: Actually answer the user's question or request. When it makes sense, ask a brief follow-up to keep the conversation going, but don't force it on every turn. \
-          Length: Keep replies short and spoken-friendly — usually 1-3 sentences. Go a little longer only when the user asks for detail or explanation. \
-          Format: Plain spoken text only. No bullet points, no markdown, no headings, no emoji — everything you say will be read aloud by a TTS engine. \
-          Goal: Feel like a real assistant the user is talking to, not a demo script.
-          Warning: ONLY reply to what the user is saying. Do not make up information or talk to yourself.`
+          `${userContext}${memoryBlock}${renderVoiceSystemPrompt(systemPromptRef.current, {
+            userName: recognizedUserRef.current,
+            modelName: models.llm.modelName,
+          })}\n${VOICE_PROMPT_SAFETY_SUFFIX}`
         );
 
         const llmTotalMs = Math.round(performance.now() - llmStart);
@@ -572,6 +588,26 @@ export default function VoiceAgentApp() {
                 <SheetTitle className="font-['Bricolage_Grotesque']">Pipeline Metrics</SheetTitle>
               </SheetHeader>
               <MetricsPanel metrics={metrics} />
+            </SheetContent>
+          </Sheet>
+
+          {/* Assistant prompt settings sheet */}
+          <Sheet>
+            <SheetTrigger asChild>
+              <button
+                aria-label="Assistant prompt settings"
+                className={cn(
+                  "w-8 h-8 flex items-center justify-center rounded-lg transition-colors",
+                  theme === "dark"
+                    ? "text-gray-500 hover:text-TT-purple-accent hover:bg-white/[0.05]"
+                    : "text-gray-400 hover:text-TT-purple-accent hover:bg-black/[0.04]"
+                )}
+              >
+                <Settings2 className="w-4 h-4" />
+              </button>
+            </SheetTrigger>
+            <SheetContent side="right" className="flex flex-col">
+              <VoiceAgentSettings value={systemPrompt} onSave={handleSaveSystemPrompt} />
             </SheetContent>
           </Sheet>
         </div>

--- a/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
@@ -130,7 +130,7 @@ export default function VoiceAgentApp() {
     (text: string) => {
       const patterns: RegExp[] = [
         /\bmy name is ([A-Za-z][\w'’\- ]{1,40})/i,
-        /\b(?:i am|i'm) (?:called |known as )?([A-Z][\w'’\-]{1,30})\b/,
+        /\b(?:i am|i'm) (?:called |known as )?([A-Z][\w'’-]{1,30})\b/,
         /\bcall me ([A-Za-z][\w'’\- ]{1,30})/i,
         /\bi(?:'m| am) a ([\w'’\- ]{2,40}?)(?:\.|,|$)/i,
         /\bi work (?:as|at|in|on) ([\w'’\- ]{2,40}?)(?:\.|,|$)/i,
@@ -421,7 +421,7 @@ export default function VoiceAgentApp() {
         setStage("done");
       }
     },
-    [models, conversations, addMessageToConversation, updateMessageInConversation]
+    [models, conversations, addMessageToConversation, updateMessageInConversation, extractMemoryFromUserTurn]
   );
 
   const handleRecordingComplete = async (audioBlob: Blob) => {

--- a/app/frontend/src/components/voiceAgent/VoiceAgentSettings.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentSettings.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RotateCcw, Check } from "lucide-react";
 import { Button } from "../ui/button";
 import { Textarea } from "../ui/textarea";
@@ -24,15 +24,23 @@ export function VoiceAgentSettings({ value, onSave }: VoiceAgentSettingsProps) {
   const [draft, setDraft] = useState(value);
   const [justSaved, setJustSaved] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const justSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dirty = draft !== value;
   const activePresetId = VOICE_PROMPT_PRESETS.find((p) => p.prompt === draft)?.id;
   const approxTokens = Math.ceil(draft.trim().length / 4);
 
+  useEffect(() => {
+    return () => {
+      if (justSavedTimeoutRef.current) clearTimeout(justSavedTimeoutRef.current);
+    };
+  }, []);
+
   const handleSave = () => {
     onSave(draft);
     setJustSaved(true);
-    setTimeout(() => setJustSaved(false), 2000);
+    if (justSavedTimeoutRef.current) clearTimeout(justSavedTimeoutRef.current);
+    justSavedTimeoutRef.current = setTimeout(() => setJustSaved(false), 2000);
   };
 
   // Insert a variable placeholder at the cursor (or append if unfocused).

--- a/app/frontend/src/components/voiceAgent/VoiceAgentSettings.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentSettings.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useRef, useState } from "react";
+import { RotateCcw, Check } from "lucide-react";
+import { Button } from "../ui/button";
+import { Textarea } from "../ui/textarea";
+import { cn } from "../../lib/utils";
+import { SheetHeader, SheetTitle, SheetDescription } from "../ui/sheet";
+import {
+  DEFAULT_VOICE_SYSTEM_PROMPT,
+  VOICE_PROMPT_PRESETS,
+  VOICE_PROMPT_SAFETY_SUFFIX,
+  VOICE_PROMPT_VARIABLES,
+} from "./lib/prompts";
+
+interface VoiceAgentSettingsProps {
+  value: string;
+  onSave: (prompt: string) => void;
+}
+
+// Editor body for the voice agent's system prompt, rendered inside a Sheet.
+export function VoiceAgentSettings({ value, onSave }: VoiceAgentSettingsProps) {
+  const [draft, setDraft] = useState(value);
+  const [justSaved, setJustSaved] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const dirty = draft !== value;
+  const activePresetId = VOICE_PROMPT_PRESETS.find((p) => p.prompt === draft)?.id;
+  const approxTokens = Math.ceil(draft.trim().length / 4);
+
+  const handleSave = () => {
+    onSave(draft);
+    setJustSaved(true);
+    setTimeout(() => setJustSaved(false), 2000);
+  };
+
+  // Insert a variable placeholder at the cursor (or append if unfocused).
+  const insertVariable = (variable: string) => {
+    const el = textareaRef.current;
+    if (!el) {
+      setDraft((d) => `${d}${variable}`);
+      return;
+    }
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const next = draft.slice(0, start) + variable + draft.slice(end);
+    setDraft(next);
+    requestAnimationFrame(() => {
+      el.focus();
+      const pos = start + variable.length;
+      el.setSelectionRange(pos, pos);
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <SheetHeader>
+        <SheetTitle className="font-['Bricolage_Grotesque']">Assistant Prompt</SheetTitle>
+        <SheetDescription>
+          Tune how the voice assistant behaves. Changes apply to the next turn and are saved in this browser.
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="flex-1 overflow-y-auto space-y-4 py-4 pr-1">
+        {/* Presets */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Presets</label>
+          <div className="flex flex-wrap gap-1.5">
+            {VOICE_PROMPT_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                title={preset.description}
+                onClick={() => setDraft(preset.prompt)}
+                className={cn(
+                  "px-2.5 py-1 rounded-full text-xs font-medium border transition-colors",
+                  activePresetId === preset.id
+                    ? "bg-TT-purple-accent text-white border-transparent"
+                    : "bg-secondary text-secondary-foreground border-border hover:bg-secondary/70"
+                )}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Editor */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <label htmlFor="voice-system-prompt" className="text-xs font-medium text-muted-foreground">
+              System prompt
+            </label>
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {draft.trim().length} chars · ~{approxTokens} tokens
+            </span>
+          </div>
+          <Textarea
+            id="voice-system-prompt"
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            spellCheck={false}
+            className="min-h-[220px] font-mono text-xs leading-relaxed resize-y"
+            placeholder="Describe how the assistant should speak and behave…"
+          />
+        </div>
+
+        {/* Template variables */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Insert variable</label>
+          <div className="flex flex-wrap gap-1.5">
+            {VOICE_PROMPT_VARIABLES.map((variable) => (
+              <button
+                key={variable}
+                type="button"
+                onClick={() => insertVariable(variable)}
+                className="px-2 py-0.5 rounded-md text-[11px] font-mono border border-border bg-muted hover:bg-muted/60 transition-colors"
+              >
+                {variable}
+              </button>
+            ))}
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Replaced per turn with the recognized user and deployed model name.
+          </p>
+        </div>
+
+        {/* Locked safety suffix */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">Always appended</label>
+          <p className="rounded-md border border-border bg-muted/40 px-2.5 py-2 text-[11px] text-muted-foreground italic">
+            {VOICE_PROMPT_SAFETY_SUFFIX}
+          </p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-2 border-t border-border pt-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setDraft(DEFAULT_VOICE_SYSTEM_PROMPT)}
+          disabled={draft === DEFAULT_VOICE_SYSTEM_PROMPT}
+          className="text-xs"
+        >
+          <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+          Reset to default
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={!dirty && !justSaved} className="text-xs">
+          {justSaved ? (
+            <>
+              <Check className="h-3.5 w-3.5 mr-1.5" />
+              Saved
+            </>
+          ) : (
+            "Save prompt"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/voiceAgent/lib/prompts.ts
+++ b/app/frontend/src/components/voiceAgent/lib/prompts.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Authoring surface for the voice agent's LLM system prompt. Keeping the prompt
+// here (and editable at runtime via the settings sheet) means tuning it no
+// longer requires a code change and rebuild.
+
+export interface VoicePromptPreset {
+  id: string;
+  label: string;
+  description: string;
+  prompt: string;
+}
+
+// Placeholders the author can drop into a prompt; filled in per turn.
+export const VOICE_PROMPT_VARIABLES = ["{user_name}", "{model_name}"] as const;
+
+// Always appended after the (editable) prompt so the anti-drift guard can't be
+// removed by accident while tuning.
+export const VOICE_PROMPT_SAFETY_SUFFIX =
+  "Warning: ONLY reply to what the user is saying. Do not make up information or talk to yourself.";
+
+export const DEFAULT_VOICE_SYSTEM_PROMPT = `Role: You are a helpful, friendly voice assistant having a real spoken conversation with the user.
+Style: Talk like a person — warm, natural, and conversational. Use contractions, light filler ("sure", "got it", "hmm"), and vary your phrasing so you don't sound scripted.
+Engagement: Actually answer the user's question or request. When it makes sense, ask a brief follow-up to keep the conversation going, but don't force it on every turn.
+Length: Keep replies short and spoken-friendly — usually 1-3 sentences. Go a little longer only when the user asks for detail or explanation.
+Format: Plain spoken text only. No bullet points, no markdown, no headings, no emoji — everything you say will be read aloud by a TTS engine.
+Goal: Feel like a real assistant the user is talking to, not a demo script.`;
+
+export const VOICE_PROMPT_PRESETS: VoicePromptPreset[] = [
+  {
+    id: "default",
+    label: "Default",
+    description: "Warm, natural, conversational.",
+    prompt: DEFAULT_VOICE_SYSTEM_PROMPT,
+  },
+  {
+    id: "concise",
+    label: "Concise",
+    description: "Short, direct, minimal chit-chat.",
+    prompt: `Role: You are a concise voice assistant in a real spoken conversation.
+Style: Direct and efficient. Answer first, skip filler and pleasantries.
+Length: One or two short sentences. Never pad.
+Format: Plain spoken text only — no markdown, headings, bullet points, or emoji, since replies are read aloud by a TTS engine.
+Goal: Give the user exactly what they asked for, fast.`,
+  },
+  {
+    id: "playful",
+    label: "Playful",
+    description: "Upbeat, lighthearted, expressive.",
+    prompt: `Role: You are an upbeat, playful voice assistant having a real spoken conversation.
+Style: Energetic and warm. Use contractions, light humor, and expressive phrasing, but stay genuinely helpful.
+Engagement: Answer the question, then keep things lively with the occasional friendly aside or follow-up.
+Length: Usually 1-3 sentences — enough to have personality without rambling.
+Format: Plain spoken text only — no markdown, headings, bullet points, or emoji, since replies are read aloud by a TTS engine.
+Goal: Feel like a fun, real companion, not a demo script.`,
+  },
+];
+
+const STORAGE_KEY = "voiceAgentSystemPrompt.v1";
+
+// Returns the saved prompt, or the default when nothing is stored.
+export function loadVoiceSystemPrompt(): string {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved && saved.trim() ? saved : DEFAULT_VOICE_SYSTEM_PROMPT;
+  } catch {
+    return DEFAULT_VOICE_SYSTEM_PROMPT;
+  }
+}
+
+export function saveVoiceSystemPrompt(prompt: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, prompt);
+  } catch {
+    /* storage full / disabled — the prompt just won't persist */
+  }
+}
+
+export function clearVoiceSystemPrompt(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* noop */
+  }
+}
+
+// Fill placeholders with per-turn context before sending to the model.
+export function renderVoiceSystemPrompt(
+  template: string,
+  vars: { userName?: string | null; modelName?: string | null }
+): string {
+  return template
+    .replace(/\{user_name\}/g, vars.userName?.trim() || "the user")
+    .replace(/\{model_name\}/g, vars.modelName?.trim() || "the assistant");
+}


### PR DESCRIPTION
## Problem

Closes #752. The voice agent's LLM system prompt was a hardcoded multi-line string inside `VoiceAgentApp.tsx`. Iterating on it — even a one-word tweak — required a code change, a frontend rebuild, and a full redeploy. Prompt quality is the biggest lever for voice UX on small models, so this friction discouraged tuning and made it hard to hand the prompt off to non-engineers.

## Change

Adds a first-class way to author, swap, and persist the voice-agent prompt without touching component code or rebuilding (Option B from the issue: in-app editor + per-browser persistence).

- **`lib/prompts.ts`** — new module that owns the default prompt as the single source of truth, plus presets (Default / Concise / Playful), `localStorage` load/save helpers, and `{user_name}` / `{model_name}` template-variable rendering.
- **`VoiceAgentSettings.tsx`** — editor rendered in a settings sheet opened from a gear button in the voice pipeline header (mirrors the existing Metrics sheet). Preset chips, an editable textarea with a char/approx-token count, clickable variable inserts, explicit Save with an unsaved/saved indicator, and Reset to default.
- **`VoiceAgentApp.tsx`** — holds the active prompt in state (seeded from `localStorage`), mirrors it into a ref so the inference callback reads the latest value without re-subscribing, and composes the final prompt at the call site.

### UX / safety notes
- The active prompt applies to the **next** turn and persists in the browser.
- Template variables are filled per turn from the recognized user and the deployed LLM's name.
- The anti-hallucination guard (`ONLY reply to what the user is saying…`) is kept as a **locked, always-appended suffix** shown read-only in the editor, so tuning can't accidentally remove the drift guard.

## Scope
Voice only, as the issue specifies. The pre-existing dynamic prefixes (recognized-user greeting, persisted memory notes) are unchanged. No backend changes.

## Verification
The full runtime stack was brought up: exercising the live voice pipeline end-to-end Whisper/LLM/TTS models on QB2.

<img width="1728" height="992" alt="Screenshot 2026-07-15 at 11 40 37 AM" src="https://github.com/user-attachments/assets/893ce670-043f-48b3-a31f-5783c28b6f8c" />
