### PR TITLE
fix: make get_env_var prioritize os.environ over .env

### DIFF
--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -78,6 +78,48 @@ class TestEnvFileRoundTrip(unittest.TestCase):
         self.assertEqual(existing.get("B"), "2")
 
 
+class TestOsEnvironPrecedence(unittest.TestCase):
+    """os.environ must take precedence over .env file values (issue #804)."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
+        self.tmp.close()
+        self.p = patch.object(_ecfg_dotenv, "ENV_FILE_PATH", self.tmp.name)
+        self.p.start()
+
+    def tearDown(self):
+        self.p.stop()
+        os.unlink(self.tmp.name)
+
+    def test_os_environ_overrides_env_file(self):
+        """Shell export must win over the .env file value."""
+        M.write_env_var("MY_VAR", "from-dotenv")
+        with patch.dict(os.environ, {"MY_VAR": "from-shell"}):
+            self.assertEqual(M.get_env_var("MY_VAR"), "from-shell")
+
+    def test_os_environ_overrides_when_no_env_file(self):
+        """Shell export must work even if .env file does not exist."""
+        os.unlink(self.tmp.name)
+        # Re-create so tearDown doesn't fail
+        open(self.tmp.name, "w").close()
+        with patch.object(_ecfg_dotenv, "ENV_FILE_PATH", "/nonexistent/.env"):
+            with patch.dict(os.environ, {"MY_VAR": "from-shell"}):
+                self.assertEqual(M.get_env_var("MY_VAR"), "from-shell")
+
+    def test_env_file_used_when_no_os_environ(self):
+        """Without a shell override, the .env file value is still returned."""
+        M.write_env_var("MY_VAR", "from-dotenv")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MY_VAR", None)
+            self.assertEqual(M.get_env_var("MY_VAR"), "from-dotenv")
+
+    def test_empty_os_environ_value_still_wins(self):
+        """An explicitly empty shell export must override the .env value."""
+        M.write_env_var("MY_VAR", "from-dotenv")
+        with patch.dict(os.environ, {"MY_VAR": ""}):
+            self.assertEqual(M.get_env_var("MY_VAR"), "")
+
+
 class TestConsistentQuoting(unittest.TestCase):
     """write_env_var must produce ONE consistent (unquoted) format."""
 

--- a/tt_setup/env_config/_dotenv.py
+++ b/tt_setup/env_config/_dotenv.py
@@ -40,7 +40,15 @@ def comment_out_env_var(var_name):
 
 
 def get_env_var(var_name, default=""):
-    """Safely get a variable from app/.env (quotes handled by python-dotenv)."""
+    """Get a variable from os.environ, falling back to app/.env, then default.
+
+    Lookup order (first wins):
+      1. os.environ  – shell exports, CI variables, container env
+      2. app/.env    – repo-root dotenv file (parsed by python-dotenv)
+      3. *default*   – caller-supplied fallback
+    """
+    if var_name in os.environ:
+        return os.environ[var_name]
     if not os.path.exists(ENV_FILE_PATH):
         return default
     value = dotenv_values(ENV_FILE_PATH, interpolate=False).get(var_name)

--- a/tt_setup/inference_server/_metadata.py
+++ b/tt_setup/inference_server/_metadata.py
@@ -85,11 +85,11 @@ def get_inference_server_version():
     
     # Fallback: try to get from environment variable
     # Check for branch first (branches don't have VERSION files typically)
-    env_branch = get_env_var("TT_INFERENCE_ARTIFACT_BRANCH") or os.getenv("TT_INFERENCE_ARTIFACT_BRANCH")
+    env_branch = get_env_var("TT_INFERENCE_ARTIFACT_BRANCH")
     if env_branch:
         return None  # Branches don't have version numbers
     
-    env_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION") or os.getenv("TT_INFERENCE_ARTIFACT_VERSION")
+    env_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION")
     if env_version and env_version != "latest":
         return env_version
     

--- a/tt_setup/services/_fastapi.py
+++ b/tt_setup/services/_fastapi.py
@@ -155,8 +155,8 @@ def start_fastapi_server(no_sudo=False, dev_mode=False):
     # Set artifact path and version/branch so inference-api uses the version-resolved artifact
     if os.path.exists(INFERENCE_ARTIFACT_DIR):
         env["TT_INFERENCE_ARTIFACT_PATH"] = INFERENCE_ARTIFACT_DIR
-        artifact_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION") or os.getenv("TT_INFERENCE_ARTIFACT_VERSION")
-        artifact_branch = get_env_var("TT_INFERENCE_ARTIFACT_BRANCH") or os.getenv("TT_INFERENCE_ARTIFACT_BRANCH")
+        artifact_version = get_env_var("TT_INFERENCE_ARTIFACT_VERSION")
+        artifact_branch = get_env_var("TT_INFERENCE_ARTIFACT_BRANCH")
         if artifact_version:
             env["TT_INFERENCE_ARTIFACT_VERSION"] = artifact_version
         if artifact_branch:


### PR DESCRIPTION
### Summary
This PR implements **Option A** from the issue description. The `get_env_var` function now behaves intuitively by checking system environment variables before falling back to the local `app/.env` file. 

This enables shell overrides (e.g., `HOST_PERSISTENT_STORAGE_VOLUME=/tmp/foo`), wrapper scripts, and CI/container environments to successfully inject environment variables without them being silently ignored.

- Fixes #804 

### Changes Made
- **Fixed `get_env_var` (`tt_setup/env_config/_dotenv.py`)**: Updated the lookup order to strictly enforce `os.environ` → `app/.env` → `default`.
- **Cleaned up Workarounds**: Removed redundant `or os.getenv(...)` fallbacks in `_metadata.py` and `_fastapi.py` that developers had added to bypass the bug.
- **Added Tests (`tests/test_env_config.py`)**: Added `TestOsEnvironPrecedence` with 4 new tests to guarantee that shell variables correctly override `.env` values, explicitly empty shell variables are respected, and missing shell variables properly fall back to the `.env` file.

### Testing
- ✅ All 22 tests in `test_env_config.py` pass.
- ✅ Verified manually that setting a variable via shell export properly overrides the hardcoded `.env` value at runtime.