### PR TITLE
Label Voice Agent components by function instead of model name

### DIFF
--- a/app/frontend/src/components/VoiceAgentSolutionStep.tsx
+++ b/app/frontend/src/components/VoiceAgentSolutionStep.tsx
@@ -492,7 +492,7 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
 
               <ModelCard
                 icon={<Mic className="w-5 h-5" />}
-                label="Whisper"
+                label="Speech-to-text"
                 deviceLabel={`Device ${whisperDeviceId}`}
                 deployState={whisperState}
                 accent="purple"
@@ -506,7 +506,7 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
 
               <ModelCard
                 icon={<Volume2 className="w-5 h-5" />}
-                label="SpeechT5 TTS"
+                label="Text-to-speech"
                 deviceLabel={`Device ${ttsDeviceId}`}
                 deployState={ttsState}
                 accent="green"

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -635,14 +635,14 @@ export default function ModelsDeployedCard(): JSX.Element {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div className="flex items-center gap-2">
-                          <PulsatingDot label="Whisper STT" color="blue" size="md" delay={0} />
+                          <PulsatingDot label="Speech-to-text" color="blue" size="md" delay={0} />
                           <PulsatingDot label="LLM" color="green" size="md" delay={400} />
-                          <PulsatingDot label="TTS" color="purple" size="md" delay={800} />
+                          <PulsatingDot label="Text-to-speech" color="purple" size="md" delay={800} />
                         </div>
                       </TooltipTrigger>
                       <TooltipContent side="bottom" className="max-w-xs">
                         <p className="text-sm">
-                          TT Studio automatically chains your deployed models: Whisper STT → LLM → TTS for seamless voice conversations
+                          TT Studio automatically chains your deployed models: Speech-to-text → LLM → Text-to-speech for seamless voice conversations
                         </p>
                       </TooltipContent>
                     </Tooltip>

--- a/app/frontend/src/components/voiceAgent/MetricsPanel.tsx
+++ b/app/frontend/src/components/voiceAgent/MetricsPanel.tsx
@@ -148,7 +148,7 @@ export function MetricsPanel({ metrics }: MetricsPanelProps) {
         </h3>
         <div className="flex flex-col gap-3">
           <TimingBar
-            label="STT (Whisper)"
+            label="Speech-to-text"
             valueMs={metrics?.stt_latency_ms}
             maxMs={5000}
           />
@@ -163,7 +163,7 @@ export function MetricsPanel({ metrics }: MetricsPanelProps) {
             maxMs={10000}
           />
           <TimingBar
-            label="TTS (SpeechT5)"
+            label="Text-to-speech"
             valueMs={metrics?.tts_latency_ms}
             maxMs={10000}
           />

--- a/app/frontend/src/components/voiceAgent/StatusPanel.tsx
+++ b/app/frontend/src/components/voiceAgent/StatusPanel.tsx
@@ -98,7 +98,7 @@ export function StatusPanel({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Mic className="w-3.5 h-3.5 text-TT-purple-accent" />
-              <span className="text-xs">Whisper</span>
+              <span className="text-xs">Speech-to-text</span>
             </div>
             <div className="flex items-center gap-1.5">
               <StatusDot connected={!!models.whisper} />
@@ -136,7 +136,7 @@ export function StatusPanel({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Volume2 className="w-3.5 h-3.5 text-TT-purple-accent" />
-              <span className="text-xs">TTS</span>
+              <span className="text-xs">Text-to-speech</span>
             </div>
             <div className="flex items-center gap-1.5">
               <StatusDot connected={!!models.tts} />

--- a/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
@@ -537,9 +537,9 @@ export default function VoiceAgentApp() {
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
                 <div className="flex flex-col gap-1">
-                  <span>Whisper: {models.whisper?.modelName || "not deployed"}</span>
+                  <span>Speech-to-text: {models.whisper?.modelName || "not deployed"}</span>
                   <span>LLM: {models.llm?.modelName || "not deployed"}</span>
-                  <span>TTS: {models.tts?.modelName || "not deployed"}</span>
+                  <span>Text-to-speech: {models.tts?.modelName || "not deployed"}</span>
                 </div>
               </TooltipContent>
             </Tooltip>


### PR DESCRIPTION
## Summary
The Voice Agent UI labeled its pipeline components by model architecture (`Whisper`, `SpeechT5 TTS`), which is jargon for most users. This renames them to functional names so the pipeline consistently reads **LLM | Speech-to-text | Text-to-speech**. `LLM` is unchanged.

## Changes
Only user-visible type labels were changed, across the Voice Agent surfaces:
- Deploy-step title cards — `VoiceAgentSolutionStep.tsx`
- Models status list — `voiceAgent/StatusPanel.tsx`
- Pipeline Timing bars (`STT (Whisper)`, `TTS (SpeechT5)`) — `voiceAgent/MetricsPanel.tsx`
- "Voice Agent Ready" card dots and the `→ LLM →` flow text — `models/ModelsDeployedCard.tsx`
- Navbar status tooltip — `voiceAgent/VoiceAgentApp.tsx`

Internal keys/props (`models.whisper`, `models.tts`, `ModelType.TTS`), the `/speech-to-text` route, and the actual deployed model-name values are intentionally left untouched.

## Verification
- `npm run type-check` — passes
- `npm run lint` — no new issues introduced on the changed files
- `npm run build` — passes
- Not exercised end-to-end in the browser: the Voice Agent screens require the Tenstorrent hardware/Docker stack. This is a static text-label change with no logic, verified via type-check, lint, and a production build.