### PR TITLE
Group desktop navbar items into Models, Tools, and Playground dropdowns

### DIFF
--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -15,6 +15,7 @@ import {
   Mic,
   Volume2,
   ScanFace,
+  ChevronDown,
   ChevronRight,
   ChevronLeft,
   Video,
@@ -36,6 +37,12 @@ import {
   NavigationMenuList,
 } from "./ui/navigation-menu";
 import { Separator } from "./ui/separator";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
@@ -196,6 +203,70 @@ const ButtonNavItem: React.FC<ButtonNavItemProps> = ({
     </Tooltip>
   </NavigationMenuItem>
 );
+
+// Grouped dropdown for the horizontal desktop navbar. Renders a trigger styled
+// like a regular nav link and lists the group's items in a dropdown; the
+// trigger takes the active border when any child route is the current one.
+interface NavDropdownProps {
+  label: string;
+  icon: LucideIcon;
+  items: NavItemData[];
+  iconColor: string;
+  getNavLinkClass: (isActive: boolean) => string;
+  isRouteActive: (route: string) => boolean;
+  onNavigate: (to: string) => void;
+}
+
+const NavDropdown: React.FC<NavDropdownProps> = ({
+  label,
+  icon: Icon,
+  items,
+  iconColor,
+  getNavLinkClass,
+  isRouteActive,
+  onNavigate,
+}) => {
+  const isActive = items.some((item) =>
+    item.type === "link"
+      ? isRouteActive(item.to)
+      : item.route
+        ? isRouteActive(item.route)
+        : false
+  );
+  return (
+    <NavigationMenuItem>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className={`${getNavLinkClass(isActive)} flex justify-start items-center`}
+          >
+            <Icon
+              className={`mr-2 ${iconColor} transition-colors duration-300 ease-in-out hover:text-TT-purple`}
+            />
+            <span>{label}</span>
+            <ChevronDown className={`ml-1 h-4 w-4 ${iconColor}`} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="font-tt_a_mono">
+          {items.map((item, index) => (
+            <DropdownMenuItem
+              key={`${item.label}-${index}`}
+              disabled={item.type === "button" && item.isDisabled}
+              title={item.type === "link" ? item.tooltip : item.tooltipText}
+              className="cursor-pointer"
+              onSelect={() =>
+                item.type === "link" ? onNavigate(item.to) : item.onClick()
+              }
+            >
+              <item.icon className="mr-2 h-4 w-4" />
+              <span>{item.label}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </NavigationMenuItem>
+  );
+};
 
 // Action button component for the utility actions
 const ActionButton: React.FC<ActionButtonProps> = ({
@@ -718,6 +789,45 @@ export default function NavBar() {
 
   const navItems: NavItemData[] = [...baseNavItems, ...createModelNavItems()];
 
+  // Group the flat nav items into submenus for the horizontal desktop navbar.
+  // Home stays top-level; anything not claimed by Models/Tools (the deployed
+  // model pages, Voice Agent, etc.) lands in Playground. The vertical and
+  // mobile navbars keep the flat icon list.
+  const modelsGroupLabels = [
+    "Models Deployed",
+    "Deployment History",
+    "Register Model",
+  ];
+  const toolsGroupLabels = [
+    "Rag Management",
+    "Workflows",
+    "Canvas",
+    "Connect Agents",
+  ];
+  const homeNavItem = navItems.find((item) => item.label === "Home");
+  const navGroups = [
+    {
+      label: "Models",
+      icon: Boxes,
+      items: navItems.filter((item) => modelsGroupLabels.includes(item.label)),
+    },
+    {
+      label: "Tools",
+      icon: Workflow,
+      items: navItems.filter((item) => toolsGroupLabels.includes(item.label)),
+    },
+    {
+      label: "Playground",
+      icon: BotMessageSquare,
+      items: navItems.filter(
+        (item) =>
+          item.label !== "Home" &&
+          !modelsGroupLabels.includes(item.label) &&
+          !toolsGroupLabels.includes(item.label)
+      ),
+    },
+  ].filter((group) => group.items.length > 0);
+
   // Define action buttons based on deployment state - include HelpIcon
   const actionButtons: ActionButtonType[] = [
     // Dark/light mode toggle disabled — app stays in dark mode.
@@ -1044,38 +1154,38 @@ export default function NavBar() {
           {/* Navigation Menu */}
           <NavigationMenu className="w-full px-4">
             <NavigationMenuList className="flex justify-between list-none">
-              {navItems.map((item, index) => (
-                <div key={item.label} className="flex items-center">
-                  {item.type === "link" ? (
-                    <NavItem
-                      to={item.to}
-                      icon={item.icon}
-                      label={item.label}
-                      tooltip={item.tooltip}
-                      isChatUI={false}
-                      iconColor={iconColor}
-                      getNavLinkClass={getNavLinkClass}
-                      isMobile={isMobile}
-                    />
-                  ) : (
-                    <ButtonNavItem
-                      onClick={item.onClick}
-                      icon={item.icon}
-                      label={item.label}
-                      isChatUI={false}
-                      iconColor={iconColor}
-                      getNavLinkClass={getNavLinkClass}
-                      isActive={
-                        item.type === "button" && item.route
-                          ? isRouteActive(item.route)
-                          : false
-                      }
-                      isDisabled={item.isDisabled}
-                      tooltipText={item.tooltipText}
-                      isMobile={isMobile}
+              {homeNavItem && homeNavItem.type === "link" && (
+                <div className="flex items-center">
+                  <NavItem
+                    to={homeNavItem.to}
+                    icon={homeNavItem.icon}
+                    label={homeNavItem.label}
+                    tooltip={homeNavItem.tooltip}
+                    isChatUI={false}
+                    iconColor={iconColor}
+                    getNavLinkClass={getNavLinkClass}
+                    isMobile={isMobile}
+                  />
+                  {navGroups.length > 0 && (
+                    <Separator
+                      className="h-6 w-px bg-zinc-400 mx-1"
+                      orientation="vertical"
                     />
                   )}
-                  {index < navItems.length - 1 && (
+                </div>
+              )}
+              {navGroups.map((group, index) => (
+                <div key={group.label} className="flex items-center">
+                  <NavDropdown
+                    label={group.label}
+                    icon={group.icon}
+                    items={group.items}
+                    iconColor={iconColor}
+                    getNavLinkClass={getNavLinkClass}
+                    isRouteActive={isRouteActive}
+                    onNavigate={navigate}
+                  />
+                  {index < navGroups.length - 1 && (
                     <Separator
                       className="h-6 w-px bg-zinc-400 mx-1"
                       orientation="vertical"

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -790,9 +790,9 @@ export default function NavBar() {
   const navItems: NavItemData[] = [...baseNavItems, ...createModelNavItems()];
 
   // Group the flat nav items into submenus for the horizontal desktop navbar.
-  // Home stays top-level; anything not claimed by Models/Tools (the deployed
-  // model pages, Voice Agent, etc.) lands in Playground. The vertical and
-  // mobile navbars keep the flat icon list.
+  // Home stays top-level; anything not claimed by Model Lifecycle/Tools (the
+  // deployed model pages: Chat UI, Speech to Text, etc.) lands in Model
+  // Interaction. The vertical and mobile navbars keep the flat icon list.
   const modelsGroupLabels = [
     "Models Deployed",
     "Deployment History",
@@ -803,6 +803,7 @@ export default function NavBar() {
     "Workflows",
     "Canvas",
     "Connect Agents",
+    "Voice Agent",
   ];
   const homeNavItem = navItems.find((item) => item.label === "Home");
   const navGroups = [
@@ -817,7 +818,7 @@ export default function NavBar() {
       items: navItems.filter((item) => toolsGroupLabels.includes(item.label)),
     },
     {
-      label: "Playground",
+      label: "Model Interaction",
       icon: BotMessageSquare,
       items: navItems.filter(
         (item) =>

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -807,7 +807,7 @@ export default function NavBar() {
   const homeNavItem = navItems.find((item) => item.label === "Home");
   const navGroups = [
     {
-      label: "Models",
+      label: "Model Lifecycle",
       icon: Boxes,
       items: navItems.filter((item) => modelsGroupLabels.includes(item.label)),
     },


### PR DESCRIPTION
## Problem

The horizontal navbar shows up to eleven top-level entries once all model-gated pages are visible (Models Deployed, Deployment History, Workflows, Canvas, Connect Agents, Voice Agent, Speech to Text, Text to Speech, Chat UI, ...). The bar gets crowded and items compress together on smaller windows.

## Change

Keep **Home** top-level and group everything else into three dropdowns on the desktop navbar:

- **Models** — Models Deployed, Deployment History, Register Model (when a stray container exists)
- **Tools** — Rag Management, Workflows, Canvas, Connect Agents
- **Playground** — the deployed-model pages (Chat UI, Speech to Text, Text to Speech, ...) plus Voice Agent

The dropdowns are built from the existing nav item definitions, so all visibility gating (healthy-model checks, coding-agent eligibility, voice stack readiness, `VITE_ENABLE_DEPLOYED`) is unchanged. A group hides entirely when none of its items are available, and the trigger takes the usual active border when a child route is the current page. The vertical (chat/canvas) sidebar and mobile navbar keep their flat icon lists.

Uses the existing `ui/dropdown-menu` primitive, so styling matches the rest of the app.

## Verification

- `npm run type-check` and ESLint on `NavBar.tsx` pass (one pre-existing `no-console` warning).
- Ran against the dev stack (backend `/up/` and frontend `/` both 200): dropdowns open with correct grouped entries, selecting **Models → Deployment History** navigates to `/deployment-history`, and gated entries stay hidden with no models deployed (Tools shows only Rag Management, Playground is hidden) — matching the previous gating behavior.