### PR TITLE
fix: give the agent a model token on fresh installs

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -119,7 +119,37 @@ json_payload = json.loads('{"team_id": "tenstorrent", "token_id":"debug-test"}')
 jwt_secret = os.getenv("JWT_SECRET")
 cloud_auth_token = os.getenv("CLOUD_CHAT_UI_AUTH_TOKEN")
 
-# Use cloud auth token if available, otherwise fall back to JWT
+
+def _fetch_backend_auth_token() -> str:
+    """Ask the backend to mint a token for calling a deployed model.
+
+    JWT_SECRET is optional in .env, and when unset the backend keeps the secret in
+    the UI-managed config, which this container cannot read. Returns "" on failure
+    so a missing token surfaces as a 401 rather than a validation error.
+    """
+    try:
+        resp = requests.get(f"{AgentConfig.BACKEND_URL}/models/agent/auth-token/", timeout=10)
+        if resp.status_code == 200:
+            return resp.json().get("token") or ""
+        print(f"Backend returned {resp.status_code} for agent auth token")
+    except Exception as e:
+        print(f"Could not fetch agent auth token from backend: {e}")
+    return ""
+
+
+def _auth_token() -> str:
+    """Token for local model calls, minted by the backend on first use and cached.
+
+    Resolved lazily so poll_for_llm()'s retries can recover if the backend was not
+    reachable yet; fetching at import would leave the agent permanently tokenless.
+    """
+    global encoded_jwt
+    if not encoded_jwt:
+        encoded_jwt = _fetch_backend_auth_token()
+    return encoded_jwt
+
+
+# Cloud token wins, then an explicit JWT_SECRET, else the backend mints one on demand.
 if cloud_auth_token:
     encoded_jwt = cloud_auth_token
     print(f"Using cloud auth token for authentication")
@@ -127,8 +157,8 @@ elif jwt_secret:
     encoded_jwt = jwt.encode(json_payload, jwt_secret, algorithm="HS256")
     print(f"Using JWT authentication")
 else:
-    encoded_jwt = None
-    print("Warning: No authentication token available (neither CLOUD_CHAT_UI_AUTH_TOKEN nor JWT_SECRET)")
+    encoded_jwt = ""
+    print("JWT_SECRET not set; will request a model token from the backend")
 
 class RequestPayload(BaseModel):
     message: str
@@ -179,7 +209,7 @@ def setup_local_container_llm(container_name: str) -> CustomLLM:
     """Setup LLM using environment-specified container"""
     llm = CustomLLM(
         server_url=f"http://{container_name}:7000", 
-        encoded_jwt=encoded_jwt, 
+        encoded_jwt=_auth_token(), 
         streaming=True,
         is_cloud=False
     )
@@ -219,7 +249,7 @@ def setup_discovered_llm(llm_info: LLMInfo) -> CustomLLM:
     
     llm = CustomLLM(
         server_url=server_url,
-        encoded_jwt=encoded_jwt,
+        encoded_jwt=_auth_token(),
         streaming=True,
         is_cloud=False,
         is_discovered=True,
@@ -256,7 +286,7 @@ def setup_local_host_llm() -> CustomLLM:
     
     llm = CustomLLM(
         server_url=f"http://{local_host}:{local_port}/v1/chat/completions",
-        encoded_jwt=encoded_jwt,
+        encoded_jwt=_auth_token(),
         streaming=True,
         is_cloud=False
     )

--- a/app/backend/model_control/urls.py
+++ b/app/backend/model_control/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("inference/", views.InferenceView.as_view()),
     path("agent/", views.AgentView.as_view()),
     path("agent/status/", views.AgentStatusView.as_view()),
+    path("agent/auth-token/", views.AgentAuthTokenView.as_view()),
     path("deployed/", views.DeployedModelsView.as_view()),
     path("model_weights/", views.ModelWeightsView.as_view()),
     path("image-generation/", views.ImageGenerationInferenceView.as_view()),

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -261,6 +261,23 @@ class AgentView(View):
         return response
 
 
+class AgentAuthTokenView(APIView):
+    """Mint the bearer token the agent uses to call a deployed model's OpenAI API.
+
+    The agent cannot resolve the JWT secret itself: when JWT_SECRET is unset in .env
+    the backend keeps it in the UI-managed config, which is root-owned and 0600 while
+    the agent runs non-root. Handing over a signed token keeps one source of truth.
+
+    No new exposure: GET /models/api-info/ already returns jwt_secret and jwt_token
+    over the same proxies, so this is strictly less sensitive. Returns the shared
+    backend token; a registered external container running its own secret still needs
+    the per-model token from auth_headers().
+    """
+
+    def get(self, request, *args, **kwargs):
+        return Response({"token": token_for()}, status=status.HTTP_200_OK)
+
+
 class AgentStatusView(APIView):
     def get(self, request, *args, **kwargs):
         """Get agent status and discovery information"""


### PR DESCRIPTION
Closes #1229

## What was broken

On a fresh install, or after `--purge-all`, the agent never started. It printed "No authentication token available" on its first line and then retried forever.

It needs a token to talk to a deployed model, and it had no way to get one. `JWT_SECRET` has been optional in `.env` since #750, and when it is unset the backend generates one into the UI-managed config instead. The backend reads it from there. The agent only ever read the environment variable, so on a clean setup it got nothing.

Existing machines kept working because their `.env` predates #750 and still carries the value, which is why this went unnoticed.

## The fix

The backend is the only component that reliably knows the secret, so it now signs a token on request and the agent asks for one. A new `GET /models/agent/auth-token/` reuses the existing token helper.

The agent resolves it lazily, on first use, rather than at import. That detail matters: `poll_for_llm()` retries but reuses the module global, and `setup_discovered_llm()` returns the LLM even when the connection test fails, so a one-shot fetch at import would turn a brief backend outage into an agent that reports itself initialized and then 401s every message. Caching only on success lets the existing retry loop recover on its own.

Two alternatives were rejected:

- **Mounting the stored config into the agent.** The file is written `0600` and root-owned, and the agent runs as a non-root user, so it cannot read it.
- **Putting `JWT_SECRET` back in `.env`.** The backend prefers the stored value, so the two containers would end up using different secrets.

Cloud token and an explicit `JWT_SECRET` keep priority, in that order. The env branch is checked before the backend mint on purpose: `inference-api` resolves `JWT_SECRET` env-first when launching a model, so `.env` winning here matches the secret the model was actually started with.

## Verified

The mechanism was confirmed against the running stack before it was written. A token signed with the backend's resolved secret, which is exactly what the new endpoint returns, authenticated to a deployed Qwen3.5-9B and returned a completion.

The retry behaviour was checked separately against a simulation of the caching contract: a failed fetch is not cached, a later attempt succeeds once the backend is back without needing a restart, and no further requests are made after success.

Also checked: all three files compile, no construction site still reads the module global, there is no longer any network call at import time, and the URL prefix matches the agent's existing `/models/deployed/` call.

## Not covered

A registered external container running its own secret still needs the per-model token the backend builds separately. Only the shared-secret case goes through this endpoint. Noted in #1229.

The same missing wiring is also why the Tavily hot-swap from #750 has never worked on a running agent. Separate fix, also noted in #1229.

Removing the dead `run_agent_container()`, which is what made this bug look already solved, is split into #1231 to keep this PR to the fix.

## Test plan

- [ ] With `JWT_SECRET` unset in `.env`, start fresh and confirm the agent reports requesting a token from the backend rather than the warning
- [ ] Send a message through the agent and confirm it reaches the model
- [ ] Stop the backend, restart the agent, confirm it keeps retrying and then recovers once the backend is back, rather than settling into a healthy-but-broken state
- [ ] With `JWT_SECRET` set in `.env`, confirm that path still takes precedence
- [ ] In cloud mode, confirm the cloud token still wins
