### PR TITLE
Cache and Report Media Models Download Progress

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.18.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.19.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/model_control/download_progress.py
+++ b/app/backend/model_control/download_progress.py
@@ -43,9 +43,10 @@ _total_bytes_lock = threading.Lock()
 # then track the resolved one for the rest of every download of that repo.
 _media_path_cache: Dict[str, str] = {}
 
-# This list defines non-PyTorch file extensions (like Flax, TensorFlow, and ONNX) 
-# that are intentionally skipped because the media server only loads safetensors or .bin weights. 
-# Excluding these formats prevents "dead weight" files from falsely inflating the total size denominator on the download progress bar.
+# This list defines non-PyTorch file extensions (like Flax, TensorFlow, and ONNX)
+# that are intentionally skipped because the media server only loads safetensors or
+# .bin weights. Excluding these formats prevents "dead weight" files from falsely
+# inflating the total size denominator on the download progress bar.
 _NON_TORCH_WEIGHT_SUFFIXES = (
     ".msgpack",     # Flax
     ".h5",          # TensorFlow / Keras

--- a/app/backend/model_control/download_progress.py
+++ b/app/backend/model_control/download_progress.py
@@ -38,6 +38,11 @@ _state_lock = threading.Lock()
 _total_bytes_cache: Dict[Tuple[str, bool], Optional[int]] = {}
 _total_bytes_lock = threading.Lock()
 
+# This is bounded by the small set of distinct models ever deployed, so it needs no pruning
+# and stays valid across redeploys. We probe both candidates only until bytes appear,
+# then track the resolved one for the rest of every download of that repo.
+_media_path_cache: Dict[str, str] = {}
+
 # This list defines non-PyTorch file extensions (like Flax, TensorFlow, and ONNX) 
 # that are intentionally skipped because the media server only loads safetensors or .bin weights. 
 # Excluding these formats prevents "dead weight" files from falsely inflating the total size denominator on the download progress bar.
@@ -88,21 +93,25 @@ _EMA_ALPHA_LATER = 0.15
 _ETA_SMOOTH_ALPHA = 0.3             # how much new raw ETA influences smoothed ETA
 _EXEC_TIMEOUT_SECONDS = 4           # bound how long du can run before we give up
 
-# Media (tt-media-inference-server) logs only the repo, not a target path.
-# Weights land in the HF hub cache under HF_HOME, which is set to
-# ${CACHE_ROOT}/huggingface by app/backend/shared_config/model_config.py:76-78.
-_MEDIA_HF_CACHE_PREFIX = "/home/container_app_user/cache_root/huggingface/hub/models--"
+# Weights land under HF_HOME, which the inference server sets for the container to
+# /home/container_app_user/cache_root/huggingface. Two on-disk layouts occur:
+#   - transformers `from_pretrained` (whisper, speecht5) → $HF_HOME/hub/models--<repo>
+#   - `snapshot_download(cache_dir=$HF_HOME)` (image/video, e.g. Z-Image-Turbo) →
+#     $HF_HOME/models--<repo> (cache_dir is used verbatim, no `hub/` segment)
+# We can't tell which a model uses up front, so we probe both at the beginning of the download.
+_MEDIA_HF_HOME = "/home/container_app_user/cache_root/huggingface"
 
 
-def _media_container_path(repo: Optional[str]) -> Optional[str]:
-    """Derive the in-container HF hub cache path for a media download.
+def _media_container_paths(repo: Optional[str]) -> list[str]:
+    """Candidate in-container HF cache dirs for a media download.
 
     Mirrors huggingface_hub's repo→path convention (slashes become "--").
-    Returns None for invalid repo strings.
+    Returns [] for invalid repo strings.
     """
     if not repo or "/" not in repo:
-        return None
-    return _MEDIA_HF_CACHE_PREFIX + repo.replace("/", "--")
+        return []
+    slug = "models--" + repo.replace("/", "--")
+    return [f"{_MEDIA_HF_HOME}/hub/{slug}", f"{_MEDIA_HF_HOME}/{slug}"]
 
 def _container_dir_size(deploy_id: str, container_path: str) -> Optional[int]:
     """Return recursive byte count of `container_path` inside the running deploy.
@@ -231,12 +240,26 @@ def compute_download_progress(
     # so the total must be computed over that same subset, not the whole tree.
     media_download = not container_path and bool(repo)
     if media_download:
-        container_path = _media_container_path(repo)
+        # Probe both locations only until one holds bytes, then remember it (keyed by repo) so
+        # subsequent polls and future deploys of the same model do a single `du`.
+        with _state_lock:
+            resolved = _media_path_cache.get(repo)
+        candidates = [resolved] if resolved else _media_container_paths(repo)
+        downloaded = None
+        for cand in candidates:
+            sz = _container_dir_size(deploy_id, cand)
+            if sz is None:
+                continue
+            if downloaded is None or sz > downloaded:
+                downloaded, best_path = sz, cand
+        if not resolved and downloaded:
+            with _state_lock:
+                _media_path_cache[repo] = best_path
+    else:
+        if not container_path:
+            return out
+        downloaded = _container_dir_size(deploy_id, container_path)
 
-    if not container_path:
-        return out
-
-    downloaded = _container_dir_size(deploy_id, container_path)
     if downloaded is None:
         return out
     out["downloaded_bytes"] = int(downloaded)

--- a/app/backend/model_control/download_progress.py
+++ b/app/backend/model_control/download_progress.py
@@ -20,7 +20,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 from shared_config.logger_config import get_logger
 from shared_config.user_config import get_hf_token
@@ -33,9 +33,53 @@ logger = get_logger(__name__)
 _state: Dict[str, Dict[str, float]] = {}
 _state_lock = threading.Lock()
 
-# total_bytes per repo is constant for a given main revision; cache it.
-_total_bytes_cache: Dict[str, Optional[int]] = {}
+# total_bytes per repo is constant for a given main revision; cache it. Keyed by
+# (repo, subset_only) because the media path fetches only a subset of the tree.
+_total_bytes_cache: Dict[Tuple[str, bool], Optional[int]] = {}
 _total_bytes_lock = threading.Lock()
+
+# This list defines non-PyTorch file extensions (like Flax, TensorFlow, and ONNX) 
+# that are intentionally skipped because the media server only loads safetensors or .bin weights. 
+# Excluding these formats prevents "dead weight" files from falsely inflating the total size denominator on the download progress bar.
+_NON_TORCH_WEIGHT_SUFFIXES = (
+    ".msgpack",     # Flax
+    ".h5",          # TensorFlow / Keras
+    ".onnx",
+    ".onnx_data",   # ONNX external data
+    ".gguf",        # llama.cpp
+    ".tflite",
+    ".mlmodel",
+    ".ot",          # rust-bert
+    ".pb",          # TF frozen graph
+)
+
+
+def _skip_for_subset(path: str, has_safetensors: bool) -> bool:
+    """True when `path` exists in the repo but `from_pretrained` won't fetch it.
+
+    Only applied to media (transformers/diffusers) downloads. Diffusers weights
+    live in per-component subfolders (unet/, vae/, transformer/…), so we only
+    exclude by folder for the dedicated `onnx/` and OpenAI `original/` trees
+    to avoid dropping weights we do need.
+    """
+    p = path.lower()
+    name = p.rsplit("/", 1)[-1]
+    parts = p.split("/")
+    if p.endswith(_NON_TORCH_WEIGHT_SUFFIXES):
+        return True
+    if "onnx" in parts[:-1] or "original" in parts[:-1]:
+        return True
+    if name.startswith("tf_model"):  # TensorFlow weights
+        return True
+    # Explicit full-precision weight variant; the default load uses the
+    # non-variant file, so the fp32 copy is never fetched. The variant token is
+    # delimited `.fp32.` for a single file or `.fp32-` when sharded
+    if name.endswith((".safetensors", ".bin")) and (".fp32." in name or ".fp32-" in name):
+        return True
+    # Prefer safetensors: the redundant .bin copy is skipped when both exist.
+    if has_safetensors and name.endswith(".bin"):
+        return True
+    return False
 
 # Tunables — keep in sync with inference-api/api.py:_weights_progress_monitor.
 _MIN_SPEED_BPS = 64 * 1024          # ignore jitter under 64 KB/s when updating EMA
@@ -78,13 +122,22 @@ def _container_dir_size(deploy_id: str, container_path: str) -> Optional[int]:
     return client.dir_size(deploy_id, container_path, timeout=_EXEC_TIMEOUT_SECONDS)
 
 
-def _fetch_total_bytes(repo: str) -> Optional[int]:
-    """Sum file sizes from the HF model tree (best-effort; cached per repo)."""
+def _fetch_total_bytes(repo: str, subset_only: bool = False) -> Optional[int]:
+    """Sum file sizes from the HF model tree (best-effort; cached per repo).
+
+    When `subset_only` is True the repo is pulled via transformers/diffusers
+    `from_pretrained` (the media path), which fetches a single torch weight
+    format plus config/processor files — so alternate-format and redundant
+    weight copies are filtered out (see `_skip_for_subset`) to avoid inflating
+    the total. When False (the vLLM path) the whole repo is snapshot_downloaded,
+    so every file counts and no filtering is applied.
+    """
     if not repo or "/" not in repo:
         return None
+    cache_key = (repo, subset_only)
     with _total_bytes_lock:
-        if repo in _total_bytes_cache:
-            return _total_bytes_cache[repo]
+        if cache_key in _total_bytes_cache:
+            return _total_bytes_cache[cache_key]
 
     url = f"https://huggingface.co/api/models/{repo}/tree/main?recursive=true"
     headers = {"User-Agent": "tt-studio/download-progress"}
@@ -92,13 +145,12 @@ def _fetch_total_bytes(repo: str) -> Optional[int]:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(url, headers=headers, method="GET")
+    total: Optional[int] = None
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             entries = json.loads(resp.read().decode("utf-8"))
-        if not isinstance(entries, list):
-            total: Optional[int] = None
-        else:
-            total = 0
+        if isinstance(entries, list):
+            files = []  # (path, size) for each blob in the tree
             for entry in entries:
                 if not isinstance(entry, dict):
                     continue
@@ -117,10 +169,25 @@ def _fetch_total_bytes(repo: str) -> Optional[int]:
                     top_size = entry.get("size")
                     if isinstance(top_size, int) and top_size > 0:
                         size = top_size
-                if size is not None:
-                    total += size
-            if total <= 0:
-                total = None
+                path = entry.get("path")
+                if size is not None and isinstance(path, str):
+                    files.append((path, size))
+
+            if subset_only:
+                # A usable safetensors weight means the redundant .bin copy is
+                # skipped; probe with has_safetensors=False so this pass only
+                # honours the format/variant rules, not the .bin rule.
+                has_safetensors = any(
+                    p.lower().endswith(".safetensors")
+                    and not _skip_for_subset(p, has_safetensors=False)
+                    for p, _ in files
+                )
+                summed = sum(
+                    s for p, s in files if not _skip_for_subset(p, has_safetensors)
+                )
+            else:
+                summed = sum(s for _, s in files)
+            total = summed if summed > 0 else None
     except urllib.error.HTTPError as e:
         logger.debug("download_progress: HF total-bytes HTTP %s for %s", e.code, repo)
         total = None
@@ -129,7 +196,7 @@ def _fetch_total_bytes(repo: str) -> Optional[int]:
         total = None
 
     with _total_bytes_lock:
-        _total_bytes_cache[repo] = total
+        _total_bytes_cache[cache_key] = total
     return total
 
 
@@ -158,8 +225,12 @@ def compute_download_progress(
     }
 
     # Media-server logs only the repo, not a target path. Derive the canonical
-    # HF hub cache path so we can du -sb it via the existing endpoint.
-    if not container_path and repo:
+    # HF hub cache path so we can du -sb it via the existing endpoint. The
+    # absence of a target path is also the signal that this is a media
+    # (`from_pretrained`) download, which fetches only a subset of the repo —
+    # so the total must be computed over that same subset, not the whole tree.
+    media_download = not container_path and bool(repo)
+    if media_download:
         container_path = _media_container_path(repo)
 
     if not container_path:
@@ -170,7 +241,7 @@ def compute_download_progress(
         return out
     out["downloaded_bytes"] = int(downloaded)
 
-    total = _fetch_total_bytes(repo) if repo else None
+    total = _fetch_total_bytes(repo, subset_only=media_download) if repo else None
     if total is not None:
         out["total_bytes"] = int(total)
 

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -336,6 +336,9 @@ class ModelHealthView(APIView):
                 # the container's stdout. Best-effort: if anything fails we still
                 # return the basic 202 so the badge logic is unaffected.
                 content["phase"] = _get_startup_phase(deploy_id)
+                # Bound the per-deploy progress state to currently-tracked deploys so it can't accumulate.
+                from .download_progress import prune_state
+                prune_state(set(get_deploy_cache().keys()))
             else:
                 ret_status = status.HTTP_503_SERVICE_UNAVAILABLE
                 content = {"message": "Unavailable", "details": health_content}

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -216,11 +216,13 @@ except ImportError as e:
     ) from e
 
 # Patch HostSetupManager.check_model_weights_dir to guard against partially-downloaded
-# HF cache snapshots. The original method globs for any *.safetensors and returns True
-# if found, but a prior interrupted download can leave some shards complete (as symlinks
-# in the snapshot dir) while earlier shards are still in-progress .incomplete blobs two
-# levels up in blobs/. Without this patch, setup skips the download and launches the
-# container with missing shards → FileNotFoundError crash.
+#
+# Two on-disk layouts must be handled:
+#   - HF cache (host-hf-cache mode): hub/models--<org>--<repo>/snapshots/<sha>/, with
+#     in-progress files as blobs/*.incomplete two levels up.
+#   - local-dir (host-volume mode): a flat dir written by `hf download --local-dir`, with
+#     in-progress files under .cache/huggingface/download/*.incomplete and, for sharded
+#     models, shards enumerated in model.safetensors.index.json.
 #
 # Only overrides True → False (never the reverse). Fails open on any exception so a
 # permission error or unexpected path layout never blocks a valid deploy.
@@ -228,34 +230,53 @@ import workflows.setup_host as _setup_host_module  # noqa: E402
 _orig_check_model_weights_dir = _setup_host_module.HostSetupManager.check_model_weights_dir
 
 
+def _local_dir_incomplete(host_weights_dir):
+    """True if a `hf download --local-dir` copy is partial: any .incomplete marker,
+    or a shard listed in model.safetensors.index.json missing from disk."""
+    if list((host_weights_dir / ".cache" / "huggingface" / "download").glob("*.incomplete")):
+        return True
+    index_file = host_weights_dir / "model.safetensors.index.json"
+    if index_file.is_file():
+        weight_map = json.loads(index_file.read_text()).get("weight_map", {})
+        missing = sorted(
+            s for s in set(weight_map.values()) if not (host_weights_dir / s).is_file()
+        )
+        if missing:
+            logging.getLogger(__name__).warning(
+                "check_model_weights_dir: %d shard(s) missing from %s — "
+                "re-download required. Files: %s",
+                len(missing), host_weights_dir, missing,
+            )
+            return True
+    return False
+
+
 def _patched_check_model_weights_dir(self, host_weights_dir):
     result = _orig_check_model_weights_dir(self, host_weights_dir)
     if not result or host_weights_dir is None:
         return result
-    # Navigate to the HF cache blobs/ dir (two levels above the snapshot dir).
-    # Layout: hub/models--<org>--<repo>/snapshots/<sha>/ → ../../blobs/
     try:
+        # HF cache layout: hub/models--<org>--<repo>/snapshots/<sha>/ → ../../blobs/
         blobs_dir = host_weights_dir.parent.parent / "blobs"
-    except Exception:
-        return result
-    if not blobs_dir.is_dir():
-        return result  # not an HF cache layout (host-volume, local dir, etc.)
-    try:
-        incomplete = list(blobs_dir.glob("*.incomplete"))
+        if blobs_dir.is_dir():
+            incomplete = [f.name for f in blobs_dir.glob("*.incomplete")]
+            if incomplete:
+                logging.getLogger(__name__).warning(
+                    "check_model_weights_dir: %d incomplete blob(s) in %s — "
+                    "re-download required. Files: %s",
+                    len(incomplete), blobs_dir, incomplete,
+                )
+                return False
+            return True
+        # local-dir layout (host-volume mode)
+        if _local_dir_incomplete(host_weights_dir):
+            return False
     except Exception as exc:
-        _patched_check_model_weights_dir_logger = logging.getLogger(__name__)
-        _patched_check_model_weights_dir_logger.warning(
-            "check_model_weights_dir: cannot scan blobs dir %s: %s", blobs_dir, exc
-        )
-        return result
-    if incomplete:
         logging.getLogger(__name__).warning(
-            "check_model_weights_dir: %d incomplete blob(s) in %s — "
-            "re-download required. Files: %s",
-            len(incomplete), blobs_dir, [f.name for f in incomplete],
+            "check_model_weights_dir: completeness scan of %s failed: %s",
+            host_weights_dir, exc,
         )
-        return False
-    return True
+    return result
 
 
 _setup_host_module.HostSetupManager.check_model_weights_dir = _patched_check_model_weights_dir

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -237,7 +237,9 @@ def _local_dir_incomplete(host_weights_dir):
         return True
     index_file = host_weights_dir / "model.safetensors.index.json"
     if index_file.is_file():
-        weight_map = json.loads(index_file.read_text()).get("weight_map", {})
+        weight_map = json.loads(index_file.read_text(encoding="utf-8")).get(
+            "weight_map", {}
+        )
         missing = sorted(
             s for s in set(weight_map.values()) if not (host_weights_dir / s).is_file()
         )


### PR DESCRIPTION
### Summary
Previously, media models (e.g. speecht5_tts, distil-large-v3) would not be cached. Their weights were downloaded inside ephemeral storage and would be lost after the container was gone. The progress bar also did not show the download progress for them on the Models Deployed page.

### The Fix
With[ tt-inference-server PR #4397](https://github.com/tenstorrent/tt-inference-server/pull/4397), HF_HOME was set which now allows media models' raw weights to be downloaded inside a named volume similar to how it was already being done for LLMs.
This PR simply ensures that the progress bar shows the correct size of the HF repo of media models, and ensures that the cache is appropriately detected and maintained.

### Verification 
1. Deployed distil-large-v3 and speecht5_tts and confirmed weights download progress showed.
2. Redeployed distil-large-v3 and confirmed cache message shows on progress bar.
3. Checked sizes of docker volumes to ensure weights were stored there.

**NOTE:** This branch uplifts the artifact for tt-studio to tt-inference-server v0.19.0!

<img width="1727" height="991" alt="Screenshot 2026-07-29 at 10 04 54 AM" src="https://github.com/user-attachments/assets/8249ed2f-e5ff-4df1-b544-2099bdfda34f" />
