### PR TITLE
HOTFIX: Remove the launcher venv in --purge-all

### DIFF
--- a/tt_setup/cleanup/_orchestrate.py
+++ b/tt_setup/cleanup/_orchestrate.py
@@ -215,6 +215,10 @@ def cleanup_resources(args):
          "docker-control virtualenv"),
         ("🐍", os.path.join(TT_STUDIO_ROOT, ".workflow_venvs"),
          "workflow virtualenvs"),
+        # Kept last: the launcher itself runs from this venv, so it must be the
+        # final path removed. bootstrap.py recreates it on the next run.
+        ("🐍", os.path.join(TT_STUDIO_ROOT, ".tt_studio_run_venv"),
+         "launcher virtualenv (recreated on next run)"),
     ]
 
     existing = [(emoji, path, desc, _path_size(path))


### PR DESCRIPTION
**HOTFIX**

Fixes #1091

`--purge-all` (and its `--cleanup-all` alias) left `.tt_studio_run_venv/` behind. Add it to the purge inventory, removed last since the launcher runs from it; `bootstrap.py` recreates it on the next run.

Verified with a `--purge-all` dry run (venv listed in the inventory, abort deletes nothing) and the launcher test suite (149 tests pass).