### PR TITLE
feat: add gemma4-31b-it to tt-studio

### DIFF
--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -41,6 +41,8 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
         return "mistral"
     if "deepseek" in s:
         return "deepseek_v3"
+    if "gemma-4-" in s:
+        return "gemma4"
     return None
 
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -180,6 +180,47 @@ def _resolve_artifact_ref(impl, device, board_type) -> Optional[str]:
     return None
 
 
+# Models whose tt-metal implementation ignores the HF_MODEL env var and instead
+# derives its weights path from vLLM's --model value (hf_config._name_or_path).
+# For these, a repo ID means the loader globs a non-existent relative directory,
+# finds no safetensors, and falls back to AutoModelForCausalLM.from_pretrained(),
+# re-downloading the full weights into the container's ephemeral HF cache on
+# every start -- even though run.py already placed them on the persistent volume.
+_LOCAL_WEIGHTS_MODEL_ARG = {"gemma-4-31B-it"}
+
+_CONTAINER_WEIGHTS_SYMLINK_ROOT = "/home/container_app_user/cache_root/model_file_symlinks_map"
+
+
+def _local_weights_overrides(impl) -> dict:
+    """vLLM args that point an HF_MODEL-ignoring model at its in-container weights.
+
+    Sets --model to the weights symlink so the loader takes its fast safetensors
+    path, and pins --served-model-name back to the HF repo ID so the API identity
+    (and every client referencing it) is unchanged.
+
+    Only effective for requires_dev_catalog models: this rides in via
+    --vllm-override-args, whose "model" key run_docker_server rejects as a
+    reserved wrapper flag. It lands instead through the model spec merge, which
+    the container only reads when dev mode mounts the resolved runtime spec.
+    """
+    if impl.model_name not in _LOCAL_WEIGHTS_MODEL_ARG:
+        return {}
+    if not impl.requires_dev_catalog:
+        logger.warning(
+            f"{impl.model_name}: needs a local --model path to avoid re-downloading "
+            f"weights, but that only applies to requires_dev_catalog deploys. "
+            f"Skipping; expect a duplicate weights download."
+        )
+        return {}
+    hf_model_id = getattr(impl, "hf_model_id", "") or impl.model_name
+    # model_setup() names the symlink after the HF repo basename, not model_name.
+    symlink_name = hf_model_id.split("/")[-1]
+    return {
+        "model": f"{_CONTAINER_WEIGHTS_SYMLINK_ROOT}/{symlink_name}",
+        "served-model-name": hf_model_id,
+    }
+
+
 # Track when deployment started
 deployment_start_times = {}  # {job_id: timestamp} - Track when deployment started
 
@@ -657,6 +698,7 @@ class DeployView(APIView):
                     reasoning_parser = get_reasoning_parser(impl.model_name)
                     if reasoning_parser:
                         overrides["reasoning-parser"] = reasoning_parser
+                    overrides.update(_local_weights_overrides(impl))
                     if overrides:
                         vllm_override_args = json.dumps(overrides)
                 override_docker_image = _resolve_override_docker_image(impl)

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -26,6 +26,7 @@ CODING_AGENT_MODEL_TYPES = (ModelTypes.CHAT, ModelTypes.VLM)
 # The parser splits reasoning into reasoning_content instead of inline <think> text.
 REASONING_MODELS = {
     "Qwen3-32B": "qwen3",
+    "gemma-4-31B-it": "gemma4",
 }
 
 # Suffix that selects thinking mode for a reasoning model over the gateway,

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.18.0",
     "generated_at": "2026-07-23T20:22:38.003837+00:00"
   },
-  "total_models": 54,
+  "total_models": 55,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -1325,6 +1325,32 @@
       "inference_artifact_ref": {
         "P150": "stisi/feat-qwen35-9b-blackhole-devicespec"
       }
+    },
+    {
+      "model_name": "gemma-4-31B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/gemma-4-31B-it",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "GEMMA4_PAGE_BLOCK_SIZE": "64",
+        "GEMMA4_MAX_TOKENS_ALL_USERS": "49152"
+      },
+      "requires_dev_catalog": true,
+      "param_count": 31
     }
   ]
 }

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -883,8 +883,18 @@ def _execute_dev_mode_subprocess(
     # before this fix (or one that hit the old empty-touch() bug) already has a
     # ".git" file on disk, and an exists-only guard would leave that stale,
     # invalid marker in place forever instead of repairing it.
+    #
+    # Point at TT-Studio's resolved *git directory*.
     git_marker = script_dir / ".git"
-    git_marker.write_text(f"gitdir: {_tt_studio_root / '.git'}\n")
+    try:
+        _tt_studio_git_dir = _subprocess.check_output(
+            ["git", "-C", str(_tt_studio_root), "rev-parse", "--absolute-git-dir"],
+            stderr=_subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (_subprocess.CalledProcessError, OSError):
+        _tt_studio_git_dir = str(_tt_studio_root / ".git")
+    git_marker.write_text(f"gitdir: {_tt_studio_git_dir}\n")
 
     logger.info(f"Job {job_id}: run.py command: python {' '.join(argv_for_attempt)}")
     logger.info(


### PR DESCRIPTION
## Summary

Adds `gemma-4-31B-it` on P300x2, enables its tool calling, and stops it re-downloading weights on every deploy.

The model exists in the 0.19.0 artifact's spec but not in the prod catalog baked into the vLLM image it pins, so deploys failed with `ValueError: No model spec found for model=google/gemma-4-31B-it`. It opts into
the dev tier instead, which forwards the host-resolved spec into the container.

## Changes

**Catalog** — new `gemma-4-31B-it` entry (P300x2, vLLM, 0.18.0 image) with `requires_dev_catalog: true`, so the deploy runs `run.py --dev-mode` in a subprocess and forwards the entry's own image as `--override-docker-image`.

**Tool calling** — `tool_call_parser_for()` had no gemma branch, so it returned `None` and tool calling was silently left off despite the model supporting it. Adds a `gemma-4-` match returning `gemma4`, and the matching `--reasoning-parser`
in `REASONING_MODELS`. Both mirror the parsers in tt-inference-server's own spec, which is what the container registers. The trailing hyphen anchors on the version segment so `medgemma-4b-it` (a gemma-3 derivative) keeps resolving to `None`.

**Duplicate weights download** — `models/demos/gemma4` derives its weights path from vLLM's `--model` value rather than reading `HF_MODEL` like tt_transformers models do. Given a repo ID it globbed a non-existent relative directory, found no safetensors, and fell back to `AutoModelForCausalLM.from_pretrained()`, pulling a second 62 GB copy into the container's ephemeral HF cache on every start — while the weights sat unused on disk. Overrides `--model` to the in-container weights symlink and pins `--served-model-name` back to the HF repo ID so the API identity is unchanged. The symlink target follows `MODEL_WEIGHTS_DIR`, so this holds for both the volume layout and the `--host-hf-cache` default.

**Dev-mode subprocess on worktree checkouts** — the `.git` marker written into the artifact pointed at TT-Studio's `.git` path, which is itself a gitfile in a linked worktree. A gitfile pointing at another gitfile is invalid, so `run.py`'s
unconditional `git rev-parse HEAD` aborted the deploy with `fatal: not a git repository`. Resolves the real git dir instead.

## Testing

- Verified parser resolution across all catalog entries: `gemma-4-31B-it` →`gemma4`, the six other gemma/medgemma models → `None`, and the four existing families unchanged.
- Confirmed the `model` override survives the spec merge into the runtime spec the container reads, and that the weights symlink resolves to both safetensors shards in a running container.
- Confirmed `git rev-parse HEAD` succeeds in the artifact after the marker fix.

Deploy of `gemma-4-31B-it` on P300x2 gets past model-spec resolution and container startup; the weights-path change has not yet been confirmed end-to-end on hardware — the first deploy should log `Loading 2 safetensor files from ...` instead of `No safetensors found`.
