### PR TITLE
feat: add security.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly using GitHub's private vulnerability reporting feature.
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+### How to Report
+
+1. Navigate to the **Security** tab of this repository
+2. Click **"Report a vulnerability"**
+3. Provide a detailed description of the vulnerability, including:
+   - Steps to reproduce the issue
+   - Potential impact
+   - Any suggested fixes (if applicable)
+
+For detailed instructions on privately reporting a security vulnerability, see [GitHub's documentation](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/report-a-vulnerability/privately-reporting-a-security-vulnerability).
+
+### Questions or Discussion
+
+If you have questions about the vulnerability or need to start a conversation about it, please contact **ospo@tenstorrent.com** directly.
+
+## Our Security Process
+
+1. **Report**: Submit a vulnerability report through GitHub's Security tab
+2. **Acknowledgment**: Tenstorrent will respond within **2 business days**
+3. **Triage**: Our team will assess the issue and update its priority and risk level
+4. **Fix Development**: A fix will be developed in a private branch, with reporter feedback when possible
+5. **Disclosure**: A security advisory will be published once the fix is patched and merged to the main branch
+
+Thank you for helping keep this project and our users safe!


### PR DESCRIPTION
The repo had no security policy, so there was no documented way to privately report a vulnerability. This adds a SECURITY.md matching the policy used in tenstorrent/vllm-tt-plugin, pointing reporters to GitHub's private vulnerability reporting and ospo@tenstorrent.com.

- [x] Add SECURITY.md at the repo root
- [x] Docs-only change; confirmed the linked GitHub docs page resolves