### PR TITLE
Mini Image pull progress bars now synced and visible + clickable throughout UI

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useSetTitle } from "./api/utlis.ts";
 import { HeroSectionProvider } from "./providers/HeroSectionContext.tsx";
 import { FooterVisibilityProvider } from "./providers/FooterVisibilityContext.tsx";
+import { ActiveDeploymentsProvider } from "./providers/ActiveDeploymentsContext.tsx";
 import CustomToaster from "./components/CustomToaster";
 // Development toolbar imports commented out - remove if not needed
 // import { StagewiseToolbar } from "@stagewise/toolbar-react";
@@ -26,7 +27,9 @@ function App() {
         <QueryClientProvider client={client}>
           <HeroSectionProvider>
             <FooterVisibilityProvider>
-              <AppRouter />
+              <ActiveDeploymentsProvider>
+                <AppRouter />
+              </ActiveDeploymentsProvider>
             </FooterVisibilityProvider>
           </HeroSectionProvider>
         </QueryClientProvider>

--- a/app/frontend/src/components/DeploymentTray.tsx
+++ b/app/frontend/src/components/DeploymentTray.tsx
@@ -197,8 +197,9 @@ function DeploymentTrayItem({
             onOpen(deployment);
           }
         }}
-        className="flex cursor-pointer items-center gap-2 text-xs"
+        aria-label={`View deployment progress for ${deployment.modelName}`}
         title="View deployment progress"
+        className="flex cursor-pointer items-center gap-2 rounded text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-TT-purple-accent focus-visible:ring-offset-2"
       >
         {isCompleted ? (
           <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
@@ -209,8 +210,7 @@ function DeploymentTrayItem({
         )}
         <span className="truncate text-sm font-medium">{deployment.modelName}</span>
         <span
-          className={`ml-auto shrink-0 tabular-nums ${isFailed ? "text-destructive" : "text-muted-foreground"
-            }`}
+          className={`ml-auto shrink-0 tabular-nums ${isFailed ? "text-destructive" : "text-muted-foreground"}`}
         >
           {statusLabel}
         </span>

--- a/app/frontend/src/components/DeploymentTray.tsx
+++ b/app/frontend/src/components/DeploymentTray.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Loader2, CheckCircle2, AlertTriangle, X, ChevronDown, Rocket } from "lucide-react";
 import { Progress } from "./ui/progress";
@@ -22,9 +23,15 @@ interface DeploymentTrayProps {
  * all deploys — including the one whose detailed bar is also open in the deploy step.
  */
 export function DeploymentTray({ deployments, progressByJob, onDismiss }: DeploymentTrayProps) {
+  const navigate = useNavigate();
   const [minimized, setMinimized] = useState(false);
   const shown = deployments;
   if (shown.length === 0) return null;
+
+  // Open the single-model deploy step (view=single skips the mode chooser), where
+  // the model's full progress bar resumes from the shared deployment state.
+  const openDeployment = (d: ActiveDeployment) =>
+    navigate(`/?view=single&resume=${encodeURIComponent(d.modelId)}`);
 
   const activeCount = shown.filter((d) => d.status === "active").length;
   const failedCount = shown.filter((d) => d.status === "failed").length;
@@ -93,6 +100,7 @@ export function DeploymentTray({ deployments, progressByJob, onDismiss }: Deploy
                   deployment={d}
                   progress={progressByJob[d.jobId] ?? null}
                   onDismiss={onDismiss}
+                  onOpen={openDeployment}
                 />
               ))}
             </div>
@@ -103,13 +111,24 @@ export function DeploymentTray({ deployments, progressByJob, onDismiss }: Deploy
   );
 }
 
-/** Coarse percent for the slim bar — download fraction during a pull, else the
- *  backend's stage progress. The detailed unified bar lives in DeploymentProgress. */
-function compactPercent(p: DeploymentProgressData | null, completed: boolean): number {
+// Mirrors DeploymentProgress's unified bar
+function compactPercent(
+  p: DeploymentProgressData | null,
+  completed: boolean,
+  hadImagePull: boolean
+): number {
   if (completed) return 100;
   if (!p) return 0;
-  if (p.stage === "pulling_image" && p.total_bytes && p.downloaded_bytes != null) {
-    return Math.min(100, Math.round((p.downloaded_bytes / p.total_bytes) * 100));
+  const isPull = p.stage === "pulling_image";
+  if (isPull || hadImagePull) {
+    if (isPull) {
+      const frac =
+        p.total_bytes && p.downloaded_bytes != null
+          ? Math.min(1, Math.max(0, p.downloaded_bytes / p.total_bytes))
+          : 0;
+      return Math.round(frac * 80);
+    }
+    return Math.min(99, Math.round(80 + Math.min(100, Math.max(0, p.progress ?? 0)) * 0.2));
   }
   return Math.min(100, Math.max(0, Math.round(p.progress ?? 0)));
 }
@@ -118,10 +137,12 @@ function DeploymentTrayItem({
   deployment,
   progress,
   onDismiss,
+  onOpen,
 }: {
   deployment: ActiveDeployment;
   progress: DeploymentProgressData | null;
   onDismiss: (jobId: string) => void;
+  onOpen: (deployment: ActiveDeployment) => void;
 }) {
   const [showLogs, setShowLogs] = useState(false);
   const [logs, setLogs] = useState<string[] | null>(null);
@@ -129,7 +150,7 @@ function DeploymentTrayItem({
 
   const isFailed = deployment.status === "failed";
   const isCompleted = deployment.status === "completed";
-  const pct = compactPercent(progress, isCompleted);
+  const pct = compactPercent(progress, isCompleted, deployment.hadImagePull);
 
   const deviceLabel =
     deployment.deviceIds.length > 0
@@ -166,7 +187,19 @@ function DeploymentTrayItem({
 
   return (
     <div className="rounded-lg border bg-background/60 px-3 py-2.5">
-      <div className="flex items-center gap-2 text-xs">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onOpen(deployment)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen(deployment);
+          }
+        }}
+        className="flex cursor-pointer items-center gap-2 text-xs"
+        title="View deployment progress"
+      >
         {isCompleted ? (
           <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
         ) : isFailed ? (
@@ -176,15 +209,17 @@ function DeploymentTrayItem({
         )}
         <span className="truncate text-sm font-medium">{deployment.modelName}</span>
         <span
-          className={`ml-auto shrink-0 tabular-nums ${
-            isFailed ? "text-destructive" : "text-muted-foreground"
-          }`}
+          className={`ml-auto shrink-0 tabular-nums ${isFailed ? "text-destructive" : "text-muted-foreground"
+            }`}
         >
           {statusLabel}
         </span>
         {(isFailed || isCompleted) && (
           <button
-            onClick={() => onDismiss(deployment.jobId)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDismiss(deployment.jobId);
+            }}
             className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
             aria-label="Dismiss"
           >

--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -13,8 +13,7 @@ import { DeployModelStep } from "./DeployModelStep";
 import { FirstStepForm } from "./FirstStepForm";
 import { ChipConfigStep } from "./ChipConfigStep";
 import { VoiceAgentSolutionStep } from "./VoiceAgentSolutionStep";
-import { DeploymentTray } from "./DeploymentTray";
-import { useActiveDeployments } from "../hooks/useActiveDeployments";
+import { useActiveDeploymentsContext } from "../providers/ActiveDeploymentsContext";
 import type { ChipStatus } from "../types/chipStatus";
 import {
   autoPlacement,
@@ -56,6 +55,9 @@ export default function StepperDemo() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const autoDeployModel = searchParams.get("auto-deploy");
+  // ?resume=<modelId> opens straight to the deploy step for an in-flight model
+  // (e.g. clicking a deployment in the tray) so its progress bar resumes.
+  const resumeModelId = searchParams.get("resume");
 
   const [chipStatus, setChipStatus] = useState<ChipStatus | null>(null);
   const [totalSlots, setTotalSlots] = useState<number | null>(null);
@@ -85,10 +87,9 @@ export default function StepperDemo() {
       });
   }, []);
 
-  // Session-wide tracker for in-flight deploys. Refresh chip-status whenever one
-  // resolves so a freed (failed) or newly-claimed (completed) slot is reflected.
-  const { deployments, progressByJob, addDeployment, removeDeployment, reservedDeviceIds } =
-    useActiveDeployments({ onResolved: () => fetchChipStatus() });
+  // Session-wide tracker for in-flight deploys (shared with the app-wide banner).
+  const { deployments, progressByJob, addDeployment, reservedDeviceIds } =
+    useActiveDeploymentsContext();
   const hasActiveDeployments = deployments.some((d) => d.status === "active");
 
   // Poll chip status faster while deploys are in flight (a pending slot must grey
@@ -98,6 +99,13 @@ export default function StepperDemo() {
     const interval = setInterval(fetchChipStatus, hasActiveDeployments ? 5000 : 7 * 60 * 1000);
     return () => clearInterval(interval);
   }, [fetchChipStatus, hasActiveDeployments]);
+
+  // Refresh chip-status the moment a deploy is added or resolves, so a freed
+  // (failed) or newly-claimed (completed) slot is reflected without waiting for a poll.
+  const deploymentSignature = deployments.map((d) => `${d.jobId}:${d.status}`).join(",");
+  useEffect(() => {
+    fetchChipStatus();
+  }, [deploymentSignature, fetchChipStatus]);
 
   // Overlay reserved devices onto chip-status so the model list greys out
   // configurations a pending deploy already claimed — before the backend
@@ -152,13 +160,19 @@ export default function StepperDemo() {
     }
   };
 
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string | null>(resumeModelId);
   const [selectedModelName, setSelectedModelName] = useState<string | null>(null);
   const [selectedDeviceIds, setSelectedDeviceIds] = useState<number[]>([]);
   const [useImageOverride, setUseImageOverride] = useState(false);
   const [loading, setLoading] = useState(false);
   const [formError, setFormError] = useState(false);
   const [isAutoDeploying, setIsAutoDeploying] = useState(false);
+
+  // A tray click can change ?resume while this page is already mounted; keep the
+  // selection in sync so the deploy step resumes the right model.
+  useEffect(() => {
+    if (resumeModelId) setSelectedModel(resumeModelId);
+  }, [resumeModelId]);
 
   // Chip requirement of the currently selected model (selectedModel holds the id).
   const selectedModelChips =
@@ -616,8 +630,10 @@ export default function StepperDemo() {
           </div>
         )}
         <Stepper
+          // Remount to jump to the deploy step when arriving via a tray click.
+          key={resumeModelId ?? "select"}
           variant="circle-alt"
-          initialStep={0}
+          initialStep={resumeModelId ? 1 : 0}
           steps={steps}
           state={loading ? "loading" : formError ? "error" : undefined}
         >
@@ -677,16 +693,6 @@ export default function StepperDemo() {
           </div>
         </Stepper>
       </ElevatedCard>
-
-      {/* Floating, minimizable deployment banner (fixed, bottom-right). Stays
-          mounted across Prev/Next so parallel deploys remain visible regardless of
-          the active step. Lists every deploy — including the one whose detailed bar
-          is also open in the deploy step. */}
-      <DeploymentTray
-        deployments={deployments}
-        progressByJob={progressByJob}
-        onDismiss={removeDeployment}
-      />
     </div>
   );
 }

--- a/app/frontend/src/providers/ActiveDeploymentsContext.tsx
+++ b/app/frontend/src/providers/ActiveDeploymentsContext.tsx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { createContext, useContext, type ReactNode } from "react";
+import { useActiveDeployments } from "../hooks/useActiveDeployments";
+
+type ActiveDeploymentsValue = ReturnType<typeof useActiveDeployments>;
+
+const ActiveDeploymentsContext = createContext<ActiveDeploymentsValue | null>(null);
+
+// Session-wide deployment tracker, mounted once at the app root so in-flight
+// deploys stay tracked on every page. The floating tray that surfaces this state
+// is rendered inside the Router (see AppRouter) so clicking an item can navigate.
+export function ActiveDeploymentsProvider({ children }: { children: ReactNode }) {
+  const value = useActiveDeployments();
+  return (
+    <ActiveDeploymentsContext.Provider value={value}>
+      {children}
+    </ActiveDeploymentsContext.Provider>
+  );
+}
+
+export function useActiveDeploymentsContext(): ActiveDeploymentsValue {
+  const ctx = useContext(ActiveDeploymentsContext);
+  if (!ctx) {
+    throw new Error("useActiveDeploymentsContext must be used within ActiveDeploymentsProvider");
+  }
+  return ctx;
+}

--- a/app/frontend/src/routes/index.tsx
+++ b/app/frontend/src/routes/index.tsx
@@ -13,6 +13,8 @@ import { BackendHealthProvider } from "../providers/BackendHealthProvider";
 import { getRoutes } from "./route-config";
 import { MainLayout } from "../layouts/MainLayout";
 import { getSettings } from "../api/settingsApi";
+import { DeploymentTray } from "../components/DeploymentTray";
+import { useActiveDeploymentsContext } from "../providers/ActiveDeploymentsContext";
 
 function FirstRunGuard({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
@@ -37,6 +39,8 @@ function FirstRunGuard({ children }: { children: React.ReactNode }) {
 
 const AppRouter = () => {
   const routes = getRoutes();
+  const { deployments, progressByJob, removeDeployment } =
+    useActiveDeploymentsContext();
 
   return (
     <BackendHealthProvider>
@@ -63,6 +67,12 @@ const AppRouter = () => {
                     ))}
                 </Routes>
               </FirstRunGuard>
+              {/* Rendered inside the Router (not the provider) so an item click can navigate. */}
+              <DeploymentTray
+                deployments={deployments}
+                progressByJob={progressByJob}
+                onDismiss={removeDeployment}
+              />
             </Router>
           </ModelsProvider>
         </RefreshProvider>


### PR DESCRIPTION
## Summary
Clicking a deployment in the floating tray now takes you straight to that model's deploy step, with its full progress bar resuming in place — instead of doing nothing.

## Changes
- Tray rows are now clickable (keyboard-accessible) and navigate to the model's deploy step.
- Moved the tray's render inside the Router so a click can navigate; the provider still owns the shared deployment state.
- Added a `?view=single&resume=<modelId>` deep link that opens the single-model flow on the deploy step and resumes the selected model's progress from shared state.

## Notes
- Applies to single-model deploys; Voice Agent "solution" deploys are unchanged.
Closes #1088 