### PR TITLE
fix: rag upload failures for .log files, drag-drop double uploads, and broken empty collections

### DIFF
--- a/app/backend/vector_db_control/document_processor.py
+++ b/app/backend/vector_db_control/document_processor.py
@@ -27,6 +27,13 @@ class DocumentProcessor:
         '.ts': 'application/typescript',
         '.tsx': 'application/typescript',
         '.jsx': 'application/javascript',
+        # Plain-text formats routed through process_text
+        '.log': 'text/plain',
+        '.json': 'text/plain',
+        '.csv': 'text/plain',
+        '.xml': 'text/plain',
+        '.yaml': 'text/plain',
+        '.yml': 'text/plain',
     }
 
     @staticmethod

--- a/app/backend/vector_db_control/document_processor.py
+++ b/app/backend/vector_db_control/document_processor.py
@@ -134,7 +134,10 @@ class DocumentProcessor:
         """Process document based on file type."""
         file_type = cls.get_file_type(file_path)
         if not file_type:
-            raise ValueError(f"Unsupported file type: {file_path}")
+            # Report only the extension — the full path is a server-side temp
+            # location and this message is surfaced to the user in the UI.
+            extension = os.path.splitext(file_path)[1] or os.path.basename(file_path)
+            raise ValueError(f"Unsupported file type: {extension}")
 
         processors = {
             'application/pdf': cls.process_pdf,

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -369,7 +369,7 @@ class VectorCollectionsAPIView(ViewSet):
             elif file_extension in ['.doc', '.docx']:
                 folder_type = "docs"
                 folder_path = f"docs/{filename}"
-            elif file_extension in ['.txt']:
+            elif file_extension in ['.txt', '.log']:
                 folder_type = "text"
                 folder_path = f"text/{filename}"
             elif file_extension in ['.ppt', '.pptx']:

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -87,24 +87,36 @@ def _filter_results_by_distance(results, max_distance):
 
 
 def _merge_query_results(primary, secondary, limit):
-    """Merge two Chroma query result dicts (single query), keeping the closest matches.
+    """Merge two Chroma query result dicts (single query), primary results first.
+
+    The primary collection is the one the caller explicitly queried, so its matches
+    take the available slots first; secondary (shared internal knowledge) results only
+    fill whatever capacity remains, closest first. Merging purely by distance instead
+    would let the large documentation corpus crowd the user's own documents out of the
+    response entirely.
 
     Preserves Chroma's ``{ids, documents, metadatas, distances}`` shape with one inner
     list per query so the response contract is unchanged.
     """
-    combined = []
-    for result in (primary, secondary):
+    def _entries(result):
         if not result or not result.get("documents") or not result["documents"][0]:
-            continue
+            return []
         documents = result["documents"][0]
         ids = result["ids"][0]
         metadatas = result["metadatas"][0] if result.get("metadatas") else [None] * len(documents)
         distances = result["distances"][0] if result.get("distances") else [None] * len(documents)
-        for i in range(len(documents)):
-            combined.append((distances[i], ids[i], documents[i], metadatas[i]))
+        return [
+            (distances[i], ids[i], documents[i], metadatas[i])
+            for i in range(len(documents))
+        ]
 
-    combined.sort(key=lambda item: item[0] if item[0] is not None else float("inf"))
-    combined = combined[:limit]
+    combined = _entries(primary)[:limit]
+    remaining = limit - len(combined)
+    if remaining > 0:
+        secondary_entries = _entries(secondary)
+        secondary_entries.sort(key=lambda item: item[0] if item[0] is not None else float("inf"))
+        combined.extend(secondary_entries[:remaining])
+
     return {
         "ids": [[item[1] for item in combined]],
         "documents": [[item[2] for item in combined]],
@@ -369,7 +381,8 @@ class VectorCollectionsAPIView(ViewSet):
             elif file_extension in ['.doc', '.docx']:
                 folder_type = "docs"
                 folder_path = f"docs/{filename}"
-            elif file_extension in ['.txt', '.log']:
+            elif file_extension in ['.txt', '.log', '.json', '.csv', '.xml', '.yaml', '.yml']:
+                # Plain-text formats handled by DocumentProcessor.process_text
                 folder_type = "text"
                 folder_path = f"text/{filename}"
             elif file_extension in ['.ppt', '.pptx']:
@@ -563,9 +576,11 @@ class VectorCollectionsAPIView(ViewSet):
             where=where,
         )
 
-        # Merge in the shared Tenstorrent knowledge so single-collection queries still
-        # surface documentation, without copying the corpus into every collection. Skip
-        # the merge when a metadata filter is set — the caller is scoping to their own chunks.
+        # Backfill leftover result slots from the shared Tenstorrent knowledge so
+        # single-collection queries can still surface documentation, without copying the
+        # corpus into every collection. The queried collection's own matches always take
+        # priority (see _merge_query_results). Skip the merge when a metadata filter is
+        # set — the caller is scoping to their own chunks.
         if pk != INTERNAL_KNOWLEDGE_COLLECTION and not where:
             try:
                 internal_results = query_collection(

--- a/app/frontend/src/components/rag/RagManagement.tsx
+++ b/app/frontend/src/components/rag/RagManagement.tsx
@@ -263,14 +263,16 @@ export default function RagManagement() {
       return { file, collectionName };
     },
     onMutate: ({ collectionName }) => {
-      setCollectionsUploading([...collectionsUploading, collectionName]);
+      setCollectionsUploading((prev) =>
+        prev.includes(collectionName) ? prev : [...prev, collectionName]
+      );
       customToast.info(
         `Creating datasource "${collectionName}" and uploading document...`
       );
     },
     onError: (error: any, { file, collectionName }) => {
-      setCollectionsUploading(
-        collectionsUploading.filter((e) => e !== collectionName)
+      setCollectionsUploading((prev) =>
+        prev.filter((e) => e !== collectionName)
       );
       if (error.message === "Collection name already exists") {
         customToast.error(
@@ -283,8 +285,8 @@ export default function RagManagement() {
       }
     },
     onSuccess: async ({ file, collectionName }) => {
-      setCollectionsUploading(
-        collectionsUploading.filter((e) => e !== collectionName)
+      setCollectionsUploading((prev) =>
+        prev.filter((e) => e !== collectionName)
       );
       customToast.success(
         `Successfully created datasource "${collectionName}" and uploaded "${file.name}"`
@@ -411,7 +413,9 @@ export default function RagManagement() {
   const uploadDocumentMutation = useMutation({
     mutationFn: uploadDocument,
     onMutate: ({ collectionName }) => {
-      setCollectionsUploading([...collectionsUploading, collectionName]);
+      setCollectionsUploading((prev) =>
+        prev.includes(collectionName) ? prev : [...prev, collectionName]
+      );
       customToast.info("Uploading document...");
     },
     onError: (error: Error, { file, collectionName }) => {
@@ -423,8 +427,8 @@ export default function RagManagement() {
       );
     },
     onSuccess: async (response, { file, collectionName }) => {
-      setCollectionsUploading(
-        collectionsUploading.filter((e) => e !== collectionName)
+      setCollectionsUploading((prev) =>
+        prev.filter((e) => e !== collectionName)
       );
 
       // Check if metadata was updated successfully

--- a/app/frontend/src/components/rag/RagManagement.tsx
+++ b/app/frontend/src/components/rag/RagManagement.tsx
@@ -16,6 +16,7 @@ import {
   createCollection,
   uploadDocument,
   fetchDocuments,
+  isSystemKnowledgeCollection,
 } from "@/src/components/rag";
 import {
   FileType,
@@ -215,9 +216,7 @@ export default function RagManagement() {
             documentsCount: col.documents?.length || 0,
             hasMetadata: Boolean(col.metadata),
             lastUploadedDoc: col.metadata?.last_uploaded_document,
-            isInternalKnowledge:
-              col.documents?.length === 0 &&
-              !col.metadata?.last_uploaded_document,
+            isInternalKnowledge: isSystemKnowledgeCollection(col),
           }))
         );
 
@@ -245,14 +244,27 @@ export default function RagManagement() {
       // First create the collection
       await createCollection({ collectionName });
 
-      // Then upload the document
-      await uploadDocument({ file, collectionName });
+      // Then upload the document; if that fails, roll back the collection so
+      // we don't leave behind an empty datasource that can't be retried.
+      try {
+        await uploadDocument({ file, collectionName });
+      } catch (uploadError) {
+        try {
+          await deleteCollection({ collectionName });
+        } catch (rollbackError) {
+          console.error(
+            `Failed to roll back collection ${collectionName} after upload error:`,
+            rollbackError
+          );
+        }
+        throw uploadError;
+      }
 
       return { file, collectionName };
     },
     onMutate: ({ collectionName }) => {
       setCollectionsUploading([...collectionsUploading, collectionName]);
-      customToast.success(
+      customToast.info(
         `Creating datasource "${collectionName}" and uploading document...`
       );
     },
@@ -400,10 +412,15 @@ export default function RagManagement() {
     mutationFn: uploadDocument,
     onMutate: ({ collectionName }) => {
       setCollectionsUploading([...collectionsUploading, collectionName]);
-      customToast.success("Uploading document...");
+      customToast.info("Uploading document...");
     },
-    onError: (_error, { file, collectionName }) => {
-      customToast.error(`Error uploading ${file.name} to ${collectionName}`);
+    onError: (error: Error, { file, collectionName }) => {
+      setCollectionsUploading((prev) =>
+        prev.filter((e) => e !== collectionName)
+      );
+      customToast.error(
+        `Error uploading ${file.name} to ${collectionName}: ${error.message}`
+      );
     },
     onSuccess: async (response, { file, collectionName }) => {
       setCollectionsUploading(
@@ -535,13 +552,12 @@ export default function RagManagement() {
       .toLowerCase();
   };
 
-  // Handle file drop
+  // Handle file drop. GentleFileUpload's dropzone already handles the dropped
+  // files and calls handleFileUpload via onChange; the event then bubbles up
+  // here, so only reset the drag styling — uploading again would duplicate it.
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setIsDragging(false);
-
-    const files = Array.from(e.dataTransfer.files);
-    handleFileUpload(files);
   };
 
   // Handle file selection
@@ -611,47 +627,12 @@ export default function RagManagement() {
     );
   }
 
-  // Helper function to check if a collection contains only internal knowledge
-  const isInternalKnowledgeCollection = (item: RagDataSource): boolean => {
-    // Check if collection has no user-uploaded documents AND exists (indicating it contains internal knowledge)
-    const hasNoUserDocs = !item.documents || item.documents.length === 0;
-    const hasValidId = Boolean(item.id);
-    const hasValidName = Boolean(item.name);
-
-    // Additional check: if metadata doesn't contain last_uploaded_document, it's likely internal only
-    const hasNoUploadedDocumentMetadata =
-      !item.metadata?.last_uploaded_document;
-
-    // Check if this is the system-created internal knowledge collection
-    const isSystemInternalCollection =
-      item.metadata?.type === "internal_knowledge" ||
-      item.metadata?.created_by === "system" ||
-      item.name === "tenstorrent_internal_knowledge";
-
-    // A collection is internal knowledge if:
-    // 1. It's the system-created internal knowledge collection OR
-    // 2. It has no user documents AND valid ID/name AND no uploaded document metadata
-    const isInternal =
-      isSystemInternalCollection ||
-      (hasNoUserDocs &&
-        hasValidId &&
-        hasValidName &&
-        hasNoUploadedDocumentMetadata);
-
-    // Debug logging
-    console.log(`[isInternalKnowledgeCollection] ${item.name}:`, {
-      hasNoUserDocs,
-      hasValidId,
-      hasValidName,
-      hasNoUploadedDocumentMetadata,
-      isSystemInternalCollection,
-      isInternal,
-      metadata: item.metadata,
-      documents: item.documents,
-    });
-
-    return isInternal;
-  };
+  // Helper function to check if a collection is the system-seeded internal
+  // knowledge collection. Only explicit system signals count — an empty user
+  // collection (e.g. one whose upload failed) must keep its Delete/Upload
+  // buttons so the user can retry or clean it up.
+  const isInternalKnowledgeCollection = (item: RagDataSource): boolean =>
+    isSystemKnowledgeCollection(item);
 
   // Action buttons component for reuse
   const ActionButtons = ({
@@ -715,7 +696,7 @@ export default function RagManagement() {
               dialogDescription={
                 item.documents && item.documents.length > 0
                   ? `This collection already has ${item.documents.length} document${item.documents.length > 1 ? "s" : ""}. Adding a new document will append it to the collection. Are you sure?`
-                  : "Select a document to upload to this collection. Supported types: PDF, TXT, DOCX, MD, HTML, and source code files."
+                  : "Select a document to upload to this collection. Supported types: PDF, TXT, LOG, DOCX, MD, HTML, and source code files."
               }
               dialogTitle={
                 item.documents && item.documents.length > 0
@@ -951,7 +932,7 @@ export default function RagManagement() {
         <input
           type="file"
           onChange={handleFileInput}
-          accept=".pdf,.txt,.docx,.doc,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/markdown,text/html,application/json,text/xml,text/csv"
+          accept=".pdf,.txt,.log,.docx,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/markdown,text/html,application/json,text/xml,text/csv"
           multiple
           ref={inputFile}
           style={{ display: "none" }}
@@ -1041,7 +1022,7 @@ export default function RagManagement() {
                         input.type = "file";
                         input.multiple = false;
                         input.accept =
-                          ".pdf,.txt,.docx,.doc,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/markdown,text/html,application/json,text/xml,text/csv";
+                          ".pdf,.txt,.log,.docx,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/markdown,text/html,application/json,text/xml,text/csv";
                         input.onchange = (e) => {
                           const target = e.target as HTMLInputElement;
                           if (target.files && target.files[0]) {

--- a/app/frontend/src/components/rag/index.ts
+++ b/app/frontend/src/components/rag/index.ts
@@ -106,6 +106,10 @@ export const uploadDocument = async ({
     );
   } catch (error) {
     console.error("Error uploading document:", error);
+    // Surface the backend's reason (e.g. "Unsupported file type") to callers
+    if (axios.isAxiosError(error) && error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
     throw error;
   }
 };

--- a/app/frontend/src/components/ui/gentle-file-upload.tsx
+++ b/app/frontend/src/components/ui/gentle-file-upload.tsx
@@ -67,7 +67,7 @@ export const GentleFileUpload = ({
           onChange={(e) => handleFileChange(Array.from(e.target.files || []))}
           className="hidden"
           multiple
-          accept=".pdf,.txt,.docx,.doc,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/msword,text/markdown,text/html,application/json,text/xml,text/csv"
+          accept=".pdf,.txt,.log,.docx,.md,.html,.py,.js,.ts,.tsx,.jsx,.json,.xml,.yaml,.yml,.csv,application/pdf,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/markdown,text/html,application/json,text/xml,text/csv"
         />
         <div className="absolute inset-0 mask-[radial-gradient(ellipse_at_center,white,transparent)]">
           <GridPattern />


### PR DESCRIPTION
## Problem

Uploading a `.log` file to RAG (reported with a tt-studio backend log) fails in a confusing cascade:

1. The document processor only accepted `.pdf/.txt/.docx/.md/.html` and a few code extensions, so the insert returned 400 `Unsupported file type` — but the collection had already been auto-created, leaving an **empty datasource** behind.
2. The empty collection was then mislabeled **Internal Knowledge** by a heuristic ("no documents + no last_uploaded_document metadata"), which disabled its Delete/Upload buttons, so it couldn't be retried or cleaned up from the UI.
3. Chat queries against the empty collection only returned the merged Tenstorrent docs corpus, so the model answered that no log data exists.
4. On top of that, drag-and-drop fired every upload **twice**: the dropzone inside `GentleFileUpload` uploads the dropped files, and the drop event then bubbles to the wrapping `Card`'s own `onDrop`, which uploaded them again — hence the duplicated "Uploading document..." and error toasts.
5. The error toast never included the backend's reason, the in-progress toast used a green success checkmark, and a failed upload left the row spinner stuck.

## Changes

- **Backend**: accept `.log/.json/.csv/.xml/.yaml/.yml` as plain-text uploads in `DocumentProcessor`; `.log` files group under the `text` folder type.
- **Frontend**:
  - `Card.onDrop` no longer re-uploads dropped files (dropzone already handles them); it only resets drag styling.
  - If the document upload fails right after auto-creating its collection, the collection is rolled back so no orphaned empty datasource remains.
  - Only explicitly system-tagged collections (`metadata.type === "internal_knowledge"`, `created_by === "system"`, or the seeded collection name) are treated as Internal Knowledge — empty user collections keep working Delete/Upload buttons.
  - Upload failure toasts now include the backend's error message (e.g. "Unsupported file type"), the uploading spinner clears on failure, and the in-progress toast is informational instead of a success checkmark.
  - File-picker `accept` lists now match what the backend supports: `.log` added, `.doc` removed (legacy Word binaries were never parseable by python-docx).

## Verification

- Exercised the document-processor change inside the `backend-dev` Docker image (same runtime deps as the deployed backend): a `.log` file now processes and chunks correctly, `.json/.csv/.yaml/.yml/.xml` map to the text handler, and unsupported types (e.g. `.zip`) are still rejected with `Unsupported file type`, which now propagates into the UI toast.
- Frontend: `tsc --noEmit` clean, ESLint clean on changed files (only pre-existing `no-console` warnings), production `npm run build` succeeds.
- Full in-browser end-to-end wasn't run: the TT-Studio stack currently running on this machine is served from a different user's checkout, so this branch couldn't be deployed against it without disrupting their session.

## Review follow-ups

Addressed the review feedback:

- **Selected datasources now actually answer from their own documents** (@rnabeelTT's report): single-collection queries merged the shared Tenstorrent docs corpus into results sorted purely by embedding distance, so the 1000+-page internal knowledge corpus could crowd the user's uploaded chunks out of the response entirely — chat then answered from docs and claimed the uploaded data didn't exist. The merge is now primary-first: the selected collection's matches take the result slots first, and internal knowledge only backfills leftover capacity (e.g. for small or empty collections).
- The `Unsupported file type` error now reports just the file extension instead of the server-side temp path, since the message is surfaced in UI toasts (Copilot).
- `.json/.csv/.xml/.yaml/.yml` uploads are now classified into the `text/` virtual folder, consistent with their processing as plain text (Copilot).
- All `collectionsUploading` state updates use functional updates with dedupe, so concurrent uploads can't clobber each other's spinner state (Copilot).

Verified in the `backend-dev` image (no running stack needed): primary-first merge keeps the selected collection's chunks and backfills/falls back to internal knowledge correctly, `.log` files process and chunk, the new extensions map to the text handler, and unsupported types are rejected with a path-free message. Frontend re-verified after the `dev` merge-in: `tsc --noEmit` clean, ESLint clean on changed files (pre-existing `no-console` warnings only), production build succeeds.
