### PR TITLE
Fix TTS API key and tool enabling issues

### DIFF
--- a/app/backend/api/tests.py
+++ b/app/backend/api/tests.py
@@ -62,6 +62,12 @@ class SettingsViewPostTests(SimpleTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_tts_api_key_is_rejected(self):
+        response = self.client.post(
+            "/settings/", {"tts_api_key": "hax"}, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+
 
 @patch("api.views.is_setup_complete", return_value=True)
 @patch("api.views.get_artifact_info", return_value={"branch": None, "version": "v0.0.0"})
@@ -93,3 +99,10 @@ class SettingsViewGetTests(SimpleTestCase):
         self.assertTrue(jwt["set"])
         self.assertIsNone(jwt["value"])
         self.assertNotEqual(jwt["masked"], "jwt-secret-value-123")
+
+    def test_tts_api_key_is_read_only(self, *_mocks):
+        # Auto-managed like the JWT secret: shown but never editable or in plaintext.
+        response = self.client.get("/settings/")
+        tts = response.data["tts_api_key"]
+        self.assertFalse(tts["editable"])
+        self.assertIsNone(tts["value"])

--- a/app/backend/api/views.py
+++ b/app/backend/api/views.py
@@ -46,7 +46,7 @@ def _field(cfg, key, value, editable=True):
     }
 
 
-_EDITABLE_FIELDS = ("tavily_api_key", "hf_token", "tts_api_key")
+_EDITABLE_FIELDS = ("tavily_api_key", "hf_token")
 _ARTIFACT_DESCRIPTION = (
     "Pins which tt-inference-server release TT Studio is built against. "
     "Changing it requires a redeploy; editing here is intentionally disabled."
@@ -69,7 +69,7 @@ class SettingsView(APIView):
             "jwt_secret": _field(cfg, "jwt_secret", jwt_value, editable=False),
             "tavily_api_key": _field(cfg, "tavily_api_key", get_tavily_api_key()),
             "hf_token": _field(cfg, "hf_token", get_hf_token()),
-            "tts_api_key": _field(cfg, "tts_api_key", get_tts_api_key()),
+            "tts_api_key": _field(cfg, "tts_api_key", get_tts_api_key(), editable=False),
             "artifact": {
                 "branch": artifact["branch"],
                 "version": artifact["version"],
@@ -83,6 +83,11 @@ class SettingsView(APIView):
         if "jwt_secret" in data:
             return Response(
                 {"error": "jwt_secret is auto-managed and cannot be set via the UI."},
+                status=400,
+            )
+        if "tts_api_key" in data:
+            return Response(
+                {"error": "tts_api_key is auto-managed and cannot be set via the UI."},
                 status=400,
             )
         if "artifact" in data or "tt_inference_artifact_branch" in data or "tt_inference_artifact_version" in data:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -420,8 +420,26 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
             payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
 
+        # Pass UI-managed secrets explicitly. The inference server runs on the host
+        # and cannot read user_config.env in the persistent volume when the backend
+        # container (root) wrote it, so the request payload is its reliable source.
+        # Mirrors start_chat_deployment in tt_inference_client.py; without this,
+        # media/forge deploys (e.g. FLUX) reach run.py with no JWT_SECRET and fall
+        # back to an interactive getpass prompt that EOFs in the non-TTY subprocess.
+        from shared_config.user_config import get_hf_token, get_jwt_secret
+        hf_token = get_hf_token()
+        if hf_token:
+            payload["hf_token"] = hf_token
+        jwt_secret = get_jwt_secret()
+        if jwt_secret:
+            payload["jwt_secret"] = jwt_secret
 
-        logger.info(f"API payload: {payload}")
+        # Redact secrets before logging the payload.
+        _redacted_payload = {
+            k: ("***" if k in ("jwt_secret", "hf_token") else v)
+            for k, v in payload.items()
+        }
+        logger.info(f"API payload: {_redacted_payload}")
 
         # Make POST request to TT Inference Server API
         api_url = f"{FASTAPI_BASE_URL}/run"

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1046,6 +1046,14 @@ class DeploymentProgressView(APIView):
                         status=status.HTTP_200_OK,
                     )
 
+            # An imgpull_ id that isn't a tracked pull job (job_id is reassigned to
+            # the real inference id on handoff above) is an orphan — its in-memory
+            # pull job was lost, e.g. the backend restarted mid-pull. It maps to no
+            # real container, so the container fallback below would fabricate endless
+            # fake progress. Report it terminal so the client stops polling.
+            if job_id.startswith("imgpull_"):
+                return Response({"status": "not_found"}, status=status.HTTP_200_OK)
+
             # Track deployment start time if not already tracked
             if job_id not in deployment_start_times:
                 deployment_start_times[job_id] = time.time()

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -638,6 +638,7 @@ class DeployView(APIView):
                             device_ids=occupied_device_ids,
                             status="starting",
                             port=service_port,
+                            tool_calling_enabled=tool_calling_supported,
                         )
                     except Exception as e:
                         logger.warning(f"Could not create placeholder ModelDeployment for {pull_id}: {e}")

--- a/app/backend/shared_config/test_user_config.py
+++ b/app/backend/shared_config/test_user_config.py
@@ -171,3 +171,13 @@ class TestGetters:
     def test_env_var_fallback(self, volume, monkeypatch):
         monkeypatch.setenv("TAVILY_API_KEY", "tvly-env")
         assert user_config.get_tavily_api_key() == "tvly-env"
+
+    def test_tts_api_key_defaults_to_media_server_key(self, volume, monkeypatch):
+        # Unconfigured TTS key must resolve to the media server's default so
+        # TTS/STT models authenticate out of the box (see _DEFAULT_TTS_API_KEY).
+        monkeypatch.delenv("TTS_API_KEY", raising=False)
+        assert user_config.get_tts_api_key() == "your-secret-key"
+
+    def test_tts_api_key_config_beats_default(self, volume):
+        user_config.save_user_config({"tts_api_key": "custom-key"})
+        assert user_config.get_tts_api_key() == "custom-key"

--- a/app/backend/shared_config/test_user_config.py
+++ b/app/backend/shared_config/test_user_config.py
@@ -174,7 +174,7 @@ class TestGetters:
 
     def test_tts_api_key_defaults_to_media_server_key(self, volume, monkeypatch):
         # Unconfigured TTS key must resolve to the media server's default so
-        # TTS/STT models authenticate out of the box (see _DEFAULT_TTS_API_KEY).
+        # TTS/STT models authenticate out of the box (see DEFAULT_TTS_API_KEY).
         monkeypatch.delenv("TTS_API_KEY", raising=False)
         assert user_config.get_tts_api_key() == "your-secret-key"
 

--- a/app/backend/shared_config/user_config.py
+++ b/app/backend/shared_config/user_config.py
@@ -188,7 +188,7 @@ def get_hf_token() -> Optional[str]:
     return os.environ.get("HF_TOKEN") or None
 
 
-def get_tts_api_key() -> Optional[str]:
+def get_tts_api_key() -> str:
     cfg = load_user_config()
     val = cfg.get("tts_api_key")
     if val:

--- a/app/backend/shared_config/user_config.py
+++ b/app/backend/shared_config/user_config.py
@@ -20,6 +20,10 @@ from typing import Optional
 _CONFIG_FILENAME = "user_config.env"
 _LEGACY_JSON_FILENAME = "user_config.json"
 
+# Default bearer token for the media (TTS/STT) inference server. Matches the
+# tt-inference-server media server's own default API_KEY (security/api_key_checker.py):
+DEFAULT_TTS_API_KEY = "your-secret-key"
+
 # Python-facing keys <-> keys as written in user_config.env.
 _ENV_KEYS = {
     "jwt_secret": "JWT_SECRET",
@@ -189,7 +193,7 @@ def get_tts_api_key() -> Optional[str]:
     val = cfg.get("tts_api_key")
     if val:
         return val
-    return os.environ.get("TTS_API_KEY") or None
+    return os.environ.get("TTS_API_KEY") or DEFAULT_TTS_API_KEY
 
 
 def get_artifact_info() -> dict:

--- a/app/frontend/src/api/settingsApi.ts
+++ b/app/frontend/src/api/settingsApi.ts
@@ -34,7 +34,6 @@ export interface SettingsResponse {
 
 export interface UpdateSettingsPayload {
   hf_token?: string;
-  tts_api_key?: string;
   tavily_api_key?: string;
   setup_complete?: true;
 }

--- a/app/frontend/src/components/SettingsDialog.tsx
+++ b/app/frontend/src/components/SettingsDialog.tsx
@@ -33,7 +33,6 @@ import {
 
 const formSchema = z.object({
   hf_token: z.string().optional(),
-  tts_api_key: z.string().optional(),
   tavily_api_key: z.string().optional(),
 });
 
@@ -143,7 +142,7 @@ export default function SettingsDialog({ open, onOpenChange }: Props) {
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
-    defaultValues: { hf_token: "", tts_api_key: "", tavily_api_key: "" },
+    defaultValues: { hf_token: "", tavily_api_key: "" },
   });
 
   const hfTokenValue = (form.watch("hf_token") || "").trim();
@@ -154,7 +153,6 @@ export default function SettingsDialog({ open, onOpenChange }: Props) {
     if (open) {
       form.reset({
         hf_token: data?.hf_token.value ?? "",
-        tts_api_key: data?.tts_api_key.value ?? "",
         tavily_api_key: data?.tavily_api_key.value ?? "",
       });
       setShowHfCheck(false);
@@ -169,7 +167,6 @@ export default function SettingsDialog({ open, onOpenChange }: Props) {
       const body: Record<string, string> = {};
       for (const key of [
         "hf_token",
-        "tts_api_key",
         "tavily_api_key",
       ] as const) {
         const val = (payload[key] || "").trim();
@@ -267,19 +264,26 @@ export default function SettingsDialog({ open, onOpenChange }: Props) {
             </div>
           </SecretField>
 
-          <SecretField
-            id="tts_api_key"
-            label="TTS API key"
-            field={data?.tts_api_key}
-            loading={isLoading}
-            placeholder="Enter TTS API key"
-            register={form.register("tts_api_key")}
-          >
+          <div className="space-y-1">
+            <Label className="flex items-center gap-1">
+              <Lock className="w-3.5 h-3.5" /> TTS API key
+            </Label>
+            <Input
+              readOnly
+              disabled
+              value={
+                isLoading ? "Loading…" : data?.tts_api_key.masked || "Auto-managed"
+              }
+            />
             <p className="text-xs text-stone-500">
-              Authenticates TTS inference calls for media / voice models. Applied
-              immediately, per request.
+              Auto-managed for media / voice (TTS &amp; STT) auth. Matches the
+              media inference server's default; to use a custom key, set{" "}
+              <code className="rounded bg-stone-100 dark:bg-stone-800 px-1 py-0.5 font-mono">
+                API_KEY
+              </code>{" "}
+              in the root .env and redeploy.
             </p>
-          </SecretField>
+          </div>
 
           <SecretField
             id="tavily_api_key"

--- a/app/frontend/src/components/SettingsDialog.tsx
+++ b/app/frontend/src/components/SettingsDialog.tsx
@@ -279,7 +279,7 @@ export default function SettingsDialog({ open, onOpenChange }: Props) {
               Auto-managed for media / voice (TTS &amp; STT) auth. Matches the
               media inference server's default; to use a custom key, set{" "}
               <code className="rounded bg-stone-100 dark:bg-stone-800 px-1 py-0.5 font-mono">
-                API_KEY
+                TTS_API_KEY
               </code>{" "}
               in the root .env and redeploy.
             </p>

--- a/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
@@ -36,8 +36,8 @@ export default function WelcomeIntroStep({ onNext }: Props) {
         <li className="flex items-start gap-2">
           <span className="text-TT-purple">•</span>
           <span>
-            <span className="font-medium">TTS API key</span> — required to call
-            TTS inference endpoints.
+            <span className="font-medium">TTS API key</span> — auto-managed;
+            authenticates media / voice (TTS &amp; STT) models for you.
           </span>
         </li>
         <li className="flex items-start gap-2">

--- a/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
@@ -12,7 +12,6 @@ import type { SettingsResponse } from "../../api/settingsApi";
 
 export interface WelcomeSecrets {
   hf_token: string;
-  tts_api_key: string;
   tavily_api_key: string;
 }
 
@@ -92,6 +91,7 @@ export default function WelcomeSecretsStep({
 }: Props) {
   const loading = !current;
   const jwtMasked = current?.jwt_secret.masked;
+  const ttsMasked = current?.tts_api_key.masked;
   const artifact = current?.artifact;
 
   return (
@@ -139,23 +139,12 @@ export default function WelcomeSecretsStep({
       </div>
 
       <div className="space-y-1.5">
-        <div className="flex items-center gap-2">
-          <Label htmlFor="tts_api_key">TTS API key</Label>
-          {current?.tts_api_key.set && <SavedBadge />}
-        </div>
-        <RevealInput
-          id="tts_api_key"
-          value={values.tts_api_key}
-          onChange={(v) => onChange({ ...values, tts_api_key: v })}
-          placeholder={fieldPlaceholder(
-            loading,
-            current?.tts_api_key.set,
-            current?.tts_api_key.masked,
-            "Enter TTS API key"
-          )}
-        />
+        <Label className="flex items-center gap-1">
+          <Lock className="w-3.5 h-3.5" /> TTS API key
+        </Label>
+        <Input readOnly disabled value={ttsMasked || "Auto-managed"} />
         <p className="text-xs text-stone-500">
-          Authenticates calls to the TTS inference server.
+          Auto-managed for media / voice (TTS &amp; STT) model auth.
         </p>
       </div>
 

--- a/app/frontend/src/pages/WelcomePage.tsx
+++ b/app/frontend/src/pages/WelcomePage.tsx
@@ -32,7 +32,6 @@ export default function WelcomePage() {
   const [stepIndex, setStepIndex] = useState(0);
   const [secrets, setSecrets] = useState<WelcomeSecrets>({
     hf_token: "",
-    tts_api_key: "",
     tavily_api_key: "",
   });
 
@@ -50,7 +49,6 @@ export default function WelcomePage() {
     prefilled.current = true;
     setSecrets({
       hf_token: current.hf_token.value ?? "",
-      tts_api_key: current.tts_api_key.value ?? "",
       tavily_api_key: current.tavily_api_key.value ?? "",
     });
   }, [current]);
@@ -63,7 +61,6 @@ export default function WelcomePage() {
       const body: Record<string, string> = {};
       for (const key of [
         "hf_token",
-        "tts_api_key",
         "tavily_api_key",
       ] as const) {
         const val = secrets[key].trim();


### PR DESCRIPTION
## Summary

Two related fixes around model tool-calling detection and the TTS API key.

### Tool-calling detection for freshly-pulled models
Chat models deployed through TT-Studio were incorrectly flagged as "tool calling off" on the Connect Agents page when their image had to be pulled first. The pre-pull placeholder `ModelDeployment` record was created without `tool_calling_enabled`, so the flag stayed `False` even though the container was launched with the correct vLLM tool-calling args. The placeholder now carries `tool_calling_enabled=tool_calling_supported`, matching the fast (already-cached) deploy path.

### TTS API key is now auto-managed
The TTS API key is no longer a user-editable secret. It defaults to the media inference server's own default key (`DEFAULT_TTS_API_KEY`), so TTS/STT models authenticate out of the box. To override, set `API_KEY` in the root `.env` and redeploy.

- **Backend**: `get_tts_api_key()` falls back to the default; `/settings/` returns the key as read-only and rejects attempts to set it.
- **Frontend**: Settings dialog and Welcome flow render the TTS key as an auto-managed, read-only field instead of an editable input.

### Orphaned jobs are now removed
When there was an image pull job running before container start that became orphaned (e.g. backend container restarted), the frontend would still infinitely keep polling it due to the job id stored in localstorage and the backend not returning a not found response. This would also make the client think that the the device slots were falsely occupied.
The backend has now been modified to return a job status of not found to signal the client to stop polling.

## Tests
- `tts_api_key` is rejected on POST and read-only on GET (`api/tests.py`).
- `get_tts_api_key()` resolves to the media-server default and lets config override it (`test_user_config.py`).
