### PR TITLE
fix: keep .artifacts/refs owned by the invoking user

### DIFF
--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -91,7 +91,7 @@ const processContent = (content: string): ProcessedContent => {
 
   // Clean the content - be aggressive about removing thinking tokens
   const cleanedContent = content
-    .replace(/[\[<|]*python_tag[\]>|]*/gi, "")
+    .replace(/[[<|]*python_tag[\]>|]*/gi, "")
     .replace(/<\|.*?\|>(&gt;)?/g, "")
     .replace(/\b(assistant|user)\b/gi, "")
     .replace(/\|(?:eot_id|start_header_id)\|/g, "")

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -695,18 +695,32 @@ def _run(args):
             startup_log.step("fastapi_server", "SKIP", "AI Playground mode")
             console.print("[muted]AI Playground mode — using cloud models; local inference server not needed[/muted]")
 
-        # Pre-create workflow_logs before docker compose up.
-        # docker-compose.yml bind-mounts this directory; if Docker creates it first, it
-        # does so as root, which blocks the FastAPI server (running as the current user)
-        # from writing logs on the first deploy. Also fix ownership if already root-owned
-        # from a previous run.
-        for _subdir in ["workflow_logs", os.path.join("workflow_logs", "run_logs")]:
-            _log_dir = os.path.join(INFERENCE_ARTIFACT_DIR, _subdir)
+        # Pre-create the host dirs docker-compose.yml bind-mounts, before compose up.
+        # Docker creates a missing bind-mount path itself, as root, which then blocks
+        # the FastAPI server (running as the current user) from writing there on the
+        # first deploy. Creating them first keeps them owned by the current user.
+        for _mount_dir in [
+            os.path.join(INFERENCE_ARTIFACT_DIR, "workflow_logs"),
+            os.path.join(INFERENCE_ARTIFACT_DIR, "workflow_logs", "run_logs"),
+            # Per-model artifact refs (e.g. Qwen3.5-9B) are downloaded here by the
+            # FastAPI server at deploy time, and bind-mounted read-only so the UI can
+            # stream their workflow logs. Without this, Docker wins the race and the
+            # ref download fails with EACCES before the model ever reaches hardware.
+            os.path.join(TT_STUDIO_ROOT, ".artifacts", "refs"),
+        ]:
             try:
-                os.makedirs(_log_dir, exist_ok=True)
+                os.makedirs(_mount_dir, exist_ok=True)
             except PermissionError:
-                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _log_dir], check=False)
-                os.makedirs(_log_dir, exist_ok=True)
+                subprocess.run(["sudo", "chown", f"{os.getuid()}:{os.getgid()}", _mount_dir], check=False)
+                os.makedirs(_mount_dir, exist_ok=True)
+            # An earlier run may have let Docker create it first. makedirs(exist_ok=True)
+            # accepts an existing root-owned dir silently, so repair ownership explicitly
+            # rather than leaving a directory we cannot write to.
+            if not os.access(_mount_dir, os.W_OK):
+                subprocess.run(
+                    ["sudo", "chown", "-R", f"{os.getuid()}:{os.getgid()}", _mount_dir],
+                    check=False,
+                )
 
         # Stamp the frontend build with the current git version (official tag or
         # branch name) so the footer shows what's actually running.


### PR DESCRIPTION
## Summary

Targets `jashan/qwen-fixes` (#1217) rather than `dev`, since both fixes are for that branch.

Found while testing #1217 on a voice-agent branch: with these commits applied, a Qwen3.5-9B deploy fails in 0.4 seconds, before the model reaches hardware. The timeout fix in this PR therefore never gets a chance to run, and the deploy reads as a crash.

## The bug

Docker creates a missing bind-mount path itself, as root. The `.artifacts/refs` mount added in "stream workflow logs for artifact-ref deploys" points at a directory nothing pre-creates, so Docker wins the race and owns it:

```
[Errno 13] Permission denied:
'.../.artifacts/refs/<pinned-ref>.tar.gz.part'
```

The FastAPI server runs as the invoking user, so it cannot write the ref tarball there. Qwen3.5-9B is the only catalog model pinned to its own inference-server build, so it is the only one affected. Ordinary models never touch this path, which is why Whisper and SpeechT5 deployed fine alongside it.

Ownership of every path the backend bind-mounts, on an affected machine:

```
<user>  app/backend
<user>  .artifacts/tt-inference-server/workflow_logs
<user>  logs/model_run_logs
<user>  tt_studio_persistent_volume
root    .artifacts/refs        <-- the only one Docker had to create
```

Every pre-existing path is user-owned. The one root-owned path is the only one that did not exist when the mount was introduced. Timestamps confirm the mechanism: the directory was created 6 ms before the backend container started.

Anyone who has run `--purge-all` is always in this state, because that removes all of `.artifacts`.

## The fix

Pre-create `.artifacts/refs` alongside `workflow_logs`, which already exists for exactly this reason and carries a comment describing the same root cause.

It also repairs ownership when the directory is already root-owned. This part matters: the existing pre-create relies on `PermissionError`, which only fires when `makedirs` actually has to create the directory. `makedirs(exist_ok=True)` accepts an existing root-owned directory silently, so pre-creating alone does not recover a machine that has already started containers against this branch. Verified against a live affected directory:

```
makedirs(exist_ok=True) -> returned without error   (would not self-heal)
os.access(dir, W_OK)    -> False                    (repair branch fires)
```

## Second commit: the lint failure

CI on this PR is red on `no-useless-escape` in `StreamingMessage.tsx`. The line predates this branch, but CI runs eslint over whole changed files rather than changed lines, so touching that file surfaced it as a blocking error. Dropping the redundant backslash clears it.

The character class still matches the same three characters. Verified against bracketed, angled, piped, bare and mixed-delimiter `python_tag` inputs.

## Test plan

- [ ] On a machine with a root-owned `.artifacts/refs`, run `python run.py` and confirm the directory ends up user-owned
- [ ] On a machine with no `.artifacts/refs`, run `python run.py` and confirm it is created user-owned rather than by Docker
- [ ] Deploy Qwen3.5-9B and confirm the ref download succeeds instead of failing with EACCES
- [ ] Confirm the deploy then exercises the metal-timeout fix and reaches the hardware
- [ ] Open the deployment logs in the UI and confirm the stream connects
- [ ] Confirm lint is green
