### PR TITLE
Connect Cursor to deployed models via the coding-agent gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ python run.py --info          # re-show the "TT Studio is ready" summary (URLs, 
 python run.py --report-bug    # bundle logs (logs/tt-studio-logs-ttbr-*.zip) + open a GitHub issue
 python run.py --install-shortcut # add a `tt-studio` shell shortcut (~/.zshrc/~/.bashrc)
 python run.py --check-headers # report files missing SPDX headers
+python run.py --cursor        # tunnel the coding-agent gateway + print Cursor settings
 ```
 
 Frontend (in `app/frontend/`): `npm run dev`, `npm run build`,

--- a/app/frontend/src/pages/CodingAgentsPage.tsx
+++ b/app/frontend/src/pages/CodingAgentsPage.tsx
@@ -78,6 +78,13 @@ export default function CodingAgentsPage() {
     return names[0] ?? PLACEHOLDER_MODEL;
   }, [info, selectedModel]);
 
+  const gatewayPort = info?.gateway_port ?? 4000;
+
+  // Cursor's servers call the endpoint (not the local client), so the gateway
+  // must be exposed over public HTTPS first — run.py --cursor automates that.
+  const cursorSnippet = `python run.py --cursor`;
+  const cursorManualSnippet = `cloudflared tunnel --url http://localhost:${gatewayPort}`;
+
   const claudeCodeSnippet = `export ANTHROPIC_BASE_URL=${anthropicBase}
 export ANTHROPIC_AUTH_TOKEN=${masterKey || "<your-api-key>"}
 export ANTHROPIC_MODEL=${activeModel}
@@ -164,8 +171,8 @@ PY`;
               Coding Agents
             </h1>
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              Connect Claude Code or any OpenAI-compatible client to your
-              locally deployed models.
+              Connect Claude Code, Cursor, or any OpenAI-compatible client to
+              your locally deployed models.
             </p>
           </div>
         </div>
@@ -314,6 +321,7 @@ PY`;
                 <Tabs defaultValue="claude-code" className="w-full">
                   <TabsList>
                     <TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+                    <TabsTrigger value="cursor">Cursor</TabsTrigger>
                     <TabsTrigger value="opencode">OpenCode</TabsTrigger>
                     <TabsTrigger value="openai">OpenAI / cURL</TabsTrigger>
                   </TabsList>
@@ -325,6 +333,53 @@ PY`;
                       with the <code>/model</code> command.
                     </p>
                     <CodeBlock code={claudeCodeSnippet} language="bash" className="text-left" />
+                  </TabsContent>
+
+                  <TabsContent value="cursor" className="space-y-3">
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      Cursor calls custom endpoints from its own servers, so the
+                      gateway must be reachable over public HTTPS. On the machine
+                      running TT-Studio, this command opens a secure tunnel and
+                      prints the exact values to paste:
+                    </p>
+                    <CodeBlock code={cursorSnippet} language="bash" className="text-left" />
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      Then in Cursor open{" "}
+                      <span className="font-medium">
+                        Settings → Models → API Keys
+                      </span>{" "}
+                      and: enable <span className="font-medium">OpenAI API Key</span>{" "}
+                      and paste the key, enable{" "}
+                      <span className="font-medium">Override OpenAI Base URL</span>{" "}
+                      and paste the tunnel URL (it ends in <code>/v1</code>), then
+                      add a custom model named{" "}
+                      <span className="font-mono">{activeModel}</span> and hit
+                      Verify.
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      Prefer doing it by hand? Start the tunnel yourself with{" "}
+                      <a
+                        href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-TT-purple underline"
+                      >
+                        cloudflared
+                      </a>{" "}
+                      and use the printed <code>trycloudflare.com</code> URL plus{" "}
+                      <code>/v1</code> as the base URL, with the API key above:
+                    </p>
+                    <CodeBlock code={cursorManualSnippet} language="bash" className="text-left" />
+                    <Alert>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertTitle>Good to know</AlertTitle>
+                      <AlertDescription>
+                        Keep the tunnel command running while you work — the URL
+                        dies with it. Cursor routes these requests through its own
+                        backend, and Tab completion always uses Cursor&apos;s
+                        built-in models regardless of API-key settings.
+                      </AlertDescription>
+                    </Alert>
                   </TabsContent>
 
                   <TabsContent value="opencode" className="space-y-3">

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -95,6 +95,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | --- | --- |
 | `--add-headers` | Add missing SPDX license headers (excludes frontend). |
 | `--check-headers` | Report files missing SPDX license headers (no changes). |
+| `--cursor` | Connect the Cursor editor to your deployed models: opens a public tunnel to the coding-agent gateway (Cursor's servers can't reach `localhost`) and prints the base URL, API key, and model name to paste into Cursor Settings → Models. Keep it running while you work. |
 
 ### Troubleshooting & Info
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,13 @@ class TestCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         ready.assert_called_once()
 
+    def test_cursor_flag_dispatches_to_connect_cursor(self):
+        # --cursor is a utility flag: it must dispatch early (no phased setup).
+        with patch("tt_setup.cursor.connect_cursor") as connect:
+            result = runner.invoke(M.app, ["--cursor"])
+        self.assertEqual(result.exit_code, 0)
+        connect.assert_called_once()
+
     def test_qb2_defaults_false_and_honors_true(self):
         # IS_QB2 is opt-in: unset defaults to false so the strict QB2 check only
         # runs when a QB2 machine (or the tt_qb2_launch release branch) opts in.

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the Cursor connect helper (pure logic; no network/tunnel)."""
+import unittest
+from unittest.mock import patch
+
+from tt_setup import cursor as M
+
+
+class TestParseTunnelUrl(unittest.TestCase):
+    def test_extracts_trycloudflare_url(self):
+        line = "2026-07-19T00:00:00Z INF +  https://brave-otter-quick.trycloudflare.com  + "
+        self.assertEqual(M.parse_tunnel_url(line),
+                         "https://brave-otter-quick.trycloudflare.com")
+
+    def test_ignores_unrelated_lines(self):
+        self.assertIsNone(M.parse_tunnel_url("INF Starting tunnel"))
+        self.assertIsNone(M.parse_tunnel_url("visit https://cloudflare.com for docs"))
+        self.assertIsNone(M.parse_tunnel_url(""))
+        self.assertIsNone(M.parse_tunnel_url(None))
+
+
+class TestBuildCursorValues(unittest.TestCase):
+    def test_appends_v1_to_tunnel_url(self):
+        base, key, models = M.build_cursor_values(
+            "https://a-b.trycloudflare.com", "sk-test", ["Llama-3.1-8B-Instruct"])
+        self.assertEqual(base, "https://a-b.trycloudflare.com/v1")
+        self.assertEqual(key, "sk-test")
+        self.assertEqual(models, ["Llama-3.1-8B-Instruct"])
+
+    def test_tolerates_trailing_slash(self):
+        base, _, _ = M.build_cursor_values("https://a-b.trycloudflare.com/", "k", [])
+        self.assertEqual(base, "https://a-b.trycloudflare.com/v1")
+
+
+class TestGatewayPort(unittest.TestCase):
+    def test_defaults_to_4000(self):
+        with patch.object(M, "get_env_var", side_effect=lambda name, default="": default):
+            self.assertEqual(M._gateway_port(), 4000)
+
+    def test_reads_litellm_port(self):
+        with patch.object(M, "get_env_var", return_value="4321"):
+            self.assertEqual(M._gateway_port(), 4321)
+
+    def test_garbage_falls_back_to_4000(self):
+        with patch.object(M, "get_env_var", return_value="not-a-port"):
+            self.assertEqual(M._gateway_port(), 4000)
+
+
+class TestGatewayModelNames(unittest.TestCase):
+    def test_returns_model_names(self):
+        info = {"health": "healthy", "models": [
+            {"name": "Llama-3.1-8B-Instruct", "type": "chat"},
+            {"name": "Qwen3-32B-thinking", "type": "chat"},
+        ]}
+        self.assertEqual(M.gateway_model_names(info),
+                         ["Llama-3.1-8B-Instruct", "Qwen3-32B-thinking"])
+
+    def test_missing_info_returns_empty(self):
+        self.assertEqual(M.gateway_model_names(None), [])
+        self.assertEqual(M.gateway_model_names({}), [])
+
+
+class TestCloudflaredDownloadUrl(unittest.TestCase):
+    def test_linux_amd64(self):
+        with patch.object(M.platform, "system", return_value="Linux"), \
+             patch.object(M.platform, "machine", return_value="x86_64"):
+            self.assertTrue(M._cloudflared_download_url().endswith("cloudflared-linux-amd64"))
+
+    def test_linux_arm64(self):
+        with patch.object(M.platform, "system", return_value="Linux"), \
+             patch.object(M.platform, "machine", return_value="aarch64"):
+            self.assertTrue(M._cloudflared_download_url().endswith("cloudflared-linux-arm64"))
+
+    def test_non_linux_is_manual_install(self):
+        with patch.object(M.platform, "system", return_value="Darwin"):
+            self.assertIsNone(M._cloudflared_download_url())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tt_setup/cli/_args.py
+++ b/tt_setup/cli/_args.py
@@ -49,6 +49,7 @@ def _entry(
     # ── Developer Tools ──────────────────────────────────────────────────────
     add_headers: bool = typer.Option(False, "--add-headers", help="Add missing SPDX license headers (excludes frontend).", rich_help_panel="Developer Tools"),
     check_headers: bool = typer.Option(False, "--check-headers", help="Check for missing SPDX license headers.", rich_help_panel="Developer Tools"),
+    cursor: bool = typer.Option(False, "--cursor", help="Connect Cursor: tunnel the coding-agent gateway and print the settings to paste.", rich_help_panel="Developer Tools"),
     # ── Troubleshooting & Info ───────────────────────────────────────────────
     help_env: bool = typer.Option(False, "--help-env", help="Show detailed environment-variables help.", rich_help_panel="Troubleshooting & Info"),
     report_bug: bool = typer.Option(False, "--report-bug", help="Collect a diagnostics bundle and open a pre-filled GitHub issue.", rich_help_panel="Troubleshooting & Info"),
@@ -80,7 +81,7 @@ def _entry(
         add_headers=add_headers, check_headers=check_headers, auto_deploy=auto_deploy,
         device_id=device_id, fix_docker=fix_docker, configure_env=configure_env,
         status=status, logs=logs, info=info, report_bug=report_bug,
-        install_shortcut=install_shortcut,
+        install_shortcut=install_shortcut, cursor=cursor,
     )
     _run(args)
 

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -228,6 +228,11 @@ def _run(args):
             install_shortcut()
             return
 
+        if args.cursor:
+            from tt_setup.cursor import connect_cursor
+            connect_cursor(args)
+            return
+
         if args.cleanup or args.cleanup_all:
             cleanup_resources(args)
             return

--- a/tt_setup/cursor.py
+++ b/tt_setup/cursor.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Connect the Cursor editor to the TT-Studio coding-agent gateway.
+
+Cursor sends custom-API-key requests from its own cloud, not from the local
+machine, so the LiteLLM gateway (localhost:4000) must be reachable over public
+HTTPS before Cursor can use it. `python run.py --cursor` automates everything
+that can be automated: it reads the gateway info from the running backend,
+opens a cloudflared quick tunnel, and prints the three values to paste into
+Cursor Settings -> Models. The paste itself stays manual because Cursor keeps
+its API-key settings in secure storage that no external tool can write.
+"""
+
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+from tt_setup.console import confirm, console, notice_panel, step
+from tt_setup.constants import ENV_FILE_PATH
+from tt_setup.env_config import get_env_var
+
+# Quick tunnels get a random subdomain here; parse it out of cloudflared's logs.
+_TUNNEL_URL_RE = re.compile(r"https://[a-z0-9-]+\.trycloudflare\.com")
+
+_CODING_AGENTS_INFO_URL = "http://localhost:8000/models/coding-agents/"
+_CLOUDFLARED_RELEASES = "https://github.com/cloudflare/cloudflared/releases/latest/download"
+_LOCAL_BIN = os.path.expanduser("~/.local/bin")
+
+
+def parse_tunnel_url(text):
+    """Return the https://*.trycloudflare.com URL in `text`, or None."""
+    match = _TUNNEL_URL_RE.search(text or "")
+    return match.group(0) if match else None
+
+
+def build_cursor_values(tunnel_url, master_key, models):
+    """Assemble the paste-ready Cursor settings from tunnel + gateway state.
+
+    Returns (base_url, api_key, model_names) — pure, so it's unit-testable.
+    """
+    base_url = tunnel_url.rstrip("/") + "/v1"
+    return base_url, master_key, list(models)
+
+
+def _gateway_port():
+    try:
+        return int(get_env_var("LITELLM_PORT", "4000") or "4000")
+    except ValueError:
+        return 4000
+
+
+def _http_get_json(url, token=None, timeout=5):
+    """GET `url` and parse JSON. Returns None on any failure."""
+    request = urllib.request.Request(url)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if response.status != 200:
+                return None
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def fetch_gateway_info():
+    """Gateway state from the running backend (the Coding Agents page source).
+
+    Returns the parsed payload — {"health", "gateway_port", "master_key",
+    "models": [{"name", "type"}, ...]} — or None if the backend is unreachable.
+    """
+    return _http_get_json(_CODING_AGENTS_INFO_URL)
+
+
+def gateway_model_names(info):
+    """Model names from a coding-agents info payload ([] if none)."""
+    if not info:
+        return []
+    return [m.get("name") for m in info.get("models", []) if m.get("name")]
+
+
+def find_cloudflared():
+    """Path to a usable cloudflared binary, or None."""
+    found = shutil.which("cloudflared")
+    if found:
+        return found
+    local = os.path.join(_LOCAL_BIN, "cloudflared")
+    if os.path.isfile(local) and os.access(local, os.X_OK):
+        return local
+    return None
+
+
+def _cloudflared_download_url():
+    """Download URL for this platform's static cloudflared binary (Linux only)."""
+    if platform.system() != "Linux":
+        return None
+    machine = platform.machine().lower()
+    arch = {"x86_64": "amd64", "amd64": "amd64", "aarch64": "arm64", "arm64": "arm64"}.get(machine)
+    if not arch:
+        return None
+    return f"{_CLOUDFLARED_RELEASES}/cloudflared-linux-{arch}"
+
+
+def install_cloudflared():
+    """Offer to download cloudflared to ~/.local/bin. Returns its path or None."""
+    url = _cloudflared_download_url()
+    console.print("[info]cloudflared (the tunnel tool) isn't installed.[/info]")
+    if url is None:
+        console.print("[warning]Install it yourself, then re-run: "
+                      "https://developers.cloudflare.com/cloudflared/ "
+                      "(macOS: brew install cloudflared)[/warning]")
+        return None
+    if not confirm(f"Download it now to {_LOCAL_BIN}?", default=True):
+        console.print("[muted]Skipped. Install cloudflared and re-run python run.py --cursor[/muted]")
+        return None
+    target = os.path.join(_LOCAL_BIN, "cloudflared")
+    with step("Downloading cloudflared"):
+        os.makedirs(_LOCAL_BIN, exist_ok=True)
+        urllib.request.urlretrieve(url, target)
+        os.chmod(target, 0o755)
+    return target
+
+
+def start_tunnel(cloudflared_path, port):
+    """Start a cloudflared quick tunnel to the gateway port.
+
+    Returns (process, public_url), or (None, None) if cloudflared exits or
+    never reports a URL.
+    """
+    process = subprocess.Popen(
+        [cloudflared_path, "tunnel", "--url", f"http://localhost:{port}", "--no-autoupdate"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # cloudflared logs the assigned URL to stderr shortly after startup.
+    collected = []
+    try:
+        for line in process.stderr:
+            collected.append(line)
+            url = parse_tunnel_url(line)
+            if url:
+                return process, url
+            if process.poll() is not None:
+                break
+    except KeyboardInterrupt:
+        process.terminate()
+        raise
+    process.terminate()
+    tail = "".join(collected[-10:]).strip()
+    if tail:
+        console.print(f"[muted]{tail}[/muted]")
+    return None, None
+
+
+def connect_cursor(args):
+    """Entry point for `python run.py --cursor`."""
+    if not os.path.exists(ENV_FILE_PATH):
+        console.print(notice_panel(
+            "[bold error]TT Studio isn't set up yet[/bold error]",
+            ["No .env file found — run [info]python run.py[/info] first to set up and start TT Studio."],
+            border_style="error"))
+        sys.exit(1)
+
+    info = fetch_gateway_info()
+    if info is None:
+        console.print(notice_panel(
+            "[bold error]TT Studio isn't running[/bold error]",
+            ["The backend didn't answer on http://localhost:8000.",
+             "Start TT Studio first: [info]python run.py[/info]",
+             "then re-run [info]python run.py --cursor[/info]."],
+            border_style="error"))
+        sys.exit(1)
+
+    if info.get("health") != "healthy":
+        console.print(notice_panel(
+            "[bold error]Coding-agent gateway is not healthy[/bold error]",
+            ["The LiteLLM gateway (tt_studio_litellm) isn't answering yet.",
+             "Give it a moment after startup, or check [info]python run.py --logs[/info]."],
+            border_style="error"))
+        sys.exit(1)
+
+    master_key = info.get("master_key") or get_env_var("LITELLM_MASTER_KEY", "")
+    if not master_key:
+        console.print(notice_panel(
+            "[bold error]Gateway key not configured[/bold error]",
+            ["LITELLM_MASTER_KEY is missing — restart TT Studio with [info]python run.py[/info]."],
+            border_style="error"))
+        sys.exit(1)
+
+    port = info.get("gateway_port") or _gateway_port()
+    models = gateway_model_names(info)
+    if not models:
+        console.print("[warning]⚠  No chat models are deployed yet — Cursor setup will still work, "
+                      "but deploy a model in TT Studio (Models page) before using it.[/warning]")
+
+    cloudflared = find_cloudflared() or install_cloudflared()
+    if not cloudflared:
+        sys.exit(1)
+
+    console.print("[info]Opening a public tunnel to the gateway "
+                  "(Cursor's servers must reach it over HTTPS)…[/info]")
+    process, tunnel_url = start_tunnel(cloudflared, port)
+    if not tunnel_url:
+        console.print(notice_panel(
+            "[bold error]Couldn't open the tunnel[/bold error]",
+            ["cloudflared didn't report a public URL. Check your internet connection and retry.",
+             f"Manual alternative: [info]cloudflared tunnel --url http://localhost:{port}[/info]"],
+            border_style="error"))
+        sys.exit(1)
+
+    base_url, api_key, model_names = build_cursor_values(tunnel_url, master_key, models)
+    # Values print as plain full-width lines (a fixed-width panel would truncate
+    # the long tunnel URL and break copy-paste); the panel below carries the steps.
+    console.print()
+    console.print("[muted]Override OpenAI Base URL[/muted]")
+    console.print(f"  [info]{base_url}[/info]")
+    console.print("[muted]OpenAI API Key[/muted]")
+    console.print(f"  [info]{api_key}[/info]")
+    console.print("[muted]Model name(s)[/muted]")
+    console.print(f"  [info]{', '.join(model_names) if model_names else '(deploy a model first)'}[/info]")
+    footer = [
+        "[muted]1 · Enable “OpenAI API Key” and paste the key above[/muted]",
+        "[muted]2 · Enable “Override OpenAI Base URL” and paste the Base URL[/muted]",
+        "[muted]3 · Add a custom model with the exact model name, then Verify[/muted]",
+        "",
+        "[muted]Keep this command running — the tunnel closes when it exits.[/muted]",
+        "[muted]Note · Cursor's Tab completion always uses Cursor's own models.[/muted]",
+    ]
+    console.print()
+    console.print(notice_panel(
+        "[bold accent]In Cursor · Settings → Models → API Keys[/bold accent]", footer))
+    console.print()
+
+    try:
+        process.wait()
+        console.print("[warning]Tunnel closed (cloudflared exited).[/warning]")
+    except KeyboardInterrupt:
+        process.terminate()
+        console.print("\n[muted]Tunnel closed.[/muted]")


### PR DESCRIPTION
## Problem

The Coding Agents page covers Claude Code and OpenCode, but there was no path for Cursor users. Cursor supports custom OpenAI-compatible endpoints, with a catch: it calls them from its own cloud, so a `localhost:4000` gateway URL can never work — the gateway has to be exposed over public HTTPS first, and Cursor's API-key settings live in secure storage that no tool can write for the user.

## Change

- **`python run.py --cursor`** (new utility flag, early-dispatch): reads gateway health/key/models from the backend's `/models/coding-agents/` endpoint, opens a cloudflared quick tunnel to the LiteLLM gateway (offers to download the static binary to `~/.local/bin` if missing), and prints the three values to paste into Cursor Settings → Models. Stays in the foreground so the tunnel lives until Ctrl-C. Clear error panels with fixes when the stack isn't up.
- **Coding Agents page**: new Cursor tab alongside Claude Code/OpenCode with the command, the manual `cloudflared tunnel --url` alternative, the click-path, and a callout on the limitations (requests transit Cursor's backend; Tab completion never uses custom keys).
- Docs: `--cursor` added to the run-py guide options table and CLAUDE.md common commands.
- Tests: `tests/test_cursor.py` for the pure helpers (tunnel-URL parsing, value assembly, port fallback, platform download URL) plus a CLI dispatch case.

## Verification (on a QB2, P300x2)

- Deployed Llama-3.1-8B-Instruct on a full P300 card (chips 0,1) and confirmed `/v1/chat/completions` through the gateway: non-streaming, streaming (SSE chunks), and native tool calling (`finish_reason: tool_calls`) all pass.
- Ran `python run.py --cursor` end-to-end: tunnel opened, values printed with the full un-truncated URL.
- Repeated the completion through the public `trycloudflare.com` URL (exactly what Cursor's servers do) — works; unauthenticated requests get 401 from the gateway, so the exposure stays key-protected.
- `tests/` suite: 162 passing. Frontend: type-check and production build clean; only pre-existing lint warning on the page.

Note from testing: deploying Llama-3.1-8B on a single chip of a P300 fails in tt-metal with "Custom fabric mesh graph descriptor path must be specified for CUSTOM cluster type"; deploying on the full card (device 0,1) works. That's an inference-server-side behavior, not addressed here.