### PR TITLE
Uplift tt-inference-server artifact to v0.18.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.17.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.18.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,37 +1,10 @@
 {
   "source": {
-    "artifact_version": "0.18.0",
-    "generated_at": "2026-07-21T17:24:36.588463+00:00"
+    "artifact_version": "0.14.0",
+    "generated_at": "2026-05-20T16:49:35.390566+00:00"
   },
-  "total_models": 67,
+  "total_models": 54,
   "models": [
-    {
-      "model_name": "DeepSeek-R1-Distill-Llama-70B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-      "inference_engine": "vLLM",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
-    },
     {
       "model_name": "distil-large-v3",
       "model_type": "SPEECH_RECOGNITION",
@@ -41,17 +14,23 @@
         "N150",
         "N300",
         "P150",
+        "P300",
         "P300x2",
         "T3K"
       ],
       "hf_model_id": "distil-whisper/distil-large-v3",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+      "version": "0.11.1",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-2508216",
       "service_route": "/v1/audio/transcriptions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -73,116 +52,13 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
-    },
-    {
-      "model_name": "FLUX.1-schnell",
-      "model_type": "IMAGE_GENERATION",
-      "display_model_type": "IMAGE",
-      "device_configurations": [
-        "GALAXY",
-        "P150X4",
-        "P150X8",
-        "P300",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "black-forest-labs/FLUX.1-schnell",
-      "inference_engine": "media",
-      "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76",
-      "service_route": "/v1/images/generations",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "Llama-3.1-70B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "meta-llama/Llama-3.1-70B",
-      "inference_engine": "vLLM",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
-    },
-    {
-      "model_name": "Llama-3.1-70B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "meta-llama/Llama-3.1-70B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
-    },
-    {
-      "model_name": "Llama-3.1-8B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "N150",
-        "N300",
-        "P100",
-        "P150",
-        "P150X4",
-        "P150X8",
-        "P300",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "meta-llama/Llama-3.1-8B",
-      "inference_engine": "vLLM",
-      "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
-      "service_route": "/v1/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 8
     },
     {
       "model_name": "Llama-3.1-8B-Instruct",
@@ -204,8 +80,8 @@
       "hf_model_id": "meta-llama/Llama-3.1-8B-Instruct",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-25305db-6e67d2d",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -231,8 +107,8 @@
       "hf_model_id": "meta-llama/Llama-3.3-70B-Instruct",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e867533-8f36910",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -264,7 +140,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 7
     },
@@ -283,7 +159,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -292,9 +173,6 @@
       "display_model_type": "VIDEO",
       "device_configurations": [
         "GALAXY",
-        "P150X4",
-        "P150X8",
-        "P300x2",
         "T3K"
       ],
       "hf_model_id": "genmo/mochi-1-preview",
@@ -302,9 +180,14 @@
       "status": "COMPLETE",
       "version": "0.10.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240",
-      "service_route": "/v1/videos/generations",
+      "service_route": "/enqueue",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -313,8 +196,6 @@
       "display_model_type": "IMAGE",
       "device_configurations": [
         "GALAXY",
-        "P150X8",
-        "P300x2",
         "T3K"
       ],
       "hf_model_id": "Motif-Technologies/Motif-Image-6B-Preview",
@@ -324,7 +205,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": 6
     },
     {
@@ -341,8 +227,8 @@
       "hf_model_id": "Qwen/Qwen3-32B",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
+      "version": "0.11.1",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.11.1-bac8b34-7c6685a",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -350,7 +236,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 32
     },
@@ -362,16 +248,22 @@
         "N150",
         "N300",
         "P150",
+        "P300",
         "P300x2"
       ],
       "hf_model_id": "microsoft/speecht5_tts",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.15.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.15.0-25891d3",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-2508216",
       "service_route": "/v1/audio/speech",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -389,7 +281,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -409,7 +306,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -429,7 +331,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -449,7 +356,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -467,7 +379,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -485,7 +402,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -501,12 +423,22 @@
       ],
       "hf_model_id": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
       "inference_engine": "media",
+      "supported_modalities": [
+        "text"
+      ],
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/videos/generations",
       "health_route": "/health",
-      "env_vars": {},
+      "shm_size": "32G",
+      "setup_type": "TT_INFERENCE_SERVER",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": 14
     },
     {
@@ -518,35 +450,23 @@
         "N150",
         "N300",
         "P150",
+        "P300",
         "P300x2",
         "T3K"
       ],
       "hf_model_id": "openai/whisper-large-v3",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+      "version": "0.11.1",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-2508216",
       "service_route": "/v1/audio/transcriptions",
       "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "yolox_nano",
-      "model_type": "CNN",
-      "display_model_type": "CNN",
-      "device_configurations": [
-        "N150",
-        "P150"
-      ],
-      "hf_model_id": "yolox_nano",
-      "inference_engine": "forge",
-      "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -616,7 +536,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 1
     },
@@ -641,7 +561,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 1
     },
@@ -657,8 +577,8 @@
       "hf_model_id": "meta-llama/Llama-3.2-3B",
       "inference_engine": "vLLM",
       "status": "FUNCTIONAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
+      "version": "0.3.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-20edc39-03cb300",
       "service_route": "/v1/completions",
       "health_route": "/health",
       "env_vars": {
@@ -712,7 +632,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "MAX_PREFILL_CHUNK_SIZE": "16"
+        "MAX_PREFILL_CHUNK_SIZE": 16
       },
       "param_count": 90
     },
@@ -735,7 +655,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "MAX_PREFILL_CHUNK_SIZE": "16"
+        "MAX_PREFILL_CHUNK_SIZE": 16
       },
       "param_count": 90
     },
@@ -755,6 +675,10 @@
       "service_route": "/v1/images/generations",
       "health_route": "/health",
       "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
         "TT_DIT_CACHE_DIR": "/tmp/TT_DIT_CACHE"
       },
       "param_count": null
@@ -775,6 +699,10 @@
       "service_route": "/v1/images/generations",
       "health_route": "/health",
       "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
         "TT_DIT_CACHE_DIR": "/tmp/TT_DIT_CACHE"
       },
       "param_count": null
@@ -800,7 +728,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 72
@@ -826,7 +754,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
         "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 72
@@ -850,59 +778,9 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 72
-    },
-    {
-      "model_name": "Qwen3-8B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "N150",
-        "N300",
-        "P300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-8B",
-      "inference_engine": "vLLM",
-      "status": "FUNCTIONAL",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 8
-    },
-    {
-      "model_name": "Qwen3-VL-32B-Instruct",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-VL-32B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "FUNCTIONAL",
-      "version": "0.14.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.14.0-80180b9-7678b70",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 32
     },
     {
       "model_name": "QwQ-32B",
@@ -925,7 +803,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 32
     },
@@ -944,7 +822,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -962,24 +845,12 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "Z-Image-Turbo",
-      "model_type": "IMAGE_GENERATION",
-      "display_model_type": "IMAGE",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "Tongyi-MAI/Z-Image-Turbo",
-      "inference_engine": "media",
-      "status": "FUNCTIONAL",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
-      "service_route": "/v1/images/generations",
-      "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     },
     {
@@ -1018,39 +889,21 @@
       "hf_model_id": "BAAI/bge-large-en-v1.5",
       "inference_engine": "media",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
       "service_route": "/enqueue",
       "health_route": "/health",
       "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
         "VLLM__MAX_NUM_BATCHED_TOKENS": "3072",
         "VLLM__MAX_MODEL_LENGTH": "384",
         "VLLM__MIN_CONTEXT_LENGTH": "32",
         "VLLM__MAX_NUM_SEQS": "8",
         "MAX_BATCH_SIZE": "8",
         "DEFAULT_THROTTLE_LEVEL": "0"
-      },
-      "param_count": null
-    },
-    {
-      "model_name": "DeepSeek-R1-0528",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY"
-      ],
-      "hf_model_id": "deepseek-ai/DeepSeek-R1-0528",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
       },
       "param_count": null
     },
@@ -1065,36 +918,17 @@
       "hf_model_id": "efficientnet",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "Falcon3-7B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "P150"
-      ],
-      "hf_model_id": "tiiuae/Falcon3-7B-Instruct",
-      "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
       "env_vars": {
-        "MAX_MODEL_LENGTH": "16384",
-        "MAX_NUM_SEQS": "4",
-        "GPU_MEMORY_UTILIZATION": "0.225",
-        "TT_KV_POOL_GB": "32",
-        "OPTIMIZATION_LEVEL": "1",
-        "ENABLE_TRACE": "true"
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
       },
-      "param_count": 7
+      "param_count": null
     },
     {
       "model_name": "gemma-3-1b-it",
@@ -1131,7 +965,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1154,7 +988,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1166,45 +1000,18 @@
       "param_count": 4
     },
     {
-      "model_name": "gemma-4-31B-it",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "google/gemma-4-31B-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "GEMMA4_PAGE_BLOCK_SIZE": "64",
-        "GEMMA4_MAX_TOKENS_ALL_USERS": "49152",
-        "GEMMA4_GEN_PREFILL_CHUNK": "4096"
-      },
-      "param_count": 31
-    },
-    {
       "model_name": "gpt-oss-120b",
       "model_type": "CHAT",
       "display_model_type": "LLM",
       "device_configurations": [
         "GALAXY",
-        "P300x2",
         "T3K"
       ],
       "hf_model_id": "openai/gpt-oss-120b",
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1238,8 +1045,8 @@
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
         "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "VLLM_ENABLE_RESPONSES_API_STORE": "1",
-        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": "1"
+        "VLLM_ENABLE_RESPONSES_API_STORE": 1,
+        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": 1
       },
       "param_count": 20
     },
@@ -1256,7 +1063,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1279,7 +1086,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1310,7 +1117,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 7
     },
@@ -1334,7 +1141,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 7
     },
@@ -1358,7 +1165,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 32
     },
@@ -1381,7 +1188,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 32
     },
@@ -1405,7 +1212,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 3
     },
@@ -1414,7 +1221,6 @@
       "model_type": "VLM",
       "display_model_type": "VLM",
       "device_configurations": [
-        "N150",
         "N300"
       ],
       "hf_model_id": "Qwen/Qwen2.5-VL-7B-Instruct",
@@ -1429,31 +1235,9 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
       },
       "param_count": 7
-    },
-    {
-      "model_name": "Qwen3-4B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen3-4B",
-      "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "2048",
-        "VLLM__MAX_MODEL_LENGTH": "2048",
-        "VLLM__MIN_MODEL_LENGTH": "32"
-      },
-      "param_count": 4
     },
     {
       "model_name": "Qwen3-Embedding-4B",
@@ -1468,11 +1252,15 @@
       "hf_model_id": "Qwen/Qwen3-Embedding-4B",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
         "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
         "VLLM__MAX_MODEL_LENGTH": "1024",
         "VLLM__MIN_CONTEXT_LENGTH": "32",
@@ -1495,42 +1283,21 @@
       "hf_model_id": "Qwen/Qwen3-Embedding-8B",
       "inference_engine": "media",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
       "service_route": "/enqueue",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "1024",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "1"
-      },
-      "param_count": 8
-    },
-    {
-      "model_name": "Qwen3.6-27B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "Qwen/Qwen3.6-27B",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
-      "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
         "VLLM_CONFIGURE_LOGGING": "1",
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "TT_QWEN35_TEXT_VER": "qwen36_blackhole",
-        "HF_MODEL": "Qwen/Qwen3.6-27B",
-        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "1024",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "1"
       },
-      "param_count": 27
+      "param_count": 8
     },
     {
       "model_name": "unet",
@@ -1543,11 +1310,16 @@
       "hf_model_id": "unet",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {},
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
       "param_count": null
     }
   ]

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,10 +1,37 @@
 {
   "source": {
-    "artifact_version": "0.14.0",
-    "generated_at": "2026-05-20T16:49:35.390566+00:00"
+    "artifact_version": "0.18.0",
+    "generated_at": "2026-07-21T17:24:36.588463+00:00"
   },
-  "total_models": 54,
+  "total_models": 67,
   "models": [
+    {
+      "model_name": "DeepSeek-R1-Distill-Llama-70B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+      "inference_engine": "vLLM",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 70
+    },
     {
       "model_name": "distil-large-v3",
       "model_type": "SPEECH_RECOGNITION",
@@ -14,23 +41,17 @@
         "N150",
         "N300",
         "P150",
-        "P300",
         "P300x2",
         "T3K"
       ],
       "hf_model_id": "distil-whisper/distil-large-v3",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.11.1",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-2508216",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/audio/transcriptions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -52,13 +73,116 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "FLUX.1-schnell",
+      "model_type": "IMAGE_GENERATION",
+      "display_model_type": "IMAGE",
+      "device_configurations": [
+        "GALAXY",
+        "P150X4",
+        "P150X8",
+        "P300",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "black-forest-labs/FLUX.1-schnell",
+      "inference_engine": "media",
+      "status": "COMPLETE",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76",
+      "service_route": "/v1/images/generations",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "Llama-3.1-70B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "meta-llama/Llama-3.1-70B",
+      "inference_engine": "vLLM",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/completions",
+      "health_route": "/health",
       "env_vars": {
         "VLLM_CONFIGURE_LOGGING": "1",
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1"
       },
-      "param_count": null
+      "param_count": 70
+    },
+    {
+      "model_name": "Llama-3.1-70B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "meta-llama/Llama-3.1-70B-Instruct",
+      "inference_engine": "vLLM",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 70
+    },
+    {
+      "model_name": "Llama-3.1-8B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "N150",
+        "N300",
+        "P100",
+        "P150",
+        "P150X4",
+        "P150X8",
+        "P300",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "meta-llama/Llama-3.1-8B",
+      "inference_engine": "vLLM",
+      "status": "COMPLETE",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "service_route": "/v1/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 8
     },
     {
       "model_name": "Llama-3.1-8B-Instruct",
@@ -80,8 +204,8 @@
       "hf_model_id": "meta-llama/Llama-3.1-8B-Instruct",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-25305db-6e67d2d",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -107,8 +231,8 @@
       "hf_model_id": "meta-llama/Llama-3.3-70B-Instruct",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e867533-8f36910",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -140,7 +264,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 7
     },
@@ -159,12 +283,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -173,6 +292,9 @@
       "display_model_type": "VIDEO",
       "device_configurations": [
         "GALAXY",
+        "P150X4",
+        "P150X8",
+        "P300x2",
         "T3K"
       ],
       "hf_model_id": "genmo/mochi-1-preview",
@@ -180,14 +302,9 @@
       "status": "COMPLETE",
       "version": "0.10.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240",
-      "service_route": "/enqueue",
+      "service_route": "/v1/videos/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -196,6 +313,8 @@
       "display_model_type": "IMAGE",
       "device_configurations": [
         "GALAXY",
+        "P150X8",
+        "P300x2",
         "T3K"
       ],
       "hf_model_id": "Motif-Technologies/Motif-Image-6B-Preview",
@@ -205,12 +324,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": 6
     },
     {
@@ -227,8 +341,8 @@
       "hf_model_id": "Qwen/Qwen3-32B",
       "inference_engine": "vLLM",
       "status": "COMPLETE",
-      "version": "0.11.1",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.11.1-bac8b34-7c6685a",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -236,7 +350,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 32
     },
@@ -248,22 +362,16 @@
         "N150",
         "N300",
         "P150",
-        "P300",
         "P300x2"
       ],
       "hf_model_id": "microsoft/speecht5_tts",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-2508216",
+      "version": "0.15.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.15.0-25891d3",
       "service_route": "/v1/audio/speech",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -281,12 +389,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -306,12 +409,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -331,12 +429,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -356,12 +449,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -379,12 +467,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -402,12 +485,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -423,22 +501,12 @@
       ],
       "hf_model_id": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
       "inference_engine": "media",
-      "supported_modalities": [
-        "text"
-      ],
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/videos/generations",
       "health_route": "/health",
-      "shm_size": "32G",
-      "setup_type": "TT_INFERENCE_SERVER",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": 14
     },
     {
@@ -450,23 +518,35 @@
         "N150",
         "N300",
         "P150",
-        "P300",
         "P300x2",
         "T3K"
       ],
       "hf_model_id": "openai/whisper-large-v3",
       "inference_engine": "media",
       "status": "COMPLETE",
-      "version": "0.11.1",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-2508216",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/audio/transcriptions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "yolox_nano",
+      "model_type": "CNN",
+      "display_model_type": "CNN",
+      "device_configurations": [
+        "N150",
+        "P150"
+      ],
+      "hf_model_id": "yolox_nano",
+      "inference_engine": "forge",
+      "status": "COMPLETE",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -536,7 +616,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 1
     },
@@ -561,7 +641,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 1
     },
@@ -577,8 +657,8 @@
       "hf_model_id": "meta-llama/Llama-3.2-3B",
       "inference_engine": "vLLM",
       "status": "FUNCTIONAL",
-      "version": "0.3.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-20edc39-03cb300",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
       "service_route": "/v1/completions",
       "health_route": "/health",
       "env_vars": {
@@ -632,7 +712,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "MAX_PREFILL_CHUNK_SIZE": 16
+        "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 90
     },
@@ -655,7 +735,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "MAX_PREFILL_CHUNK_SIZE": 16
+        "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 90
     },
@@ -675,10 +755,6 @@
       "service_route": "/v1/images/generations",
       "health_route": "/health",
       "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
         "TT_DIT_CACHE_DIR": "/tmp/TT_DIT_CACHE"
       },
       "param_count": null
@@ -699,10 +775,6 @@
       "service_route": "/v1/images/generations",
       "health_route": "/health",
       "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
         "TT_DIT_CACHE_DIR": "/tmp/TT_DIT_CACHE"
       },
       "param_count": null
@@ -728,7 +800,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
         "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 72
@@ -754,7 +826,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1,
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
         "MAX_PREFILL_CHUNK_SIZE": "16"
       },
       "param_count": 72
@@ -778,9 +850,59 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 72
+    },
+    {
+      "model_name": "Qwen3-8B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "N150",
+        "N300",
+        "P300",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-8B",
+      "inference_engine": "vLLM",
+      "status": "FUNCTIONAL",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 8
+    },
+    {
+      "model_name": "Qwen3-VL-32B-Instruct",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-VL-32B-Instruct",
+      "inference_engine": "vLLM",
+      "status": "FUNCTIONAL",
+      "version": "0.14.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.14.0-80180b9-7678b70",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 32
     },
     {
       "model_name": "QwQ-32B",
@@ -803,7 +925,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 32
     },
@@ -822,12 +944,7 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -845,12 +962,24 @@
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "Z-Image-Turbo",
+      "model_type": "IMAGE_GENERATION",
+      "display_model_type": "IMAGE",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "Tongyi-MAI/Z-Image-Turbo",
+      "inference_engine": "media",
+      "status": "FUNCTIONAL",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+      "service_route": "/v1/images/generations",
+      "health_route": "/health",
+      "env_vars": {},
       "param_count": null
     },
     {
@@ -889,21 +1018,39 @@
       "hf_model_id": "BAAI/bge-large-en-v1.5",
       "inference_engine": "media",
       "status": "EXPERIMENTAL",
-      "version": "0.14.0",
+      "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
       "service_route": "/enqueue",
       "health_route": "/health",
       "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
         "VLLM__MAX_NUM_BATCHED_TOKENS": "3072",
         "VLLM__MAX_MODEL_LENGTH": "384",
         "VLLM__MIN_CONTEXT_LENGTH": "32",
         "VLLM__MAX_NUM_SEQS": "8",
         "MAX_BATCH_SIZE": "8",
         "DEFAULT_THROTTLE_LEVEL": "0"
+      },
+      "param_count": null
+    },
+    {
+      "model_name": "DeepSeek-R1-0528",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY"
+      ],
+      "hf_model_id": "deepseek-ai/DeepSeek-R1-0528",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
       },
       "param_count": null
     },
@@ -918,17 +1065,36 @@
       "hf_model_id": "efficientnet",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.14.0",
+      "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
+    },
+    {
+      "model_name": "Falcon3-7B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P150"
+      ],
+      "hf_model_id": "tiiuae/Falcon3-7B-Instruct",
+      "inference_engine": "forge",
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "MAX_MODEL_LENGTH": "16384",
+        "MAX_NUM_SEQS": "4",
+        "GPU_MEMORY_UTILIZATION": "0.225",
+        "TT_KV_POOL_GB": "32",
+        "OPTIMIZATION_LEVEL": "1",
+        "ENABLE_TRACE": "true"
+      },
+      "param_count": 7
     },
     {
       "model_name": "gemma-3-1b-it",
@@ -965,7 +1131,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -988,7 +1154,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1000,18 +1166,45 @@
       "param_count": 4
     },
     {
+      "model_name": "gemma-4-31B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/gemma-4-31B-it",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "GEMMA4_PAGE_BLOCK_SIZE": "64",
+        "GEMMA4_MAX_TOKENS_ALL_USERS": "49152",
+        "GEMMA4_GEN_PREFILL_CHUNK": "4096"
+      },
+      "param_count": 31
+    },
+    {
       "model_name": "gpt-oss-120b",
       "model_type": "CHAT",
       "display_model_type": "LLM",
       "device_configurations": [
         "GALAXY",
+        "P300x2",
         "T3K"
       ],
       "hf_model_id": "openai/gpt-oss-120b",
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1045,8 +1238,8 @@
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
         "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "VLLM_ENABLE_RESPONSES_API_STORE": 1,
-        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": 1
+        "VLLM_ENABLE_RESPONSES_API_STORE": "1",
+        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": "1"
       },
       "param_count": 20
     },
@@ -1063,7 +1256,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1086,7 +1279,7 @@
       "inference_engine": "vLLM",
       "status": "EXPERIMENTAL",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-aecd1d7-0da90eb",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1117,7 +1310,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 7
     },
@@ -1141,7 +1334,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 7
     },
@@ -1165,7 +1358,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 32
     },
@@ -1188,7 +1381,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 32
     },
@@ -1212,7 +1405,7 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 3
     },
@@ -1221,6 +1414,7 @@
       "model_type": "VLM",
       "display_model_type": "VLM",
       "device_configurations": [
+        "N150",
         "N300"
       ],
       "hf_model_id": "Qwen/Qwen2.5-VL-7B-Instruct",
@@ -1235,9 +1429,31 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": 1
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
       },
       "param_count": 7
+    },
+    {
+      "model_name": "Qwen3-4B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen3-4B",
+      "inference_engine": "forge",
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "2048",
+        "VLLM__MAX_MODEL_LENGTH": "2048",
+        "VLLM__MIN_MODEL_LENGTH": "32"
+      },
+      "param_count": 4
     },
     {
       "model_name": "Qwen3-Embedding-4B",
@@ -1252,15 +1468,11 @@
       "hf_model_id": "Qwen/Qwen3-Embedding-4B",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.14.0",
+      "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
         "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
         "VLLM__MAX_MODEL_LENGTH": "1024",
         "VLLM__MIN_CONTEXT_LENGTH": "32",
@@ -1283,21 +1495,42 @@
       "hf_model_id": "Qwen/Qwen3-Embedding-8B",
       "inference_engine": "media",
       "status": "EXPERIMENTAL",
-      "version": "0.14.0",
+      "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
       "service_route": "/enqueue",
       "health_route": "/health",
       "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
         "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
         "VLLM__MAX_MODEL_LENGTH": "1024",
         "VLLM__MIN_CONTEXT_LENGTH": "32",
         "VLLM__MAX_NUM_SEQS": "1"
       },
       "param_count": 8
+    },
+    {
+      "model_name": "Qwen3.6-27B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "Qwen/Qwen3.6-27B",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "TT_QWEN35_TEXT_VER": "qwen36_blackhole",
+        "HF_MODEL": "Qwen/Qwen3.6-27B",
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto"
+      },
+      "param_count": 27
     },
     {
       "model_name": "unet",
@@ -1310,16 +1543,11 @@
       "hf_model_id": "unet",
       "inference_engine": "forge",
       "status": "EXPERIMENTAL",
-      "version": "0.14.0",
+      "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
+      "env_vars": {},
       "param_count": null
     }
   ]


### PR DESCRIPTION
## What

Uplift the pinned tt-inference-server artifact from **v0.17.0 → v0.18.0** and regenerate the backend model catalog to match.

- `.env.default`: `TT_INFERENCE_ARTIFACT_VERSION=v0.17.0` → `v0.18.0`
- `models_from_inference_server.json`: regenerated from the real v0.18.0 artifact (54 → **67 models**)

## Why

v0.18.0 ships **Falcon3-7B-Instruct** (Forge, P150) natively in its prod catalog. On v0.17.0 the model was advertised in the UI but had no catalog spec, so deploys crashed in argparse (`invalid choice`) and hung on a frozen spinner. On v0.18.0 it resolves and passes `validate_runtime_args` via a plain `--model Falcon3-7B-Instruct` — no runtime-model-spec workaround needed.

## How the catalog was regenerated

The v0.18.0 release tarball ships no pre-built catalog JSON, so it was produced authoritatively rather than hand-edited:

1. Downloaded `refs/tags/v0.18.0.tar.gz`
2. Ran the artifact's own `export_model_specs_json(MODEL_SPECS)` (confirmed `release_version: 0.18.0`)
3. Normalized through the repo's `sync_models_from_inference_server.py`

Validated: valid JSON, `total_models` matches array length, every model has required fields, existing models retained (e.g. `distil-large-v3`), engines present = `forge` / `media` / `vLLM`, Falcon3-7B-Instruct present (`CHAT` / `forge` / `P150`).

## Not touched (intentionally)

- **`.env`** — gitignored; regenerates from `.env.default` on next `python run.py` (picks up v0.18.0 and re-downloads the artifact).
- **Wan T2V media-image pin** (`docker_control/docker_utils.py`) — a separate `tt-media-inference-server` image ref carrying the MODEL_WEIGHTS_DIR fix, independent of the tt-inference-server artifact version.

## Test plan

- [ ] `python run.py` fetches the v0.18.0 artifact (tag reachable, HTTP 200 confirmed)
- [ ] Deploy **Falcon3-7B-Instruct** on P150 — resolves via `--model`, no argparse crash, weights download proceeds
- [ ] Regression: deploy an existing vLLM model (e.g. a Qwen) — unchanged
