### PR TITLE
Hotfix: keep Welcome setup completed across restarts

### DIFF
--- a/app/backend/shared_config/test_user_config.py
+++ b/app/backend/shared_config/test_user_config.py
@@ -71,12 +71,30 @@ class TestSaveLoadRoundTrip:
         user_config.save_user_config({"hf_token": "hf_abc123", "evil_key": "x"})
         assert "evil_key" not in user_config.load_user_config()
 
-    def test_setup_complete_round_trip(self, volume):
+    def test_setup_complete_round_trip(self, volume, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
         assert not user_config.is_setup_complete()
         user_config.mark_setup_complete()
         assert user_config.is_setup_complete()
         content = (volume / "backend_volume" / "user_config.env").read_text()
         assert "SETUP_COMPLETE=true" in content
+
+    def test_setup_complete_when_required_secret_configured(self, volume, monkeypatch):
+        """The Welcome guide is driven by env completeness (issue #1145): a
+        configured HF token counts as complete even without the flag, and a
+        finished wizard counts even if every secret was skipped."""
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        user_config.save_user_config({"hf_token": "hf_abc123"})
+        assert user_config.is_setup_complete()
+
+    def test_setup_complete_honors_env_var_token(self, volume, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "hf_from_env")
+        assert user_config.is_setup_complete()
+
+    def test_setup_incomplete_without_flag_or_token(self, volume, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        user_config.save_user_config({"tavily_api_key": "tvly-x"})
+        assert not user_config.is_setup_complete()
 
 
 class TestValueSanitization:

--- a/app/backend/shared_config/user_config.py
+++ b/app/backend/shared_config/user_config.py
@@ -201,7 +201,19 @@ def get_artifact_info() -> dict:
 
 
 def is_setup_complete() -> bool:
-    return bool(load_user_config().get("setup_complete"))
+    """Whether the first-run Welcome guide can be skipped.
+
+    True once the wizard was finished (flag set), or when the required secret
+    (the HF token) is already configured via user_config.env or the
+    environment — e.g. a preprovisioned .env. The guide should reappear only
+    when something it collects is actually missing, not because the completion
+    flag was lost (issue #1145). The flag alone also counts: the wizard allows
+    skipping every secret, and requiring the token on top of the flag would
+    bounce those users straight back to /welcome.
+    """
+    if load_user_config().get("setup_complete"):
+        return True
+    return bool(get_hf_token())
 
 
 def mark_setup_complete() -> None:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -193,6 +193,33 @@ class CleanupAllTests(unittest.TestCase):
             self.assertTrue(sentinel.exists())
             self.assertTrue(sentinel.read_text().isdigit())
 
+    def test_plain_stop_preserves_welcome_setup_state(self):
+        # A plain --stop must leave user_config.env byte-identical — secrets AND
+        # the SETUP_COMPLETE flag — so the Welcome wizard doesn't re-run on the
+        # next bring-up. Only --purge-all resets first-run state.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backend_volume = root / "tt_studio_persistent_volume" / "backend_volume"
+            backend_volume.mkdir(parents=True)
+            user_config = backend_volume / "user_config.env"
+            original = "HF_TOKEN=hf_test\nSETUP_COMPLETE=true\n"
+            user_config.write_text(original)
+
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(patch.object(_cl_orch, "TT_STUDIO_ROOT", str(root)))
+                stack.enter_context(patch.object(_cl_orch,
+                    "get_env_var",
+                    side_effect=lambda name, default="": default,
+                ))
+                stack.enter_context(patch.object(_cl_orch, "check_docker_access", return_value=True))
+                stack.enter_context(patch.object(_cl_orch, "_cleanup_runtime"))
+                stack.enter_context(patch.object(_cl_orch, "_docker_daemon_status", return_value="down"))
+                args = SimpleNamespace(cleanup_all=False, yes=False, no_sudo=True, dev=False)
+                with contextlib.redirect_stdout(io.StringIO()):
+                    run.cleanup_resources(args)
+
+            self.assertEqual(user_config.read_text(), original)
+
 
 class CleanupDockerSurfaceTests(unittest.TestCase):
     """Covers the gaps the original cleanup-all missed: deployment containers

--- a/tt_setup/cleanup/_orchestrate.py
+++ b/tt_setup/cleanup/_orchestrate.py
@@ -4,9 +4,7 @@
 """--stop / --purge-all orchestration: build the inventory, confirm, then run the
 teardown and (for --purge-all) wipe persistent state."""
 
-import json
 import os
-import subprocess
 from rich.table import Table
 from tt_setup.constants import *
 from tt_setup.constants import _CLEANUP_VOLUME_PREFIX
@@ -46,96 +44,12 @@ def _print_preserved_summary(has_docker_access):
 
     rows = [
         ("Model deployments", models),
-        ("Config & secrets", ".env"),
+        ("Config & secrets", ".env, saved settings (Welcome setup)"),
         ("Saved data", "model weights, chat history, RAG"),
     ]
     footer = ["[muted]Remove these too →[/muted]  [accent]python run.py --purge-all[/accent]"]
     console.print()
     console.print(kept_panel("[bold]Preserved[/bold]", rows, footer))
-
-
-def _atomic_write_0600(path, text):
-    """Rewrite `path` with `text` atomically at mode 0600, never leaving a
-    world-readable temp file behind (secrets must not be briefly exposed)."""
-    tmp = os.path.join(os.path.dirname(path) or ".", ".user_config.tmp")
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        with os.fdopen(fd, "w") as f:
-            os.fchmod(f.fileno(), 0o600)
-            f.write(text)
-        os.replace(tmp, path)
-    except Exception:
-        try:
-            os.remove(tmp)
-        except OSError:
-            pass
-        raise
-
-
-def _reset_welcome_flag(user_config_path, legacy_json_path, no_sudo):
-    """Drop the Welcome/SETUP_COMPLETE flag while preserving saved secrets.
-
-    Prefers an in-place, atomic, secrets-preserving rewrite; only removes a file
-    outright as a last resort (root-owned and no sudo) so the backend can
-    regenerate it. Returns a short status string for the step detail."""
-    # Preferred store: the dotenv file. Strip the SETUP_COMPLETE line, keep the rest.
-    if os.path.exists(user_config_path):
-        try:
-            with open(user_config_path, "r") as f:
-                lines = f.readlines()
-            kept = [ln for ln in lines if not ln.strip().startswith("SETUP_COMPLETE")]
-            if len(kept) == len(lines):
-                return "already cleared"
-            _atomic_write_0600(user_config_path, "".join(kept))
-            return "SETUP_COMPLETE cleared"
-        except PermissionError:
-            # Root-owned (Docker wrote it on the host volume). Prefer a sudo
-            # in-place strip that keeps the saved secrets and the 0600 mode;
-            # only remove the whole file if that isn't possible.
-            if not no_sudo and _sudo_strip_setup_complete(user_config_path):
-                return "SETUP_COMPLETE cleared (sudo)"
-            if _remove_path(user_config_path, no_sudo=no_sudo):
-                return "removed root-owned user_config.env (secrets reset)"
-            return None
-
-    # Legacy JSON from before the .env migration: strip the flag in place so the
-    # backend migrates the remaining secrets (and deletes the file) on next start.
-    if os.path.exists(legacy_json_path):
-        try:
-            with open(legacy_json_path, "r") as f:
-                data = json.load(f)
-            if not isinstance(data, dict) or "setup_complete" not in data:
-                return "already cleared"
-            data.pop("setup_complete", None)
-            _atomic_write_0600(legacy_json_path, json.dumps(data))
-            return "SETUP_COMPLETE cleared (legacy JSON; secrets kept)"
-        except PermissionError:
-            # Can't safely edit a root-owned legacy JSON without risking its
-            # secrets; removal lets the backend re-run Welcome.
-            if _remove_path(legacy_json_path, no_sudo=no_sudo):
-                return "removed root-owned legacy user_config.json"
-            return None
-        except (OSError, json.JSONDecodeError):
-            if _remove_path(legacy_json_path, no_sudo=no_sudo):
-                return "removed unreadable legacy user_config.json"
-            return None
-
-    return "nothing to reset"
-
-
-def _sudo_strip_setup_complete(path):
-    """Remove the SETUP_COMPLETE line from a root-owned dotenv file via sudo.
-
-    `sed -i` edits in place, preserving the file's existing owner and 0600 mode,
-    so saved secrets survive. Returns True on success."""
-    try:
-        subprocess.run(
-            ["sudo", "sed", "-i", "/^[[:space:]]*SETUP_COMPLETE/d", path],
-            check=True,
-        )
-        return True
-    except Exception:
-        return False
 
 
 def cleanup_resources(args):
@@ -148,25 +62,9 @@ def cleanup_resources(args):
         has_access = check_docker_access()
         _cleanup_runtime(args, has_access)
 
-        # Unset the Welcome flag so the next bring-up re-runs first-run setup,
-        # while preserving saved secrets (HF token, etc.). See _reset_welcome_flag
-        # for the in-place/atomic rewrite and root-owned fallbacks.
-        host_persistent_volume = get_env_var("HOST_PERSISTENT_STORAGE_VOLUME") or \
-            os.path.join(TT_STUDIO_ROOT, "tt_studio_persistent_volume")
-        backend_volume = os.path.join(host_persistent_volume, "backend_volume")
-        user_config_path = os.path.join(backend_volume, "user_config.env")
-        legacy_json_path = os.path.join(backend_volume, "user_config.json")
-        if os.path.exists(user_config_path) or os.path.exists(legacy_json_path):
-            with step("Resetting Welcome flag", spinner=False) as s:
-                detail = _reset_welcome_flag(
-                    user_config_path, legacy_json_path, no_sudo=args.no_sudo
-                )
-                if detail is None:
-                    s.fail()
-                    s.detail("permission denied")
-                else:
-                    s.detail(detail)
-
+        # user_config.env (saved secrets + the Welcome/SETUP_COMPLETE flag) is
+        # left untouched: a plain --stop must not re-trigger first-run setup.
+        # Only --purge-all resets it, by removing the persistent volume.
         _print_preserved_summary(has_access)
         return
 


### PR DESCRIPTION
Fixes #1145

## Problem

The first-run Welcome wizard (terms, HF token / TTS / Tavily secrets, HF access check) re-appears in the web UI after every stop/start cycle, in both dev mode and production mode. Once a user completes setup, it should stay completed — the guide should only come back when required configuration is actually missing.

## Cause

Two things drove the spurious re-onboarding:

1. A plain `python run.py --stop` (and the deprecated `--cleanup` alias) intentionally stripped the `SETUP_COMPLETE` line from `tt_studio_persistent_volume/backend_volume/user_config.env`. Since the CLI's own Ctrl+C and error hints recommend `--stop`, every normal restart re-triggered first-run setup.
2. The wizard's appearance was driven purely by that flag, so losing `user_config.env` for any incidental reason re-onboarded users whose required secrets were already configured.

## Fix (hotfix)

- `--stop` now leaves `user_config.env` untouched — saved secrets and the Welcome/setup state are both preserved. Removed the now-unused `_reset_welcome_flag` / `_atomic_write_0600` / `_sudo_strip_setup_complete` helpers and updated the `--stop` "Preserved" panel to mention the saved settings.
- `is_setup_complete()` is now env-completeness driven: setup counts as complete when the wizard was finished **or** when the required secret (the HF token) is already configured via `user_config.env` or the environment. The guide only reappears when something it collects is actually missing. The flag alone still counts because the wizard allows skipping every secret — requiring the token on top of the flag would bounce those users straight back to `/welcome`.
- First-run setup still resets on `python run.py --purge-all` (or `--cleanup-all`), which removes the persistent volume and `.env`.

## Verification

- CLI test suite: 163 tests green, including a new regression test asserting a plain `--stop` leaves `user_config.env` byte-identical (`SETUP_COMPLETE` + secrets).
- Backend suite: `shared_config/test_user_config.py` — 21 tests green, including new cases for the completeness check (flag only, token via file, token via env, neither).
- End-to-end on a live stack: marked setup complete via the settings API, ran `python run.py --stop` — the flag survived; restarted — `GET /up/` 200, frontend serving, inference server `{"status":"ok"}`, and `GET /settings/` reports `setup_complete: true`. Separately verified the completeness path: with `user_config.env` absent but `HF_TOKEN` set in the environment, `GET /settings/` still reports `setup_complete: true`, so the app no longer redirects to `/welcome`.
