### PR TITLE
feat: add qwen3.8-27b for p300x2

### DIFF
--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -35,9 +35,12 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
     s = f"{hf_model_id} {model_name}".lower()
     if "llama-3" in s or "llama3" in s:
         return "llama3_json"
-    # Qwen3.5 / Qwen3.6 blackhole builds ship with the qwen3_coder parser; older
-    # Qwen families use hermes.
-    if "qwen3.5" in s or "qwen3.6" in s or "qwen35" in s or "qwen36" in s:
+    # Qwen3.5 / Qwen3.6 / Qwen3.8 blackhole builds ship with the qwen3_coder
+    # parser; older Qwen families use hermes.
+    if (
+        "qwen3.5" in s or "qwen3.6" in s or "qwen3.8" in s
+        or "qwen35" in s or "qwen36" in s or "qwen38" in s
+    ):
         return "qwen3_coder"
     if "qwen" in s or "qwq" in s:
         return "hermes"

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -16,6 +16,7 @@ CODING_AGENT_ELIGIBLE_MODELS = {
     "Llama-3.1-8B-Instruct",
     "Llama-3.3-70B-Instruct",
     "Qwen3.6-27B",
+    "Qwen3.8-27B",
     "gemma-4-31B-it"
 }
 
@@ -27,6 +28,7 @@ CODING_AGENT_MODEL_TYPES = (ModelTypes.CHAT, ModelTypes.VLM)
 REASONING_MODELS = {
     "Qwen3-32B": "qwen3",
     "Qwen3.5-9B": "qwen3",
+    "Qwen3.8-27B": "qwen3",
     "gemma-4-31B-it": "gemma4",
 }
 

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1351,6 +1351,38 @@
       },
       "requires_dev_catalog": true,
       "param_count": 31
+    },
+    {
+      "model_name": "Qwen3.8-27B",
+      "hand_owned": true,
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "Qwen/Qwen3.8-27B",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-studio/studio_images:qwen38-27b-blackhole-20260814-0.20.0-9a04829-c127c17",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "TT_QWEN35_TEXT_VER": "qwen36_blackhole",
+        "HF_MODEL": "Qwen/Qwen3.8-27B",
+        "MESH_DEVICE": "(1, 4)",
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+        "QWEN36_MAX_TOKENS_ALL_USERS": "525312"
+      },
+      "param_count": 27,
+      "requires_dev_catalog": true,
+      "inference_artifact_ref": {
+        "P300x2": "stisi/feat-qwen38-27b-dev-spec"
+      }
     }
   ]
 }


### PR DESCRIPTION
Makes Qwen3.8-27B deployable and usable in the chat UI on a P300x2 board (4 chips).

The model isn't in the tt-inference-server build TT-Studio normally ships with, so the catalog entry points at its own build and its own image instead of the default one. The image is published to `tt-studio/studio_images`, so this works on any box and not just the one it was built on.

Two lookups in the backend also needed the new version. The first picks the vLLM tool-call parser by matching on the model name, and it didn't know about "3.8". That meant the model fell through to `hermes`, and TT-Studio then sent that as an override which replaced the `qwen3_coder` parser the model actually asks for. The second controls which models get a thinking mode. Without an entry there, the model got no thinking variant and no reasoning stats even though it does produce reasoning.

- [x] Add the catalog entry, P300x2 only so it allocates all 4 chips
- [x] Recognize 3.8 in the tool-call parser lookup so it resolves to `qwen3_coder` instead of `hermes`
- [x] Register it as a reasoning model so it gets a thinking variant
- [x] Deployed on a P300x2 box, pulled the image from GHCR, confirmed healthy
- [x] Checked the container starts with `--tool_call_parser qwen3_coder` and `--reasoning_parser qwen3`
- [x] Chatted through the same inference path the UI uses, and the thinking came back separately from the answer rather than leaking into the reply
- [x] Confirmed the weights load from the normal Hugging Face cache with no re-download

Marked EXPERIMENTAL. Vision isn't reachable from the UI yet, so it's text only in practice, though the server still warms the vision tower on start.
