### PR TITLE
feat: add per-model dev-catalog override for deploys

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -12,7 +12,7 @@ from django.core.cache import caches
 
 from shared_config.device_config import DeviceConfigurations
 from shared_config.logger_config import get_logger
-from shared_config.model_config import model_implmentations, _impl_id
+from shared_config.model_config import model_implmentations, _impl_selector
 from shared_config.backend_config import backend_config
 from shared_config.model_type_config import ModelTypes
 from shared_config.user_config import get_tavily_api_key
@@ -424,10 +424,11 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training
         # spec on P150); without an impl the server defaults to the wrong engine and
         # pulls the wrong image. `impl.inference_impl` comes from the catalog.
-        # The server declares `impl: Optional[str]`, so send the impl_id string.
-        # _impl_id() is belt-and-braces: the catalog loader already reduces this
-        # field, but a directly-constructed ModelImpl would otherwise 422 here.
-        inference_impl = _impl_id(getattr(impl, "inference_impl", None))
+        # The server declares `impl: Optional[str]` and matches it against
+        # spec.impl.impl_name, so send the hyphenated impl_name. _impl_selector()
+        # is belt-and-braces: the catalog loader already reduces this field, but a
+        # directly-constructed ModelImpl would otherwise 422 here.
+        inference_impl = _impl_selector(getattr(impl, "inference_impl", None))
         if inference_impl:
             payload["impl"] = inference_impl
 

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -12,7 +12,7 @@ from django.core.cache import caches
 
 from shared_config.device_config import DeviceConfigurations
 from shared_config.logger_config import get_logger
-from shared_config.model_config import model_implmentations
+from shared_config.model_config import model_implmentations, _impl_id
 from shared_config.backend_config import backend_config
 from shared_config.model_type_config import ModelTypes
 from shared_config.user_config import get_tavily_api_key
@@ -424,7 +424,10 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training
         # spec on P150); without an impl the server defaults to the wrong engine and
         # pulls the wrong image. `impl.inference_impl` comes from the catalog.
-        inference_impl = getattr(impl, "inference_impl", None)
+        # The server declares `impl: Optional[str]`, so send the impl_id string.
+        # _impl_id() is belt-and-braces: the catalog loader already reduces this
+        # field, but a directly-constructed ModelImpl would otherwise 422 here.
+        inference_impl = _impl_id(getattr(impl, "inference_impl", None))
         if inference_impl:
             payload["impl"] = inference_impl
 

--- a/app/backend/docker_control/tests.py
+++ b/app/backend/docker_control/tests.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIClient
 
 from docker_control.chip_allocator import ChipSlotAllocator
 from docker_control.deployment_sync import _classify_failure
+from docker_control.views import _resolve_override_docker_image, _LLAMA_V014_IMAGE
 from shared_config.model_config import model_implmentations
 
 
@@ -152,3 +153,24 @@ class DeployViewHfPreCheckTests(SimpleTestCase):
         # First probe config.json (default), then fall back to model_index.json.
         self.assertEqual(repo_mock.call_count, 2)
         self.assertEqual(repo_mock.call_args_list[1].args[2], "model_index.json")
+
+
+@dataclass
+class _FakeModelImpl:
+    model_name: str = "SomeModel"
+    requires_dev_catalog: bool = False
+    image_version: str = "ghcr.io/example/img:v1"
+
+
+class OverrideDockerImageResolutionTests(SimpleTestCase):
+    def test_llama_v014_pin_takes_priority(self):
+        impl = _FakeModelImpl(model_name="Llama-3.1-8B", requires_dev_catalog=True)
+        self.assertEqual(_resolve_override_docker_image(impl), _LLAMA_V014_IMAGE)
+
+    def test_dev_catalog_model_forwards_its_own_catalog_image(self):
+        impl = _FakeModelImpl(requires_dev_catalog=True, image_version="ghcr.io/x/dev:0.19.0")
+        self.assertEqual(_resolve_override_docker_image(impl), "ghcr.io/x/dev:0.19.0")
+
+    def test_ordinary_model_gets_no_override(self):
+        impl = _FakeModelImpl()
+        self.assertIsNone(_resolve_override_docker_image(impl))

--- a/app/backend/docker_control/tests.py
+++ b/app/backend/docker_control/tests.py
@@ -11,7 +11,11 @@ from rest_framework.test import APIClient
 
 from docker_control.chip_allocator import ChipSlotAllocator
 from docker_control.deployment_sync import _classify_failure
-from docker_control.views import _resolve_override_docker_image, _LLAMA_V014_IMAGE
+from docker_control.views import (
+    _LLAMA_V014_IMAGE,
+    _resolve_artifact_ref,
+    _resolve_override_docker_image,
+)
 from shared_config.model_config import model_implmentations
 
 
@@ -160,6 +164,7 @@ class _FakeModelImpl:
     model_name: str = "SomeModel"
     requires_dev_catalog: bool = False
     image_version: str = "ghcr.io/example/img:v1"
+    inference_artifact_ref: Optional[dict] = None
 
 
 class OverrideDockerImageResolutionTests(SimpleTestCase):
@@ -174,3 +179,66 @@ class OverrideDockerImageResolutionTests(SimpleTestCase):
     def test_ordinary_model_gets_no_override(self):
         impl = _FakeModelImpl()
         self.assertIsNone(_resolve_override_docker_image(impl))
+
+
+class ArtifactRefResolutionTests(SimpleTestCase):
+    """Per-(model, device) tt-inference-server build selection.
+
+    Every path except an explicit, matched, eligible pin must return None, which
+    the caller reads as "use the globally pinned artifact".
+    """
+
+    def test_matches_resolved_runtime_device(self):
+        impl = _FakeModelImpl(
+            requires_dev_catalog=True,
+            inference_artifact_ref={"P150": "stisi/feat-qwen"},
+        )
+        self.assertEqual(_resolve_artifact_ref(impl, "p150", "P150"), "stisi/feat-qwen")
+
+    def test_matches_board_type_when_device_differs(self):
+        """P300x2 hardware deploys with --tt-device p150 (_BOARD_TO_SINGLE_CHIP_DEVICE),
+        so a pin keyed on the board the user actually sees must still match."""
+        impl = _FakeModelImpl(
+            requires_dev_catalog=True,
+            inference_artifact_ref={"P300x2": "stisi/feat-p300"},
+        )
+        self.assertEqual(_resolve_artifact_ref(impl, "p150", "P300x2"), "stisi/feat-p300")
+
+    def test_device_match_wins_over_board_match(self):
+        impl = _FakeModelImpl(
+            requires_dev_catalog=True,
+            inference_artifact_ref={"p150": "by-device", "P300x2": "by-board"},
+        )
+        self.assertEqual(_resolve_artifact_ref(impl, "p150", "P300x2"), "by-device")
+
+    def test_key_matching_is_case_insensitive(self):
+        impl = _FakeModelImpl(
+            requires_dev_catalog=True,
+            inference_artifact_ref={"p150": "stisi/feat-qwen"},
+        )
+        self.assertEqual(_resolve_artifact_ref(impl, "P150", "P150"), "stisi/feat-qwen")
+
+    def test_unmatched_device_falls_back_to_global(self):
+        impl = _FakeModelImpl(
+            requires_dev_catalog=True,
+            inference_artifact_ref={"P150": "stisi/feat-qwen"},
+        )
+        self.assertIsNone(_resolve_artifact_ref(impl, "n300", "N300"))
+
+    def test_non_dev_catalog_model_ignores_its_ref(self):
+        """Only the dev-catalog path runs run.py as a subprocess, which is the only
+        way to target a different artifact -- honouring a ref elsewhere would
+        silently deploy against the wrong build."""
+        impl = _FakeModelImpl(
+            requires_dev_catalog=False,
+            inference_artifact_ref={"P150": "stisi/feat-qwen"},
+        )
+        self.assertIsNone(_resolve_artifact_ref(impl, "p150", "P150"))
+
+    def test_no_ref_configured(self):
+        impl = _FakeModelImpl(requires_dev_catalog=True)
+        self.assertIsNone(_resolve_artifact_ref(impl, "p150", "P150"))
+
+    def test_empty_ref_map(self):
+        impl = _FakeModelImpl(requires_dev_catalog=True, inference_artifact_ref={})
+        self.assertIsNone(_resolve_artifact_ref(impl, "p150", "P150"))

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -120,6 +120,7 @@ def start_chat_deployment(
     vllm_override_args: Optional[str] = None,
     override_tt_config: Optional[str] = None,
     override_docker_image: Optional[str] = None,
+    artifact_ref: Optional[str] = None,
 ) -> TTInferenceRunResult:
     """Start a chat model deployment via TT Inference Server (/run).
 
@@ -147,6 +148,8 @@ def start_chat_deployment(
         payload["override_tt_config"] = override_tt_config
     if override_docker_image is not None:
         payload["override_docker_image"] = override_docker_image
+    if artifact_ref is not None:
+        payload["artifact_ref"] = artifact_ref
 
     # Pass UI-managed secrets explicitly. The inference server runs on the host
     # and cannot read user_config.env in the persistent volume when the backend

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -82,23 +82,36 @@ def resolve_deploy_image(
         fastapi_base_url or backend_config.tt_inference_api_url
     ).rstrip("/")
     try:
-        params = {"model": model_name}
+        base_params = {"model": model_name}
         if device:
-            params["device"] = device
+            base_params["device"] = device
+
+        # Try impl-qualified first, then fall back to a plain lookup. An impl the
+        # server can't match (e.g. a spec outside the prod tier) 404s the qualified
+        # request even when the plain one would resolve, so a redundant impl must
+        # not block resolution. The catalog now records impl only when it truly
+        # disambiguates, making this a defensive backstop.
+        attempts = []
         if impl:
-            params["impl"] = impl
-        r = requests.get(
-            f"{fastapi_base_url}/resolve-image",
-            params=params,
-            timeout=timeout_seconds,
-        )
-        if r.status_code != 200:
-            logger.warning(
-                f"resolve-image for model={model_name} device={device} returned HTTP {r.status_code}: {r.text[:200]}"
+            attempts.append({**base_params, "impl": impl})
+        attempts.append(base_params)
+
+        for params in attempts:
+            r = requests.get(
+                f"{fastapi_base_url}/resolve-image",
+                params=params,
+                timeout=timeout_seconds,
             )
-            return None
-        image = (r.json() or {}).get("docker_image")
-        return image or None
+            if r.status_code != 200:
+                logger.warning(
+                    f"resolve-image for model={model_name} device={device} "
+                    f"impl={params.get('impl')} returned HTTP {r.status_code}: {r.text[:200]}"
+                )
+                continue
+            image = (r.json() or {}).get("docker_image")
+            if image:
+                return image
+        return None
     except requests.exceptions.RequestException as e:
         logger.warning(f"resolve-image request failed for model={model_name}: {e}")
         return None

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -604,7 +604,7 @@ class DeployView(APIView):
                     vllm_override_args=vllm_override_args,
                     override_tt_config=override_tt_config,
                     override_docker_image=override_docker_image,
-                    dev_mode=False,
+                    dev_mode=impl.requires_dev_catalog,
                 )
 
                 # If the image isn't cached yet, pull it here first so the UI can show real byte-level progress, then trigger the deployment

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -47,7 +47,7 @@ from shared_config.coding_agent_config import get_reasoning_parser
 from .docker_control_client import get_docker_client
 from .image_pull import start_prepull_and_deploy, get_pull_job, clamp_progress_pct
 from uuid import uuid4
-from shared_config.model_config import model_implmentations, infer_chips_required
+from shared_config.model_config import model_implmentations, infer_chips_required, _impl_id
 from shared_config.model_type_config import ModelTypes
 from .serializers import DeploymentSerializer
 from shared_config.logger_config import get_logger
@@ -831,7 +831,9 @@ class DeployView(APIView):
 
                 # Pre-pull the media image first so the UI shows real progress.
                 media_device = infer_inference_server_device(impl)
-                inference_impl = getattr(impl, "inference_impl", None)
+                # resolve-image declares `impl: Optional[str]`; send the impl_id
+                # string. See the matching guard in docker_utils.run_container.
+                inference_impl = _impl_id(getattr(impl, "inference_impl", None))
                 deploy_image = resolve_deploy_image(impl.model_name, media_device, impl=inference_impl) or impl.image_version
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -17,6 +17,7 @@ import subprocess
 import signal
 import os
 from pathlib import Path
+from typing import Optional
 
 import re
 import os
@@ -109,6 +110,25 @@ _LLAMA_V014_MODELS = {
     "Llama-3.1-70B-Instruct",
     "Llama-3.3-70B-Instruct",
 }
+
+
+def _resolve_override_docker_image(impl) -> Optional[str]:
+    """Pin an explicit docker image where the inference server can't infer one.
+
+    Two independent reasons a model needs this:
+    - _LLAMA_V014_MODELS: the inference server's own model_spec default is an
+      older image that's rejected on P300x2 (PR #815) -- unrelated to catalog tier.
+    - requires_dev_catalog: "dev" tier catalog entries don't pin a docker_image
+      (unlike "prod"), so run.py refuses to guess one and requires
+      --override-docker-image whenever --dev-mode is combined with
+      --docker-server. The catalog's own image_version is exactly what's needed.
+    """
+    if impl.model_name in _LLAMA_V014_MODELS:
+        return _LLAMA_V014_IMAGE
+    if impl.requires_dev_catalog:
+        return impl.image_version
+    return None
+
 
 # Track when deployment started
 deployment_start_times = {}  # {job_id: timestamp} - Track when deployment started
@@ -589,11 +609,7 @@ class DeployView(APIView):
                         overrides["reasoning-parser"] = reasoning_parser
                     if overrides:
                         vllm_override_args = json.dumps(overrides)
-                # Some Llama models need a newer image than the inference server's model_spec default
-                # e.g. Llama-3.3-70B-Instruct@P300X2 defaults to a v0.10.0 image which inference server will reject.
-                override_docker_image = (
-                    _LLAMA_V014_IMAGE if impl.model_name in _LLAMA_V014_MODELS else None
-                )
+                override_docker_image = _resolve_override_docker_image(impl)
                 chat_deploy_kwargs = dict(
                     model_name=impl.model_name,
                     device=device,

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -130,6 +130,56 @@ def _resolve_override_docker_image(impl) -> Optional[str]:
     return None
 
 
+def _resolve_artifact_ref(impl, device, board_type) -> Optional[str]:
+    """Pick this entry's tt-inference-server build for the board being deployed to.
+
+    The catalog field is keyed by device because one entry usually covers several
+    boards (47 of 56 entries do) and only some may need a non-default build.
+
+    Returns None -- meaning "use the globally pinned artifact" -- for every case
+    except an explicit, matched, eligible pin. Callers need no other fallback.
+    """
+    ref_map = getattr(impl, "inference_artifact_ref", None)
+    if not ref_map:
+        return None
+
+    # Only dev-catalog deploys run run.py as a subprocess, which is the only path
+    # that can be pointed at a different artifact directory. The in-process path
+    # is bound to the artifact imported at inference-api boot, so honouring a ref
+    # there would silently deploy against the wrong build.
+    if not impl.requires_dev_catalog:
+        logger.warning(
+            f"{impl.model_name}: ignoring inference_artifact_ref -- it only applies to "
+            f"models with requires_dev_catalog=true. Using the globally pinned artifact."
+        )
+        return None
+
+    # Match the resolved runtime device first ("p150"), then the detected board
+    # type ("P300x2"). These differ on multi-chip boards: _BOARD_TO_SINGLE_CHIP_DEVICE
+    # maps P300x2 -> p150, so a P300x2 box actually deploys with --tt-device p150.
+    # Accept either spelling so a catalog author can key on what they see.
+    lookup = {str(k).strip().lower(): v for k, v in ref_map.items()}
+    for candidate in (device, board_type):
+        if not candidate:
+            continue
+        ref = lookup.get(str(candidate).strip().lower())
+        if ref:
+            logger.info(
+                f"{impl.model_name}: using tt-inference-server ref '{ref}' "
+                f"(matched '{candidate}')"
+            )
+            return ref
+
+    # A pin exists but nothing matched -- almost always a typo'd key. Say so
+    # rather than silently falling back to a build that lacks this model.
+    logger.warning(
+        f"{impl.model_name}: inference_artifact_ref has no entry for device "
+        f"'{device}' or board '{board_type}' (keys: {sorted(ref_map)}). "
+        f"Using the globally pinned artifact."
+    )
+    return None
+
+
 # Track when deployment started
 deployment_start_times = {}  # {job_id: timestamp} - Track when deployment started
 
@@ -610,6 +660,7 @@ class DeployView(APIView):
                     if overrides:
                         vllm_override_args = json.dumps(overrides)
                 override_docker_image = _resolve_override_docker_image(impl)
+                artifact_ref = _resolve_artifact_ref(impl, device, board_type)
                 chat_deploy_kwargs = dict(
                     model_name=impl.model_name,
                     device=device,
@@ -621,6 +672,7 @@ class DeployView(APIView):
                     override_tt_config=override_tt_config,
                     override_docker_image=override_docker_image,
                     dev_mode=impl.requires_dev_catalog,
+                    artifact_ref=artifact_ref,
                 )
 
                 # If the image isn't cached yet, pull it here first so the UI can show real byte-level progress, then trigger the deployment

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -47,7 +47,7 @@ from shared_config.coding_agent_config import get_reasoning_parser
 from .docker_control_client import get_docker_client
 from .image_pull import start_prepull_and_deploy, get_pull_job, clamp_progress_pct
 from uuid import uuid4
-from shared_config.model_config import model_implmentations, infer_chips_required, _impl_id
+from shared_config.model_config import model_implmentations, infer_chips_required, _impl_selector
 from shared_config.model_type_config import ModelTypes
 from .serializers import DeploymentSerializer
 from shared_config.logger_config import get_logger
@@ -831,9 +831,9 @@ class DeployView(APIView):
 
                 # Pre-pull the media image first so the UI shows real progress.
                 media_device = infer_inference_server_device(impl)
-                # resolve-image declares `impl: Optional[str]`; send the impl_id
-                # string. See the matching guard in docker_utils.run_container.
-                inference_impl = _impl_id(getattr(impl, "inference_impl", None))
+                # resolve-image declares `impl: Optional[str]` and matches on
+                # impl_name. See the matching guard in docker_utils.run_container.
+                inference_impl = _impl_selector(getattr(impl, "inference_impl", None))
                 deploy_image = resolve_deploy_image(impl.model_name, media_device, impl=inference_impl) or impl.image_version
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -40,13 +40,24 @@ def load_dotenv_dict(env_path: Union[str, Path]) -> Dict[str, str]:
     return env_dict
 
 
-def _impl_id(value) -> Optional[str]:
-    """The catalog stores tt-inference-server's whole impl object; the server's
-    /run and /resolve-image endpoints want only its impl_id string."""
+def _impl_selector(value) -> Optional[str]:
+    """Reduce tt-inference-server's impl object to the string its endpoints match on.
+
+    The server selects a spec with `spec.impl.impl_name == impl`
+    (workflows/model_spec.py::get_runtime_model_spec) and run.py builds its
+    --impl argparse choices from impl_name too. impl_name is the hyphenated
+    form ("tt-transformers"); impl_id is the underscored one
+    ("tt_transformers"). They differ for 9 of the 10 impls in the v0.19.0
+    artifact, so sending impl_id resolves nothing. impl_id is only a fallback
+    for an object that predates impl_name.
+    """
     if isinstance(value, str):
         return value or None
     if isinstance(value, dict):
-        return value.get("impl_id") or None
+        for key in ("impl_name", "impl_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
     return None
 
 
@@ -74,10 +85,11 @@ class ModelImpl:
     health_route: str = "/health"
     display_model_type: str = "LLM"
     inference_engine: str = "vllm"
-    # tt-inference-server impl_id (e.g. "training_lora", "tt_transformers"),
-    # extracted from the catalog's impl object by _impl_id(). Disambiguates
-    # models whose name+device match multiple engine specs so the server deploys
-    # the intended one instead of defaulting to another engine.
+    # tt-inference-server impl_name (e.g. "training-lora", "tt-transformers"),
+    # extracted from the catalog's impl object by _impl_selector(). Note the
+    # hyphens: this is the value the server matches on, not the underscored
+    # impl_id. Disambiguates models whose name+device match multiple engine
+    # specs so the server deploys the intended one instead of another engine.
     inference_impl: Optional[str] = None
     param_count: Optional[int] = None
     # Model exists only in tt-inference-server's dev-tier catalog (not yet
@@ -345,7 +357,7 @@ def load_model_implementations_from_json(json_path: Path) -> list:
             shm_size=entry.get("shm_size", "32G"),
             display_model_type=entry.get("display_model_type", "LLM"),
             inference_engine=entry.get("inference_engine", "vllm"),
-            inference_impl=_impl_id(entry.get("impl")),
+            inference_impl=_impl_selector(entry.get("impl")),
             param_count=entry.get("param_count"),
             requires_dev_catalog=entry.get("requires_dev_catalog", False),
             inference_artifact_ref=entry.get("inference_artifact_ref"),

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -69,6 +69,10 @@ class ModelImpl:
     # server deploys the intended one instead of defaulting to another engine.
     inference_impl: Optional[str] = None
     param_count: Optional[int] = None
+    # Model exists only in tt-inference-server's dev-tier catalog (not yet
+    # promoted to prod), so its deploy must set MODEL_SPECS_ENV=dev or run.py
+    # won't recognize --model.
+    requires_dev_catalog: bool = False
 
     def __post_init__(self):
         # _init methods compute values that are dependent on other values
@@ -324,6 +328,7 @@ def load_model_implementations_from_json(json_path: Path) -> list:
             inference_engine=entry.get("inference_engine", "vllm"),
             inference_impl=entry.get("impl"),
             param_count=entry.get("param_count"),
+            requires_dev_catalog=entry.get("requires_dev_catalog", False),
         )
         impls.append(impl)
     return impls

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -73,6 +73,14 @@ class ModelImpl:
     # promoted to prod), so its deploy must set MODEL_SPECS_ENV=dev or run.py
     # won't recognize --model.
     requires_dev_catalog: bool = False
+    # Per-board tt-inference-server build this model needs, e.g.
+    # {"P150": "stisi/feat-qwen35-9b-blackhole-devicespec"}. Keyed by device
+    # because one catalog entry usually covers several boards and only some of
+    # them may need a non-default build. Values accept a branch, tag, or 40-char
+    # commit SHA. Absent/unmatched device -> the globally pinned artifact.
+    # Only honoured for requires_dev_catalog models (see
+    # docker_control.views._resolve_artifact_ref).
+    inference_artifact_ref: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         # _init methods compute values that are dependent on other values
@@ -329,6 +337,7 @@ def load_model_implementations_from_json(json_path: Path) -> list:
             inference_impl=entry.get("impl"),
             param_count=entry.get("param_count"),
             requires_dev_catalog=entry.get("requires_dev_catalog", False),
+            inference_artifact_ref=entry.get("inference_artifact_ref"),
         )
         impls.append(impl)
     return impls

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -40,6 +40,16 @@ def load_dotenv_dict(env_path: Union[str, Path]) -> Dict[str, str]:
     return env_dict
 
 
+def _impl_id(value) -> Optional[str]:
+    """The catalog stores tt-inference-server's whole impl object; the server's
+    /run and /resolve-image endpoints want only its impl_id string."""
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, dict):
+        return value.get("impl_id") or None
+    return None
+
+
 @dataclass(frozen=True)
 class ModelImpl:
     """
@@ -64,9 +74,10 @@ class ModelImpl:
     health_route: str = "/health"
     display_model_type: str = "LLM"
     inference_engine: str = "vllm"
-    # tt-inference-server impl name (e.g. "training_lora", "tt_transformers").
-    # Disambiguates models whose name+device match multiple engine specs so the
-    # server deploys the intended one instead of defaulting to another engine.
+    # tt-inference-server impl_id (e.g. "training_lora", "tt_transformers"),
+    # extracted from the catalog's impl object by _impl_id(). Disambiguates
+    # models whose name+device match multiple engine specs so the server deploys
+    # the intended one instead of defaulting to another engine.
     inference_impl: Optional[str] = None
     param_count: Optional[int] = None
     # Model exists only in tt-inference-server's dev-tier catalog (not yet
@@ -334,7 +345,7 @@ def load_model_implementations_from_json(json_path: Path) -> list:
             shm_size=entry.get("shm_size", "32G"),
             display_model_type=entry.get("display_model_type", "LLM"),
             inference_engine=entry.get("inference_engine", "vllm"),
-            inference_impl=entry.get("impl"),
+            inference_impl=_impl_id(entry.get("impl")),
             param_count=entry.get("param_count"),
             requires_dev_catalog=entry.get("requires_dev_catalog", False),
             inference_artifact_ref=entry.get("inference_artifact_ref"),

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1236,6 +1236,7 @@
     },
     {
       "model_name": "gemma-1.1-2b-it",
+      "hand_owned": true,
       "model_type": "TRAINING",
       "display_model_type": "TRAINING",
       "device_configurations": [
@@ -1266,6 +1267,7 @@
     },
     {
       "model_name": "Llama-3.1-8B",
+      "hand_owned": true,
       "model_type": "TRAINING",
       "display_model_type": "TRAINING",
       "device_configurations": [

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -45,6 +45,19 @@ _CANDIDATE_SOURCES = [
 HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref")
 
 
+def _impl_id(value):
+    """Reduce tt-inference-server's impl object to its impl_id string. The
+    server's /run and /resolve-image endpoints expect a string, not the whole
+    {impl_id, impl_name, repo_url, code_path} object. Stdlib-only, kept local:
+    this script runs standalone on the host interpreter, so it can't import the
+    Django-bound copy in model_config."""
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, dict):
+        return value.get("impl_id") or None
+    return None
+
+
 def load_existing_catalog(path: Path) -> dict:
     """Return {model_name: entry} for the catalog already on disk, or {} if none.
 
@@ -302,10 +315,11 @@ def _iter_v1_entries(model_specs: dict):
             for _engine, by_impl in by_engine.items():
                 for _impl_name, entry in by_impl.items():
                     if isinstance(entry, dict):
-                        # The impl name is the nesting key, not always a field on
-                        # the leaf. Carry it so the catalog can disambiguate models
-                        # whose name+device match multiple engine specs.
-                        entry.setdefault("impl", _impl_name)
+                        # Store the impl_id STRING so the catalog can disambiguate
+                        # models whose name+device match multiple engine specs.
+                        # The leaf's "impl" is the whole impl object; reduce it to
+                        # its impl_id, falling back to the nesting key when absent.
+                        entry["impl"] = _impl_id(entry.get("impl")) or _impl_name
                         yield entry
 
 
@@ -398,6 +412,13 @@ def main():
     # discards anything the source can't express (issue #977).
     existing = load_existing_catalog(OUTPUT_JSON.resolve())
     models, preserved, retained = merge_hand_owned(models, existing)
+
+    # Hand-retained entries bypass normalize() entirely and may carry a stale
+    # impl object from an older catalog; reduce every impl to its impl_id string.
+    for _m in models:
+        if "impl" in _m:
+            _m["impl"] = _impl_id(_m.get("impl"))
+
     if preserved:
         print(f"Preserved {len(preserved)} hand-set field(s): {', '.join(preserved)}")
     if retained:

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -371,6 +371,17 @@ def normalize(source_path: Path) -> list[dict]:
         raw_model_type = first.get("model_type", "LLM")
         service_route = map_service_route(inference_engine, hf_model_id=first.get("hf_model_repo", ""), raw_model_type=raw_model_type)
 
+        # Record an impl only when it actually disambiguates. The server does a
+        # stricter (model, device, impl) lookup that misses specs outside the prod
+        # tier, so an impl that buys no disambiguation turns a working resolve into
+        # a 404 (e.g. speecht5_tts on Blackhole). A future dev-catalog spec that
+        # collides on name+device won't appear in this prod artifact, so it can't be
+        # seen here; such models arrive as hand-added retained entries whose impl is
+        # preserved, or the impl can be set by hand.
+        distinct_impls = {_impl_id(e.get("impl")) for e in entries}
+        distinct_impls.discard(None)
+        disambiguating_impl = _impl_id(first.get("impl")) if len(distinct_impls) > 1 else None
+
         models.append({
             "model_name": model_name,
             "model_type": map_model_type(raw_model_type, inference_engine),
@@ -378,7 +389,7 @@ def normalize(source_path: Path) -> list[dict]:
             "device_configurations": device_configurations,
             "hf_model_id": first.get("hf_model_repo"),
             "inference_engine": inference_engine,
-            "impl": first.get("impl"),
+            "impl": disambiguating_impl,
             "status": status,
             "version": canonical.get("version", "0.0.0"),
             "docker_image": canonical.get("docker_image"),

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -42,7 +42,18 @@ _CANDIDATE_SOURCES = [
 # rebuilds the catalog from scratch and silently drops them -- someone fixes a
 # deploy by editing the catalog, then loses the fix on the next --resync with no
 # error. Adding a future hand-owned field means adding it here. See issue #977.
-HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref")
+HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref", "hand_owned")
+
+# Marker on a catalog entry that exists only because someone added it by hand
+# (e.g. the forge TRAINING rows, which no prod release snapshot contains). Such
+# an entry outranks a synced entry of the same model_name: the source JSON has a
+# vLLM CHAT "Llama-3.1-8B" whose name collides with the hand-added forge TRAINING
+# one, and without this the resync silently replaces the training row -- taking
+# the fine-tuning feature offline, since training_control filters on
+# model_type == TRAINING. Catalog model_name must stay unique: several lookups
+# (model_config.get_model_impl, docker_utils' deployment->impl mapping) take the
+# first name match, so keeping both would make them pick arbitrarily.
+HAND_OWNED_MARKER = "hand_owned"
 
 
 def _impl_selector(value):
@@ -98,9 +109,30 @@ def merge_hand_owned(models: list, existing: dict) -> tuple[list, list, list]:
     - A model that exists ONLY in the dev-tier catalog can't appear in a prod
       release snapshot at all, so a rebuild deletes the whole entry.
 
+    A third loss, and the reason for HAND_OWNED_MARKER: a hand-added entry whose
+    model_name COLLIDES with a synced one. Name-keyed preservation silently hands
+    the synced entry the hand-owned fields and throws the rest of the hand-added
+    row away -- a different model_type, engine, service_route and env_vars. The
+    marked entry wins outright instead, and the colliding synced entry is dropped
+    so model_name stays unique.
+
     Returns (merged_models, preserved_field_names, retained_model_names).
     """
     preserved, retained = [], []
+    hand_owned = {
+        name for name, old in existing.items() if old.get(HAND_OWNED_MARKER)
+    }
+
+    # Drop synced entries whose name is claimed by a hand-owned entry; the
+    # hand-owned row is re-appended intact by the retain loop below.
+    displaced = [m["model_name"] for m in models if m["model_name"] in hand_owned]
+    if displaced:
+        models = [m for m in models if m["model_name"] not in hand_owned]
+        print(
+            f"Kept {len(displaced)} hand-owned entry(ies) over a same-named source "
+            f"entry: {', '.join(sorted(displaced))}"
+        )
+
     synced_names = {m["model_name"] for m in models}
 
     for model in models:

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -35,6 +35,66 @@ _CANDIDATE_SOURCES = [
 ]
 
 
+# Catalog keys that are curated by hand and can never be derived from the
+# tt-inference-server source JSON. Without explicit preservation, every resync
+# rebuilds the catalog from scratch and silently drops them -- someone fixes a
+# deploy by editing the catalog, then loses the fix on the next --resync with no
+# error. Adding a future hand-owned field means adding it here. See issue #977.
+HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref")
+
+
+def load_existing_catalog(path: Path) -> dict:
+    """Return {model_name: entry} for the catalog already on disk, or {} if none.
+
+    Never fatal: a missing or malformed catalog just means there is nothing to
+    preserve, which is the correct outcome for a first-time sync.
+    """
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Warning: could not read existing catalog ({e}); nothing to preserve")
+        return {}
+    return {
+        m["model_name"]: m
+        for m in data.get("models", [])
+        if isinstance(m, dict) and m.get("model_name")
+    }
+
+
+def merge_hand_owned(models: list, existing: dict) -> tuple[list, list, list]:
+    """Fold hand-curated state from `existing` into freshly-synced `models`.
+
+    Two distinct losses to prevent:
+    - A hand-set field on a model that IS in the source JSON (e.g. a dev-catalog
+      flag) has nothing in the source to regenerate it.
+    - A model that exists ONLY in the dev-tier catalog can't appear in a prod
+      release snapshot at all, so a rebuild deletes the whole entry.
+
+    Returns (merged_models, preserved_field_names, retained_model_names).
+    """
+    preserved, retained = [], []
+    synced_names = {m["model_name"] for m in models}
+
+    for model in models:
+        old = existing.get(model["model_name"])
+        if not old:
+            continue
+        for key in HAND_OWNED_KEYS:
+            if key in old and key not in model:
+                model[key] = old[key]
+                preserved.append(f"{model['model_name']}.{key}")
+
+    for name, old in existing.items():
+        if name not in synced_names:
+            models.append(old)
+            retained.append(name)
+
+    return models, preserved, retained
+
+
 def resolve_source_json(override: str | None = None) -> Path:
     """Return the path to model_specs_output.json, trying candidates in order."""
     if override:
@@ -329,6 +389,20 @@ def main():
         raise FileNotFoundError(f"Source not found: {source_path}")
 
     models = normalize(source_path)
+
+    # Fold in hand-curated state before writing. normalize() rebuilds every entry
+    # purely from the source JSON, so without this the write below silently
+    # discards anything the source can't express (issue #977).
+    existing = load_existing_catalog(OUTPUT_JSON.resolve())
+    models, preserved, retained = merge_hand_owned(models, existing)
+    if preserved:
+        print(f"Preserved {len(preserved)} hand-set field(s): {', '.join(preserved)}")
+    if retained:
+        print(f"Retained {len(retained)} model(s) absent from source: {', '.join(retained)}")
+
+    # Re-sort after merging so retained entries land in their proper position
+    # rather than appended at the end (same key as normalize()).
+    models.sort(key=lambda m: (-STATUS_ORDER.get(m["status"], 0), m["model_name"].lower()))
 
     # Resolve artifact version from VERSION file or env vars (avoid leaking absolute paths)
     artifact_version = None

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -45,16 +45,26 @@ _CANDIDATE_SOURCES = [
 HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref")
 
 
-def _impl_id(value):
-    """Reduce tt-inference-server's impl object to its impl_id string. The
-    server's /run and /resolve-image endpoints expect a string, not the whole
-    {impl_id, impl_name, repo_url, code_path} object. Stdlib-only, kept local:
-    this script runs standalone on the host interpreter, so it can't import the
-    Django-bound copy in model_config."""
+def _impl_selector(value):
+    """Reduce tt-inference-server's impl object to the string its endpoints match on.
+
+    The server selects with `spec.impl.impl_name == impl` and run.py builds its
+    --impl choices from impl_name, so the hyphenated impl_name ("tt-transformers")
+    is the wire value -- not the underscored impl_id ("tt_transformers"). The two
+    differ for 9 of the 10 impls in the v0.19.0 artifact. impl_id is a fallback
+    for objects that predate impl_name.
+
+    Stdlib-only, kept local: this script runs standalone on the host interpreter,
+    so it can't import the Django-bound copy in model_config. Keep the two in
+    step -- shared_config/test_sync_models.py and test_model_config.py assert the
+    same vectors against each."""
     if isinstance(value, str):
         return value or None
     if isinstance(value, dict):
-        return value.get("impl_id") or None
+        for key in ("impl_name", "impl_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
     return None
 
 
@@ -313,13 +323,16 @@ def _iter_v1_entries(model_specs: dict):
     for _hf_id, by_device in model_specs.items():
         for _device_type, by_engine in by_device.items():
             for _engine, by_impl in by_engine.items():
-                for _impl_name, entry in by_impl.items():
+                for _impl_key, entry in by_impl.items():
                     if isinstance(entry, dict):
-                        # Store the impl_id STRING so the catalog can disambiguate
+                        # Store the impl_name STRING so the catalog can disambiguate
                         # models whose name+device match multiple engine specs.
-                        # The leaf's "impl" is the whole impl object; reduce it to
-                        # its impl_id, falling back to the nesting key when absent.
-                        entry["impl"] = _impl_id(entry.get("impl")) or _impl_name
+                        # No fallback to _impl_key: that nesting key is the
+                        # underscored impl_id, which the server does not match on,
+                        # and a wrong impl is a hard failure (argparse invalid
+                        # choice / ValueError) whereas None just lets the server
+                        # pick its default spec.
+                        entry["impl"] = _impl_selector(entry.get("impl"))
                         yield entry
 
 
@@ -378,9 +391,9 @@ def normalize(source_path: Path) -> list[dict]:
         # collides on name+device won't appear in this prod artifact, so it can't be
         # seen here; such models arrive as hand-added retained entries whose impl is
         # preserved, or the impl can be set by hand.
-        distinct_impls = {_impl_id(e.get("impl")) for e in entries}
+        distinct_impls = {_impl_selector(e.get("impl")) for e in entries}
         distinct_impls.discard(None)
-        disambiguating_impl = _impl_id(first.get("impl")) if len(distinct_impls) > 1 else None
+        disambiguating_impl = _impl_selector(first.get("impl")) if len(distinct_impls) > 1 else None
 
         models.append({
             "model_name": model_name,
@@ -428,7 +441,7 @@ def main():
     # impl object from an older catalog; reduce every impl to its impl_id string.
     for _m in models:
         if "impl" in _m:
-            _m["impl"] = _impl_id(_m.get("impl"))
+            _m["impl"] = _impl_selector(_m.get("impl"))
 
     if preserved:
         print(f"Preserved {len(preserved)} hand-set field(s): {', '.join(preserved)}")

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -3,8 +3,9 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 """
-Sync script: reads ../../tt-inference-server/model_specs_output.json and
-normalizes it into models_from_inference_server.json (co-located with this script).
+Sync script: reads ../../tt-inference-server/release_model_spec.json (or the
+legacy model_specs_output.json / model_spec.json names) and normalizes it into
+models_from_inference_server.json (co-located with this script).
 
 Run from any directory:
     python app/backend/shared_config/sync_models_from_inference_server.py
@@ -26,12 +27,13 @@ OUTPUT_JSON = SCRIPT_DIR / "models_from_inference_server.json"
 #   2. TT_INFERENCE_ARTIFACT_PATH env var (set by run.py after artifact download)
 #   3. .artifacts/tt-inference-server/ next to repo root (artifact default location)
 #   4. tt-inference-server/ next to repo root (manual local dev checkout)
+# Filenames tried per directory, newest release layout first:
+_SOURCE_FILENAMES = ["release_model_spec.json", "model_specs_output.json", "model_spec.json"]
 _REPO_ROOT = SCRIPT_DIR / "../../.."
 _CANDIDATE_SOURCES = [
-    _REPO_ROOT / ".artifacts/tt-inference-server/model_specs_output.json",
-    _REPO_ROOT / ".artifacts/tt-inference-server/model_spec.json",
-    _REPO_ROOT / "tt-inference-server/model_specs_output.json",
-    _REPO_ROOT / "tt-inference-server/model_spec.json",
+    _REPO_ROOT / f".artifacts/tt-inference-server/{name}" for name in _SOURCE_FILENAMES
+] + [
+    _REPO_ROOT / f"tt-inference-server/{name}" for name in _SOURCE_FILENAMES
 ]
 
 
@@ -96,7 +98,7 @@ def merge_hand_owned(models: list, existing: dict) -> tuple[list, list, list]:
 
 
 def resolve_source_json(override: str | None = None) -> Path:
-    """Return the path to model_specs_output.json, trying candidates in order."""
+    """Return the path to the model spec JSON, trying candidates in order."""
     if override:
         p = Path(override)
         if not p.exists():
@@ -106,9 +108,10 @@ def resolve_source_json(override: str | None = None) -> Path:
     # Check env var set by run.py
     artifact_path = os.environ.get("TT_INFERENCE_ARTIFACT_PATH")
     if artifact_path:
-        p = Path(artifact_path) / "model_specs_output.json"
-        if p.exists():
-            return p.resolve()
+        for name in _SOURCE_FILENAMES:
+            p = Path(artifact_path) / name
+            if p.exists():
+                return p.resolve()
 
     # Try static candidates
     for candidate in _CANDIDATE_SOURCES:
@@ -116,7 +119,7 @@ def resolve_source_json(override: str | None = None) -> Path:
             return candidate.resolve()
 
     raise FileNotFoundError(
-        "Cannot find model_specs_output.json. Tried:\n"
+        "Cannot find a model spec JSON. Tried:\n"
         + "\n".join(f"  {c.resolve()}" for c in _CANDIDATE_SOURCES)
     )
 

--- a/app/backend/shared_config/test_model_config.py
+++ b/app/backend/shared_config/test_model_config.py
@@ -2,35 +2,54 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 """
-Tests for model_config._impl_id — the boundary that reduces the catalog's impl
-object to the impl_id string the inference server's /run and /resolve-image
-endpoints expect. Django SimpleTestCase so it runs where TT_STUDIO_ROOT (read at
-import by backend_config) is set.
+Tests for model_config._impl_selector — the boundary that reduces the catalog's
+impl object to the string the inference server's /run and /resolve-image
+endpoints match on. Django SimpleTestCase so it runs where TT_STUDIO_ROOT (read
+at import by backend_config) is set.
+
+The server compares `spec.impl.impl_name == impl`, so the hyphenated impl_name
+is the wire value. Every vector below that carries both keys deliberately gives
+them DIFFERENT values: fixtures where impl_id == impl_name cannot tell a correct
+implementation from one that returns impl_id.
 """
 
 from django.test import SimpleTestCase
 
-from shared_config.model_config import _impl_id
+from shared_config.model_config import _impl_selector
 
 
-class ImplIdTests(SimpleTestCase):
-    def test_reduces_object_to_impl_id(self):
+class ImplSelectorTests(SimpleTestCase):
+    def test_prefers_impl_name_over_impl_id(self):
         obj = {
             "impl_id": "tt_transformers",
             "impl_name": "tt-transformers",
             "repo_url": "https://github.com/tenstorrent/tt-metal",
             "code_path": "models/tt_transformers",
         }
-        self.assertEqual(_impl_id(obj), "tt_transformers")
+        self.assertEqual(_impl_selector(obj), "tt-transformers")
+
+    def test_speecht5_tts_resolves_to_hyphenated_name(self):
+        """The impl from the regression this fix exists for: the two forms differ,
+        and sending impl_id makes run.py reject it as an invalid --impl choice."""
+        obj = {"impl_id": "speecht5_tts", "impl_name": "speecht5-tts"}
+        self.assertEqual(_impl_selector(obj), "speecht5-tts")
+
+    def test_falls_back_to_impl_id_when_name_absent(self):
+        self.assertEqual(_impl_selector({"impl_id": "legacy_only"}), "legacy_only")
 
     def test_passes_through_plain_string(self):
-        self.assertEqual(_impl_id("whisper"), "whisper")
+        self.assertEqual(_impl_selector("whisper"), "whisper")
 
     def test_none_returns_none(self):
-        self.assertIsNone(_impl_id(None))
+        self.assertIsNone(_impl_selector(None))
 
-    def test_object_missing_impl_id_returns_none(self):
-        self.assertIsNone(_impl_id({"impl_name": "orphan"}))
+    def test_empty_object_returns_none(self):
+        self.assertIsNone(_impl_selector({}))
 
     def test_empty_string_returns_none(self):
-        self.assertIsNone(_impl_id(""))
+        self.assertIsNone(_impl_selector(""))
+
+    def test_non_string_impl_values_return_none(self):
+        """Coercion at a trust boundary: never hand a non-string to the server."""
+        self.assertIsNone(_impl_selector({"impl_name": 7, "impl_id": ["a"]}))
+        self.assertIsNone(_impl_selector(7))

--- a/app/backend/shared_config/test_model_config.py
+++ b/app/backend/shared_config/test_model_config.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for model_config._impl_id — the boundary that reduces the catalog's impl
+object to the impl_id string the inference server's /run and /resolve-image
+endpoints expect. Django SimpleTestCase so it runs where TT_STUDIO_ROOT (read at
+import by backend_config) is set.
+"""
+
+from django.test import SimpleTestCase
+
+from shared_config.model_config import _impl_id
+
+
+class ImplIdTests(SimpleTestCase):
+    def test_reduces_object_to_impl_id(self):
+        obj = {
+            "impl_id": "tt_transformers",
+            "impl_name": "tt-transformers",
+            "repo_url": "https://github.com/tenstorrent/tt-metal",
+            "code_path": "models/tt_transformers",
+        }
+        self.assertEqual(_impl_id(obj), "tt_transformers")
+
+    def test_passes_through_plain_string(self):
+        self.assertEqual(_impl_id("whisper"), "whisper")
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_impl_id(None))
+
+    def test_object_missing_impl_id_returns_none(self):
+        self.assertIsNone(_impl_id({"impl_name": "orphan"}))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(_impl_id(""))

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -10,7 +10,7 @@ import json
 import pytest
 from sync_models_from_inference_server import (
     HAND_OWNED_KEYS,
-    _impl_id,
+    _impl_selector,
     _iter_v1_entries,
     load_existing_catalog,
     map_service_route,
@@ -133,47 +133,55 @@ class TestHandOwnedFieldPreservation:
 
 
 class TestImplNormalization:
-    """The inference server's /run and /resolve-image expect a string impl_id;
-    the artifact leaves carry the whole impl object, so the catalog must store
-    only the impl_id string (issue: media/non-chat deploy HTTP 422)."""
+    """The server selects with `spec.impl.impl_name == impl`, so the catalog must
+    store the hyphenated impl_name, not the underscored impl_id. Fixtures here
+    deliberately give the two keys DIFFERENT values -- equal-key fixtures cannot
+    distinguish a correct implementation from one returning impl_id."""
 
-    def test_impl_id_reduces_object_to_string(self):
+    def test_selector_prefers_impl_name(self):
         obj = {
-            "impl_id": "whisper",
-            "impl_name": "whisper",
+            "impl_id": "speecht5_tts",
+            "impl_name": "speecht5-tts",
             "repo_url": "https://github.com/tenstorrent/tt-metal",
-            "code_path": "models/demos/whisper",
+            "code_path": "models/demos/speecht5",
         }
-        assert _impl_id(obj) == "whisper"
+        assert _impl_selector(obj) == "speecht5-tts"
 
-    def test_impl_id_passes_through_string(self):
-        assert _impl_id("tt_transformers") == "tt_transformers"
+    def test_selector_falls_back_to_impl_id(self):
+        assert _impl_selector({"impl_id": "legacy_only"}) == "legacy_only"
 
-    def test_impl_id_handles_none_and_missing_id(self):
-        assert _impl_id(None) is None
-        assert _impl_id({}) is None
-        assert _impl_id("") is None
+    def test_selector_passes_through_string(self):
+        assert _impl_selector("tt-transformers") == "tt-transformers"
 
-    def test_v1_entries_yield_impl_id_string(self):
-        """A leaf whose impl is the full object should surface as its impl_id."""
+    def test_selector_handles_none_and_missing(self):
+        assert _impl_selector(None) is None
+        assert _impl_selector({}) is None
+        assert _impl_selector("") is None
+
+    def test_v1_entries_yield_impl_name_string(self):
+        """A leaf whose impl is the full object surfaces as its impl_name."""
         model_specs = {
-            "org/distil-large-v3": {
+            "org/Llama-3.2-3B": {
                 "P150": {
-                    "media": {
-                        "whisper": {
-                            "model_name": "distil-large-v3",
-                            "impl": {"impl_id": "whisper", "impl_name": "whisper"},
+                    "vLLM": {
+                        "tt_transformers": {
+                            "model_name": "Llama-3.2-3B",
+                            "impl": {
+                                "impl_id": "tt_transformers",
+                                "impl_name": "tt-transformers",
+                            },
                         }
                     }
                 }
             }
         }
         entries = list(_iter_v1_entries(model_specs))
-        assert [e["impl"] for e in entries] == ["whisper"]
+        assert [e["impl"] for e in entries] == ["tt-transformers"]
 
-    def test_v1_entries_fall_back_to_nesting_key(self):
-        """A leaf with no impl object should fall back to the nesting key so the
-        catalog can still disambiguate engine specs."""
+    def test_v1_entries_do_not_fall_back_to_nesting_key(self):
+        """The nesting key is the underscored impl_id, which the server does not
+        match on. A leaf with no impl object must yield None rather than a value
+        that would make run.py reject the deploy as an invalid --impl choice."""
         model_specs = {
             "org/some-model": {
                 "P150": {
@@ -186,17 +194,17 @@ class TestImplNormalization:
             }
         }
         entries = list(_iter_v1_entries(model_specs))
-        assert [e["impl"] for e in entries] == ["tt_transformers"]
+        assert [e["impl"] for e in entries] == [None]
 
     def test_retained_entry_dict_impl_is_normalized(self):
         """A hand-retained model bypasses normalize() and can carry a stale impl
-        object; the main() normalization loop reduces it to its impl_id string."""
+        object; the main() normalization loop reduces it to its impl_name string."""
         models = [{"model_name": "Synced", "status": "COMPLETE", "impl": "whisper"}]
         existing = {
             "Retained": {
                 "model_name": "Retained",
                 "requires_dev_catalog": True,
-                "impl": {"impl_id": "qwen36_blackhole", "impl_name": "qwen36"},
+                "impl": {"impl_id": "qwen36_blackhole", "impl_name": "qwen36-blackhole"},
             }
         }
 
@@ -204,16 +212,20 @@ class TestImplNormalization:
         # Mirror main(): normalize impl across every merged entry.
         for m in merged:
             if "impl" in m:
-                m["impl"] = _impl_id(m.get("impl"))
+                m["impl"] = _impl_selector(m.get("impl"))
 
         assert retained == ["Retained"]
         by_name = {m["model_name"]: m for m in merged}
-        assert by_name["Retained"]["impl"] == "qwen36_blackhole"
+        assert by_name["Retained"]["impl"] == "qwen36-blackhole"
         assert by_name["Synced"]["impl"] == "whisper"
 
 
 def _leaf(model_name, impl_id, *, model_type="LLM", engine="vLLM"):
-    """A minimal model_spec leaf sufficient for normalize()."""
+    """A minimal model_spec leaf sufficient for normalize().
+
+    impl_name is the hyphenated form of impl_id, mirroring the real artifact
+    where the two differ for 9 of 10 impls. Keeping them distinct is what makes
+    these fixtures able to catch a regression back to emitting impl_id."""
     return {
         "model_name": model_name,
         "model_type": model_type,
@@ -222,7 +234,7 @@ def _leaf(model_name, impl_id, *, model_type="LLM", engine="vLLM"):
         "status": "COMPLETE",
         "version": "1.0.0",
         "docker_image": f"ghcr.io/x/{model_name}:1.0.0",
-        "impl": {"impl_id": impl_id, "impl_name": impl_id},
+        "impl": {"impl_id": impl_id, "impl_name": impl_id.replace("_", "-")},
     }
 
 
@@ -268,7 +280,8 @@ class TestImplAmbiguity:
             }
         }
         by_name = _normalize_specs(tmp_path, model_specs)
-        assert by_name["Llama-3.2-3B"]["impl"] in {"tt_transformers", "training"}
+        # Hyphenated: the recorded impl must be the impl_name the server matches on.
+        assert by_name["Llama-3.2-3B"]["impl"] in {"tt-transformers", "training"}
         assert by_name["Llama-3.2-3B"]["impl"] is not None
 
     def test_gpu_only_second_impl_is_not_ambiguous(self, tmp_path):

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -5,8 +5,15 @@
 Tests for sync_models_from_inference_server.py route derivation logic.
 """
 
+import json
+
 import pytest
-from sync_models_from_inference_server import map_service_route
+from sync_models_from_inference_server import (
+    HAND_OWNED_KEYS,
+    load_existing_catalog,
+    map_service_route,
+    merge_hand_owned,
+)
 
 
 class TestServiceRouteMapping:
@@ -48,6 +55,103 @@ class TestServiceRouteMapping:
         """Forge models should use /v1/chat/completions."""
         assert map_service_route("forge", "", "") == "/v1/chat/completions"
         assert map_service_route("forge", "", "CNN") == "/v1/chat/completions"
+
+
+class TestHandOwnedFieldPreservation:
+    """A resync rebuilds every entry from the source JSON, so hand-curated state
+    has to be explicitly folded back in or it is silently lost (issue #977)."""
+
+    def test_preserves_hand_set_field_on_synced_model(self):
+        models = [{"model_name": "Qwen3-8B", "status": "COMPLETE", "version": "1.0"}]
+        existing = {"Qwen3-8B": {"model_name": "Qwen3-8B", "requires_dev_catalog": True}}
+
+        merged, preserved, retained = merge_hand_owned(models, existing)
+
+        assert merged[0]["requires_dev_catalog"] is True
+        assert preserved == ["Qwen3-8B.requires_dev_catalog"]
+        assert retained == []
+
+    def test_preserves_artifact_ref_map(self):
+        models = [{"model_name": "Qwen3.5-9B", "status": "EXPERIMENTAL"}]
+        existing = {
+            "Qwen3.5-9B": {
+                "model_name": "Qwen3.5-9B",
+                "inference_artifact_ref": {"P150": "stisi/feat-qwen"},
+            }
+        }
+
+        merged, preserved, _ = merge_hand_owned(models, existing)
+
+        assert merged[0]["inference_artifact_ref"] == {"P150": "stisi/feat-qwen"}
+        assert preserved == ["Qwen3.5-9B.inference_artifact_ref"]
+
+    def test_retains_model_absent_from_source(self):
+        """A dev-tier-only model can never appear in a prod release snapshot, so
+        a rebuild would drop the whole entry, not just one field."""
+        models = [{"model_name": "Qwen3-8B", "status": "COMPLETE"}]
+        existing = {
+            "Qwen3-8B": {"model_name": "Qwen3-8B"},
+            "Qwen3.5-9B": {"model_name": "Qwen3.5-9B", "requires_dev_catalog": True},
+        }
+
+        merged, _, retained = merge_hand_owned(models, existing)
+
+        assert retained == ["Qwen3.5-9B"]
+        assert {m["model_name"] for m in merged} == {"Qwen3-8B", "Qwen3.5-9B"}
+
+    def test_fresh_value_wins_over_stale_one(self):
+        """Once the source JSON starts carrying a field, it is no longer
+        hand-owned for that model -- don't overwrite it with the old value."""
+        models = [{"model_name": "Qwen3-8B", "requires_dev_catalog": False}]
+        existing = {"Qwen3-8B": {"model_name": "Qwen3-8B", "requires_dev_catalog": True}}
+
+        merged, preserved, _ = merge_hand_owned(models, existing)
+
+        assert merged[0]["requires_dev_catalog"] is False
+        assert preserved == []
+
+    def test_first_sync_with_no_existing_catalog(self):
+        models = [{"model_name": "Qwen3-8B", "status": "COMPLETE"}]
+
+        merged, preserved, retained = merge_hand_owned(models, {})
+
+        assert merged == [{"model_name": "Qwen3-8B", "status": "COMPLETE"}]
+        assert preserved == [] and retained == []
+
+    def test_every_hand_owned_key_is_actually_carried(self):
+        """Guards the constant against drifting out of sync with the merge."""
+        models = [{"model_name": "M"}]
+        existing = {"M": {"model_name": "M", **{k: "sentinel" for k in HAND_OWNED_KEYS}}}
+
+        merged, _, _ = merge_hand_owned(models, existing)
+
+        for key in HAND_OWNED_KEYS:
+            assert merged[0][key] == "sentinel", f"{key} was not preserved"
+
+
+class TestLoadExistingCatalog:
+    def test_missing_file_is_not_fatal(self, tmp_path):
+        assert load_existing_catalog(tmp_path / "nope.json") == {}
+
+    def test_malformed_file_is_not_fatal(self, tmp_path):
+        """A corrupt catalog must not block a resync -- it just means there is
+        nothing to preserve."""
+        path = tmp_path / "catalog.json"
+        path.write_text("{not valid json")
+        assert load_existing_catalog(path) == {}
+
+    def test_indexes_models_by_name(self, tmp_path):
+        path = tmp_path / "catalog.json"
+        path.write_text(json.dumps({"models": [
+            {"model_name": "A", "requires_dev_catalog": True},
+            {"model_name": "B"},
+            {"no_name": "skipped"},
+        ]}))
+
+        loaded = load_existing_catalog(path)
+
+        assert set(loaded) == {"A", "B"}
+        assert loaded["A"]["requires_dev_catalog"] is True
 
 
 if __name__ == "__main__":

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -132,6 +132,71 @@ class TestHandOwnedFieldPreservation:
             assert merged[0][key] == "sentinel", f"{key} was not preserved"
 
 
+class TestHandOwnedCollision:
+    """A hand-added entry whose model_name collides with a synced one must win.
+
+    The source JSON carries a vLLM CHAT "Llama-3.1-8B"; the catalog carries a
+    hand-added forge TRAINING row of the same name. Name-keyed merging replaced
+    the training row on every resync, taking fine-tuning offline (training_control
+    filters on model_type == TRAINING) while leaving the entry-name set unchanged,
+    so a count or name-set check could not see it."""
+
+    def _rows(self):
+        synced = [{
+            "model_name": "Llama-3.1-8B",
+            "model_type": "CHAT",
+            "inference_engine": "vLLM",
+            "service_route": "/v1/completions",
+        }]
+        existing = {"Llama-3.1-8B": {
+            "model_name": "Llama-3.1-8B",
+            "hand_owned": True,
+            "model_type": "TRAINING",
+            "inference_engine": "forge",
+            "service_route": "/v1/jobs",
+            "env_vars": {"MODEL_RUNNER": "training-lora"},
+        }}
+        return synced, existing
+
+    def test_hand_owned_row_survives_name_collision(self):
+        synced, existing = self._rows()
+        merged, _, retained = merge_hand_owned(synced, existing)
+
+        by_name = {m["model_name"]: m for m in merged}
+        assert by_name["Llama-3.1-8B"]["model_type"] == "TRAINING"
+        assert by_name["Llama-3.1-8B"]["inference_engine"] == "forge"
+        assert by_name["Llama-3.1-8B"]["service_route"] == "/v1/jobs"
+        assert by_name["Llama-3.1-8B"]["env_vars"] == {"MODEL_RUNNER": "training-lora"}
+        assert retained == ["Llama-3.1-8B"]
+
+    def test_collision_does_not_duplicate_the_name(self):
+        """model_name must stay unique: get_model_impl and the deployment->impl
+        mapping both take the first name match, so a duplicate is ambiguous."""
+        synced, existing = self._rows()
+        merged, _, _ = merge_hand_owned(synced, existing)
+
+        assert [m["model_name"] for m in merged].count("Llama-3.1-8B") == 1
+
+    def test_marker_itself_survives_the_resync(self):
+        """hand_owned is in HAND_OWNED_KEYS, so the protection is not one-shot."""
+        synced, existing = self._rows()
+        merged, _, _ = merge_hand_owned(synced, existing)
+
+        by_name = {m["model_name"]: m for m in merged}
+        assert by_name["Llama-3.1-8B"]["hand_owned"] is True
+
+    def test_unmarked_existing_row_still_yields_to_source(self):
+        """Only marked rows win. An ordinary catalog entry is still rebuilt from
+        the source, which is the whole point of a resync."""
+        synced = [{"model_name": "Qwen3-8B", "model_type": "CHAT", "version": "2.0"}]
+        existing = {"Qwen3-8B": {"model_name": "Qwen3-8B", "model_type": "CHAT", "version": "1.0"}}
+
+        merged, _, retained = merge_hand_owned(synced, existing)
+
+        assert merged[0]["version"] == "2.0"
+        assert retained == []
+
+
 class TestImplNormalization:
     """The server selects with `spec.impl.impl_name == impl`, so the catalog must
     store the hyphenated impl_name, not the underscored impl_id. Fixtures here

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -10,6 +10,8 @@ import json
 import pytest
 from sync_models_from_inference_server import (
     HAND_OWNED_KEYS,
+    _impl_id,
+    _iter_v1_entries,
     load_existing_catalog,
     map_service_route,
     merge_hand_owned,
@@ -127,6 +129,86 @@ class TestHandOwnedFieldPreservation:
 
         for key in HAND_OWNED_KEYS:
             assert merged[0][key] == "sentinel", f"{key} was not preserved"
+
+
+class TestImplNormalization:
+    """The inference server's /run and /resolve-image expect a string impl_id;
+    the artifact leaves carry the whole impl object, so the catalog must store
+    only the impl_id string (issue: media/non-chat deploy HTTP 422)."""
+
+    def test_impl_id_reduces_object_to_string(self):
+        obj = {
+            "impl_id": "whisper",
+            "impl_name": "whisper",
+            "repo_url": "https://github.com/tenstorrent/tt-metal",
+            "code_path": "models/demos/whisper",
+        }
+        assert _impl_id(obj) == "whisper"
+
+    def test_impl_id_passes_through_string(self):
+        assert _impl_id("tt_transformers") == "tt_transformers"
+
+    def test_impl_id_handles_none_and_missing_id(self):
+        assert _impl_id(None) is None
+        assert _impl_id({}) is None
+        assert _impl_id("") is None
+
+    def test_v1_entries_yield_impl_id_string(self):
+        """A leaf whose impl is the full object should surface as its impl_id."""
+        model_specs = {
+            "org/distil-large-v3": {
+                "P150": {
+                    "media": {
+                        "whisper": {
+                            "model_name": "distil-large-v3",
+                            "impl": {"impl_id": "whisper", "impl_name": "whisper"},
+                        }
+                    }
+                }
+            }
+        }
+        entries = list(_iter_v1_entries(model_specs))
+        assert [e["impl"] for e in entries] == ["whisper"]
+
+    def test_v1_entries_fall_back_to_nesting_key(self):
+        """A leaf with no impl object should fall back to the nesting key so the
+        catalog can still disambiguate engine specs."""
+        model_specs = {
+            "org/some-model": {
+                "P150": {
+                    "vLLM": {
+                        "tt_transformers": {
+                            "model_name": "some-model",
+                        }
+                    }
+                }
+            }
+        }
+        entries = list(_iter_v1_entries(model_specs))
+        assert [e["impl"] for e in entries] == ["tt_transformers"]
+
+    def test_retained_entry_dict_impl_is_normalized(self):
+        """A hand-retained model bypasses normalize() and can carry a stale impl
+        object; the main() normalization loop reduces it to its impl_id string."""
+        models = [{"model_name": "Synced", "status": "COMPLETE", "impl": "whisper"}]
+        existing = {
+            "Retained": {
+                "model_name": "Retained",
+                "requires_dev_catalog": True,
+                "impl": {"impl_id": "qwen36_blackhole", "impl_name": "qwen36"},
+            }
+        }
+
+        merged, _, retained = merge_hand_owned(models, existing)
+        # Mirror main(): normalize impl across every merged entry.
+        for m in merged:
+            if "impl" in m:
+                m["impl"] = _impl_id(m.get("impl"))
+
+        assert retained == ["Retained"]
+        by_name = {m["model_name"]: m for m in merged}
+        assert by_name["Retained"]["impl"] == "qwen36_blackhole"
+        assert by_name["Synced"]["impl"] == "whisper"
 
 
 class TestLoadExistingCatalog:

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -15,6 +15,7 @@ from sync_models_from_inference_server import (
     load_existing_catalog,
     map_service_route,
     merge_hand_owned,
+    normalize,
 )
 
 
@@ -209,6 +210,78 @@ class TestImplNormalization:
         by_name = {m["model_name"]: m for m in merged}
         assert by_name["Retained"]["impl"] == "qwen36_blackhole"
         assert by_name["Synced"]["impl"] == "whisper"
+
+
+def _leaf(model_name, impl_id, *, model_type="LLM", engine="vLLM"):
+    """A minimal model_spec leaf sufficient for normalize()."""
+    return {
+        "model_name": model_name,
+        "model_type": model_type,
+        "inference_engine": engine,
+        "hf_model_repo": f"org/{model_name}",
+        "status": "COMPLETE",
+        "version": "1.0.0",
+        "docker_image": f"ghcr.io/x/{model_name}:1.0.0",
+        "impl": {"impl_id": impl_id, "impl_name": impl_id},
+    }
+
+
+def _normalize_specs(tmp_path, model_specs):
+    """Write a v0.1.0 model_specs doc and return {model_name: catalog entry}.
+
+    Mirrors the real artifact, where each leaf carries a device_type equal to its
+    nesting key (that field is what normalize() uses to skip GPU specs)."""
+    for by_device in model_specs.values():
+        for device_type, by_engine in by_device.items():
+            for by_impl in by_engine.values():
+                for leaf in by_impl.values():
+                    leaf.setdefault("device_type", device_type)
+    src = tmp_path / "model_spec.json"
+    src.write_text(json.dumps({"schema_version": "0.1.0", "model_specs": model_specs}))
+    return {m["model_name"]: m for m in normalize(src)}
+
+
+class TestImplAmbiguity:
+    """An impl is only worth recording when it disambiguates multiple engine
+    specs for a model. Recording a redundant impl makes the server's stricter
+    (model, device, impl) lookup miss non-prod-tier specs and 404 (speecht5_tts
+    on Blackhole)."""
+
+    def test_single_impl_across_devices_yields_null(self, tmp_path):
+        model_specs = {
+            "org/speecht5_tts": {
+                "P150": {"media": {"speecht5_tts": _leaf("speecht5_tts", "speecht5_tts", engine="media")}},
+                "N150": {"media": {"speecht5_tts": _leaf("speecht5_tts", "speecht5_tts", engine="media")}},
+                "P300X2": {"media": {"speecht5_tts": _leaf("speecht5_tts", "speecht5_tts", engine="media")}},
+            }
+        }
+        by_name = _normalize_specs(tmp_path, model_specs)
+        assert by_name["speecht5_tts"]["impl"] is None
+
+    def test_multiple_impls_retains_impl(self, tmp_path):
+        model_specs = {
+            "org/Llama-3.2-3B": {
+                "P150": {
+                    "vLLM": {"tt_transformers": _leaf("Llama-3.2-3B", "tt_transformers")},
+                    "forge": {"training": _leaf("Llama-3.2-3B", "training", engine="forge")},
+                }
+            }
+        }
+        by_name = _normalize_specs(tmp_path, model_specs)
+        assert by_name["Llama-3.2-3B"]["impl"] in {"tt_transformers", "training"}
+        assert by_name["Llama-3.2-3B"]["impl"] is not None
+
+    def test_gpu_only_second_impl_is_not_ambiguous(self, tmp_path):
+        """normalize() skips GPU entries, so a second impl that appears only on a
+        GPU spec must not make the model look ambiguous."""
+        model_specs = {
+            "org/some-model": {
+                "P150": {"vLLM": {"tt_transformers": _leaf("some-model", "tt_transformers")}},
+                "GPU": {"vLLM": {"gpu_impl": _leaf("some-model", "gpu_impl")}},
+            }
+        }
+        by_name = _normalize_specs(tmp_path, model_specs)
+        assert by_name["some-model"]["impl"] is None
 
 
 class TestLoadExistingCatalog:

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -362,6 +362,7 @@ log_store: Dict[str, deque] = {}
 progress_lock = threading.Lock()
 _run_main_lock = threading.Lock()
 
+
 # Store per-deployment log handlers for cleanup
 deployment_log_handlers: Dict[str, logging.FileHandler] = {}
 
@@ -388,6 +389,10 @@ _HF_DOWNLOAD_REPO_RE = re.compile(
 # setup_host.py:388 emits "✅ HF_HOME set to {path}" (no "HOST_" prefix).
 _HOST_HF_HOME_RE = re.compile(r"HF_HOME set to\s*(?P<path>\S+)")
 _HOST_VOLUME_WEIGHTS_MISSING_RE = re.compile(r"Weights directory does not exist for\s*(?P<model>.+?)\.")
+# Dev-mode subprocess has no exception object to introspect (unlike the in-process
+# path's `except PermissionError`), so this special case is detected from captured
+# stderr text instead -- a root-owned workflow_logs dir from a prior sudo run.
+_WORKFLOW_LOGS_PERMISSION_ERROR_RE = re.compile(r"PermissionError.*workflow_logs")
 # setup_host.py:582 emits "Weights already exist in host volume, skipping download" on cache hit.
 _HF_CACHED_RE = re.compile(r"Weights already exist in host volume")
 _PREFERRED_HOST_VOLUME_PATH = Path("~/data/tt-cache")
@@ -747,6 +752,180 @@ def _job_has_host_volume_weights_warning(job_id: str) -> bool:
         _HOST_VOLUME_WEIGHTS_MISSING_RE.search(entry.get("message", ""))
         for entry in entries
     )
+
+
+def _build_retry_argv_and_reason(current_argv: list[str], request: "RunRequest") -> Tuple[list[str], str]:
+    """Build the adjusted argv for a single retry attempt, and a human-readable
+    reason string for logging/progress messages. Shared by the in-process
+    dev_mode=False path (called with sys.argv) and the dev-mode subprocess path
+    (called with the first attempt's own argv, since there's no shared sys.argv)."""
+    retry_argv = list(current_argv)
+    retry_reason_parts: list[str] = []
+    if "--host-volume" in retry_argv:
+        retry_argv = _strip_cli_option(retry_argv, "--host-volume")
+        retry_reason_parts.append("baseline startup without --host-volume")
+    if "--host-hf-cache" in retry_argv:
+        retry_argv = _strip_cli_option(retry_argv, "--host-hf-cache")
+        retry_reason_parts.append("baseline startup without --host-hf-cache")
+    if request.skip_system_sw_validation and "--skip-system-sw-validation" not in retry_argv:
+        retry_argv.append("--skip-system-sw-validation")
+        retry_reason_parts.append("--skip-system-sw-validation")
+    retry_reason = " and ".join(retry_reason_parts) if retry_reason_parts else "same options"
+    return retry_argv, retry_reason
+
+
+def _stream_subprocess_to_job(pipe, job_id: str, levelno: int, levelname: str,
+                               pull_state: Dict[str, int], run_logger: logging.Logger) -> None:
+    """Read a dev-mode run.py subprocess's stdout/stderr pipe line by line and feed
+    each line into both run_logger (-> deployment_log_handler's on-disk per-job log
+    + _RunLogForwarder, both already attached unconditionally before this thread
+    starts) and _process_run_output_line (-> log_store/progress_store), mirroring
+    the artifact's own run_command()/stream_subprocess_output() pattern
+    (workflows/utils.py) used today for real-time `docker pull` output capture."""
+    with pipe:
+        for line in iter(pipe.readline, ""):
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            run_logger.log(levelno, line)
+            _process_run_output_line(job_id, line, levelno, levelname, pull_state)
+
+
+def _execute_dev_mode_subprocess(
+    job_id: str,
+    argv_for_attempt: list[str],
+    script_dir: Path,
+    env_vars_to_set: Dict[str, str],
+    pull_state: Dict[str, int],
+    run_logger: logging.Logger,
+) -> Tuple[int, Optional[Dict[str, Any]]]:
+    """Run one dev-mode deploy attempt as a genuine OS subprocess instead of the
+    in-process run_main() call. A subprocess gets its own fresh Python interpreter,
+    so it imports workflows.model_spec at the correct ("dev") catalog tier natively
+    -- no importlib.reload() trickery needed, and no shared api.py process state
+    (sys.argv/os.environ/cwd) is touched at all.
+
+    container_info is always None here, matching the in-process path: run.py's own
+    main() always returns a bare int today, so isinstance(run_result, tuple) is
+    already always False in production -- this branch changes nothing downstream
+    of the `if return_code == 0:` block, which only ever reads log_store[job_id].
+    """
+    attempt_mode = "host-volume" if "--host-volume" in argv_for_attempt else "baseline"
+    argv = [sys.executable, str(script_dir / "run.py")] + argv_for_attempt[1:]
+
+    child_env = os.environ.copy()       # per-call snapshot; never mutates api.py's own os.environ
+    child_env.update(env_vars_to_set)   # AUTOMATIC_HOST_SETUP, SERVICE_PORT, HF_HUB_DISABLE_XET,
+                                         # and -- a nice side benefit -- JWT_SECRET/HF_TOKEN now
+                                         # flow ONLY into this dict, never into the shared process env
+    child_env["MODEL_SPECS_ENV"] = "dev"  # belt-and-braces; run.py's own argv scan already does this
+
+    # workflows/utils.py's get_repo_root_path() walks up from __file__ looking for
+    # a ".git" marker (default) to find its own root. The fetched artifact is a
+    # plain tarball extraction with no .git of its own, so an unpatched run --
+    # exactly what a subprocess is -- walks past the artifact root and incorrectly
+    # resolves to TT-Studio's OWN repo root a few directories up (it always has
+    # one, since .artifacts/ lives inside it), breaking any path this function
+    # builds relative to the repo root (e.g. reference_config/... lookups at
+    # import time). api.py's in-process path never hits this because it patches
+    # get_repo_root_path in memory; a subprocess can't inherit that patch, so
+    # ensure the marker the artifact's own code expects actually exists instead.
+    git_marker = script_dir / ".git"
+    if not git_marker.exists():
+        git_marker.touch()
+
+    logger.info(f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}")
+    logger.info(
+        "Job %s: Starting run.py subprocess in %s mode: %s",
+        job_id, attempt_mode, " ".join(argv_for_attempt),
+    )
+
+    process = _subprocess.Popen(
+        argv,
+        cwd=str(script_dir),
+        env=child_env,
+        stdin=_subprocess.DEVNULL,  # no interactive prompt (e.g. getpass) can hang forever
+        stdout=_subprocess.PIPE,
+        stderr=_subprocess.PIPE,
+        bufsize=1,
+        text=True,
+        start_new_session=True,  # isolates this child's own docker/docker-pull descendants
+                                  # from api.py's signal group, same intent as _isolated_popen
+    )
+    stdout_thread = threading.Thread(
+        target=_stream_subprocess_to_job,
+        args=(process.stdout, job_id, logging.INFO, "INFO", pull_state, run_logger),
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_stream_subprocess_to_job,
+        args=(process.stderr, job_id, logging.WARNING, "WARNING", pull_state, run_logger),
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    stdout_thread.join()
+    stderr_thread.join()
+    process.wait()
+
+    attempt_return_code = process.returncode
+    logger.info(f"Job {job_id}: run.py subprocess return code: {attempt_return_code}")
+    return attempt_return_code, None
+
+
+def _run_dev_mode_job(
+    job_id: str,
+    initial_argv: list[str],
+    script_dir: Path,
+    env_vars_to_set: Dict[str, str],
+    request: "RunRequest",
+    run_logger: logging.Logger,
+    expected_host_volume_dir: Optional[Path] = None,
+    expected_host_weights_dir: Optional[Path] = None,
+) -> Tuple[int, Optional[Dict[str, Any]]]:
+    """Orchestrate a dev-mode deploy: one subprocess attempt, and (mirroring the
+    in-process path's retry logic exactly) one retry with adjusted argv if it fails
+    -- except the workflow_logs PermissionError special case, which has no
+    exception object to introspect here, so it's detected from captured log text
+    instead."""
+    pull_state: Dict[str, int] = {"pull_layers_total": 0, "pull_layers_complete": 0}
+
+    return_code, container_info = _execute_dev_mode_subprocess(
+        job_id, list(initial_argv), script_dir, env_vars_to_set, pull_state, run_logger
+    )
+    if return_code != 0:
+        if _job_logs_contain(job_id, _WORKFLOW_LOGS_PERMISSION_ERROR_RE):
+            logger.error(
+                "Job %s: PermissionError on workflow_logs directory — directory is likely "
+                "root-owned from a previous sudo-based startup. Fix with: "
+                "sudo chown -R $USER: %s/workflow_logs",
+                job_id, script_dir,
+            )
+            return return_code, container_info  # no retry, mirrors the in-process re-raise
+
+        retry_argv, retry_reason = _build_retry_argv_and_reason(initial_argv, request)
+        if "--host-volume" in initial_argv and _job_has_host_volume_weights_warning(job_id):
+            logger.warning(
+                "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
+                job_id, expected_host_volume_dir, expected_host_weights_dir,
+            )
+        logger.warning(
+            "Job %s: first run.py subprocess failed (code %s), retrying once with %s",
+            job_id, return_code, retry_reason,
+        )
+        with progress_lock:
+            if job_id in progress_store:
+                current_progress = progress_store[job_id].get("progress", 0)
+                progress_store[job_id].update({
+                    "status": "retrying",
+                    "stage": "container_setup",
+                    "progress": max(current_progress, 70),
+                    "message": f"Retrying deployment with {retry_reason}...",
+                    "last_updated": time.time(),
+                })
+        return_code, container_info = _execute_dev_mode_subprocess(
+            job_id, retry_argv, script_dir, env_vars_to_set, pull_state, run_logger
+        )
+    return return_code, container_info
 
 
 def _format_bytes(num_bytes: Optional[float]) -> str:
@@ -1257,9 +1436,205 @@ def _extract_from_job_logs(job_id: str) -> Dict[str, Optional[str]]:
     }
 
 
+def _process_run_output_line(
+    job_id: str,
+    message: str,
+    levelno: int,
+    levelname: str,
+    pull_state: Dict[str, int],
+    timestamp: Optional[float] = None,
+) -> None:
+    """Parse one line of run.py output into log_store[job_id]/progress_store[job_id].
+
+    This is the body of ProgressHandler.emit(), extracted so it's callable both
+    from (a) ProgressHandler.emit() itself, for the in-process dev_mode=False path,
+    and (b) the dev-mode subprocess reader threads (_stream_subprocess_to_job),
+    which have no logging.Handler/logging.LogRecord to attach to. pull_state is a
+    {"pull_layers_total": int, "pull_layers_complete": int} dict the caller owns
+    per job, replacing what used to be per-handler-instance counters, so the same
+    running state carries across a dev-mode retry's second subprocess attempt.
+    """
+    ts = timestamp if timestamp is not None else time.time()
+
+    # Store raw log message
+    with progress_lock:
+        if job_id in log_store:
+            log_store[job_id].append({
+                "timestamp": ts,
+                "level": levelname,
+                "message": message
+            })
+
+    # 1) Structured DEBUG path - prefer this when available
+    structured_parsed = False
+    if levelno <= logging.DEBUG:
+        m = PROG_RE.search(message)
+        if m:
+            stage, pct, text = m.group(1), int(m.group(2)), m.group(3)
+            status = "running"
+            if stage == "complete":
+                status = "completed"
+            elif stage == "error":
+                status = "error"
+
+            with progress_lock:
+                if job_id in progress_store:
+                    cur = progress_store[job_id]
+                    cur_status = cur.get("status", "running")
+                    if cur_status in ("completed", "failed", "cancelled"):
+                        pass
+                    else:
+                        prev = cur.get("progress", 0)
+                        pct = max(prev, pct)  # monotonic clamp
+                        progress_store[job_id].update({
+                            "status": status,
+                            "stage": stage,
+                            "progress": pct,
+                            "message": text[:200],
+                            "last_updated": time.time(),
+                        })
+                else:
+                    # Initialize if not exists
+                    progress_store[job_id] = {
+                        "status": status,
+                        "stage": stage,
+                        "progress": pct,
+                        "message": text[:200],
+                        "last_updated": time.time(),
+                    }
+            structured_parsed = True
+
+    # 2) Fallback: existing INFO-based heuristics (only if structured parsing didn't work)
+    if not structured_parsed:
+        stage = "unknown"
+        progress = 0
+        status = "running"
+
+        # Based on the model_run.log patterns, parse deployment stages
+        if any(keyword in message.lower() for keyword in ["validate_runtime_args", "handle_secrets", "validate_local_setup"]):
+            stage = "initialization"
+            progress = 5
+        elif any(keyword in message.lower() for keyword in ["setup_host", "setting up python venv", "loaded environment"]):
+            stage = "setup"
+            progress = 15
+        elif "setup already completed" in message.lower():
+            stage = "setup"
+            progress = 16
+            message = "Environment ready..."
+        elif any(keyword in message.lower() for keyword in ["downloading model", "huggingface-cli download"]):
+            stage = "model_preparation"
+            progress = 28
+        # HF metadata/config file fetch (e.g. "Fetching 15 files:  47%|...")
+        elif "fetching" in message.lower() and "files" in message.lower():
+            stage = "model_preparation"
+            progress = 20
+            message = "Downloading model configuration files..."
+        # Docker image layer pull (e.g. "abc123: Download complete", "Pulling from ...")
+        elif any(keyword in message.lower() for keyword in [
+            "pulling from",
+            ": pulling fs layer",
+            ": download complete",
+            ": verifying checksum",
+            ": pull complete",
+            ": already exists",
+        ]):
+            stage = "container_setup"
+            msg_l = message.lower()
+            if ": pulling fs layer" in msg_l:
+                pull_state["pull_layers_total"] += 1
+            elif ": pull complete" in msg_l or ": already exists" in msg_l:
+                pull_state["pull_layers_complete"] += 1
+            if pull_state["pull_layers_total"] > 0:
+                ratio = min(1.0, pull_state["pull_layers_complete"] / pull_state["pull_layers_total"])
+                progress = 20 + int(ratio * 12)  # ramp 20 -> 32 during pull
+                message = (
+                    f"Pulling container image layers "
+                    f"({pull_state['pull_layers_complete']}/{pull_state['pull_layers_total']})..."
+                )
+            else:
+                progress = 20
+                message = "Pulling container image layers..."
+        elif any(keyword in message.lower() for keyword in ["docker image pulled successfully", "docker image available locally"]):
+            stage = "image_ready"
+            progress = 34
+            message = "Container image ready."
+        elif any(keyword in message.lower() for keyword in ["docker run command", "running docker container"]):
+            stage = "container_setup"
+            progress = 42
+            message = "Creating and starting the container..."
+        elif "created docker container id" in message.lower():
+            stage = "container_started"
+            progress = 60
+            message = "Container is running..."
+        elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
+            stage = "container_started"
+            progress = 64
+            message = "Locating the container..."
+        elif any(keyword in message.lower() for keyword in ["connected container", "tt_studio_network"]):
+            stage = "network_setup"
+            progress = 84
+            message = "Connecting to the network..."
+        elif "renamed container" in message.lower():
+            # This is the KEY indicator that deployment is complete!
+            stage = "complete"
+            progress = 100
+            status = "completed"
+        elif "deployment completed successfully" in message.lower():
+            stage = "complete"
+            progress = 100
+            status = "completed"
+        elif any(p in message.lower() for p in ["401", "403", "token invalid", "access not granted", "gated repo", "unauthorized", "hf_token"]) and any(p in message.lower() for p in ["huggingface", "hugging face", "hf_token", "token"]):
+            status = "error"
+            stage = "error"
+            message = "HF_TOKEN authentication failed: your Hugging Face token is invalid, expired, or does not have access to this model. Re-run 'python run.py' to update your token."
+        elif any(keyword in message for keyword in ["⛔", "Error", "Failed", "error"]):
+            false_positives = [
+                "any errors will be in the logs",
+                "if you encounter any issues",
+                "see error messages in logs",
+                "this log file is saved",
+                "no config file found",
+                "the output of the workflows is not checked",
+            ]
+            if not any(fp in message.lower() for fp in false_positives):
+                status = "error"
+                stage = "error"
+
+        # Update progress store (only if we have meaningful progress)
+        if progress > 0 or status in ["error", "completed"]:
+            with progress_lock:
+                if job_id in progress_store:
+                    current_progress = progress_store[job_id].get("progress", 0)
+                    current_status = progress_store[job_id].get("status", "running")
+                    # Never let a log-line override a terminal status
+                    if current_status in ("completed", "failed", "cancelled"):
+                        pass
+                    elif progress > current_progress or status == "error" or status == "completed":
+                        update_payload = {
+                            "status": status,
+                            "stage": stage,
+                            "progress": progress,
+                            "message": message[:200],
+                            "last_updated": time.time()
+                        }
+                        if pull_state["pull_layers_total"] > 0:
+                            update_payload["pull_layers_complete"] = pull_state["pull_layers_complete"]
+                            update_payload["pull_layers_total"] = pull_state["pull_layers_total"]
+                        progress_store[job_id].update(update_payload)
+                else:
+                    # Initialize if not exists
+                    progress_store[job_id] = {
+                        "status": status,
+                        "stage": stage,
+                        "progress": progress,
+                        "message": message[:200],
+                        "last_updated": time.time()
+                    }
+
+
 class ProgressHandler(logging.Handler):
     """Custom logging handler to capture progress from run.py execution"""
-    
+
     def __init__(self, job_id: str):
         super().__init__()
         self.job_id = job_id
@@ -1271,195 +1646,22 @@ class ProgressHandler(logging.Handler):
         self._owner_thread = threading.current_thread().ident
         # Per-layer counters for docker pull so the bar/message advances
         # instead of sitting at a flat 50% during multi-GB image downloads.
-        self._pull_layers_total = 0
-        self._pull_layers_complete = 0
+        self._pull_state: Dict[str, int] = {"pull_layers_total": 0, "pull_layers_complete": 0}
 
         # Initialize log store for this job
         with progress_lock:
             if job_id not in log_store:
                 log_store[job_id] = deque(maxlen=MAX_LOG_MESSAGES)
-        
+
     def emit(self, record):
         # Ignore records from other job threads to prevent cross-contamination
         # of log stores when multiple models are deployed concurrently.
         if record.thread != self._owner_thread:
             return
-        message = record.getMessage()
-        
-        # Store raw log message
-        with progress_lock:
-            if self.job_id in log_store:
-                log_store[self.job_id].append({
-                    "timestamp": record.created,
-                    "level": record.levelname,
-                    "message": message
-                })
-        
-        # 1) Structured DEBUG path - prefer this when available
-        structured_parsed = False
-        if record.levelno <= logging.DEBUG:
-            m = PROG_RE.search(message)
-            if m:
-                stage, pct, text = m.group(1), int(m.group(2)), m.group(3)
-                status = "running"
-                if stage == "complete":
-                    status = "completed"
-                elif stage == "error":
-                    status = "error"
-
-                with progress_lock:
-                    if self.job_id in progress_store:
-                        cur = progress_store[self.job_id]
-                        cur_status = cur.get("status", "running")
-                        if cur_status in ("completed", "failed", "cancelled"):
-                            pass
-                        else:
-                            prev = cur.get("progress", 0)
-                            pct = max(prev, pct)  # monotonic clamp
-                            progress_store[self.job_id].update({
-                                "status": status,
-                                "stage": stage,
-                                "progress": pct,
-                                "message": text[:200],
-                                "last_updated": time.time(),
-                            })
-                    else:
-                        # Initialize if not exists
-                        progress_store[self.job_id] = {
-                            "status": status,
-                            "stage": stage,
-                            "progress": pct,
-                            "message": text[:200],
-                            "last_updated": time.time(),
-                        }
-                structured_parsed = True
-
-        # 2) Fallback: existing INFO-based heuristics (only if structured parsing didn't work)
-        if not structured_parsed:
-            stage = "unknown"
-            progress = 0
-            status = "running"
-        
-            # Based on the model_run.log patterns, parse deployment stages
-            if any(keyword in message.lower() for keyword in ["validate_runtime_args", "handle_secrets", "validate_local_setup"]):
-                stage = "initialization"
-                progress = 5
-            elif any(keyword in message.lower() for keyword in ["setup_host", "setting up python venv", "loaded environment"]):
-                stage = "setup"
-                progress = 15
-            elif "setup already completed" in message.lower():
-                stage = "setup"
-                progress = 16
-                message = "Environment ready..."
-            elif any(keyword in message.lower() for keyword in ["downloading model", "huggingface-cli download"]):
-                stage = "model_preparation"
-                progress = 28
-            # HF metadata/config file fetch (e.g. "Fetching 15 files:  47%|...")
-            elif "fetching" in message.lower() and "files" in message.lower():
-                stage = "model_preparation"
-                progress = 20
-                message = "Downloading model configuration files..."
-            # Docker image layer pull (e.g. "abc123: Download complete", "Pulling from ...")
-            elif any(keyword in message.lower() for keyword in [
-                "pulling from",
-                ": pulling fs layer",
-                ": download complete",
-                ": verifying checksum",
-                ": pull complete",
-                ": already exists",
-            ]):
-                stage = "container_setup"
-                msg_l = message.lower()
-                if ": pulling fs layer" in msg_l:
-                    self._pull_layers_total += 1
-                elif ": pull complete" in msg_l or ": already exists" in msg_l:
-                    self._pull_layers_complete += 1
-                if self._pull_layers_total > 0:
-                    ratio = min(1.0, self._pull_layers_complete / self._pull_layers_total)
-                    progress = 20 + int(ratio * 12)  # ramp 20 -> 32 during pull
-                    message = (
-                        f"Pulling container image layers "
-                        f"({self._pull_layers_complete}/{self._pull_layers_total})..."
-                    )
-                else:
-                    progress = 20
-                    message = "Pulling container image layers..."
-            elif any(keyword in message.lower() for keyword in ["docker image pulled successfully", "docker image available locally"]):
-                stage = "image_ready"
-                progress = 34
-                message = "Container image ready."
-            elif any(keyword in message.lower() for keyword in ["docker run command", "running docker container"]):
-                stage = "container_setup"
-                progress = 42
-                message = "Creating and starting the container..."
-            elif "created docker container id" in message.lower():
-                stage = "container_started"
-                progress = 60
-                message = "Container is running..."
-            elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
-                stage = "container_started"
-                progress = 64
-                message = "Locating the container..."
-            elif any(keyword in message.lower() for keyword in ["connected container", "tt_studio_network"]):
-                stage = "network_setup"
-                progress = 84
-                message = "Connecting to the network..."
-            elif "renamed container" in message.lower():
-                # This is the KEY indicator that deployment is complete!
-                stage = "complete"
-                progress = 100
-                status = "completed"
-            elif "deployment completed successfully" in message.lower():
-                stage = "complete"
-                progress = 100
-                status = "completed"
-            elif any(p in message.lower() for p in ["401", "403", "token invalid", "access not granted", "gated repo", "unauthorized", "hf_token"]) and any(p in message.lower() for p in ["huggingface", "hugging face", "hf_token", "token"]):
-                status = "error"
-                stage = "error"
-                message = "HF_TOKEN authentication failed: your Hugging Face token is invalid, expired, or does not have access to this model. Re-run 'python run.py' to update your token."
-            elif any(keyword in message for keyword in ["⛔", "Error", "Failed", "error"]):
-                false_positives = [
-                    "any errors will be in the logs",
-                    "if you encounter any issues",
-                    "see error messages in logs",
-                    "this log file is saved",
-                    "no config file found",
-                    "the output of the workflows is not checked",
-                ]
-                if not any(fp in message.lower() for fp in false_positives):
-                    status = "error"
-                    stage = "error"
-                
-            # Update progress store (only if we have meaningful progress)
-            if progress > 0 or status in ["error", "completed"]:
-                with progress_lock:
-                    if self.job_id in progress_store:
-                        current_progress = progress_store[self.job_id].get("progress", 0)
-                        current_status = progress_store[self.job_id].get("status", "running")
-                        # Never let a log-line override a terminal status
-                        if current_status in ("completed", "failed", "cancelled"):
-                            pass
-                        elif progress > current_progress or status == "error" or status == "completed":
-                            update_payload = {
-                                "status": status,
-                                "stage": stage,
-                                "progress": progress,
-                                "message": message[:200],
-                                "last_updated": time.time()
-                            }
-                            if self._pull_layers_total > 0:
-                                update_payload["pull_layers_complete"] = self._pull_layers_complete
-                                update_payload["pull_layers_total"] = self._pull_layers_total
-                            progress_store[self.job_id].update(update_payload)
-                    else:
-                        # Initialize if not exists
-                        progress_store[self.job_id] = {
-                            "status": status,
-                            "stage": stage,
-                            "progress": progress,
-                            "message": message[:200],
-                            "last_updated": time.time()
-                        }
+        _process_run_output_line(
+            self.job_id, record.getMessage(), record.levelno, record.levelname,
+            self._pull_state, timestamp=record.created,
+        )
 
 
 class FastAPIHandler(logging.Handler):
@@ -1598,6 +1800,13 @@ def setup_run_logging_to_fastapi():
     Using a module-level class fixes isinstance() and the global flag prevents
     any double-installation race.
     """
+    # The artifact's own setup_run_logger() normally sets this as a side effect,
+    # but that only runs for the in-process (dev_mode=False) path -- a process
+    # whose first-ever /run call is dev_mode=True would otherwise double-log
+    # every line into model_run.log (once via _RunLogForwarder, once via
+    # propagation to the root logger's own FileHandler).
+    logging.getLogger("run_log").propagate = False
+
     global _run_log_forwarder_installed
     if _run_log_forwarder_installed:
         return
@@ -2062,161 +2271,164 @@ async def run_inference(request: RunRequest):
 
                 # Forward run.py logs and parse TT_PROGRESS
                 setup_run_logging_to_fastapi()
-                progress_handler = ProgressHandler(job_id)
-                run_logger.addHandler(progress_handler)
+                # Dev-mode deploys run in a subprocess and stream output via reader
+                # threads (_stream_subprocess_to_job), not this thread -- attaching
+                # ProgressHandler here would just have every line silently dropped
+                # by its thread-ownership guard.
+                if not request.dev_mode:
+                    progress_handler = ProgressHandler(job_id)
+                    run_logger.addHandler(progress_handler)
 
                 # run_main() relies on process globals (sys.argv, os.environ, cwd), so
                 # serialize this setup/execution phase across concurrent /run requests.
                 with _run_main_lock:
-                    prev_argv = list(sys.argv)
-                    prev_cwd = Path.cwd()
-                    prev_env = os.environ.copy()
-                    try:
-                        # Apply env vars (including secrets if provided)
-                        for key, value in env_vars_to_set.items():
-                            if key in ["JWT_SECRET", "HF_TOKEN"]:
-                                logger.info(f"Setting environment variable: {key}=[REDACTED]")
-                            else:
-                                logger.info(f"Setting environment variable: {key}={value}")
-                            os.environ[key] = value
-
-                        # Switch cwd for tt-inference-server execution
-                        if prev_cwd != script_dir:
-                            os.chdir(script_dir)
-
-                        sys.argv = list(initial_argv)
-
-                        def _execute_run(argv_for_attempt: list[str]) -> Tuple[int, Optional[Dict[str, Any]]]:
-                            """Execute run_main() for one attempt and return (code, container_info)."""
-                            attempt_mode = "host-volume" if "--host-volume" in argv_for_attempt else "baseline"
-                            sys.argv = argv_for_attempt
-                            logger.info(
-                                f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}"
-                            )
-                            logger.info(
-                                "Job %s: Starting run_main() in %s mode: %s",
-                                job_id,
-                                attempt_mode,
-                                " ".join(argv_for_attempt),
-                            )
-                            run_result = run_main()
-                            if isinstance(run_result, tuple):
-                                attempt_return_code, attempt_container_info = run_result
-                            else:
-                                attempt_return_code = run_result
-                                attempt_container_info = None
-                            logger.info(f"Job {job_id}: run_main() return code: {attempt_return_code}")
-                            logger.info(f"Job {job_id}: container_info:= {attempt_container_info}")
-                            return attempt_return_code, attempt_container_info
-
-                        def _build_retry_argv_and_reason() -> Tuple[list[str], str]:
-                            retry_argv = list(sys.argv)
-                            retry_reason_parts: list[str] = []
-                            if "--host-volume" in retry_argv:
-                                retry_argv = _strip_cli_option(retry_argv, "--host-volume")
-                                retry_reason_parts.append("baseline startup without --host-volume")
-                            if "--host-hf-cache" in retry_argv:
-                                retry_argv = _strip_cli_option(retry_argv, "--host-hf-cache")
-                                retry_reason_parts.append("baseline startup without --host-hf-cache")
-                            if request.skip_system_sw_validation and "--skip-system-sw-validation" not in retry_argv:
-                                retry_argv.append("--skip-system-sw-validation")
-                                retry_reason_parts.append("--skip-system-sw-validation")
-                            retry_reason = " and ".join(retry_reason_parts) if retry_reason_parts else "same options"
-                            return retry_argv, retry_reason
-
+                    if request.dev_mode:
+                        # Dev-tier deploys run as a genuine subprocess (see
+                        # _run_dev_mode_job) instead of the in-process run_main()
+                        # call below, so they never touch api.py's own sys.argv/
+                        # os.environ/cwd -- kept under this same lock anyway, since
+                        # run.py still touches shared host resources (workflow_logs/,
+                        # device/board allocation, the Docker daemon) that the rest
+                        # of the system assumes are serialized system-wide.
+                        return_code, container_info = _run_dev_mode_job(
+                            job_id, initial_argv, script_dir, env_vars_to_set, request, run_logger,
+                            expected_host_volume_dir, expected_host_weights_dir,
+                        )
+                    else:
+                        prev_argv = list(sys.argv)
+                        prev_cwd = Path.cwd()
+                        prev_env = os.environ.copy()
                         try:
-                            return_code, container_info = _execute_run(sys.argv)
-                        except Exception as first_attempt_error:
-                            # run_main() can raise directly (e.g. local setup validation errors)
-                            # and bypass return-code based retry logic.
-                            #
-                            # PermissionError on the log directory means the workflow_logs dir is
-                            # root-owned (leftover from a previous sudo-based startup). Retrying
-                            # with different Docker args won't help — re-raise immediately so the
-                            # caller gets a clear error instead of a misleading retry.
-                            if isinstance(first_attempt_error, PermissionError) and "workflow_logs" in str(first_attempt_error):
-                                logger.error(
-                                    "Job %s: PermissionError on workflow_logs directory — directory is likely "
-                                    "root-owned from a previous sudo-based startup. Fix with: "
-                                    "sudo chown -R $USER: %s/workflow_logs",
-                                    job_id,
-                                    script_dir,
+                            # Apply env vars (including secrets if provided)
+                            for key, value in env_vars_to_set.items():
+                                if key in ["JWT_SECRET", "HF_TOKEN"]:
+                                    logger.info(f"Setting environment variable: {key}=[REDACTED]")
+                                else:
+                                    logger.info(f"Setting environment variable: {key}={value}")
+                                os.environ[key] = value
+
+                            # Switch cwd for tt-inference-server execution
+                            if prev_cwd != script_dir:
+                                os.chdir(script_dir)
+
+                            sys.argv = list(initial_argv)
+
+                            def _execute_run(argv_for_attempt: list[str]) -> Tuple[int, Optional[Dict[str, Any]]]:
+                                """Execute run_main() for one attempt and return (code, container_info)."""
+                                attempt_mode = "host-volume" if "--host-volume" in argv_for_attempt else "baseline"
+                                sys.argv = argv_for_attempt
+                                logger.info(
+                                    f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}"
                                 )
-                                raise
-                            retry_argv, retry_reason = _build_retry_argv_and_reason()
-                            if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
-                                logger.warning(
-                                    "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
+                                logger.info(
+                                    "Job %s: Starting run_main() in %s mode: %s",
                                     job_id,
-                                    expected_host_volume_dir,
-                                    expected_host_weights_dir,
+                                    attempt_mode,
+                                    " ".join(argv_for_attempt),
                                 )
-                            logger.warning(
-                                "Job %s: first run raised (%s), retrying once with %s",
-                                job_id,
-                                type(first_attempt_error).__name__,
-                                retry_reason,
-                            )
-                            with progress_lock:
-                                if job_id in progress_store:
-                                    current_progress = progress_store[job_id].get("progress", 0)
-                                    progress_store[job_id].update(
-                                        {
-                                            "status": "retrying",
-                                            "stage": "container_setup",
-                                            "progress": max(current_progress, 70),
-                                            "message": f"Retrying deployment with {retry_reason}...",
-                                            "last_updated": time.time(),
-                                        }
+                                run_result = run_main()
+                                if isinstance(run_result, tuple):
+                                    attempt_return_code, attempt_container_info = run_result
+                                else:
+                                    attempt_return_code = run_result
+                                    attempt_container_info = None
+                                logger.info(f"Job {job_id}: run_main() return code: {attempt_return_code}")
+                                logger.info(f"Job {job_id}: container_info:= {attempt_container_info}")
+                                return attempt_return_code, attempt_container_info
+
+                            try:
+                                return_code, container_info = _execute_run(sys.argv)
+                            except Exception as first_attempt_error:
+                                # run_main() can raise directly (e.g. local setup validation errors)
+                                # and bypass return-code based retry logic.
+                                #
+                                # PermissionError on the log directory means the workflow_logs dir is
+                                # root-owned (leftover from a previous sudo-based startup). Retrying
+                                # with different Docker args won't help — re-raise immediately so the
+                                # caller gets a clear error instead of a misleading retry.
+                                if isinstance(first_attempt_error, PermissionError) and "workflow_logs" in str(first_attempt_error):
+                                    logger.error(
+                                        "Job %s: PermissionError on workflow_logs directory — directory is likely "
+                                        "root-owned from a previous sudo-based startup. Fix with: "
+                                        "sudo chown -R $USER: %s/workflow_logs",
+                                        job_id,
+                                        script_dir,
                                     )
-                            return_code, container_info = _execute_run(retry_argv)
-
-                        # Retry once when the initial run fails.
-                        if return_code != 0:
-                            retry_argv, retry_reason = _build_retry_argv_and_reason()
-                            if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
-                                logger.warning(
-                                    "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
-                                    job_id,
-                                    expected_host_volume_dir,
-                                    expected_host_weights_dir,
-                                )
-                            logger.warning(
-                                "Job %s: first run failed (code %s), retrying once with %s",
-                                job_id,
-                                return_code,
-                                retry_reason,
-                            )
-                            with progress_lock:
-                                if job_id in progress_store:
-                                    current_progress = progress_store[job_id].get("progress", 0)
-                                    progress_store[job_id].update(
-                                        {
-                                            "status": "retrying",
-                                            "stage": "container_setup",
-                                            "progress": max(current_progress, 70),
-                                            "message": f"Retrying deployment with {retry_reason}...",
-                                            "last_updated": time.time(),
-                                        }
+                                    raise
+                                retry_argv, retry_reason = _build_retry_argv_and_reason(sys.argv, request)
+                                if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
+                                    logger.warning(
+                                        "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
+                                        job_id,
+                                        expected_host_volume_dir,
+                                        expected_host_weights_dir,
                                     )
-                            return_code, container_info = _execute_run(retry_argv)
-                    finally:
-                        # Restore globals while still holding lock so the next run
-                        # starts from a consistent process state.
-                        try:
-                            sys.argv = prev_argv
-                        except Exception:
-                            pass
-                        try:
-                            if Path.cwd() != prev_cwd:
-                                os.chdir(prev_cwd)
-                        except Exception:
-                            pass
-                        try:
-                            os.environ.clear()
-                            os.environ.update(prev_env)
-                        except Exception:
-                            pass
+                                logger.warning(
+                                    "Job %s: first run raised (%s), retrying once with %s",
+                                    job_id,
+                                    type(first_attempt_error).__name__,
+                                    retry_reason,
+                                )
+                                with progress_lock:
+                                    if job_id in progress_store:
+                                        current_progress = progress_store[job_id].get("progress", 0)
+                                        progress_store[job_id].update(
+                                            {
+                                                "status": "retrying",
+                                                "stage": "container_setup",
+                                                "progress": max(current_progress, 70),
+                                                "message": f"Retrying deployment with {retry_reason}...",
+                                                "last_updated": time.time(),
+                                            }
+                                        )
+                                return_code, container_info = _execute_run(retry_argv)
+
+                            # Retry once when the initial run fails.
+                            if return_code != 0:
+                                retry_argv, retry_reason = _build_retry_argv_and_reason(sys.argv, request)
+                                if "--host-volume" in sys.argv and _job_has_host_volume_weights_warning(job_id):
+                                    logger.warning(
+                                        "Job %s: host-volume attempt for %s logged a missing weights directory warning before the retry. Expected weights under %s",
+                                        job_id,
+                                        expected_host_volume_dir,
+                                        expected_host_weights_dir,
+                                    )
+                                logger.warning(
+                                    "Job %s: first run failed (code %s), retrying once with %s",
+                                    job_id,
+                                    return_code,
+                                    retry_reason,
+                                )
+                                with progress_lock:
+                                    if job_id in progress_store:
+                                        current_progress = progress_store[job_id].get("progress", 0)
+                                        progress_store[job_id].update(
+                                            {
+                                                "status": "retrying",
+                                                "stage": "container_setup",
+                                                "progress": max(current_progress, 70),
+                                                "message": f"Retrying deployment with {retry_reason}...",
+                                                "last_updated": time.time(),
+                                            }
+                                        )
+                                return_code, container_info = _execute_run(retry_argv)
+                        finally:
+                            # Restore globals while still holding lock so the next run
+                            # starts from a consistent process state.
+                            try:
+                                sys.argv = prev_argv
+                            except Exception:
+                                pass
+                            try:
+                                if Path.cwd() != prev_cwd:
+                                    os.chdir(prev_cwd)
+                            except Exception:
+                                pass
+                            try:
+                                os.environ.clear()
+                                os.environ.update(prev_env)
+                            except Exception:
+                                pass
 
                 if return_code == 0:
                     # Always extract from captured job logs — provides docker_log_file_path

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -15,6 +15,7 @@ import threading
 import uuid
 import re
 import json
+import shutil
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
@@ -194,6 +195,11 @@ workflows_log_setup.setup_run_logger = _patched_setup_run_logger
 # See issue #825.
 import subprocess as _subprocess  # noqa: E402
 _orig_popen = _subprocess.Popen
+
+# Fetches per-model tt-inference-server builds named by a catalog entry's
+# inference_artifact_ref. Local module, not part of the artifact.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_refs import ArtifactRefError, resolve_artifact_dir  # noqa: E402
 
 
 def _isolated_popen(*args, **kwargs):
@@ -818,6 +824,33 @@ def _execute_dev_mode_subprocess(
                                          # and -- a nice side benefit -- JWT_SECRET/HF_TOKEN now
                                          # flow ONLY into this dict, never into the shared process env
     child_env["MODEL_SPECS_ENV"] = "dev"  # belt-and-braces; run.py's own argv scan already does this
+
+    # api.py was launched pointing at the globally pinned artifact, so anything it
+    # inherited that holds an absolute path into that checkout is wrong whenever
+    # script_dir is a per-model artifact (RunRequest.artifact_ref). Re-point those
+    # at the artifact actually being executed. No-ops when script_dir IS the global
+    # artifact -- the values get rewritten to what they already were.
+    child_env["TT_INFERENCE_ARTIFACT_PATH"] = str(script_dir)
+    _benchmark_targets = (
+        script_dir / "benchmarking" / "benchmark_targets" / "model_performance_reference.json"
+    )
+    if _benchmark_targets.is_file():
+        child_env["OVERRIDE_BENCHMARK_TARGETS"] = str(_benchmark_targets)
+    else:
+        # Leaving the inherited value would point run.py at another checkout's
+        # benchmark file, which it asserts on.
+        child_env.pop("OVERRIDE_BENCHMARK_TARGETS", None)
+
+    # run.py reads .env from its own repo root, and sync_tokens_from_tt_studio()
+    # refreshes that file inside the global artifact on every /run. A per-model
+    # artifact is its own root, so mirror the freshly-synced file across.
+    if artifact_path and Path(artifact_path).resolve() != script_dir.resolve():
+        _src_env = Path(artifact_path) / ".env"
+        if _src_env.is_file():
+            try:
+                shutil.copyfile(_src_env, script_dir / ".env")
+            except OSError as e:
+                logger.warning("Job %s: could not copy .env into %s: %s", job_id, script_dir, e)
 
     # workflows/utils.py's get_repo_root_path() walks up from __file__ looking for
     # a ".git" marker (default) to find its own root. The fetched artifact is a
@@ -1740,6 +1773,11 @@ class RunRequest(BaseModel):
     disable_trace_capture: Optional[bool] = False
     dev_mode: Optional[bool] = False
     override_docker_image: Optional[str] = None
+    # tt-inference-server branch/tag/commit this deploy needs, when the globally
+    # pinned artifact doesn't carry the model. Fetched and cached on demand; only
+    # honoured alongside dev_mode, since that's the path that runs run.py as a
+    # subprocess and can therefore be pointed at a different artifact directory.
+    artifact_ref: Optional[str] = None
     device_id: Optional[str] = None
     override_tt_config: Optional[str] = None
     vllm_override_args: Optional[str] = None
@@ -2295,6 +2333,31 @@ async def run_inference(request: RunRequest):
                     progress_handler = ProgressHandler(job_id)
                     run_logger.addHandler(progress_handler)
 
+                # A model whose catalog entry names its own tt-inference-server build
+                # runs against that build instead of the globally pinned artifact.
+                # Resolved BEFORE taking _run_main_lock: the first use of a ref
+                # downloads ~18MB, and there's no reason to block unrelated deploys
+                # on that. An ArtifactRefError here propagates to the outer handler,
+                # which marks the job failed -- deliberately louder than falling back
+                # to a build that doesn't contain the model.
+                job_script_dir = script_dir
+                if request.dev_mode and request.artifact_ref:
+                    with progress_lock:
+                        if job_id in progress_store:
+                            progress_store[job_id].update({
+                                "status": "running",
+                                "stage": "artifact_setup",
+                                "message": f"Fetching tt-inference-server {request.artifact_ref}...",
+                                "last_updated": time.time(),
+                            })
+                    job_script_dir = resolve_artifact_dir(
+                        request.artifact_ref, _tt_studio_root / ".artifacts"
+                    )
+                    logger.info(
+                        "Job %s: using tt-inference-server ref '%s' at %s",
+                        job_id, request.artifact_ref, job_script_dir,
+                    )
+
                 # run_main() relies on process globals (sys.argv, os.environ, cwd), so
                 # serialize this setup/execution phase across concurrent /run requests.
                 with _run_main_lock:
@@ -2307,7 +2370,7 @@ async def run_inference(request: RunRequest):
                         # device/board allocation, the Docker daemon) that the rest
                         # of the system assumes are serialized system-wide.
                         return_code, container_info = _run_dev_mode_job(
-                            job_id, initial_argv, script_dir, env_vars_to_set, request, run_logger,
+                            job_id, initial_argv, job_script_dir, env_vars_to_set, request, run_logger,
                             expected_host_volume_dir, expected_host_weights_dir,
                         )
                     else:
@@ -2608,6 +2671,22 @@ async def run_inference(request: RunRequest):
                                     "last_updated": time.time(),
                                 }
                             )
+            except ArtifactRefError as e:
+                # Already a complete, actionable sentence naming the ref and URL --
+                # surface it verbatim rather than as a truncated "Deployment error",
+                # and skip the traceback (a missing branch isn't a crash).
+                logger.error("Job %s: %s", job_id, e)
+                with progress_lock:
+                    if job_id in progress_store:
+                        progress_store[job_id].update(
+                            {
+                                "status": "error",
+                                "stage": "error",
+                                "progress": 0,
+                                "message": str(e),
+                                "last_updated": time.time(),
+                            }
+                        )
             except Exception as e:
                 logger.error(f"Job {job_id}: error: {e}", exc_info=True)
                 with progress_lock:

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -794,7 +794,7 @@ def _stream_subprocess_to_job(pipe, job_id: str, levelno: int, levelname: str,
             if not line:
                 continue
             run_logger.log(levelno, line)
-            _process_run_output_line(job_id, line, levelno, levelname, pull_state)
+            _process_run_output_line(job_id, line, levelname, pull_state)
 
 
 def _execute_dev_mode_subprocess(
@@ -1488,7 +1488,6 @@ def _extract_from_job_logs(job_id: str) -> Dict[str, Optional[str]]:
 def _process_run_output_line(
     job_id: str,
     message: str,
-    levelno: int,
     levelname: str,
     pull_state: Dict[str, int],
     timestamp: Optional[float] = None,
@@ -1514,44 +1513,47 @@ def _process_run_output_line(
                 "message": message
             })
 
-    # 1) Structured DEBUG path - prefer this when available
+    # 1) Structured progress path - prefer this when available. Deliberately not
+    # gated on log level: the dev-mode subprocess reader threads label a line
+    # INFO or WARNING purely by which pipe it arrived on
+    # (_stream_subprocess_to_job), so a TT_PROGRESS line from a subprocess can
+    # never look like DEBUG. The regex match is the only reliable signal.
     structured_parsed = False
-    if levelno <= logging.DEBUG:
-        m = PROG_RE.search(message)
-        if m:
-            stage, pct, text = m.group(1), int(m.group(2)), m.group(3)
-            status = "running"
-            if stage == "complete":
-                status = "completed"
-            elif stage == "error":
-                status = "error"
+    m = PROG_RE.search(message)
+    if m:
+        stage, pct, text = m.group(1), int(m.group(2)), m.group(3)
+        status = "running"
+        if stage == "complete":
+            status = "completed"
+        elif stage == "error":
+            status = "error"
 
-            with progress_lock:
-                if job_id in progress_store:
-                    cur = progress_store[job_id]
-                    cur_status = cur.get("status", "running")
-                    if cur_status in ("completed", "failed", "cancelled"):
-                        pass
-                    else:
-                        prev = cur.get("progress", 0)
-                        pct = max(prev, pct)  # monotonic clamp
-                        progress_store[job_id].update({
-                            "status": status,
-                            "stage": stage,
-                            "progress": pct,
-                            "message": text[:200],
-                            "last_updated": time.time(),
-                        })
+        with progress_lock:
+            if job_id in progress_store:
+                cur = progress_store[job_id]
+                cur_status = cur.get("status", "running")
+                if cur_status in ("completed", "failed", "cancelled"):
+                    pass
                 else:
-                    # Initialize if not exists
-                    progress_store[job_id] = {
+                    prev = cur.get("progress", 0)
+                    pct = max(prev, pct)  # monotonic clamp
+                    progress_store[job_id].update({
                         "status": status,
                         "stage": stage,
                         "progress": pct,
                         "message": text[:200],
                         "last_updated": time.time(),
-                    }
-            structured_parsed = True
+                    })
+            else:
+                # Initialize if not exists
+                progress_store[job_id] = {
+                    "status": status,
+                    "stage": stage,
+                    "progress": pct,
+                    "message": text[:200],
+                    "last_updated": time.time(),
+                }
+        structured_parsed = True
 
     # 2) Fallback: existing INFO-based heuristics (only if structured parsing didn't work)
     if not structured_parsed:
@@ -1708,7 +1710,7 @@ class ProgressHandler(logging.Handler):
         if record.thread != self._owner_thread:
             return
         _process_run_output_line(
-            self.job_id, record.getMessage(), record.levelno, record.levelname,
+            self.job_id, record.getMessage(), record.levelname,
             self._pull_state, timestamp=record.created,
         )
 

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -829,9 +829,21 @@ def _execute_dev_mode_subprocess(
     # import time). api.py's in-process path never hits this because it patches
     # get_repo_root_path in memory; a subprocess can't inherit that patch, so
     # ensure the marker the artifact's own code expects actually exists instead.
+    #
+    # A bare empty file satisfies that ".exists()" check but breaks run.py's own
+    # `git -C script_dir rev-parse HEAD` (get_current_commit_sha(), called
+    # unconditionally early in main()): real git treats a ".git" *file* as a
+    # "gitfile" pointer (the linked-worktree/submodule format) and demands valid
+    # "gitdir: <path>" contents, so an empty file crashes it with "invalid
+    # gitfile format" instead of just failing repo discovery. Write a real
+    # gitfile pointer at TT-Studio's own .git instead -- satisfies both
+    # consumers: the existence check still passes, and real git commands follow
+    # the pointer to a legitimate repo (so rev-parse HEAD succeeds, just
+    # reporting TT-Studio's own commit rather than the artifact's true SHA --
+    # cosmetic, since this value is only used for a version summary display).
     git_marker = script_dir / ".git"
     if not git_marker.exists():
-        git_marker.touch()
+        git_marker.write_text(f"gitdir: {_tt_studio_root / '.git'}\n")
 
     logger.info(f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}")
     logger.info(

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -841,9 +841,13 @@ def _execute_dev_mode_subprocess(
     # the pointer to a legitimate repo (so rev-parse HEAD succeeds, just
     # reporting TT-Studio's own commit rather than the artifact's true SHA --
     # cosmetic, since this value is only used for a version summary display).
+    #
+    # Always (re)write it rather than gating on ".exists()": an artifact fetched
+    # before this fix (or one that hit the old empty-touch() bug) already has a
+    # ".git" file on disk, and an exists-only guard would leave that stale,
+    # invalid marker in place forever instead of repairing it.
     git_marker = script_dir / ".git"
-    if not git_marker.exists():
-        git_marker.write_text(f"gitdir: {_tt_studio_root / '.git'}\n")
+    git_marker.write_text(f"gitdir: {_tt_studio_root / '.git'}\n")
 
     logger.info(f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}")
     logger.info(

--- a/inference-api/artifact_refs.py
+++ b/inference-api/artifact_refs.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""On-demand fetching of per-model tt-inference-server builds.
+
+TT-Studio normally runs one globally pinned tt-inference-server artifact,
+extracted to ``.artifacts/tt-inference-server/`` at startup from the
+``TT_INFERENCE_ARTIFACT_BRANCH``/``_VERSION`` pin in ``.env``. A model that only
+exists on a feature branch of tt-inference-server can't be deployed from that
+build, and pinning ``.env`` to the feature branch just moves the problem onto
+every other model (and is erased by ``run.py --purge-all``).
+
+A catalog entry can instead name the build it needs per board. This module
+fetches those builds and caches them beside the global one, so a dev-catalog
+deploy can be pointed at its own artifact without disturbing anything else.
+
+Deliberately self-contained: ``inference-api`` runs from its own virtualenv and
+cannot import ``tt_setup`` (which pulls in the launcher's console dependencies),
+so the small amount of download/extract logic here intentionally mirrors
+``tt_setup/inference_server/_orchestrator.py`` rather than sharing code with it.
+"""
+
+import logging
+import os
+import shutil
+import tarfile
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_REPO_ARCHIVE_BASE = "https://github.com/tenstorrent/tt-inference-server/archive"
+
+# Serializes fetches of the same ref so two concurrent deploys don't download and
+# extract into the same destination at once. Different refs still fetch in
+# parallel. _locks itself is guarded by _locks_guard.
+_locks_guard = threading.Lock()
+_locks: Dict[str, threading.Lock] = {}
+
+
+class ArtifactRefError(Exception):
+    """A cited tt-inference-server ref could not be fetched or validated.
+
+    Raised rather than silently falling back to the global artifact: deploying a
+    model against a build that doesn't contain it fails much later with an opaque
+    "invalid choice" argparse error that reads like a TT-Studio bug.
+    """
+
+
+def _sanitize(ref: str) -> str:
+    """Filesystem-safe form of a ref ('a/b' -> 'a-b'), matching GitHub's own
+    archive naming so the extracted directory name is predictable."""
+    return ref.replace("/", "-")
+
+
+def _is_commit_sha(ref: str) -> bool:
+    """True if ref looks like a full 40-char hex commit SHA.
+
+    Mirrors tt_setup.inference_server._git._is_commit_sha; GitHub serves SHAs and
+    branch names from different archive paths.
+    """
+    return bool(ref) and len(ref) == 40 and all(c in "0123456789abcdefABCDEF" for c in ref)
+
+
+def _archive_url(ref: str) -> str:
+    if _is_commit_sha(ref):
+        return f"{_REPO_ARCHIVE_BASE}/{ref}.tar.gz"
+    return f"{_REPO_ARCHIVE_BASE}/refs/heads/{ref}.tar.gz"
+
+
+def _is_valid_artifact_dir(path: Path) -> bool:
+    """True if `path` looks like a usable tt-inference-server checkout.
+
+    Same structural check the launcher uses (validate_artifact_structure): a
+    non-empty workflows/utils.py is the cheapest reliable signal, and it is
+    written late enough in extraction that a partial tree fails it.
+    """
+    utils = path / "workflows" / "utils.py"
+    try:
+        return utils.is_file() and utils.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _is_valid_targz(path: Path) -> bool:
+    """True if `path` is a readable, non-empty gzip tarball.
+
+    An interrupted download leaves a truncated .tar.gz that fails deep inside
+    extraction with an opaque EOFError, so walk the member headers up front
+    before trusting a cached file.
+    """
+    try:
+        if not path.is_file() or path.stat().st_size == 0:
+            return False
+        with tarfile.open(path, "r:gz") as tar:
+            for _ in tar:
+                pass
+        return True
+    except Exception:
+        return False
+
+
+def _download(url: str, dest: Path, ref: str) -> None:
+    """Download `url` to `dest`, leaving no partial file behind on failure."""
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp, open(tmp, "wb") as fh:
+            shutil.copyfileobj(resp, fh)
+    except urllib.error.HTTPError as e:
+        tmp.unlink(missing_ok=True)
+        if e.code == 404:
+            raise ArtifactRefError(
+                f"tt-inference-server ref '{ref}' not found (HTTP 404): {url}. "
+                f"Check the branch/tag/commit named in the model's "
+                f"inference_artifact_ref catalog field."
+            ) from e
+        raise ArtifactRefError(
+            f"Failed to download tt-inference-server ref '{ref}' (HTTP {e.code}): {url}"
+        ) from e
+    except Exception as e:
+        tmp.unlink(missing_ok=True)
+        raise ArtifactRefError(
+            f"Failed to download tt-inference-server ref '{ref}' from {url}: {e}"
+        ) from e
+
+    if tmp.stat().st_size == 0:
+        tmp.unlink(missing_ok=True)
+        raise ArtifactRefError(
+            f"Downloaded tt-inference-server ref '{ref}' is empty: {url}"
+        )
+    os.replace(tmp, dest)
+
+
+def _extract(tarball: Path, refs_root: Path, dest: Path, ref: str, url: str) -> None:
+    """Extract `tarball` and move the resulting tree into `dest` atomically.
+
+    Extraction happens in a sibling temp directory and only lands at `dest` via a
+    single rename, so an interrupted fetch can never leave a half-extracted tree
+    that a later call would mistake for a warm cache.
+    """
+    staging = Path(tempfile.mkdtemp(prefix=f".tmp-{dest.name}-", dir=str(refs_root)))
+    try:
+        try:
+            with tarfile.open(tarball, "r:gz") as tar:
+                # "data" refuses members that would escape the destination via
+                # absolute paths, "..", or links -- worth having on an archive
+                # fetched over the network. Feature-detected because the argument
+                # only exists on newer Pythons (it becomes the default in 3.14).
+                extract_kwargs = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
+                tar.extractall(staging, **extract_kwargs)
+        except Exception as e:
+            raise ArtifactRefError(
+                f"Failed to extract tt-inference-server ref '{ref}' from {url}: {e}. "
+                f"The cached tarball may be corrupt; it has been removed, so retrying "
+                f"will download it again."
+            ) from e
+
+        # GitHub archives contain a single top-level tt-inference-server-<ref> dir.
+        candidates = [p for p in staging.iterdir() if p.is_dir()]
+        extracted = next(
+            (p for p in candidates if p.name.startswith("tt-inference-server")),
+            candidates[0] if len(candidates) == 1 else None,
+        )
+        if extracted is None:
+            raise ArtifactRefError(
+                f"tt-inference-server ref '{ref}' extracted no recognizable directory "
+                f"(found: {[p.name for p in candidates]}) from {url}"
+            )
+        if not _is_valid_artifact_dir(extracted):
+            raise ArtifactRefError(
+                f"tt-inference-server ref '{ref}' is missing workflows/utils.py -- "
+                f"it does not look like a tt-inference-server checkout ({url})"
+            )
+
+        # dest can exist here only if a previous attempt left an invalid tree.
+        if dest.exists():
+            shutil.rmtree(dest, ignore_errors=True)
+        os.replace(extracted, dest)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def resolve_artifact_dir(ref: str, artifacts_root) -> Path:
+    """Return a validated tt-inference-server directory for `ref`, fetching it if needed.
+
+    Cached under ``<artifacts_root>/refs/<sanitized-ref>/``. The nesting is
+    deliberate: the launcher's own setup scans ``.artifacts/`` for any entry whose
+    name starts with "tt-inference-server" and adopts the first match as the
+    global artifact when its expected directory is missing
+    (tt_setup/inference_server/_orchestrator.py). Per-ref builds sitting at that
+    level could be silently adopted as the global build, so they live one
+    directory down where that scan can't see them.
+
+    Raises ArtifactRefError if the ref cannot be fetched or doesn't validate.
+    """
+    if not ref or not ref.strip():
+        raise ArtifactRefError("Empty tt-inference-server ref")
+    ref = ref.strip()
+
+    refs_root = Path(artifacts_root) / "refs"
+    sanitized = _sanitize(ref)
+    dest = refs_root / sanitized
+
+    if _is_valid_artifact_dir(dest):
+        return dest
+
+    with _locks_guard:
+        lock = _locks.setdefault(sanitized, threading.Lock())
+
+    with lock:
+        # Another thread may have completed the fetch while we waited.
+        if _is_valid_artifact_dir(dest):
+            return dest
+
+        refs_root.mkdir(parents=True, exist_ok=True)
+        tarball = refs_root / f"{sanitized}.tar.gz"
+        url = _archive_url(ref)
+
+        if _is_valid_targz(tarball):
+            logger.info("Using cached tt-inference-server tarball for ref '%s'", ref)
+        else:
+            tarball.unlink(missing_ok=True)
+            logger.info("Fetching tt-inference-server ref '%s' from %s", ref, url)
+            _download(url, tarball, ref)
+
+        try:
+            _extract(tarball, refs_root, dest, ref, url)
+        except ArtifactRefError:
+            # A corrupt cached tarball would otherwise fail identically forever.
+            tarball.unlink(missing_ok=True)
+            raise
+
+        logger.info("tt-inference-server ref '%s' ready at %s", ref, dest)
+        return dest

--- a/inference-api/requirements.txt
+++ b/inference-api/requirements.txt
@@ -15,3 +15,6 @@ PyYAML
 # Note: tt-inference-server code is provided as an artifact (tarball/zip)
 # and extracted to a path specified by TT_INFERENCE_ARTIFACT_PATH
 # The artifact contains run.py and workflows/ which are imported by api.py
+
+# Dev/test only
+pytest==9.0.3

--- a/inference-api/tests/__init__.py
+++ b/inference-api/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC

--- a/inference-api/tests/test_artifact_refs.py
+++ b/inference-api/tests/test_artifact_refs.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for on-demand per-model tt-inference-server builds (artifact_refs.py).
+
+No network: every test builds a real tarball on disk and points the fetcher at a
+file:// URL, so the download, integrity check, extraction and atomic-rename paths
+are all genuinely exercised.
+"""
+
+import sys
+import tarfile
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import artifact_refs  # noqa: E402
+from artifact_refs import ArtifactRefError, resolve_artifact_dir  # noqa: E402
+
+
+def _make_artifact_tarball(dest: Path, ref: str = "some-branch", valid: bool = True) -> Path:
+    """Build a tarball shaped like a GitHub source archive of tt-inference-server."""
+    root = dest / "src" / f"tt-inference-server-{ref}"
+    (root / "workflows").mkdir(parents=True)
+    if valid:
+        (root / "workflows" / "utils.py").write_text("# stand-in for the real module\n")
+    (root / "VERSION").write_text("0.0.0\n")
+
+    tarball = dest / "archive.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(root, arcname=root.name)
+    return tarball
+
+
+@pytest.fixture
+def served(tmp_path, monkeypatch):
+    """Serve a locally-built tarball in place of the GitHub archive URL."""
+    tarball = _make_artifact_tarball(tmp_path)
+    monkeypatch.setattr(artifact_refs, "_archive_url", lambda ref: tarball.as_uri())
+    return tarball
+
+
+def test_fetches_and_validates(tmp_path, served):
+    artifacts = tmp_path / ".artifacts"
+
+    result = resolve_artifact_dir("feat/some-branch", artifacts)
+
+    # Sanitized name, nested under refs/ so the launcher's "tt-inference-server*"
+    # scan of .artifacts/ can never adopt it as the global artifact.
+    assert result == artifacts / "refs" / "feat-some-branch"
+    assert (result / "workflows" / "utils.py").is_file()
+    assert not list(artifacts.glob("tt-inference-server*"))
+
+
+def test_cache_hit_skips_download(tmp_path, served, monkeypatch):
+    artifacts = tmp_path / ".artifacts"
+    resolve_artifact_dir("some-branch", artifacts)
+
+    def _fail(*a, **k):
+        raise AssertionError("re-downloaded an already-cached ref")
+
+    monkeypatch.setattr(artifact_refs, "_download", _fail)
+    assert resolve_artifact_dir("some-branch", artifacts).is_dir()
+
+
+def test_concurrent_same_ref_downloads_once(tmp_path, served, monkeypatch):
+    """Two deploys of the same model must not extract into one destination at once."""
+    artifacts = tmp_path / ".artifacts"
+    calls = []
+    real_download = artifact_refs._download
+
+    def counting_download(url, dest, ref):
+        calls.append(ref)
+        return real_download(url, dest, ref)
+
+    monkeypatch.setattr(artifact_refs, "_download", counting_download)
+
+    results, errors = [], []
+
+    def worker():
+        try:
+            results.append(resolve_artifact_dir("some-branch", artifacts))
+        except Exception as e:  # pragma: no cover - only on regression
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert len(calls) == 1
+    assert len(set(results)) == 1
+
+
+def test_missing_ref_raises_with_ref_and_url(tmp_path, monkeypatch):
+    """A deleted branch must fail loudly rather than silently using the global
+    build, which would surface much later as an opaque argparse error."""
+    monkeypatch.setattr(
+        artifact_refs, "_archive_url", lambda ref: (tmp_path / "absent.tar.gz").as_uri()
+    )
+
+    with pytest.raises(ArtifactRefError) as exc:
+        resolve_artifact_dir("no-such-branch", tmp_path / ".artifacts")
+
+    assert "no-such-branch" in str(exc.value)
+    assert "absent.tar.gz" in str(exc.value)
+
+
+def test_tarball_without_workflows_is_rejected(tmp_path, monkeypatch):
+    tarball = _make_artifact_tarball(tmp_path, valid=False)
+    monkeypatch.setattr(artifact_refs, "_archive_url", lambda ref: tarball.as_uri())
+    artifacts = tmp_path / ".artifacts"
+
+    with pytest.raises(ArtifactRefError, match="workflows/utils.py"):
+        resolve_artifact_dir("some-branch", artifacts)
+
+    # No partial tree left behind that a later call would take as a cache hit.
+    assert not (artifacts / "refs" / "some-branch").exists()
+    assert not list((artifacts / "refs").glob(".tmp-*"))
+
+
+def test_corrupt_tarball_is_discarded_so_retry_can_recover(tmp_path, monkeypatch):
+    """A truncated cached tarball would otherwise fail identically forever."""
+    artifacts = tmp_path / ".artifacts"
+    refs_root = artifacts / "refs"
+    refs_root.mkdir(parents=True)
+    corrupt = refs_root / "some-branch.tar.gz"
+    corrupt.write_bytes(b"not a gzip stream at all")
+
+    good = _make_artifact_tarball(tmp_path)
+    monkeypatch.setattr(artifact_refs, "_archive_url", lambda ref: good.as_uri())
+
+    # The corrupt cache is detected up front and re-downloaded, not trusted.
+    result = resolve_artifact_dir("some-branch", artifacts)
+    assert (result / "workflows" / "utils.py").is_file()
+
+
+def test_empty_ref_rejected(tmp_path):
+    with pytest.raises(ArtifactRefError):
+        resolve_artifact_dir("   ", tmp_path / ".artifacts")
+
+
+def test_commit_sha_uses_bare_archive_path():
+    sha = "a" * 40
+    assert artifact_refs._archive_url(sha).endswith(f"/archive/{sha}.tar.gz")
+    assert artifact_refs._archive_url("my-branch").endswith(
+        "/archive/refs/heads/my-branch.tar.gz"
+    )

--- a/inference-api/tests/test_dev_mode_subprocess.py
+++ b/inference-api/tests/test_dev_mode_subprocess.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for api.py's dev-mode subprocess deploy path (_run_dev_mode_job /
+_execute_dev_mode_subprocess).
+
+Builds a minimal fake tt-inference-server artifact whose run.py doubles as both
+the import-time bootstrap target (api.py does `from run import main as run_main,
+...` at its own module import) and the actual script the new subprocess branch
+executes -- driven entirely by env-var toggles so one fixture script covers every
+scenario. It prints plain text lines mimicking real run.py output (no `logging`
+module needed -- just print()/stderr writes), and records each invocation's
+argv/cwd/env as a JSON line to a dump file, so the tests can verify subprocess
+isolation and retry behavior without needing the real artifact, Docker, or
+hardware.
+"""
+
+import json
+import logging
+import os
+import sys
+import tempfile
+import textwrap
+import uuid
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+
+INFERENCE_API_DIR = Path(__file__).resolve().parent.parent
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content))
+
+
+WORKFLOWS_UTILS_SRC = """
+    from pathlib import Path
+
+    def get_repo_root_path(marker=".git"):
+        return Path(__file__).resolve().parent.parent
+
+    default_dotenv_path = Path(__file__).resolve().parent.parent / ".env"
+
+    def load_dotenv(dotenv_path=None):
+        return {}
+
+    def write_dotenv(key, value, dotenv_path=None):
+        pass
+"""
+
+LOG_SETUP_SRC = """
+    import logging
+
+    class ConditionalFormatter(logging.Formatter):
+        pass
+
+    def setup_run_logger(logger, run_id, run_log_path, log_level=logging.DEBUG):
+        return logger
+"""
+
+SETUP_HOST_SRC = """
+    class HostSetupManager:
+        def check_model_weights_dir(self, host_weights_dir):
+            return True
+"""
+
+# api.py's own process never needs dev-tier awareness anymore (real deploy
+# execution moved to a subprocess with its own fresh interpreter) -- no tier
+# logic needed here, just enough for `from workflows.model_spec import
+# MODEL_SPECS, get_runtime_model_spec` (api.py's own bootstrap import) to succeed.
+MODEL_SPEC_SRC = """
+    MODEL_SPECS = {}
+
+    def get_runtime_model_spec(model_name, device=None, impl=None):
+        raise ValueError(f"model {model_name} not in catalog")
+"""
+
+# The real script the dev-mode subprocess branch executes. Env-var toggles let one
+# fixture drive every test scenario:
+#   FAKE_RUN_DUMP_PATH            -- append one JSON line per invocation with
+#                                    argv/cwd/env, so tests can inspect exactly
+#                                    what _execute_dev_mode_subprocess launched.
+#   FAKE_RUN_FAIL_ALWAYS=1        -- always exit 1.
+#   FAKE_RUN_FAIL_ON_HOST_VOLUME=1 -- exit 1 only while --host-volume is in argv
+#                                    (mimics a real host-volume-missing failure
+#                                    that a retry without --host-volume clears).
+RUN_PY_SRC = """
+    import json, os, sys
+    from enum import Enum
+
+    class WorkflowType(Enum):
+        SERVER = "server"
+
+    class DeviceTypes(Enum):
+        CPU = "cpu"
+
+    def main():
+        argv = sys.argv[1:]
+        dump_path = os.environ.get("FAKE_RUN_DUMP_PATH")
+        if dump_path:
+            with open(dump_path, "a") as f:
+                f.write(json.dumps({
+                    "argv": argv,
+                    "cwd": os.getcwd(),
+                    "MODEL_SPECS_ENV": os.environ.get("MODEL_SPECS_ENV"),
+                    "AUTOMATIC_HOST_SETUP": os.environ.get("AUTOMATIC_HOST_SETUP"),
+                    "FAKE_RUN_DUMP_PATH_present": "FAKE_RUN_DUMP_PATH" in os.environ,
+                }) + "\\n")
+        print("Downloading model configuration files: Fetching 3 files:  10%", flush=True)
+        print(": pulling fs layer", flush=True)
+        print(": pull complete", flush=True)
+        sys.stderr.write("diagnostic line on stderr\\n")
+        sys.stderr.flush()
+        if os.environ.get("FAKE_RUN_FAIL_ALWAYS") == "1":
+            print("Weights directory does not exist for demo-model.", flush=True)
+            return 1
+        if os.environ.get("FAKE_RUN_FAIL_ON_HOST_VOLUME") == "1" and "--host-volume" in argv:
+            print("Weights directory does not exist for demo-model.", flush=True)
+            return 1
+        print("This log file is saved on local machine at: /tmp/fake_run_log.log", flush=True)
+        print("renamed container", flush=True)
+        return 0
+
+    if __name__ == "__main__":
+        sys.exit(main())
+"""
+
+
+class TestDevModeSubprocess(TestCase):
+    """Exercises api._run_dev_mode_job()/_execute_dev_mode_subprocess() against a
+    fake run.py, run as a genuine subprocess -- the same mechanism used for real
+    dev-tier deploys."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.artifact_dir = Path(cls._tmp.name)
+
+        (cls.artifact_dir / "workflows").mkdir()
+        _write(cls.artifact_dir / "workflows" / "__init__.py", "")
+        _write(cls.artifact_dir / "workflows" / "utils.py", WORKFLOWS_UTILS_SRC)
+        _write(cls.artifact_dir / "workflows" / "log_setup.py", LOG_SETUP_SRC)
+        _write(cls.artifact_dir / "workflows" / "setup_host.py", SETUP_HOST_SRC)
+        _write(cls.artifact_dir / "workflows" / "model_spec.py", MODEL_SPEC_SRC)
+        _write(cls.artifact_dir / "run.py", RUN_PY_SRC)
+
+        os.environ["TT_INFERENCE_ARTIFACT_PATH"] = str(cls.artifact_dir)
+
+        sys.path.insert(0, str(INFERENCE_API_DIR))
+        import api  # noqa: E402 -- must import after env/sys.path are ready
+
+        cls.api = api
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.job_id = f"test-{uuid.uuid4().hex[:8]}"
+        self.dump_path = self.artifact_dir / f"dump-{self.job_id}.jsonl"
+        self.run_logger = logging.getLogger("run_log")
+        # Mirror run_inference()'s own seeding of these two module-level dicts
+        # (api.py:~1900-1907) before the background job ever starts.
+        self.api.progress_store[self.job_id] = {
+            "status": "starting", "stage": "initialization", "progress": 0,
+            "message": "Starting deployment...", "last_updated": 0,
+        }
+        self.api.log_store[self.job_id] = deque(maxlen=100)
+
+    def tearDown(self):
+        self.api.progress_store.pop(self.job_id, None)
+        self.api.log_store.pop(self.job_id, None)
+
+    def _dump_lines(self):
+        if not self.dump_path.exists():
+            return []
+        return [json.loads(l) for l in self.dump_path.read_text().splitlines() if l]
+
+    def _log_messages(self):
+        return [e["message"] for e in self.api.log_store[self.job_id]]
+
+    def test_happy_path_populates_log_and_progress_store(self):
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {"AUTOMATIC_HOST_SETUP": "True"}
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        return_code, container_info = self.api._run_dev_mode_job(
+            self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+        )
+
+        self.assertEqual(return_code, 0)
+        self.assertIsNone(container_info)
+        messages = self._log_messages()
+        self.assertTrue(any(": pulling fs layer" in m for m in messages))
+        self.assertTrue(any("renamed container" in m for m in messages))
+        self.assertTrue(any("diagnostic line on stderr" in m for m in messages))
+        self.assertEqual(self.api.progress_store[self.job_id]["status"], "completed")
+        self.assertEqual(self.api.progress_store[self.job_id]["progress"], 100)
+
+    def test_subprocess_is_isolated_from_parent_process_state(self):
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {"AUTOMATIC_HOST_SETUP": "True", "FAKE_RUN_DUMP_PATH": str(self.dump_path)}
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        prev_argv = list(sys.argv)
+        prev_cwd = Path.cwd()
+        prev_env = dict(os.environ)
+
+        self.api._run_dev_mode_job(
+            self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+        )
+
+        # Zero shared-state mutation, unlike the in-process path.
+        self.assertEqual(sys.argv, prev_argv)
+        self.assertEqual(Path.cwd(), prev_cwd)
+        self.assertEqual(dict(os.environ), prev_env)
+        self.assertNotIn("FAKE_RUN_DUMP_PATH", os.environ)
+        self.assertNotIn("AUTOMATIC_HOST_SETUP", os.environ)
+
+        # But the CHILD saw everything it needed.
+        dumps = self._dump_lines()
+        self.assertEqual(len(dumps), 1)
+        self.assertIn("--model", dumps[0]["argv"])
+        self.assertIn("--dev-mode", dumps[0]["argv"])
+        self.assertEqual(dumps[0]["cwd"], str(self.artifact_dir.resolve()))
+        self.assertEqual(dumps[0]["MODEL_SPECS_ENV"], "dev")
+        self.assertEqual(dumps[0]["AUTOMATIC_HOST_SETUP"], "True")
+
+    def test_retries_once_then_succeeds(self):
+        initial_argv = [
+            "run.py", "--model", "TestModel", "--dev-mode", "--docker-server",
+            "--host-volume", "/fake/path",
+        ]
+        env_vars = {
+            "AUTOMATIC_HOST_SETUP": "True",
+            "FAKE_RUN_DUMP_PATH": str(self.dump_path),
+            "FAKE_RUN_FAIL_ON_HOST_VOLUME": "1",
+        }
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        return_code, _ = self.api._run_dev_mode_job(
+            self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+        )
+
+        self.assertEqual(return_code, 0)
+        dumps = self._dump_lines()
+        self.assertEqual(len(dumps), 2)
+        self.assertIn("--host-volume", dumps[0]["argv"])
+        self.assertNotIn("--host-volume", dumps[1]["argv"])
+
+    def test_retries_once_then_still_fails(self):
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {
+            "AUTOMATIC_HOST_SETUP": "True",
+            "FAKE_RUN_DUMP_PATH": str(self.dump_path),
+            "FAKE_RUN_FAIL_ALWAYS": "1",
+        }
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        return_code, _ = self.api._run_dev_mode_job(
+            self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+        )
+
+        self.assertNotEqual(return_code, 0)
+        dumps = self._dump_lines()
+        self.assertEqual(len(dumps), 2)  # exactly one retry, not zero, not a loop


### PR DESCRIPTION
## Summary

Experimental models couldn't be deployed at all. This makes them deployable, with no change to models that already work.

## The problem

The inference server keeps two model catalogs — a stable one and a richer experimental one — and TT-Studio only ever used the stable one, so an experimental model failed instantly with an error that read like a bug. Getting one working surfaced three further blockers behind it.

## What changed

- **A model can opt into the experimental catalog** for its own deploy. Every other model is untouched.
- **Its container image is now supplied automatically.** Experimental entries don't carry one the way stable entries do, and the deploy was rejected without it.
- **Experimental deploys now run in isolation.** They previously shared one long-lived process and could briefly corrupt other people's catalog lookups mid-deploy.
- **A model can name the exact inference-server build it needs, per board.** That used to be a single setting for the whole installation, kept in a file a full reset erases — so it silently reverted and the next deploy failed for a reason that looked unrelated. It now travels with the model and survives a reset.
- **Refreshing the catalog no longer discards hand-set values.** It rebuilt from scratch every time, so a fix applied by hand vanished on the next refresh with no warning. It now merges. (Refs #977.)

## Status

Verified end-to-end on real hardware, including the case this was built for: with the installation deliberately left on a build that does not contain the model, the deploy succeeded against the model's own build, the shared build was untouched, and a catalog refresh preserved the settings. Naming a build that doesn't exist fails immediately and says which one.
