### PR TITLE
fix: disable spinners on host service cleanup to keep sudo prompts visible

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -478,6 +478,34 @@ class CleanupDockerSurfaceTests(unittest.TestCase):
         order = self._record_runtime_order(args)
         self.assertEqual(order[:3], ["deployments", "compose_down", "network_rm"])
 
+    def test_host_service_cleanup_steps_never_hide_sudo_prompts(self):
+        """Host cleanup may discover sudo is needed after the preflight probe.
+
+        Keep both service-cleanup steps non-animated so a late sudo prompt is
+        always visible, even when lsof cannot identify the owning process or a
+        stale PID file points at a root-owned process.
+        """
+        args = SimpleNamespace(dev=False, no_sudo=False, cleanup_all=False)
+        step_calls = []
+
+        @contextlib.contextmanager
+        def fake_step(label, spinner=True):
+            step_calls.append((label, spinner))
+            yield SimpleNamespace()
+
+        with patch.object(_cl_runt, "_docker_daemon_status", return_value="down"), \
+             patch.object(_cl_runt, "_port_owned_by_root", return_value=False), \
+             patch.object(_cl_runt, "step", side_effect=fake_step), \
+             patch.object(_cl_runt, "cleanup_fastapi_server"), \
+             patch.object(_cl_runt, "cleanup_docker_control_service"), \
+             contextlib.redirect_stdout(io.StringIO()):
+            run._cleanup_runtime(args, has_docker_access=True)
+
+        self.assertEqual(step_calls, [
+            ("Stopping inference API", False),
+            ("Stopping Docker control", False),
+        ])
+
 
 class TermsAcceptanceGateTests(unittest.TestCase):
     def test_accepting_terms_persists_prefs_and_gates_off_first_run(self):

--- a/tt_setup/cleanup/_runtime.py
+++ b/tt_setup/cleanup/_runtime.py
@@ -87,7 +87,13 @@ def _cleanup_runtime(args, has_docker_access):
                       "host service (ports 8001/8002).[/warning]")
         subprocess.run(["sudo", "-v"], check=False)
 
-    with step("Stopping inference API", spinner=True):
+    # Host-service cleanup can discover a sudo requirement late (for example
+    # from a stale/root-owned PID file, or when lsof cannot identify the
+    # listener). Keep these steps static so any unexpected sudo prompt remains
+    # visible instead of being hidden behind an animation. The early
+    # authentication above still avoids prompting in the common root-owned
+    # listener case.
+    with step("Stopping inference API", spinner=False):
         cleanup_fastapi_server(no_sudo=args.no_sudo)
-    with step("Stopping Docker control", spinner=True):
+    with step("Stopping Docker control", spinner=False):
         cleanup_docker_control_service(no_sudo=args.no_sudo)


### PR DESCRIPTION
### Description
During runtime cleanup, host service cleanup (`cleanup_fastapi_server` and `cleanup_docker_control_service`) can discover a `sudo` requirement **after** the initial preflight check—for example, when encountering stale/root-owned PID files or when `lsof` cannot identify the owning process.

Previously, these steps ran inside animated step spinners (`step(..., spinner=True)`). When a late `sudo` prompt occurred during the animated step, the prompt was obscured or hidden by the spinner updates, leading to user input hangs.

- Fixes #1171 

### Changes
- **`tt_setup/cleanup/_runtime.py`**: Set `spinner=False` for "Stopping inference API" and "Stopping Docker control" cleanup steps so late `sudo` prompts remain visible and interactive.
- **`tests/test_cleanup.py`**: Added `test_host_service_cleanup_steps_never_hide_sudo_prompts` to verify these steps execute non-animated.

### Validation & Screenshot
- Added and ran unit test `test_host_service_cleanup_steps_never_hide_sudo_prompts`.


https://github.com/user-attachments/assets/a54b9179-8f73-4b69-b5bf-4aebeaaa01fe

