### PR TITLE
Launcher: --uninstall, --switch, and stale tt-studio shortcut auto-repair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ python run.py --logs          # stream all container logs (docker compose logs -
 python run.py --info          # re-show the "TT Studio is ready" summary (URLs, mode, hardware)
 python run.py --report-bug    # bundle logs (logs/tt-studio-logs-ttbr-*.zip) + open a GitHub issue
 python run.py --install-shortcut # add a `tt-studio` shell shortcut (~/.zshrc/~/.bashrc)
+python run.py --switch REF    # fetch + check out a tt-studio branch/tag (e.g. an RC), then re-run
+python run.py --uninstall     # --purge-all teardown + remove the `tt-studio` shell shortcut
 python run.py --check-headers # report files missing SPDX headers
 ```
 

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -44,6 +44,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | `--configure-env` | Interactively configure **all** environment variables (secrets, modes, cloud endpoints). |
 | `--reconfigure-inference-server` (alias `--reconfig-inf`) | Reconfigure the TT Inference Server artifact (version/branch selection). Prompts only for the artifact source; verifies the release tag / branch / commit exists upstream before accepting it. |
 | `--install-shortcut` | Add a `tt-studio` shell shortcut (a function in your `~/.zshrc` / `~/.bashrc`) so you can launch from any directory without typing `python run.py`. |
+| `--switch REF` | Switch this checkout to a git branch or tag (e.g. `dev`, `v2.9.0-rc1`): fetches origin, checks the ref out (fast-forwarding branches), then exits — re-run to start on that version. Refuses if you have uncommitted changes. |
 
 ### Model Deployment
 
@@ -74,6 +75,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | --- | --- |
 | `--purge-all` | Stop and wipe **everything** including the persistent volume and `.env`. (Deprecated alias: `--cleanup-all`.) |
 | `--yes`, `-y` | Skip the `--purge-all` confirmation prompt (for non-interactive/scripted runs). |
+| `--uninstall` | Full uninstall: run the `--purge-all` teardown **and** remove the `tt-studio` shell shortcut from your shell config. Declining the confirmation leaves both untouched. |
 
 ### Advanced
 
@@ -496,6 +498,30 @@ subshell, so your current directory is untouched). Reopen your terminal (or
 etc. The first time you launch without the shortcut installed, TT-Studio also
 offers to set it up for you (once). Bash/zsh are handled automatically; other
 shells get a snippet to paste.
+
+The shortcut bakes in the repo path it was installed from. If you move the repo
+or start launching from a different clone, the next normal startup re-points the
+shortcut to that checkout automatically (a one-line notice tells you when it
+does).
+
+### Switching Versions
+```bash
+python run.py --switch dev          # a branch
+python run.py --switch v2.9.0-rc1   # a release tag / RC
+```
+Fetches origin and checks out the given branch (fast-forwarded to origin) or tag
+(detached HEAD), then exits — re-run `python run.py` (or `tt-studio`) to start on
+that version. It refuses to run if your checkout has uncommitted changes, and if
+TT-Studio is currently running you should `--stop` and start again so the stack
+matches the new code.
+
+### Uninstalling
+```bash
+python run.py --uninstall
+```
+Runs the full `--purge-all` teardown (containers, volumes, `.env`, artifacts) and
+then removes the `tt-studio` shell function from your shell config. One
+confirmation covers both; answering no leaves everything in place.
 
 ### Reporting a Bug
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ class TestCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         output_without_ansi = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         for flag in ("--dev", "--stop", "--purge-all", "--help-env", "--no-sudo",
-                     "--logs", "--info"):
+                     "--logs", "--info", "--uninstall", "--switch"):
             self.assertIn(flag, output_without_ansi)
 
     def test_info_flag_dispatches_to_ready_panel(self):
@@ -151,6 +151,41 @@ class TestCli(unittest.TestCase):
             self.assertIn(panel, result.output)
         # Service-control flags live under Advanced now, not their own panel.
         self.assertNotIn("Service Control", result.output)
+
+    def test_uninstall_runs_purge_then_removes_shortcut(self):
+        with patch.object(_cli_run, "cleanup_resources", return_value=True) as cleanup, \
+             patch.object(_cli_run, "uninstall_shortcut") as remove:
+            result = runner.invoke(M.app, ["--uninstall"])
+        self.assertEqual(result.exit_code, 0)
+        cleanup.assert_called_once()
+        remove.assert_called_once()
+        # --uninstall implies the full purge (and therefore the stop trigger).
+        ns = cleanup.call_args[0][0]
+        self.assertTrue(ns.cleanup_all)
+        self.assertTrue(ns.cleanup)
+
+    def test_uninstall_keeps_shortcut_when_purge_aborted(self):
+        # Declining the purge confirmation aborts the whole uninstall.
+        with patch.object(_cli_run, "cleanup_resources", return_value=False), \
+             patch.object(_cli_run, "uninstall_shortcut") as remove:
+            result = runner.invoke(M.app, ["--uninstall"])
+        self.assertEqual(result.exit_code, 0)
+        remove.assert_not_called()
+
+    def test_switch_dispatches_with_ref(self):
+        with patch.object(_cli_run, "switch_checkout", return_value=0) as switch:
+            result = runner.invoke(M.app, ["--switch", "v2.9.0-rc1"])
+        self.assertEqual(result.exit_code, 0)
+        switch.assert_called_once_with("v2.9.0-rc1")
+
+    def test_switch_requires_value(self):
+        result = runner.invoke(M.app, ["--switch"])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_switch_nonzero_exit_propagates(self):
+        with patch.object(_cli_run, "switch_checkout", return_value=1):
+            result = runner.invoke(M.app, ["--switch", "dev"])
+        self.assertEqual(result.exit_code, 1)
 
     def test_main_is_callable_entrypoint(self):
         self.assertTrue(callable(M.main))

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the tt-studio shell shortcut: path extraction, uninstall, repair."""
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+try:
+    from tt_setup import shortcut as M
+except ImportError:
+    import run as M
+
+
+def _block_for(path):
+    return (
+        f"{M._MARKER_START}\n"
+        f'tt-studio() {{ ( cd "{path}" && python3 run.py "$@" ); }}\n'
+        f"{M._MARKER_END}\n"
+    )
+
+
+class TestExtractShortcutPath(unittest.TestCase):
+    def test_extract_shortcut_path_from_block(self):
+        content = "export FOO=1\n" + _block_for("/opt/tt-studio")
+        self.assertEqual(M.extract_shortcut_path(content), "/opt/tt-studio")
+
+    def test_extract_shortcut_path_none_when_absent(self):
+        self.assertIsNone(M.extract_shortcut_path("export FOO=1\nalias ll='ls -l'\n"))
+        self.assertIsNone(M.extract_shortcut_path(""))
+
+
+class _RcFileCase(unittest.TestCase):
+    """Base: a temp dir with an rc file, and _detect_shell_rc patched to it."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.rc_path = os.path.join(self._tmp.name, ".zshrc")
+
+    def _write_rc(self, content):
+        with open(self.rc_path, "w") as f:
+            f.write(content)
+
+    def _read_rc(self):
+        with open(self.rc_path, "r") as f:
+            return f.read()
+
+    def _patch_shell(self):
+        return patch.object(M, "_detect_shell_rc", return_value=("zsh", self.rc_path))
+
+
+class TestInstalledShortcutPath(_RcFileCase):
+    def test_installed_shortcut_path_reads_rc_file(self):
+        self._write_rc("# prelude\n" + _block_for("/repos/tt-studio"))
+        self.assertEqual(M.installed_shortcut_path(self.rc_path), "/repos/tt-studio")
+
+    def test_installed_shortcut_path_missing_file_returns_none(self):
+        self.assertIsNone(M.installed_shortcut_path(self.rc_path))
+
+    def test_installed_shortcut_path_no_block_returns_none(self):
+        self._write_rc("export FOO=1\n")
+        self.assertIsNone(M.installed_shortcut_path(self.rc_path))
+
+
+class TestStripBlock(unittest.TestCase):
+    def test_strip_block_removes_complete_block(self):
+        lines = ("before\n" + _block_for("/x") + "after\n").splitlines(keepends=True)
+        self.assertEqual(M._strip_block(lines), ["before\n", "after\n"])
+
+    def test_strip_block_leaves_unbalanced_markers_untouched(self):
+        lines = f"before\n{M._MARKER_START}\ntt-studio() {{ :; }}\n".splitlines(keepends=True)
+        self.assertEqual(M._strip_block(lines), lines)
+
+
+class TestUninstallShortcut(_RcFileCase):
+    def test_uninstall_shortcut_removes_block_and_returns_true(self):
+        prelude = "export PATH=$PATH:/bin\nalias ll='ls -l'\n"
+        self._write_rc(prelude + _block_for("/repos/tt-studio"))
+        with self._patch_shell():
+            self.assertTrue(M.uninstall_shortcut())
+        content = self._read_rc()
+        self.assertNotIn(M._MARKER_START, content)
+        self.assertNotIn("tt-studio()", content)
+        # The rest of the rc file is preserved.
+        self.assertIn("alias ll='ls -l'", content)
+        self.assertIn("export PATH=$PATH:/bin", content)
+
+    def test_uninstall_shortcut_returns_false_when_not_installed(self):
+        self._write_rc("export FOO=1\n")
+        with self._patch_shell():
+            self.assertFalse(M.uninstall_shortcut())
+        self.assertEqual(self._read_rc(), "export FOO=1\n")
+
+    def test_uninstall_shortcut_refuses_unbalanced_markers(self):
+        content = f"export FOO=1\n{M._MARKER_START}\ntt-studio() {{ :; }}\n"
+        self._write_rc(content)
+        with self._patch_shell():
+            self.assertFalse(M.uninstall_shortcut())
+        self.assertEqual(self._read_rc(), content)
+
+    def test_uninstall_shortcut_unsupported_shell_returns_false(self):
+        with patch.object(M, "_detect_shell_rc", return_value=("fish", None)):
+            self.assertFalse(M.uninstall_shortcut())
+
+
+class TestMaybeRepairShortcut(_RcFileCase):
+    def test_maybe_repair_rewrites_stale_path(self):
+        self._write_rc("# prelude\n" + _block_for("/old/checkout"))
+        with self._patch_shell(), patch.object(M, "TT_STUDIO_ROOT", self._tmp.name):
+            M.maybe_repair_shortcut()
+        content = self._read_rc()
+        self.assertEqual(M.extract_shortcut_path(content), self._tmp.name)
+        self.assertNotIn("/old/checkout", content)
+        self.assertIn("# prelude", content)
+        self.assertEqual(content.count(M._MARKER_START), 1)
+
+    def test_maybe_repair_noop_when_path_matches(self):
+        self._write_rc(_block_for(self._tmp.name))
+        before = self._read_rc()
+        with self._patch_shell(), patch.object(M, "TT_STUDIO_ROOT", self._tmp.name):
+            M.maybe_repair_shortcut()
+        self.assertEqual(self._read_rc(), before)
+
+    def test_maybe_repair_noop_when_paths_are_symlink_equivalent(self):
+        real = os.path.join(self._tmp.name, "repo")
+        os.mkdir(real)
+        link = os.path.join(self._tmp.name, "repo-link")
+        os.symlink(real, link)
+        self._write_rc(_block_for(link))
+        before = self._read_rc()
+        with self._patch_shell(), patch.object(M, "TT_STUDIO_ROOT", real):
+            M.maybe_repair_shortcut()
+        self.assertEqual(self._read_rc(), before)
+
+    def test_maybe_repair_never_raises(self):
+        with patch.object(M, "_detect_shell_rc", side_effect=RuntimeError("boom")):
+            M.maybe_repair_shortcut()  # must swallow, not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for --switch: ref classification and the git command sequence (mocked)."""
+import subprocess
+import unittest
+from unittest.mock import patch
+
+try:
+    from tt_setup import switch as M
+except ImportError:
+    import run as M
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["git"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+class TestPlanSwitch(unittest.TestCase):
+    def test_plan_switch_prefers_branch_over_tag(self):
+        self.assertEqual(M.plan_switch(True, True, True), "branch")
+        self.assertEqual(M.plan_switch(True, False, False), "branch")
+
+    def test_plan_switch_remote_branch_counts(self):
+        self.assertEqual(M.plan_switch(False, True, False), "branch")
+
+    def test_plan_switch_tag_only(self):
+        self.assertEqual(M.plan_switch(False, False, True), "tag")
+
+    def test_plan_switch_unknown_returns_none(self):
+        self.assertIsNone(M.plan_switch(False, False, False))
+
+
+class _GitRecorder:
+    """Fake _git: records argv tuples and answers from a script of responses."""
+
+    def __init__(self, responses):
+        self.calls = []
+        self._responses = responses  # dict: first argv token (or tuple) -> proc
+
+    def __call__(self, *argv):
+        self.calls.append(argv)
+        for key, proc in self._responses.items():
+            if argv[:len(key)] == key:
+                return proc
+        return _proc()
+
+
+class TestSwitchCheckout(unittest.TestCase):
+    def test_switch_refuses_dirty_worktree(self):
+        git = _GitRecorder({("status",): _proc(stdout=" M run.py\n")})
+        with patch.object(M, "_git", git):
+            self.assertEqual(M.switch_checkout("dev"), 1)
+        # Refused before touching the network or the checkout.
+        self.assertEqual([c[0] for c in git.calls], ["status"])
+
+    def test_switch_fetch_failure_returns_error(self):
+        git = _GitRecorder({("fetch",): _proc(returncode=1, stderr="no route to host")})
+        with patch.object(M, "_git", git):
+            self.assertEqual(M.switch_checkout("dev"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_switch_unknown_ref_returns_error(self):
+        git = _GitRecorder({("rev-parse", "--verify"): _proc(returncode=1)})
+        with patch.object(M, "_git", git):
+            self.assertEqual(M.switch_checkout("nonsense"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_switch_branch_checkout_and_ff_pull(self):
+        calls = []
+
+        def fake_git(*argv):
+            calls.append(argv)
+            if argv[:2] == ("rev-parse", "--verify"):
+                # Branch exists (locally and on origin); no tag of the same name.
+                ok = argv[-1].startswith(("refs/heads/", "refs/remotes/"))
+                return _proc(returncode=0 if ok else 1)
+            return _proc()
+
+        with patch.object(M, "_git", fake_git):
+            self.assertEqual(M.switch_checkout("dev"), 0)
+        self.assertIn(("checkout", "dev"), calls)
+        self.assertIn(("pull", "--ff-only", "origin", "dev"), calls)
+
+    def test_switch_tag_detached_checkout(self):
+        calls = []
+
+        def fake_git(*argv):
+            calls.append(argv)
+            if argv[:2] == ("rev-parse", "--verify"):
+                return _proc(returncode=0 if argv[-1].startswith("refs/tags/") else 1)
+            if argv[:2] == ("rev-parse", "--short"):
+                return _proc(stdout="abc1234\n")
+            return _proc()
+
+        with patch.object(M, "_git", fake_git):
+            self.assertEqual(M.switch_checkout("v2.9.0-rc1"), 0)
+        self.assertIn(("checkout", "tags/v2.9.0-rc1"), calls)
+        self.assertNotIn(("pull", "--ff-only", "origin", "v2.9.0-rc1"), calls)
+
+    def test_switch_diverged_branch_pull_failure_returns_error(self):
+        def fake_git(*argv):
+            if argv[:2] == ("rev-parse", "--verify"):
+                return _proc(returncode=0 if argv[-1].startswith("refs/heads/") else 1)
+            if argv[0] == "pull":
+                return _proc(returncode=1, stderr="fatal: Not possible to fast-forward")
+            return _proc()
+
+        with patch.object(M, "_git", fake_git):
+            self.assertEqual(M.switch_checkout("dev"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tt_setup/cleanup/_orchestrate.py
+++ b/tt_setup/cleanup/_orchestrate.py
@@ -54,7 +54,9 @@ def _print_preserved_summary(has_docker_access):
 
 
 def cleanup_resources(args):
-    """Clean up TT Studio Docker resources, and (with --purge-all) all persistent state."""
+    """Clean up TT Studio Docker resources, and (with --purge-all) all persistent
+    state. Returns True when the cleanup ran, False when the user aborted at the
+    confirmation prompt (so callers like --uninstall can skip their follow-up)."""
     full_cleanup = bool(getattr(args, "cleanup_all", False))
     assume_yes = bool(getattr(args, "yes", False))
 
@@ -67,7 +69,7 @@ def cleanup_resources(args):
         # left untouched: a plain --stop must not re-trigger first-run setup.
         # Only --purge-all resets it, by removing the persistent volume.
         _print_preserved_summary(has_access)
-        return
+        return True
 
     # --- --purge-all: build full inventory and ask once ---
     host_persistent_volume = get_env_var("HOST_PERSISTENT_STORAGE_VOLUME") or \
@@ -142,13 +144,16 @@ def cleanup_resources(args):
     total_bytes = host_bytes + sum(docker_sizes.values())
 
     # --- Danger header ---
+    danger_lines = [
+        "Resets TT Studio to a fresh-clone state.",
+        "[bold]Everything below is permanently deleted — this cannot be undone.[/bold]",
+    ]
+    if getattr(args, "uninstall", False):
+        danger_lines.append("Also removes the `tt-studio` shell shortcut from your shell config.")
     console.print()
     console.print(notice_panel(
         "[bold]⚠  --purge-all · full reset[/bold]",
-        [
-            "Resets TT Studio to a fresh-clone state.",
-            "[bold]Everything below is permanently deleted — this cannot be undone.[/bold]",
-        ],
+        danger_lines,
         border_style="error",
     ))
 
@@ -199,12 +204,12 @@ def cleanup_resources(args):
                 confirm = console.input("\n[warning]Proceed with full reset?[/warning] [muted](y/yes or n/no)[/muted] ").strip().lower()
             except (KeyboardInterrupt, EOFError):
                 console.print("\n[warning]🛑 Aborted — nothing was deleted.[/warning]")
-                return
+                return False
             if confirm in ("y", "yes"):
                 break
             if confirm in ("n", "no", ""):
                 console.print("\n[info]🛑 Aborted — nothing was deleted.[/info]")
-                return
+                return False
             console.print("[muted]Please answer y/yes or n/no.[/muted]")
     else:
         console.print("\n[muted]--yes passed; proceeding without prompt.[/muted]")
@@ -258,3 +263,4 @@ def cleanup_resources(args):
     print(f"\n{C_CYAN}🌐 Browser data (chat history, theme, login) will auto-clear the")
     print(f"   next time you open http://localhost:3000.")
     print(f"   To clear immediately: DevTools → Application → Storage → Clear site data.{C_RESET}")
+    return True

--- a/tt_setup/cli/_args.py
+++ b/tt_setup/cli/_args.py
@@ -25,6 +25,7 @@ def _entry(
     reconfigure_inference_server: bool = typer.Option(False, "--reconfigure-inference-server", "--reconfig-inf", help="Reconfigure the TT Inference Server artifact (short alias: --reconfig-inf).", rich_help_panel="Setup & Configuration"),
     configure_env: bool = typer.Option(False, "--configure-env", help="Interactively configure all environment variables.", rich_help_panel="Setup & Configuration"),
     install_shortcut: bool = typer.Option(False, "--install-shortcut", help="Add a `tt-studio` shell shortcut so you can skip typing `python run.py`.", rich_help_panel="Setup & Configuration"),
+    switch: str = typer.Option(None, "--switch", metavar="REF", help="Switch this checkout to a git branch or tag (e.g. dev, v2.9.0-rc1), then exit; re-run to start.", rich_help_panel="Setup & Configuration"),
     # ── Model Deployment ─────────────────────────────────────────────────────
     auto_deploy: str = typer.Option(None, "--auto-deploy", metavar="MODEL_NAME", help="Auto-deploy the given model after startup.", rich_help_panel="Model Deployment"),
     device_id: int = typer.Option(0, "--device-id", metavar="CHIP_ID", help="Chip slot index (0-7) for --auto-deploy.", rich_help_panel="Model Deployment"),
@@ -36,6 +37,7 @@ def _entry(
     # ── Reset (--purge-all) ──────────────────────────────────────────────────
     purge_all: bool = typer.Option(False, "--purge-all", help="Stop and wipe everything incl. persistent data and .env.", rich_help_panel="Reset (--purge-all)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the --purge-all confirmation prompt.", rich_help_panel="Reset (--purge-all)"),
+    uninstall: bool = typer.Option(False, "--uninstall", help="Full uninstall: run the --purge-all teardown and remove the `tt-studio` shell shortcut.", rich_help_panel="Reset (--purge-all)"),
     # ── Advanced (less-common setup/runtime knobs) ───────────────────────────
     reconfigure: bool = typer.Option(False, "--reconfigure", help="Reset preferences and reconfigure all options.", rich_help_panel="Advanced"),
     resync: bool = typer.Option(False, "--resync", help="Force resync of the model catalog.", rich_help_panel="Advanced"),
@@ -68,7 +70,8 @@ def _entry(
         legacy = "--cleanup-all" if cleanup_all else "--cleanup"
         replacement = "--purge-all" if cleanup_all else "--stop"
         console.print(f"[warning]⚠  {legacy} is deprecated; use {replacement} instead.[/warning]")
-    full_teardown = purge_all or cleanup_all
+    # --uninstall is the full purge plus shell-shortcut removal.
+    full_teardown = purge_all or cleanup_all or uninstall
     stop_requested = stop or cleanup or full_teardown
 
     args = SimpleNamespace(
@@ -80,7 +83,7 @@ def _entry(
         add_headers=add_headers, check_headers=check_headers, auto_deploy=auto_deploy,
         device_id=device_id, fix_docker=fix_docker, configure_env=configure_env,
         status=status, logs=logs, info=info, report_bug=report_bug,
-        install_shortcut=install_shortcut,
+        install_shortcut=install_shortcut, switch=switch, uninstall=uninstall,
     )
     _run(args)
 

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -18,7 +18,8 @@ from tt_setup.docker_diag import handle_docker_compose_result, run_docker_compos
 from tt_setup.docker import build_docker_compose_command, check_docker_access, check_docker_installation, detect_tt_hardware, fix_docker_issues
 from tt_setup.env_config import configure_environment_sequentially, get_env_var, parse_boolean_env, save_setup_config, set_app_version_env
 from tt_setup.bug_report import report_bug
-from tt_setup.shortcut import install_shortcut, maybe_offer_shortcut
+from tt_setup.shortcut import install_shortcut, maybe_offer_shortcut, maybe_repair_shortcut, uninstall_shortcut
+from tt_setup.switch import switch_checkout
 from tt_setup.cleanup import cleanup_resources
 from tt_setup.services import check_and_free_ports, ensure_frontend_dependencies, get_frontend_config, setup_fastapi_environment, snapshot_health, start_docker_control_service, start_fastapi_server, wait_for_all_services, wait_for_frontend_and_open_browser
 from tt_setup.inference_server import _sync_model_catalog, setup_tt_inference_server
@@ -189,6 +190,8 @@ def _run(args):
   {C_CYAN}python run.py --status{C_RESET}               Open the live monitor TUI
   {C_CYAN}python run.py --report-bug{C_RESET}           Bundle logs + open a pre-filled GitHub issue
   {C_CYAN}python run.py --install-shortcut{C_RESET}     Add a `tt-studio` shell shortcut
+  {C_CYAN}python run.py --switch REF{C_RESET}           Switch this checkout to a branch/tag (e.g. an RC), then re-run
+  {C_CYAN}python run.py --uninstall{C_RESET}            Full teardown + remove the `tt-studio` shell shortcut
   {C_CYAN}python run.py --skip-fastapi{C_RESET}         Skip FastAPI server setup
   {C_CYAN}python run.py --no-sudo{C_RESET}              Skip sudo usage (may limit functionality)
   {C_CYAN}python run.py --check-headers{C_RESET}        Check for missing SPDX license headers
@@ -228,6 +231,17 @@ def _run(args):
             install_shortcut()
             return
 
+        if getattr(args, "switch", None):
+            sys.exit(switch_checkout(args.switch))
+
+        # Must dispatch before the generic cleanup branch: --uninstall implies
+        # cleanup_all. All-or-nothing — declining the purge prompt keeps the
+        # shell shortcut too.
+        if getattr(args, "uninstall", False):
+            if cleanup_resources(args):
+                uninstall_shortcut()
+            return
+
         if args.cleanup or args.cleanup_all:
             cleanup_resources(args)
             return
@@ -265,6 +279,10 @@ def _run(args):
         if detect_tt_hardware():
             mode_parts.append("TT Hardware")
         console.print(steps_panel(context=[f"Mode · {' + '.join(mode_parts)}"]))
+
+        # Repo moved (or a different clone launched)? Re-point the tt-studio
+        # shell shortcut at this checkout. Silent no-op otherwise.
+        maybe_repair_shortcut()
 
         # Get git hash for startup log
         try:

--- a/tt_setup/shortcut.py
+++ b/tt_setup/shortcut.py
@@ -15,6 +15,7 @@ and a one-time offer on a normal launch when it isn't already set up.
 """
 
 import os
+import re
 
 from tt_setup.console import confirm, console, notice_panel
 from tt_setup.constants import OS_NAME, TT_STUDIO_ROOT
@@ -56,6 +57,35 @@ def _shortcut_block():
     return f"{_MARKER_START}\n{_shortcut_line()}\n{_MARKER_END}\n"
 
 
+# Matches the shell function to recover the repo path baked into an install.
+_SHORTCUT_PATH_RE = re.compile(
+    rf'^{re.escape(SHORTCUT_NAME)}\(\)\s*{{\s*\(\s*cd\s+"(.+)"\s+&&'
+)
+
+
+def extract_shortcut_path(content):
+    """Repo path baked into an installed shortcut block, or None. Pure."""
+    for line in content.splitlines():
+        match = _SHORTCUT_PATH_RE.match(line.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def installed_shortcut_path(rc_path=None):
+    """Repo path the installed shortcut points at, or None when there is no
+    supported rc file, no block, or the file can't be read."""
+    if rc_path is None:
+        _, rc_path = _detect_shell_rc()
+    if not rc_path or not os.path.exists(rc_path):
+        return None
+    try:
+        with open(rc_path, "r") as f:
+            return extract_shortcut_path(f.read())
+    except OSError:
+        return None
+
+
 def _strip_block(lines):
     """Drop a *complete* marked block (inclusive) so re-install replaces cleanly.
 
@@ -95,6 +125,74 @@ def is_shortcut_installed(rc_path=None):
         return False
 
 
+def _write_shortcut_block(rc_path):
+    """Strip any existing complete block and append a fresh one pointing at the
+    current TT_STUDIO_ROOT. Returns True on success."""
+    try:
+        existing = ""
+        if os.path.exists(rc_path):
+            with open(rc_path, "r") as f:
+                existing = f.read()
+        cleaned = "".join(_strip_block(existing.splitlines(keepends=True))).rstrip("\n")
+        new_content = (cleaned + "\n\n" if cleaned else "") + _shortcut_block()
+        with open(rc_path, "w") as f:
+            f.write(new_content)
+    except OSError as e:
+        console.print(f"[error]❌ Could not update {rc_path}: {e}[/error]")
+        return False
+    return True
+
+
+def maybe_repair_shortcut():
+    """Re-point an installed shortcut whose baked-in path no longer matches this
+    checkout (the repo moved, or the user launched a different clone). Silent
+    no-op otherwise; never raises — a broken rc file must not block startup."""
+    try:
+        _, rc_path = _detect_shell_rc()
+        if not rc_path or not is_shortcut_installed(rc_path):
+            return
+        current = installed_shortcut_path(rc_path)
+        if not current or os.path.realpath(current) == os.path.realpath(TT_STUDIO_ROOT):
+            return
+        if _write_shortcut_block(rc_path):
+            console.print(
+                f"[muted]Updated the {SHORTCUT_NAME} shortcut to this checkout: {TT_STUDIO_ROOT}[/muted]"
+            )
+    except Exception:
+        pass
+
+
+def uninstall_shortcut():
+    """Remove the marked shortcut block from the shell rc. Returns True if the
+    block was removed."""
+    _, rc_path = _detect_shell_rc()
+    if not rc_path or not is_shortcut_installed(rc_path):
+        console.print(f"[muted]No {SHORTCUT_NAME} shell shortcut found — nothing to remove.[/muted]")
+        return False
+    try:
+        with open(rc_path, "r") as f:
+            lines = f.read().splitlines(keepends=True)
+        stripped = _strip_block(lines)
+        if stripped == lines:
+            # Unbalanced markers: _strip_block refused rather than truncate.
+            console.print(
+                f"[warning]⚠  Couldn't remove the {SHORTCUT_NAME} shortcut automatically — "
+                f"the markers in {rc_path} look edited. Remove the lines between "
+                f"'{_MARKER_START}' and '{_MARKER_END}' manually.[/warning]"
+            )
+            return False
+        with open(rc_path, "w") as f:
+            f.write("".join(stripped))
+    except OSError as e:
+        console.print(f"[error]❌ Could not update {rc_path}: {e}[/error]")
+        return False
+    console.print(
+        f"[success]✓[/success] Removed the {SHORTCUT_NAME} shortcut from {rc_path} "
+        f"[muted](reopen your terminal, or `source {rc_path}`, to drop it from this shell)[/muted]"
+    )
+    return True
+
+
 def install_shortcut():
     """Add (or update) the `tt-studio` shortcut in the user's shell rc. Returns
     True on success. Unsupported shells get a printed manual snippet instead."""
@@ -114,17 +212,7 @@ def install_shortcut():
         return False
 
     already = is_shortcut_installed(rc_path)
-    try:
-        existing = ""
-        if os.path.exists(rc_path):
-            with open(rc_path, "r") as f:
-                existing = f.read()
-        cleaned = "".join(_strip_block(existing.splitlines(keepends=True))).rstrip("\n")
-        new_content = (cleaned + "\n\n" if cleaned else "") + _shortcut_block()
-        with open(rc_path, "w") as f:
-            f.write(new_content)
-    except OSError as e:
-        console.print(f"[error]❌ Could not update {rc_path}: {e}[/error]")
+    if not _write_shortcut_block(rc_path):
         return False
 
     # Put the activation command on the clipboard so it's one paste away — the

--- a/tt_setup/switch.py
+++ b/tt_setup/switch.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""`--switch REF`: move this tt-studio checkout to a branch or release tag.
+
+Fetches origin, then checks out the requested ref — a branch (local or
+origin-only, fast-forwarded to origin) or a tag (detached HEAD, how release
+candidates are consumed). Always exits afterwards instead of continuing into
+startup: the code on disk just changed under the running process, so the next
+`python run.py` must re-bootstrap against the new ref.
+"""
+
+import subprocess
+
+from tt_setup.console import console, notice_panel, step
+from tt_setup.constants import TT_STUDIO_ROOT
+
+
+def _git(*argv):
+    """Run git in the repo root with output captured (surfaced only on failure)."""
+    return subprocess.run(
+        ["git", "-C", TT_STUDIO_ROOT, *argv],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _ref_exists(full_ref):
+    return _git("rev-parse", "--verify", "--quiet", full_ref).returncode == 0
+
+
+def plan_switch(has_local_branch, has_remote_branch, has_tag):
+    """Classify a ref as 'branch', 'tag', or None. A branch of the same name
+    wins over a tag — branches are the common case and stay updatable."""
+    if has_local_branch or has_remote_branch:
+        return "branch"
+    if has_tag:
+        return "tag"
+    return None
+
+
+def _fail_panel(title, lines):
+    console.print(notice_panel(f"[bold]{title}[/bold]", lines, border_style="error"))
+    return 1
+
+
+def switch_checkout(ref):
+    """Orchestrate `--switch REF`. Returns a process exit code (0 ok, 1 failed)."""
+    dirty = _git("status", "--porcelain", "--untracked-files=no")
+    if dirty.returncode != 0:
+        return _fail_panel(
+            "⛔ Couldn't inspect this checkout",
+            [
+                "[muted]git wasn't able to report the working-tree state:[/muted]",
+                (dirty.stderr or dirty.stdout).strip() or "(no output)",
+            ],
+        )
+    if dirty.stdout.strip():
+        return _fail_panel(
+            "⛔ Your tt-studio checkout has local changes — can't switch",
+            [
+                "Switching branches would clobber uncommitted work.",
+                "",
+                f"[bold]Fix →[/bold]  commit or stash your changes ([info]git status[/info] shows them),",
+                f"then re-run  [info]python run.py --switch {ref}[/info]",
+            ],
+        )
+
+    fetch_error = ""
+    with step("Fetching origin (branches and tags)") as s:
+        fetched = _git("fetch", "origin", "--tags")
+        if fetched.returncode != 0:
+            fetch_error = (fetched.stderr or fetched.stdout).strip()
+            s.fail()
+    if fetch_error:
+        return _fail_panel(
+            "⛔ Couldn't reach origin",
+            [
+                "[muted]Check your network connection / git remote, or switch manually with git.[/muted]",
+                "",
+                fetch_error,
+            ],
+        )
+
+    kind = plan_switch(
+        _ref_exists(f"refs/heads/{ref}"),
+        _ref_exists(f"refs/remotes/origin/{ref}"),
+        _ref_exists(f"refs/tags/{ref}"),
+    )
+    if kind is None:
+        return _fail_panel(
+            f"⛔ '{ref}' isn't a branch or tag on origin",
+            [
+                "[muted]List what's available with[/muted] [info]git branch -r[/info]"
+                " [muted]and[/muted] [info]git tag[/info][muted], then retry.[/muted]",
+            ],
+        )
+
+    checkout_error = ""
+    if kind == "branch":
+        with step(f"Switching to branch {ref}") as s:
+            # `checkout <ref>` also creates the local tracking branch when the
+            # ref only exists on origin; the ff-only pull then syncs it without
+            # ever merging (a diverged local branch fails instead).
+            result = _git("checkout", ref)
+            if result.returncode == 0:
+                result = _git("pull", "--ff-only", "origin", ref)
+            if result.returncode != 0:
+                checkout_error = (result.stderr or result.stdout).strip()
+                s.fail()
+        if checkout_error:
+            return _fail_panel(
+                f"⛔ Couldn't switch to branch '{ref}'",
+                [
+                    f"[muted]If your local '{ref}' has diverged from origin, resolve it "
+                    "with git, then retry.[/muted]",
+                    "",
+                    checkout_error,
+                ],
+            )
+        switched_to = f"branch '{ref}'"
+    else:
+        with step(f"Checking out tag {ref}") as s:
+            result = _git("checkout", f"tags/{ref}")
+            if result.returncode != 0:
+                checkout_error = (result.stderr or result.stdout).strip()
+                s.fail()
+        if checkout_error:
+            return _fail_panel(
+                f"⛔ Couldn't check out tag '{ref}'",
+                ["", checkout_error],
+            )
+        sha = _git("rev-parse", "--short", "HEAD").stdout.strip()
+        switched_to = f"tag {ref}" + (f" (detached at {sha})" if sha else "")
+
+    console.print(notice_panel(
+        f"[bold]✅ Switched to {switched_to}[/bold]",
+        [
+            f"[bold]Next →[/bold]  re-run [info]python run.py[/info] [muted](or [/muted][info]tt-studio[/info][muted]) to start on this version.[/muted]",
+            "[muted]If TT Studio is currently running, restart it:[/muted] "
+            "[info]python run.py --stop[/info][muted], then start again.[/muted]",
+        ],
+        border_style="accent",
+    ))
+    return 0


### PR DESCRIPTION
The `tt-studio` shell shortcut bakes in the repo path it was installed from, so launching from a different or newer checkout kept starting the old one — and there was no way to remove the shortcut or move a checkout to a release candidate from the CLI.

- On a normal startup, if the installed shortcut points at a different checkout, it is re-pointed to the current one with a one-line notice.
- `--uninstall`: runs the `--purge-all` teardown and then removes the shell shortcut. One confirmation covers both; declining leaves everything untouched.
- `--switch REF`: fetches origin and checks out a branch (fast-forwarded) or tag (detached, for RCs), then exits so the next run starts on the new code. Refuses on a dirty working tree.

Verified with the launcher test suite (193 tests passing, including new `tests/test_shortcut.py` and `tests/test_switch.py`), plus manual runs: stale-shortcut repair and uninstall against a scratch rc file, `--switch` dirty-tree refusal (exit 1), and the `--uninstall` decline path. A real branch switch / full purge wasn't run on this machine since a live dev stack with deployed models is using the checkout; those paths are covered by the mocked git-sequence tests.