### PR TITLE
feat: fix qwen3.5-9b deploy timeouts and workflow log streaming

### DIFF
--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -35,6 +35,10 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
     s = f"{hf_model_id} {model_name}".lower()
     if "llama-3" in s or "llama3" in s:
         return "llama3_json"
+    # Qwen3.5 / Qwen3.6 blackhole builds ship with the qwen3_coder parser; older
+    # Qwen families use hermes.
+    if "qwen3.5" in s or "qwen3.6" in s or "qwen35" in s or "qwen36" in s:
+        return "qwen3_coder"
     if "qwen" in s or "qwq" in s:
         return "hermes"
     if "mistral" in s:
@@ -136,6 +140,7 @@ def start_chat_deployment(
     override_tt_config: Optional[str] = None,
     override_docker_image: Optional[str] = None,
     artifact_ref: Optional[str] = None,
+    disable_metal_timeout: bool = False,
 ) -> TTInferenceRunResult:
     """Start a chat model deployment via TT Inference Server (/run).
 
@@ -165,6 +170,8 @@ def start_chat_deployment(
         payload["override_docker_image"] = override_docker_image
     if artifact_ref is not None:
         payload["artifact_ref"] = artifact_ref
+    if disable_metal_timeout:
+        payload["disable_metal_timeout"] = True
 
     # Pass UI-managed secrets explicitly. The inference server runs on the host
     # and cannot read user_config.env in the persistent volume when the backend

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -983,6 +983,13 @@ def _find_workflow_log_for_deployment(deployment) -> str | None:
         Path(tt_studio_root) / ".artifacts" / "tt-inference-server" / "workflow_logs" / "docker_server",
         Path(tt_studio_root) / "tt-inference-server" / "workflow_logs" / "docker_server",
     ]
+    # Per-model artifact refs (e.g. Qwen3.5-9B) write under .artifacts/refs/<ref>/...
+    refs_root = Path(tt_studio_root) / ".artifacts" / "refs"
+    if refs_root.is_dir():
+        for ref_dir in sorted(refs_root.iterdir()):
+            ref_logs = ref_dir / "workflow_logs" / "docker_server"
+            if ref_logs.is_dir():
+                candidate_dirs.append(ref_logs)
 
     # Pass 1: exact timestamp match — try common prefixes (vllm, media, and bare model name)
     for prefix in ("vllm", "media", model.lower()):
@@ -2781,12 +2788,22 @@ class WorkflowLogStreamView(View):
             logger.info(f"Found deployment: {deployment.model_name}, workflow_log_path: {deployment.workflow_log_path}")
             
             if not deployment.workflow_log_path:
-                logger.warning(f"No workflow log path for deployment {deployment_id}")
-                return HttpResponse(
-                    status=404,
-                    content="No workflow log file available for this deployment"
-                )
-            
+                found_path = _find_workflow_log_for_deployment(deployment)
+                if found_path:
+                    deployment.workflow_log_path = found_path
+                    try:
+                        deployment.save(update_fields=["workflow_log_path"])
+                    except Exception as save_err:
+                        logger.warning(
+                            f"Could not save workflow_log_path for deployment {deployment_id}: {save_err}"
+                        )
+                else:
+                    logger.warning(f"No workflow log path for deployment {deployment_id}")
+                    return HttpResponse(
+                        status=404,
+                        content="No workflow log file available for this deployment"
+                    )
+
             log_file_path = deployment.workflow_log_path
             
             # Check if file exists

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -720,6 +720,11 @@ class DeployView(APIView):
                     override_docker_image=override_docker_image,
                     dev_mode=impl.requires_dev_catalog,
                     artifact_ref=artifact_ref,
+                    # First-load weight remaps on experimental blackhole builds can
+                    # exceed the default 5s metal op timeout and abort a healthy deploy.
+                    disable_metal_timeout=bool(
+                        impl.requires_dev_catalog or artifact_ref
+                    ),
                 )
 
                 # If the image isn't cached yet, pull it here first so the UI can show real byte-level progress, then trigger the deployment

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -26,6 +26,7 @@ CODING_AGENT_MODEL_TYPES = (ModelTypes.CHAT, ModelTypes.VLM)
 # The parser splits reasoning into reasoning_content instead of inline <think> text.
 REASONING_MODELS = {
     "Qwen3-32B": "qwen3",
+    "Qwen3.5-9B": "qwen3",
     "gemma-4-31B-it": "gemma4",
 }
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - ./backend:/backend
       # Mount tt-inference-server workflow logs for viewing deployment logs
       - ${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:${TT_STUDIO_ROOT}/.artifacts/tt-inference-server/workflow_logs:ro
+      # Per-model artifact refs (e.g. Qwen3.5-9B) write logs under .artifacts/refs/<ref>/
+      - ${TT_STUDIO_ROOT}/.artifacts/refs:${TT_STUDIO_ROOT}/.artifacts/refs:ro
       # Mount logs/model_run_logs/ directory so the backend can read per-deployment logs
       - ${TT_STUDIO_ROOT}/logs/model_run_logs:${TT_STUDIO_ROOT}/logs/model_run_logs:ro
 

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -70,6 +70,38 @@ const parseSearchInfo = (text: string): SearchInfo => {
 
 const LEAKED_TOOL_CALL_RE = /\{\s*"name"\s*:\s*"[^"]*(?:tavily|search)[^"]*"\s*,\s*"(?:parameters|arguments)"\s*:\s*\{[^}]*\}\s*\}/gi;
 
+// A reply that opens with a "Thinking Process:" heading is a scratchpad, not an
+// answer. Qwen3.5-9B writes its reasoning that way — plain prose, no <think>
+// tags and no reasoning_content — so vLLM's reasoning parsers, which key off
+// the tags, pass it straight through as reply text.
+const PROSE_THINKING_HEADING = /^[\s#*_]*(?:thinking|thought)\s+process\s*:/i;
+// It ends where the answer begins: a gap of two or more blank lines. Steps
+// within the outline are separated by a single blank line.
+const PROSE_THINKING_END = /\n[ \t]*\n[ \t]*\n/;
+
+/** Tag an untagged prose scratchpad so it renders in the thinking panel. */
+const tagProseThinking = (
+  content: string,
+  isStreamFinished: boolean
+): string => {
+  if (/<\/?think>/i.test(content) || !PROSE_THINKING_HEADING.test(content)) {
+    return content;
+  }
+
+  const answerGap = PROSE_THINKING_END.exec(content);
+  if (answerGap) {
+    return `<think>${content.slice(0, answerGap.index)}</think>${content.slice(
+      answerGap.index + answerGap[0].length
+    )}`;
+  }
+
+  // No answer section. Mid-stream the model is still reasoning; if the stream is
+  // over it never reached an answer (it ran out of tokens mid-scratchpad), which
+  // is the same empty-reply-with-thinking state a parsed reasoning model shows
+  // when it is cut off. Either way the text stays reachable through the panel.
+  return isStreamFinished ? `<think>${content}</think>` : `<think>${content}`;
+};
+
 const processContent = (content: string): ProcessedContent => {
   const thinkingBlocks: string[] = [];
 
@@ -125,11 +157,15 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     showThinking: externalShowThinking,
     hideThinkingPanel = false,
   }) {
+    // Everything below reasons about thinking in terms of <think> tags, so
+    // normalize prose scratchpads into tags once, up front.
+    const taggedContent = tagProseThinking(content, isStreamFinished);
+
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
     const [showSearchDetails, setShowSearchDetails] = useState(false);
     const [isThinkingActive, setIsThinkingActive] = useState(false);
-    const contentRef = useRef(processContent(content).cleanedContent);
+    const contentRef = useRef(processContent(taggedContent).cleanedContent);
     const thinkingBlocksRef = useRef<string[]>([]);
     const intervalRef = useRef<number | null>(null);
     const lastChunkRef = useRef("");
@@ -154,7 +190,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     }, [renderedContent]);
 
     useEffect(() => {
-      const processed = processContent(content);
+      const processed = processContent(taggedContent);
       contentRef.current = processed.cleanedContent;
       thinkingBlocksRef.current = processed.thinkingBlocks;
 
@@ -168,7 +204,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
 
       // Check if thinking is actively streaming (has <think> but no closing </think>)
       const hasIncompleteThinking =
-        !isStreamFinished && /<think>(?!.*<\/think>)/is.test(content);
+        !isStreamFinished && /<think>(?!.*<\/think>)/is.test(taggedContent);
       setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
@@ -199,7 +235,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
         }
       };
     }, [
-      content,
+      taggedContent,
       isStreamFinished,
       renderNextChunk,
       renderedContent,
@@ -217,7 +253,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // });
 
     // Extract live thinking text from incomplete <think> block during streaming
-    const liveThinkMatch = !isStreamFinished ? content.match(/^<think>([\s\S]*)$/i) : null;
+    const liveThinkMatch = !isStreamFinished ? taggedContent.match(/^<think>([\s\S]*)$/i) : null;
     const liveThinkingText = liveThinkMatch ? liveThinkMatch[1] : null;
 
     // Detect whether the thinking block represents a web search

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -73,6 +73,15 @@ const LEAKED_TOOL_CALL_RE = /\{\s*"name"\s*:\s*"[^"]*(?:tavily|search)[^"]*"\s*,
 const processContent = (content: string): ProcessedContent => {
   const thinkingBlocks: string[] = [];
 
+  // Qwen-style chat templates put the opening <think> in the prompt, so the
+  // model streams only the closing </think>. If the server ran without a
+  // reasoning parser, that thinking arrives inline — restore the opening tag
+  // so it lands in the thinking block instead of the visible reply.
+  const closeIdx = content.indexOf("</think>");
+  if (closeIdx !== -1 && !content.slice(0, closeIdx).includes("<think>")) {
+    content = "<think>" + content;
+  }
+
   // Extract completed thinking blocks with <think>...</think> tags (before cleaning)
   const thinkingRegex = /<think>(.*?)<\/think>/gis;
   let match;

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -91,7 +91,7 @@ const processContent = (content: string): ProcessedContent => {
 
   // Clean the content - be aggressive about removing thinking tokens
   const cleanedContent = content
-    .replace(/[\[<|]*python_tag[\]>|]*/gi, "")
+    .replace(/[[<|]*python_tag[\]>|]*/gi, "")
     .replace(/<\|.*?\|>(&gt;)?/g, "")
     .replace(/\b(assistant|user)\b/gi, "")
     .replace(/\|(?:eot_id|start_header_id)\|/g, "")

--- a/app/frontend/src/utils/deviceFit.ts
+++ b/app/frontend/src/utils/deviceFit.ts
@@ -164,7 +164,9 @@ export function autoPlacement(
     slots.find((s) => s.slot_id === id)?.status === "available";
 
   if (placement.cardGroups.length > 0) {
-    if (board.every(isFree)) return { deviceIds: board, fullBoard: true };
+    if (placement.allowsFullBoard && board.every(isFree)) {
+      return { deviceIds: board, fullBoard: true };
+    }
     for (const group of placement.cardGroups) {
       if (group.every(isFree)) return { deviceIds: group, fullBoard: false };
     }

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -1832,6 +1832,10 @@ class RunRequest(BaseModel):
     # Internal flag to track if this is already a retry (to prevent infinite loops)
     is_retry: Optional[bool] = False
     skip_system_sw_validation: Optional[bool] = False
+    # Pass --disable-metal-timeout to run.py so the container does not set the
+    # aggressive 5s TT_METAL_OPERATION_TIMEOUT_SECONDS (needed for large first-load
+    # weight remaps on experimental models like Qwen3.5-9B).
+    disable_metal_timeout: Optional[bool] = False
 
 def normalize_device_alias(device: str) -> str:
     """Normalize device aliases to supported device names"""
@@ -2297,6 +2301,8 @@ async def run_inference(request: RunRequest):
             base_argv.extend(["--override-tt-config", request.override_tt_config])
         if request.vllm_override_args:
             base_argv.extend(["--vllm-override-args", request.vllm_override_args])
+        if request.disable_metal_timeout:
+            base_argv.append("--disable-metal-timeout")
 
         preferred_host_volume = None
         expected_host_volume_dir: Optional[Path] = None

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -695,18 +695,32 @@ def _run(args):
             startup_log.step("fastapi_server", "SKIP", "AI Playground mode")
             console.print("[muted]AI Playground mode — using cloud models; local inference server not needed[/muted]")
 
-        # Pre-create workflow_logs before docker compose up.
-        # docker-compose.yml bind-mounts this directory; if Docker creates it first, it
-        # does so as root, which blocks the FastAPI server (running as the current user)
-        # from writing logs on the first deploy. Also fix ownership if already root-owned
-        # from a previous run.
-        for _subdir in ["workflow_logs", os.path.join("workflow_logs", "run_logs")]:
-            _log_dir = os.path.join(INFERENCE_ARTIFACT_DIR, _subdir)
+        # Pre-create the host dirs docker-compose.yml bind-mounts, before compose up.
+        # Docker creates a missing bind-mount path itself, as root, which then blocks
+        # the FastAPI server (running as the current user) from writing there on the
+        # first deploy. Creating them first keeps them owned by the current user.
+        for _mount_dir in [
+            os.path.join(INFERENCE_ARTIFACT_DIR, "workflow_logs"),
+            os.path.join(INFERENCE_ARTIFACT_DIR, "workflow_logs", "run_logs"),
+            # Per-model artifact refs (e.g. Qwen3.5-9B) are downloaded here by the
+            # FastAPI server at deploy time, and bind-mounted read-only so the UI can
+            # stream their workflow logs. Without this, Docker wins the race and the
+            # ref download fails with EACCES before the model ever reaches hardware.
+            os.path.join(TT_STUDIO_ROOT, ".artifacts", "refs"),
+        ]:
             try:
-                os.makedirs(_log_dir, exist_ok=True)
+                os.makedirs(_mount_dir, exist_ok=True)
             except PermissionError:
-                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _log_dir], check=False)
-                os.makedirs(_log_dir, exist_ok=True)
+                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _mount_dir], check=False)
+                os.makedirs(_mount_dir, exist_ok=True)
+            # An earlier run may have let Docker create it first. makedirs(exist_ok=True)
+            # accepts an existing root-owned dir silently, so repair ownership explicitly
+            # rather than leaving a directory we cannot write to.
+            if not os.access(_mount_dir, os.W_OK):
+                subprocess.run(
+                    ["sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", _mount_dir],
+                    check=False,
+                )
 
         # Stamp the frontend build with the current git version (official tag or
         # branch name) so the footer shows what's actually running.


### PR DESCRIPTION
## Summary

Follow-ups to #1210 (Qwen3.5-9B on Blackhole) that dev does not have yet. This PR was previously based on the pre-rewrite `stisi/feat-qwen35-9b-p150` branch; it has been rebuilt on `dev`, dropping everything #1210 already landed (the catalog entry, published image pin, and artifact-ref deploy path). What remains:

- **Metal op timeout** — first-load weight remaps and kernel compiles on experimental Blackhole builds can exceed the default 5s `TT_METAL_OPERATION_TIMEOUT_SECONDS` and abort a healthy deploy. `DeployView` now passes `disable_metal_timeout` through the inference API to `run.py --disable-metal-timeout`, only for `requires_dev_catalog` / artifact-ref deploys.
- **Workflow log streaming for artifact-ref deploys** — per-model refs write logs under `.artifacts/refs/<ref>/workflow_logs/`, which the backend neither mounted nor searched, so the UI log stream 404'd. Adds the read-only mount, includes ref dirs in log discovery, and lazily backfills `workflow_log_path` in `WorkflowLogStreamView` the same way `DeploymentHistoryView` already does.
- **Tool-call parser** — Qwen3.5/3.6 map to the `qwen3_coder` parser their Blackhole builds register; older Qwen families keep `hermes`.
- **Thinking shown inline in the chat UI** — Qwen3.5-9B had no `REASONING_MODELS` entry, so deploys ran without `--reasoning-parser` and its thinking streamed into the visible reply. Maps it to the `qwen3` parser its build registers (mirroring the pinned tt-inference-server spec), which also exposes the `Qwen3.5-9B-thinking` gateway variant. The chat UI additionally restores the opening `<think>` tag when a model emits only the closing one (Qwen-style templates), so leaked thinking still lands in the thinking block on parser-less servers.
- **Auto-placement** — `autoPlacement` claimed the whole board whenever all slots were free, even for models whose placement only allows a card pair; it now respects `placement.allowsFullBoard`.

Dropped from the original PR as already tackled in dev: the 0.19.0 catalog regeneration and Qwen3.5-9B catalog entry (#1210 added a hand-owned entry pinned to a published image), and the dev-mode `.git`-marker fix (landed via #1222). The unused P300x2 card-pair helpers change was dropped as dead code — nothing imports them and dev pins Qwen3.5-9B to P150.

## Testing

- Reasoning-parser mapping and thinking-leak normalization verified: deploy overrides for Qwen3.5-9B now assemble `--tool-call-parser qwen3_coder --reasoning-parser qwen3`; the chat UI's `processContent` routes untagged `…</think>` thinking into the thinking block with tagged/plain/partial-stream cases unchanged. Verified the running gemma-4 deploy streams cleanly through `/models/inference/` with no reasoning leak.
- Parser matrix verified in the running backend container: Qwen3.5/3.6 → `qwen3_coder`; Qwen3-32B/QwQ → `hermes`; gemma-4 → `gemma4`; medgemma → `None`; llama/mistral/deepseek unchanged.
- Refs log discovery verified functionally (exact and fuzzy timestamp match) against a synthetic `.artifacts/refs/<ref>/workflow_logs/docker_server` tree.
- Backend hot-reloaded the changes cleanly; `GET /up/` returns 200. `--disable-metal-timeout` confirmed supported by both the 0.19.0 artifact's `run.py` and the stisi ref's `run.py`.
- `eslint` clean on `deviceFit.ts`; `tsc` failures are pre-existing on dev (`recharts` in `TrainingJobDetailPage.tsx`).

## Remaining validation

- [ ] End-to-end Qwen3.5-9B deploy on hardware with the log stream open (board currently occupied by a gemma-4 deploy)
