### PR TITLE
fix: footer shows all device IDs for multi-chip models

### DIFF
--- a/app/frontend/src/components/Footer.tsx
+++ b/app/frontend/src/components/Footer.tsx
@@ -20,6 +20,7 @@ import { getBuildInfo } from "../api/githubApi";
 import { HardwareIcon } from "./aiPlaygroundHome/HardwareIcon";
 import { cn } from "../lib/utils";
 import { useFooterVisibility } from "../hooks/useFooterVisibility";
+import { deviceIdsForRow } from "../utils/deviceIds";
 
 interface FooterProps {
   className?: string;
@@ -499,10 +500,10 @@ const Footer: React.FC<FooterProps> = ({ className }) => {
                               onClick={handleRefreshBoardDetection}
                               disabled={refreshing || isInCooldown}
                               className={`p-1 rounded-full border border-transparent transition-colors duration-150 ${refreshing
-                                  ? "opacity-70 cursor-wait"
-                                  : isInCooldown
-                                    ? "opacity-60 cursor-not-allowed"
-                                    : "hover:bg-TT-purple-accent/10 dark:hover:bg-TT-purple-accent/20"
+                                ? "opacity-70 cursor-wait"
+                                : isInCooldown
+                                  ? "opacity-60 cursor-not-allowed"
+                                  : "hover:bg-TT-purple-accent/10 dark:hover:bg-TT-purple-accent/20"
                                 }`}
                               aria-label="Retry board detection"
                             >
@@ -625,9 +626,9 @@ const Footer: React.FC<FooterProps> = ({ className }) => {
                               </div>
 
                               {/* Device ID badge */}
-                              {model.device_id != null && (
+                              {deviceIdsForRow(model) && (
                                 <span className="text-[9px] px-1.5 py-0.5 rounded bg-TT-purple-accent/10 text-TT-purple/70 font-mono flex-shrink-0">
-                                  dev:{model.device_id}
+                                  dev:{deviceIdsForRow(model)?.join(",")}
                                 </span>
                               )}
                             </motion.div>

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -52,15 +52,7 @@ import { useDeleteStream } from "../../hooks/useDeleteStream";
 import axios from "axios";
 import { ChipStatusDisplay } from "../ChipStatusDisplay";
 import type { ChipStatus } from "../../types/chipStatus";
-
-const deviceIdsForRow = (
-  row?: { device_ids?: number[]; device_id?: number | null },
-): number[] | undefined => {
-  if (!row) return undefined;
-  if (Array.isArray(row.device_ids) && row.device_ids.length > 0) return row.device_ids;
-  if (row.device_id != null) return [row.device_id];
-  return undefined;
-};
+import { deviceIdsForRow } from "../../utils/deviceIds";
 
 export default function ModelsDeployedCard(): JSX.Element {
   const { models, setModels, refreshModels, userStoppedModel, setUserStoppedModel, setIsDeleteInFlight } = useModels();

--- a/app/frontend/src/utils/deviceIds.ts
+++ b/app/frontend/src/utils/deviceIds.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+export const deviceIdsForRow = (row?: {
+  device_ids?: number[];
+  device_id?: number | null;
+}): number[] | undefined => {
+  if (!row) return undefined;
+  if (Array.isArray(row.device_ids) && row.device_ids.length > 0)
+    return row.device_ids;
+  if (row.device_id != null) return [row.device_id];
+  return undefined;
+};


### PR DESCRIPTION
### Description

The deployed-models popover in the Footer was previously only rendering the scalar `device_id`, which caused it to only display a single chip (e.g. `dev:0`) when a model was actually allocated across multiple chips (e.g. `--device-id 0,1`). 

This PR resolves the issue and aligns the Footer's logic with the `ModelsDeployedCard` component.

- Fixes #1147 
### Changes Made
* Extracted the `deviceIdsForRow` logic into a shared utility (`app/frontend/src/utils/deviceIds.ts`).
* Updated `Footer.tsx` to utilize this shared utility, correctly prioritizing the `device_ids` array when rendering the badge.
* Cleaned up `ModelsDeployedCard.tsx` to use the new shared import.

### Validation & Screenshot
Since I don't have access to Tenstorrent hardware locally to test a multi-chip deployment, I've added an automated E2E test (`footer-device-ids.spec.ts`). This test mocks the backend response with multiple allocated chips (`device_ids: [0, 1, 3]`) and successfully validates that the UI renders the correct multi-chip string (`dev:0,1,3`).

<img width="1470" height="839" alt="Screenshot 2026-07-24 at 3 41 38 PM" src="https://github.com/user-attachments/assets/12f7d032-1a27-497a-8821-18e41c71d8db" />
