### PR TITLE
ci: add backend CI workflow with lint gate, tests, and boot checks

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -111,8 +111,6 @@ jobs:
         working-directory: app/backend
     env:
       TT_STUDIO_ROOT: ${{ github.workspace }}
-      HOST_PERSISTENT_STORAGE_VOLUME: ${{ runner.temp }}/tt_studio_volume
-      INTERNAL_PERSISTENT_STORAGE_VOLUME: ${{ runner.temp }}/tt_studio_volume
       BACKEND_API_HOSTNAME: localhost
       CHROMA_DB_HOST: localhost
       CHROMA_DB_PORT: "8111"
@@ -122,6 +120,11 @@ jobs:
       DJANGO_SECRET_KEY: django-insecure-ci
     steps:
       - uses: actions/checkout@v5
+      - name: Point the persistent volume at the runner temp dir
+        # runner.temp is not available in job-level env, so export it here.
+        run: |
+          echo "HOST_PERSISTENT_STORAGE_VOLUME=$RUNNER_TEMP/tt_studio_volume" >> "$GITHUB_ENV"
+          echo "INTERNAL_PERSISTENT_STORAGE_VOLUME=$RUNNER_TEMP/tt_studio_volume" >> "$GITHUB_ENV"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# Backend CI — gates every PR on the Python side of TT-Studio:
+#   - lint gate for the real-bug rule classes (undefined names, syntax errors)
+#     plus a non-blocking full lint/format report on the run summary
+#   - dependency installability (pip install + pip check) for all four
+#     Python services, each in its own venv (their pins conflict on purpose)
+#   - Django sanity: system checks, migration drift, migrate, ASGI import
+#   - the hardware-free unit-test suite with a coverage summary
+#   - boot-time budgets for a bare uvicorn boot and for the real Docker image
+#   - docker compose validation for every overlay combination run.py assembles
+#
+# Live-stack and Tenstorrent-hardware testing is owned by deploy-healthcheck.yml
+# (workflow_dispatch on self-hosted runners) — deliberately not duplicated here.
+
+name: Backend CI
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [dev, main]
+    paths:
+      - "app/backend/**"
+      - "app/agent/**"
+      - "inference-api/**"
+      - "docker-control-service/**"
+      - "app/docker-compose*.yml"
+      - ".env.default"
+      - "ruff.toml"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    branches: [dev, main, staging]
+    types: [opened, reopened, synchronize]
+    paths:
+      - "app/backend/**"
+      - "app/agent/**"
+      - "inference-api/**"
+      - "docker-control-service/**"
+      - "app/docker-compose*.yml"
+      - ".env.default"
+      - "ruff.toml"
+      - ".github/workflows/backend-ci.yml"
+
+concurrency:
+  group: backend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-gate:
+    name: ruff gate (undefined names, syntax errors)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        # version pinned to match dev-tools/requirements-dev.txt and the pre-commit hook
+        run: pip install ruff==0.7.0
+      - name: Undefined names and syntax errors are hard failures
+        run: ruff check --select F821,E9 app/backend app/agent inference-api docker-control-service
+
+  lint-report:
+    name: ruff full report (advisory)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff==0.7.0
+      - name: Full lint + format drift (never fails; see the run Summary)
+        run: |
+          DIRS="app/backend app/agent inference-api docker-control-service"
+          {
+            echo "### Ruff advisory report (default rules, ruff 0.7.0)"
+            echo ""
+            echo "Full-tree lint and format drift. Informational until the"
+            echo "existing debt is cleared and the hard gate widens beyond F821/E9."
+            echo ""
+            echo '```'
+            ruff check --exit-zero --statistics $DIRS
+            echo '```'
+            UNFORMATTED=$(ruff format --check $DIRS 2>/dev/null | grep -c "^Would reformat" || true)
+            echo ""
+            echo "**Files needing \`ruff format\`:** $UNFORMATTED"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  backend:
+    name: backend deps, django sanity, unit tests, boot timing
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    # vector_db_control.apps.ready() connects to ChromaDB during django.setup(),
+    # so every Django entrypoint below (checks, tests, uvicorn) needs a live
+    # chroma. The image's default command listens on 8000 internally.
+    services:
+      chroma:
+        image: chromadb/chroma:0.5.3
+        ports:
+          - 8111:8000
+    defaults:
+      run:
+        working-directory: app/backend
+    env:
+      TT_STUDIO_ROOT: ${{ github.workspace }}
+      HOST_PERSISTENT_STORAGE_VOLUME: ${{ runner.temp }}/tt_studio_volume
+      INTERNAL_PERSISTENT_STORAGE_VOLUME: ${{ runner.temp }}/tt_studio_volume
+      BACKEND_API_HOSTNAME: localhost
+      CHROMA_DB_HOST: localhost
+      CHROMA_DB_PORT: "8111"
+      # Set explicitly so settings import doesn't auto-generate a secret and
+      # persist user_config.env (shared_config/user_config.py does that when unset).
+      JWT_SECRET: ci-test-jwt-secret
+      DJANGO_SECRET_KEY: django-insecure-ci
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: app/backend/requirements.txt
+      - name: Cache the embedding model
+        # ready() also preloads all-MiniLM-L6-v2 via sentence-transformers;
+        # cache it so boots don't re-download it from Hugging Face every run.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-cache-all-MiniLM-L6-v2
+      - name: System build deps
+        # chroma-hnswlib is pinned --no-binary (C++ build) and pysqlite3 is a
+        # source-only distribution that needs the sqlite3 headers.
+        run: sudo apt-get update -q && sudo apt-get install -y --no-install-recommends libsqlite3-dev
+      - name: Install backend requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip check
+          # Mirrors app/backend/Dockerfile: openwakeword hard-pins tflite-runtime,
+          # which has no py3.12 wheel; we run inference_framework="onnx" and
+          # onnxruntime is already pinned in requirements.txt. Installed after
+          # `pip check` because its unsatisfiable tflite-runtime pin would
+          # otherwise fail the check by design.
+          pip install --no-deps openwakeword==0.6.0
+      - name: Wait for chroma
+        run: |
+          for _ in $(seq 1 30); do
+            curl -fsS http://localhost:8111/api/v1/heartbeat >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "::error::ChromaDB service container never became healthy"
+          exit 1
+      - name: Django sanity
+        run: |
+          python manage.py check
+          python manage.py makemigrations --check --dry-run
+          python manage.py migrate --noinput
+          python -c "import api.asgi; print('ASGI app imports cleanly')"
+      - name: Unit tests + coverage
+        run: |
+          pip install coverage==7.15.1  # pinned in dev-tools/requirements-dev.txt
+          coverage run --source=api,board_control,docker_control,logs_control,model_control,shared_config,training_control,vector_db_control,wakeword_control,workflow_control \
+            -m pytest
+          coverage report -m
+          {
+            echo "### Backend unit-test coverage"
+            echo ""
+            coverage report --format=markdown
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Boot-time budget (bare uvicorn)
+        # Boots in single-digit seconds warm; the budget leaves headroom for a
+        # cold Hugging Face download of the embedding model on cache misses.
+        run: |
+          set -euo pipefail
+          BUDGET=120
+          START=$(date +%s)
+          uvicorn api.asgi:application --host 127.0.0.1 --port 8000 &
+          UVICORN_PID=$!
+          BOOTED=""
+          for _ in $(seq 1 "$BUDGET"); do
+            if curl -fsS http://127.0.0.1:8000/up/ >/dev/null 2>&1; then BOOTED=1; break; fi
+            sleep 1
+          done
+          ELAPSED=$(( $(date +%s) - START ))
+          kill "$UVICORN_PID" 2>/dev/null || true
+          if [ -z "$BOOTED" ]; then
+            echo "::error::Backend did not answer /up/ within ${BUDGET}s"
+            exit 1
+          fi
+          echo "Backend booted in ${ELAPSED}s (budget ${BUDGET}s)"
+          echo "### Boot timing (bare uvicorn): **${ELAPSED}s** (budget ${BUDGET}s)" >> "$GITHUB_STEP_SUMMARY"
+
+  deps:
+    name: deps — ${{ matrix.service }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each service gets its own venv on purpose: the agent's langchain
+          # pins conflict with the backend's, and inference-api is pydantic v1.
+          - service: agent
+            python: "3.11" # app/agent/Dockerfile: python:3.11-slim-bookworm
+            workdir: app/agent
+            requirements: requirements.txt
+          - service: inference-api
+            python: "3.12"
+            workdir: inference-api
+            requirements: requirements.txt
+          - service: docker-control-service
+            python: "3.12"
+            workdir: docker-control-service
+            requirements: requirements-api.txt
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: ${{ matrix.workdir }}/${{ matrix.requirements }}
+      - name: Install + pip check
+        working-directory: ${{ matrix.workdir }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ${{ matrix.requirements }}
+          pip check
+      - name: Byte-compile sources
+        working-directory: ${{ matrix.workdir }}
+        run: python -m compileall -q -x '(\.venv|__pycache__)' .
+      - name: Import FastAPI app
+        # Only docker-control-service imports cleanly on a bare runner:
+        # inference-api imports the tt-inference-server artifact at module level.
+        if: matrix.service == 'docker-control-service'
+        working-directory: ${{ matrix.workdir }}
+        run: python -c "import api; print('docker-control-service app imports cleanly')"
+
+  compose-validate:
+    name: compose config (run.py overlay combos)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Materialize .env from the template
+        # Only TT_STUDIO_ROOT is a placeholder; everything else in .env.default
+        # is usable as-is for interpolation.
+        run: sed "s|<PATH_TO_ROOT_OF_REPO>|$GITHUB_WORKSPACE|" .env.default > "$RUNNER_TEMP/ci.env"
+      - name: Validate every overlay combination run.py can assemble
+        # Mirrors build_docker_compose_command() in tt_setup/docker.py:
+        # base + (dev-mode | prod) [+ tt-hardware when a card is detected].
+        run: |
+          set -euo pipefail
+          compose() {
+            docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml "$@" config -q
+          }
+          compose -f app/docker-compose.dev-mode.yml
+          compose -f app/docker-compose.prod.yml
+          compose -f app/docker-compose.dev-mode.yml -f app/docker-compose.tt-hardware.yml
+          compose -f app/docker-compose.prod.yml -f app/docker-compose.tt-hardware.yml
+          echo "All compose overlay combinations are valid"
+
+  docker-boot-smoke:
+    name: docker image build + boot smoke
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - name: Build backend image
+        # VITE_ENABLE_DEPLOYED=true skips the Rust/tt-smi layer (no TT hardware
+        # on hosted runners). The tag must match app/docker-compose.yml so
+        # `up --no-build` picks this image up.
+        uses: docker/build-push-action@v6
+        with:
+          context: app/backend
+          load: true
+          tags: ghcr.io/tenstorrent/tt-studio/backend:v0.0.1
+          build-args: |
+            VITE_ENABLE_DEPLOYED=true
+          cache-from: type=gha,scope=backend-image
+          cache-to: type=gha,scope=backend-image,mode=max
+      - name: Prepare environment
+        run: |
+          sed "s|<PATH_TO_ROOT_OF_REPO>|$GITHUB_WORKSPACE|" .env.default > "$RUNNER_TEMP/ci.env"
+          # Host directories referenced by the compose bind mounts.
+          mkdir -p .artifacts/tt-inference-server/workflow_logs \
+                   logs/model_run_logs \
+                   tt_studio_persistent_volume/chroma
+          # The compose network is external (run.py creates it at startup).
+          docker network create tt_studio_network
+          # Pre-pull chroma so the boot timer measures the backend, not the pull.
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml pull -q tt_studio_chroma
+      - name: Boot backend + chroma and enforce the boot budget
+        run: |
+          set -euo pipefail
+          BUDGET=180
+          START=$(date +%s)
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml \
+            up -d --no-build tt_studio_backend
+          BOOTED=""
+          for _ in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/up/ >/dev/null 2>&1; then BOOTED=1; break; fi
+            sleep 5
+          done
+          ELAPSED=$(( $(date +%s) - START ))
+          if [ -z "$BOOTED" ]; then
+            echo "::error::Backend container did not answer /up/ within 300s"
+            exit 1
+          fi
+          if [ "$ELAPSED" -gt "$BUDGET" ]; then
+            echo "::error::Backend boot took ${ELAPSED}s — over the ${BUDGET}s budget"
+            exit 1
+          fi
+          echo "Backend container booted in ${ELAPSED}s (budget ${BUDGET}s)"
+          echo "### Boot timing (docker, migrate + 4 uvicorn workers): **${ELAPSED}s** (budget ${BUDGET}s)" >> "$GITHUB_STEP_SUMMARY"
+      - name: Collect container logs
+        if: failure()
+        run: |
+          mkdir -p /tmp/compose-logs
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml logs --no-color > /tmp/compose-logs/compose.log 2>&1 || true
+          docker ps -a > /tmp/compose-logs/docker-ps.txt || true
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-smoke-logs
+          path: /tmp/compose-logs/
+          retention-days: 7
+      - name: Teardown
+        if: always()
+        run: |
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml down -v --remove-orphans || true
+          docker network rm tt_studio_network || true

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -278,13 +278,16 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - name: Build backend image
         # VITE_ENABLE_DEPLOYED=true skips the Rust/tt-smi layer (no TT hardware
-        # on hosted runners). The tag must match app/docker-compose.yml so
-        # `up --no-build` picks this image up.
+        # on hosted runners). The tag must match the prod overlay's backend
+        # image so `up --no-build` picks this image up. The prod overlay is
+        # required throughout: the base compose file alone is not a valid
+        # project (tt_studio_frontend has no image/build without an overlay),
+        # and base+prod is what run.py assembles by default.
         uses: docker/build-push-action@v6
         with:
           context: app/backend
           load: true
-          tags: ghcr.io/tenstorrent/tt-studio/backend:v0.0.1
+          tags: ghcr.io/tenstorrent/tt-studio/backend-prod:v0.0.1
           build-args: |
             VITE_ENABLE_DEPLOYED=true
           cache-from: type=gha,scope=backend-image
@@ -299,14 +302,14 @@ jobs:
           # The compose network is external (run.py creates it at startup).
           docker network create tt_studio_network
           # Pre-pull chroma so the boot timer measures the backend, not the pull.
-          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml pull -q tt_studio_chroma
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml pull -q tt_studio_chroma
       - name: Boot backend + chroma and enforce the boot budget
         run: |
           set -euo pipefail
           BUDGET=180
           SLEEP=5
           START=$(date +%s)
-          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml \
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml \
             up -d --no-build tt_studio_backend
           BOOTED=""
           for _ in $(seq 1 $((BUDGET / SLEEP))); do
@@ -328,7 +331,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p /tmp/compose-logs
-          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml logs --no-color > /tmp/compose-logs/compose.log 2>&1 || true
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml logs --no-color > /tmp/compose-logs/compose.log 2>&1 || true
           docker ps -a > /tmp/compose-logs/docker-ps.txt || true
       - name: Upload logs on failure
         if: failure()
@@ -340,5 +343,5 @@ jobs:
       - name: Teardown
         if: always()
         run: |
-          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml down -v --remove-orphans || true
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml down -v --remove-orphans || true
           docker network rm tt_studio_network || true

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -295,6 +295,9 @@ jobs:
       - name: Prepare environment
         run: |
           sed "s|<PATH_TO_ROOT_OF_REPO>|$GITHUB_WORKSPACE|" .env.default > "$RUNNER_TEMP/ci.env"
+          # Containers on hosted runners have no reliable egress; the caches
+          # the backend needs at boot are pre-seeded host-side below.
+          echo "HF_HUB_OFFLINE=1" >> "$RUNNER_TEMP/ci.env"
           # Host directories referenced by the compose bind mounts.
           mkdir -p .artifacts/tt-inference-server/workflow_logs \
                    logs/model_run_logs \
@@ -303,6 +306,25 @@ jobs:
           docker network create tt_studio_network
           # Pre-pull chroma so the boot timer measures the backend, not the pull.
           docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml pull -q tt_studio_chroma
+      - name: Seed model caches host-side (containers have no egress)
+        # django.setup() preloads the all-MiniLM-L6-v2 embedding model and the
+        # openwakeword preprocessing models. Hosted-runner bridge networks
+        # cannot reach the internet, so download both through the host network
+        # into the volume/bind-mount the backend will read them from.
+        run: |
+          set -euo pipefail
+          docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml -f app/docker-compose.prod.yml \
+            create --no-build tt_studio_backend
+          HF_VOL=$(docker volume ls -q | grep '_hf_cache$' | head -1)
+          echo "seeding hf cache volume: $HF_VOL"
+          docker run --rm --network host -v "$HF_VOL":/root/.cache/huggingface \
+            ghcr.io/tenstorrent/tt-studio/backend-prod:v0.0.1 \
+            python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+          # Wake-word preprocessing models (the wake-word model itself is bundled
+          # in-repo); mirrors wakeword_control/apps.py so ready() has nothing to fetch.
+          docker run --rm --network host -v "$GITHUB_WORKSPACE/tt_studio_persistent_volume":/tt_studio_persistent_volume \
+            ghcr.io/tenstorrent/tt-studio/backend-prod:v0.0.1 \
+            python -c "import openwakeword; from openwakeword.utils import download_file; from pathlib import Path; t = Path('/tt_studio_persistent_volume/openwakeword_models'); t.mkdir(parents=True, exist_ok=True); [download_file(m['download_url'].replace('.tflite', '.onnx'), str(t)) for m in openwakeword.FEATURE_MODELS.values()]"
       - name: Boot backend + chroma and enforce the boot budget
         run: |
           set -euo pipefail

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -301,17 +301,18 @@ jobs:
         run: |
           set -euo pipefail
           BUDGET=180
+          SLEEP=5
           START=$(date +%s)
           docker compose --env-file "$RUNNER_TEMP/ci.env" -f app/docker-compose.yml \
             up -d --no-build tt_studio_backend
           BOOTED=""
-          for _ in $(seq 1 60); do
+          for _ in $(seq 1 $((BUDGET / SLEEP))); do
             if curl -fsS http://localhost:8000/up/ >/dev/null 2>&1; then BOOTED=1; break; fi
-            sleep 5
+            sleep "$SLEEP"
           done
           ELAPSED=$(( $(date +%s) - START ))
           if [ -z "$BOOTED" ]; then
-            echo "::error::Backend container did not answer /up/ within 300s"
+            echo "::error::Backend container did not answer /up/ within ${BUDGET}s"
             exit 1
           fi
           if [ "$ELAPSED" -gt "$BUDGET" ]; then

--- a/app/backend/api/tests.py
+++ b/app/backend/api/tests.py
@@ -10,6 +10,14 @@ from rest_framework.test import APIClient
 from api.views import _mask
 
 
+class UpStatusTests(SimpleTestCase):
+    def test_up_returns_200(self):
+        # Doubles as an import smoke test: resolving /up/ loads ROOT_URLCONF,
+        # which imports every installed app's urls and views.
+        response = APIClient().get("/up/")
+        self.assertEqual(response.status_code, 200)
+
+
 class MaskTests(SimpleTestCase):
     def test_none_and_empty(self):
         self.assertIsNone(_mask(None))

--- a/app/backend/conftest.py
+++ b/app/backend/conftest.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Pytest bootstrap for the backend suite — plain pytest, no pytest-django.
+
+Order matters here: shared_config/backend_config.py and api/settings.py
+hard-require TT_STUDIO_ROOT / *_PERSISTENT_STORAGE_VOLUME /
+BACKEND_API_HOSTNAME at import time (fail-fast by design), backend_config
+mkdirs the backend volume on import, and get_jwt_secret() auto-generates *and
+persists* user_config.env when JWT_SECRET is unset — so everything is pointed
+at a throwaway temp dir before Django loads.
+
+A reachable ChromaDB is required: vector_db_control.apps.ready() connects to
+it during django.setup(). CI runs a chromadb/chroma:0.5.3 service container;
+locally the dev stack's chroma (localhost:8111) works, or a throwaway one:
+`docker run --rm -p 8111:8000 chromadb/chroma:0.5.3`.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+_scratch = Path(tempfile.mkdtemp(prefix="tt_studio_test_"))
+os.environ.setdefault("TT_STUDIO_ROOT", str(_scratch / "tt_studio_root"))
+os.environ.setdefault("HOST_PERSISTENT_STORAGE_VOLUME", str(_scratch / "volume"))
+os.environ.setdefault("INTERNAL_PERSISTENT_STORAGE_VOLUME", str(_scratch / "volume"))
+os.environ.setdefault("BACKEND_API_HOSTNAME", "localhost")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("DJANGO_SECRET_KEY", "django-insecure-test")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+# The settings default (tt_studio_chromadb) only resolves inside the compose
+# network; outside a container the chroma port is published on localhost.
+os.environ.setdefault("CHROMA_DB_HOST", "localhost")
+os.environ.setdefault("CHROMA_DB_PORT", "8111")
+# DockerControlClient's constructor fails fast without these; tests that use
+# it mock the actual HTTP traffic, so dummy values are fine.
+os.environ.setdefault("DOCKER_CONTROL_SERVICE_URL", "http://localhost:8002")
+os.environ.setdefault("DOCKER_CONTROL_JWT_SECRET", "test-docker-control-secret")
+
+import django  # noqa: E402  (env vars above must be set before Django loads)
+
+django.setup()
+
+# What Django's own test runner (and pytest-django) do before tests run:
+# adds "testserver" to ALLOWED_HOSTS so the django/DRF test clients work,
+# switches to the locmem email backend, etc.
+from django.test.utils import setup_test_environment  # noqa: E402
+
+setup_test_environment()
+
+# Live-stack tests need deployed models and/or Tenstorrent hardware, and
+# model_control/test_model_utils.py deploys a container at *import* time —
+# marker deselection is not enough because pytest imports every collected
+# module. Keep them out of collection entirely unless explicitly requested;
+# they run via deploy-healthcheck.yml on self-hosted hardware runners.
+if not os.environ.get("TT_STUDIO_LIVE_TESTS"):
+    collect_ignore = [
+        "docker_control/test_docker_utils.py",
+        "docker_control/test_docker_control_api.py",
+        "model_control/test_model_api.py",
+        "model_control/test_model_utils.py",
+        "model_control/test_e2e.py",
+    ]

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -546,7 +546,7 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
 def run_agent_container(container_name, port_bindings, impl):
     # runs agent container after associated llm container runs
     run_kwargs = copy.deepcopy(impl.docker_config)
-    host_agent_port = get_host_agent_port()
+    host_agent_port = get_host_port(impl)
     llm_host_port = list(port_bindings.values())[0] # port that llm is using for naming convention (for easier removal later)
 
     docker_client = get_docker_client()

--- a/app/backend/docker_control/test_docker_control_api.py
+++ b/app/backend/docker_control/test_docker_control_api.py
@@ -5,6 +5,7 @@
 import json
 import time
 
+import pytest
 import requests
 import jwt
 
@@ -18,12 +19,14 @@ from .test_docker_utils import (
     valid_vllm_api_call,
 )
 
-from django.test import APITestCase
+from rest_framework.test import APITestCase
 from django.urls import reverse
 from rest_framework import status
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
+
+pytestmark = pytest.mark.live_stack
 
 
 def create_auth_token():

--- a/app/backend/docker_control/test_docker_utils.py
+++ b/app/backend/docker_control/test_docker_utils.py
@@ -7,6 +7,7 @@ import time
 from collections import defaultdict
 from unittest.mock import patch
 
+import pytest
 import requests
 from requests.exceptions import RequestException
 import jwt
@@ -19,6 +20,8 @@ from .docker_utils import run_container, stop_container
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
+
+pytestmark = pytest.mark.live_stack
 
 
 # Simple dict-based cache mock
@@ -56,13 +59,15 @@ def test_deploy_mock_model():
         assert valid_vllm_api_call(api_url, headers, vllm_model=impl.model_name)
     except Exception as e:
         logger.error(f"Error: {e}")
-        has_error = True
+        caught_exc = e
+    else:
+        caught_exc = None
     # 3. stop container
     logger.info(f"stop deployed container: container_id={container_id}")
     stop_status = stop_container(container_id)
     logger.info(f"status:={stop_status}")
-    if has_error:
-        raise e
+    if caught_exc is not None:
+        raise caught_exc
     assert stop_status["status"] == "success"
 
 

--- a/app/backend/model_control/test_e2e.py
+++ b/app/backend/model_control/test_e2e.py
@@ -7,12 +7,15 @@ import time
 import os
 import logging
 
+import pytest
 import requests
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 logger.info(f"importing {__file__}")
+
+pytestmark = pytest.mark.live_stack
 
 
 def test_e2e():

--- a/app/backend/model_control/test_model_api.py
+++ b/app/backend/model_control/test_model_api.py
@@ -5,6 +5,7 @@
 import json
 import time
 
+import pytest
 import requests
 from requests.exceptions import RequestException
 import jwt
@@ -14,6 +15,8 @@ from shared_config.logger_config import get_logger
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
+
+pytestmark = pytest.mark.live_stack
 
 
 on_bridge_network = False
@@ -89,6 +92,7 @@ def test_model_life_cycle():
     )
     logger.info(f'response.headers={response.headers.get("transfer-encoding")}')
     assert response.headers.get("transfer-encoding") == "chunked"
+    all_chunks = ""
     for chunk_idx, chunk in enumerate(
         response.iter_content(chunk_size=None, decode_unicode=True)
     ):

--- a/app/backend/model_control/test_model_utils.py
+++ b/app/backend/model_control/test_model_utils.py
@@ -6,6 +6,7 @@ import json
 import time
 import os
 
+import pytest
 import requests
 import jwt
 
@@ -21,6 +22,8 @@ from model_control.model_utils import (
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
+
+pytestmark = pytest.mark.live_stack
 
 # for test script set up Django using settings
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")

--- a/app/backend/model_control/test_tts_fallback.py
+++ b/app/backend/model_control/test_tts_fallback.py
@@ -16,21 +16,26 @@ from model_control.views import TtsInferenceView, OpenAIAudioSpeechView
 class TestTtsInferenceFallback:
     """Test TTS inference view with fallback to /v1/audio/speech on 404."""
     
+    # InferenceSerializer.validate() resolves get_deploy_cache through
+    # model_control.serializers, so it needs its own patch — without it the
+    # real deploy cache hits the docker-control-service.
+    @patch('model_control.serializers.get_deploy_cache')
     @patch('model_control.views.get_deploy_cache')
     @patch('model_control.views.requests.post')
-    def test_tts_fallback_on_404_from_enqueue(self, mock_post, mock_cache):
+    def test_tts_fallback_on_404_from_enqueue(self, mock_post, mock_cache, mock_serializer_cache):
         """When /enqueue returns 404 for TTS media model, should retry with /v1/audio/speech."""
         # Setup mock deploy cache
         mock_impl = Mock()
         mock_impl.model_name = "speecht5_tts"
         mock_impl.inference_engine = "media"
-        
+
         mock_cache.return_value = {
             "test_deploy_id": {
                 "internal_url": "speecht5_tts:7000/enqueue",
                 "model_impl": mock_impl
             }
         }
+        mock_serializer_cache.return_value = mock_cache.return_value
         
         # First call returns 404, second call succeeds
         mock_resp_404 = Mock()
@@ -63,21 +68,23 @@ class TestTtsInferenceFallback:
         assert "/v1/audio/speech" in second_call_url
         assert response.status_code == 200
     
+    @patch('model_control.serializers.get_deploy_cache')
     @patch('model_control.views.get_deploy_cache')
     @patch('model_control.views.requests.post')
-    def test_tts_success_without_fallback(self, mock_post, mock_cache):
+    def test_tts_success_without_fallback(self, mock_post, mock_cache, mock_serializer_cache):
         """When initial request succeeds, should not retry."""
         # Setup mock deploy cache
         mock_impl = Mock()
         mock_impl.model_name = "speecht5_tts"
         mock_impl.inference_engine = "media"
-        
+
         mock_cache.return_value = {
             "test_deploy_id": {
                 "internal_url": "speecht5_tts:7000/v1/audio/speech",
                 "model_impl": mock_impl
             }
         }
+        mock_serializer_cache.return_value = mock_cache.return_value
         
         # First call succeeds
         mock_resp_success = Mock()

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -1486,11 +1486,14 @@ class ContainerLogsView(View):
 
         except Exception as e:
             logger.error(f"Error streaming container data: {str(e)}")
+            # Capture the message now: `e` is unbound once the except block
+            # exits, but the generator below runs later, inside the response.
+            error_message = str(e)
 
             async def error_stream():
                 error_data = {
                     "type": "service_unavailable",
-                    "message": f"Failed to initialize log stream: {str(e)}",
+                    "message": f"Failed to initialize log stream: {error_message}",
                     "timestamp": datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
                 }
                 yield f"data: {json.dumps(error_data)}\n\n".encode('utf-8')

--- a/app/backend/pytest.ini
+++ b/app/backend/pytest.ini
@@ -1,3 +1,5 @@
 # pytest.ini
 [pytest]
 addopts = -s --log-cli-level=INFO
+markers =
+    live_stack: needs a live TT-Studio stack (deployed models / TT hardware); excluded from CI collection by conftest.py — set TT_STUDIO_LIVE_TESTS=1 to collect

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -6,7 +6,7 @@ Tests for sync_models_from_inference_server.py route derivation logic.
 """
 
 import pytest
-from sync_models_from_inference_server import map_service_route
+from shared_config.sync_models_from_inference_server import map_service_route
 
 
 class TestServiceRouteMapping:

--- a/app/backend/test_no_header.py
+++ b/app/backend/test_no_header.py
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-#
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
-
-print("hello world")

--- a/app/backend/training_control/tests.py
+++ b/app/backend/training_control/tests.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+from rest_framework.test import APIClient
+
+from shared_config.model_type_config import ModelTypes
+from training_control.views import _base_url, _find_training_container
+
+
+def _entry(model_type=ModelTypes.TRAINING, internal_url="training-host:7000/v1/jobs"):
+    return {
+        "model_impl": Mock(model_type=model_type),
+        "internal_url": internal_url,
+    }
+
+
+class FindTrainingContainerTests(SimpleTestCase):
+    @patch("training_control.views.get_deploy_cache")
+    def test_deploy_id_found(self, cache_mock):
+        entry = _entry()
+        cache_mock.return_value = {"dep-1": entry}
+        found, err = _find_training_container("dep-1")
+        self.assertIs(found, entry)
+        self.assertIsNone(err)
+
+    @patch("training_control.views.get_deploy_cache")
+    def test_unknown_deploy_id_is_404(self, cache_mock):
+        cache_mock.return_value = {}
+        found, err = _find_training_container("nope")
+        self.assertIsNone(found)
+        self.assertEqual(err.status_code, 404)
+
+    @patch("training_control.views.get_deploy_cache")
+    def test_non_training_deploy_id_is_400(self, cache_mock):
+        cache_mock.return_value = {"dep-1": _entry(model_type=ModelTypes.CHAT)}
+        found, err = _find_training_container("dep-1")
+        self.assertIsNone(found)
+        self.assertEqual(err.status_code, 400)
+
+    @patch("training_control.views.get_deploy_cache")
+    def test_no_deploy_id_picks_first_training_entry(self, cache_mock):
+        training = _entry()
+        cache_mock.return_value = {
+            "dep-chat": _entry(model_type=ModelTypes.CHAT),
+            "dep-train": training,
+        }
+        found, err = _find_training_container()
+        self.assertIs(found, training)
+        self.assertIsNone(err)
+
+    @patch("training_control.views.get_deploy_cache")
+    def test_no_training_container_is_404(self, cache_mock):
+        cache_mock.return_value = {"dep-chat": _entry(model_type=ModelTypes.CHAT)}
+        found, err = _find_training_container()
+        self.assertIsNone(found)
+        self.assertEqual(err.status_code, 404)
+
+
+class BaseUrlTests(SimpleTestCase):
+    def test_strips_route_from_internal_url(self):
+        self.assertEqual(
+            _base_url({"internal_url": "container:7000/v1/jobs"}),
+            "http://container:7000",
+        )
+
+    def test_plain_host_port(self):
+        self.assertEqual(
+            _base_url({"internal_url": "container:7000"}),
+            "http://container:7000",
+        )
+
+
+class TrainingJobsRouteTests(SimpleTestCase):
+    """Exercises api/urls.py -> training_control/urls.py -> views end to end."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    @patch("training_control.views.get_deploy_cache", return_value={})
+    def test_no_training_container_returns_404_json(self, _cache_mock):
+        response = self.client.get("/training/jobs/")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.json()["error"], "No running training container found."
+        )
+
+    @patch("training_control.views.requests.get")
+    @patch("training_control.views.get_deploy_cache")
+    def test_unreachable_container_returns_502(self, cache_mock, get_mock):
+        import requests
+
+        cache_mock.return_value = {"dep-train": _entry()}
+        get_mock.side_effect = requests.ConnectionError("boom")
+        response = self.client.get("/training/jobs/")
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("not reachable", response.json()["error"])
+        get_mock.assert_called_once()
+        self.assertTrue(
+            get_mock.call_args.args[0].startswith("http://training-host:7000")
+        )

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       # Force huggingface_hub to use plain HTTPS instead of the Xet CDN, which can
       # be extremely slow/hang here and stall the embedding-model download on boot.
       - HF_HUB_DISABLE_XET=1
+      # Pass-through (unset in normal runs). CI sets it to 1 after pre-seeding
+      # the hf_cache volume, because containers on CI runners have no egress.
+      - HF_HUB_OFFLINE
       # ./backend is bind-mounted from the host repo; keep root-owned
       # __pycache__ out of the source tree
       - PYTHONDONTWRITEBYTECODE=1

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -2461,10 +2461,6 @@ async def run_inference(request: RunRequest):
                         "last_updated": time.time()
                     })
         
-        # Restore working directory in case of exception
-        if 'original_cwd' in locals() and 'script_dir' in locals() and original_cwd != script_dir:
-            os.chdir(original_cwd)
-        
         # Return JSONResponse instead of raising HTTPException to include job_id
         if 'job_id' in locals():
             return JSONResponse(

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# Shared ruff config for the whole repo.
+#
+# Rules deliberately stay at ruff 0.7.0 DEFAULTS: the pre-commit hook
+# (dev-tools/.pre-commit-config.yaml, ruff-pre-commit v0.7.0) runs with no
+# explicit config and silently picks this file up, so selecting extra rules
+# here would change what the hook enforces on every developer's machine.
+target-version = "py312"
+
+extend-exclude = [
+    "**/.venv",
+    "tt_studio_persistent_volume",
+    "**/node_modules",
+    "**/migrations",
+]


### PR DESCRIPTION
The Python side of TT-Studio had no PR gate at all — backend breakage only surfaced after merging. This adds a backend CI workflow that runs on PRs to dev/main/staging (path-filtered to backend-relevant files) and on pushes to dev/main, and fixes the real bugs the new gates caught so the pipeline is green from the first run.

- [x] `backend-ci.yml` with six parallel jobs: ruff gate (F821/E9 — the real-bug classes — with a non-blocking full lint/format report on the run summary), backend deps + Django sanity + unit tests + a 120s bare-uvicorn boot budget, per-service dependency installs (agent py3.11, inference-api, docker-control-service), compose config validation for all four overlay combos run.py assembles, and a docker image build + containerized boot smoke with a 180s budget
- [x] `conftest.py` so `pytest` works from a bare checkout (env defaults + scratch volume + django setup, no pytest-django, no new deps); live-stack/hardware tests are kept out of CI collection and stay with deploy-healthcheck.yml — `TT_STUDIO_LIVE_TESTS=1` re-enables them locally
- [x] Bug fixes required by the lint gate: undefined `get_host_agent_port()` on the agent container launch path, unbound `e` in ContainerLogsView's error stream, dead `original_cwd` block in inference-api, plus two broken test files (`APITestCase` import, missing patch in the TTS fallback tests)
- [x] First tests for `training_control` and an `/up/` smoke test; root `ruff.toml` (default rules, just excludes — pre-commit behavior unchanged)
- [x] Verified locally: full unit suite green against an empty chroma with no docker-control-service reachable (runner conditions), Django checks + migration drift clean, bare uvicorn boots in 6s, the deployed-mode image boots to `/up/` in 25s, all compose combos validate, and the F821/E9 gate passes across all four services

Follow-up (not in this PR): clear the remaining ~150 advisory lint errors / ~85 unformatted files in a mechanical pass, then widen the hard gate to full default rules. The advisory job tracks that debt on every run. The agent deps leg was only syntax-checked locally (no py3.11 on this machine) — it runs for real in this PR's checks.