### PR TITLE
feat: add motif-image-6B-preview for p300x2

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -423,6 +423,18 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
             payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
 
+        # Motif pinned to a patched 0.18.0 media image. The artifact spec pins
+        # 0.9.0-c180ef7, which cannot run Motif at all: its ModelNames enum predates
+        # the rename to exact-case values ("motif-image-6b-preview" vs the
+        # "Motif-Image-6B-Preview" that run.py passes as MODEL) and it has no Motif
+        # P300X2 device config. The stock 0.18.0 image fixes both but its tt-metal
+        # MotifPipeline lacks a (2, 2) mesh preset, so the p300x2 mesh dies with
+        # KeyError: 'num_links'. The patch layer adds that preset (T3K preset with
+        # tensor-parallel halved); drop it once tt-metal ships the preset and the
+        # artifact re-pins.
+        if impl.model_name == "Motif-Image-6B-Preview":
+            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-studio/tt-media-inference-server:0.18.0-c49bb76-motif-p300x2"
+
         # Disambiguate the target model_spec. Some models share a name+device across
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training
         # spec on P150); without an impl the server defaults to the wrong engine and

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -433,7 +433,7 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # tensor-parallel halved); drop it once tt-metal ships the preset and the
         # artifact re-pins.
         if impl.model_name == "Motif-Image-6B-Preview":
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-studio/tt-media-inference-server:0.18.0-c49bb76-motif-p300x2"
+            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-studio/studio_images:motif-image-6b-p300x2-20260814-0.18.0-c49bb76"
 
         # Disambiguate the target model_spec. Some models share a name+device across
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -342,6 +342,34 @@ def deploys_whole_board(impl, board_type=None):
     return infer_inference_server_device(impl, board_type) not in _SINGLE_CHIP_DEVICE_NAMES
 
 
+# Per-model media image pins. These win over the tt-inference-server model_spec
+# (GET /resolve-image) whenever the spec pins an image that cannot run the model.
+# Consulted both by run_container (deploy) and by the media pre-pull in
+# views.py, so the image the UI pulls with progress is the image that deploys.
+_MEDIA_IMAGE_OVERRIDES = {
+    # Wan T2V pinned to the 0.17.0 media image: carries the MODEL_WEIGHTS_DIR fix
+    # (#4107) so it uses the mounted host HF cache instead of re-downloading ~118GB.
+    # Pinned explicitly because per-device resolution would otherwise pick older
+    # images on some boards (e.g. 0.10.0-555f240 for Wan on p150x4) that lack the fix.
+    "Wan2.2-T2V-A14B-Diffusers": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+    # Motif pinned to a patched 0.18.0 media image. The artifact spec pins
+    # 0.9.0-c180ef7, which cannot run Motif at all: its ModelNames enum predates
+    # the rename to exact-case values ("motif-image-6b-preview" vs the
+    # "Motif-Image-6B-Preview" that run.py passes as MODEL) and it has no Motif
+    # P300X2 device config. The stock 0.18.0 image fixes both but its tt-metal
+    # MotifPipeline lacks a (2, 2) mesh preset, so the p300x2 mesh dies with
+    # KeyError: 'num_links'. The patch layer adds that preset (T3K preset with
+    # tensor-parallel halved); drop it once tt-metal ships the preset and the
+    # artifact re-pins.
+    "Motif-Image-6B-Preview": "ghcr.io/tenstorrent/tt-studio/studio_images:motif-image-6b-p300x2-20260814-0.18.0-c49bb76",
+}
+
+
+def resolve_media_override_image(impl):
+    """Pinned media image for this model, or None when the spec image is fine."""
+    return _MEDIA_IMAGE_OVERRIDES.get(impl.model_name)
+
+
 def run_container(impl, weights_id, device_id=0, host_port=None, use_image_override=True):
     """Run a docker container.
 
@@ -416,24 +444,11 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # if use_image_override and impl.model_name in {"whisper-large-v3", "speecht5_tts"} and board_type == "P300x2":
         #     payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:qb2_launch-6900b0c-dev"
 
-        # Wan T2V pinned to the 0.17.0 media image: carries the MODEL_WEIGHTS_DIR fix
-        # (#4107) so it uses the mounted host HF cache instead of re-downloading ~118GB.
-        # Pinned explicitly because per-device resolution would otherwise pick older
-        # images on some boards (e.g. 0.10.0-555f240 for Wan on p150x4) that lack the fix.
-        if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
-
-        # Motif pinned to a patched 0.18.0 media image. The artifact spec pins
-        # 0.9.0-c180ef7, which cannot run Motif at all: its ModelNames enum predates
-        # the rename to exact-case values ("motif-image-6b-preview" vs the
-        # "Motif-Image-6B-Preview" that run.py passes as MODEL) and it has no Motif
-        # P300X2 device config. The stock 0.18.0 image fixes both but its tt-metal
-        # MotifPipeline lacks a (2, 2) mesh preset, so the p300x2 mesh dies with
-        # KeyError: 'num_links'. The patch layer adds that preset (T3K preset with
-        # tensor-parallel halved); drop it once tt-metal ships the preset and the
-        # artifact re-pins.
-        if impl.model_name == "Motif-Image-6B-Preview":
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-studio/studio_images:motif-image-6b-p300x2-20260814-0.18.0-c49bb76"
+        # Per-model media pins (see _MEDIA_IMAGE_OVERRIDES). The media pre-pull in
+        # views.py resolves through the same helper so pull and deploy agree.
+        media_override_image = resolve_media_override_image(impl)
+        if media_override_image:
+            payload["override_docker_image"] = media_override_image
 
         # Disambiguate the target model_spec. Some models share a name+device across
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -37,6 +37,7 @@ from .docker_utils import (
     map_board_type_to_device_name,
     infer_inference_server_device,
     deploys_whole_board,
+    resolve_media_override_image,
     _BOARD_TO_SINGLE_CHIP_DEVICE,
     WHOLE_BOARD_DEFAULT_BOARDS,
     update_deploy_cache,
@@ -886,7 +887,16 @@ class DeployView(APIView):
                 # resolve-image declares `impl: Optional[str]` and matches on
                 # impl_name. See the matching guard in docker_utils.run_container.
                 inference_impl = _impl_selector(getattr(impl, "inference_impl", None))
-                deploy_image = resolve_deploy_image(impl.model_name, media_device, impl=inference_impl) or impl.image_version
+                # Per-model pins win over the model_spec resolution so the image
+                # pulled here (with UI progress) is the one run_container deploys —
+                # the spec may pin an image that cannot run the model (see
+                # _MEDIA_IMAGE_OVERRIDES in docker_utils). Mirrors the chat path,
+                # which checks override_docker_image before resolve_deploy_image.
+                deploy_image = (
+                    resolve_media_override_image(impl)
+                    or resolve_deploy_image(impl.model_name, media_device, impl=inference_impl)
+                    or impl.image_version
+                )
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False
                 if image_name:

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1366,7 +1366,7 @@
       "inference_engine": "media",
       "status": "COMPLETE",
       "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-studio/tt-media-inference-server:0.18.0-c49bb76-motif-p300x2",
+      "docker_image": "ghcr.io/tenstorrent/tt-studio/studio_images:motif-image-6b-p300x2-20260814-0.18.0-c49bb76",
       "service_route": "/v1/images/generations",
       "health_route": "/health",
       "env_vars": {},

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.18.0",
     "generated_at": "2026-07-23T20:22:38.003837+00:00"
   },
-  "total_models": 55,
+  "total_models": 59,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -1351,6 +1351,26 @@
       },
       "requires_dev_catalog": true,
       "param_count": 31
+    },
+    {
+      "model_name": "Motif-Image-6B-Preview",
+      "model_type": "IMAGE_GENERATION",
+      "display_model_type": "IMAGE",
+      "device_configurations": [
+        "GALAXY",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "Motif-Technologies/Motif-Image-6B-Preview",
+      "inference_engine": "media",
+      "status": "COMPLETE",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-studio/tt-media-inference-server:0.18.0-c49bb76-motif-p300x2",
+      "service_route": "/v1/images/generations",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
     }
   ]
 }


### PR DESCRIPTION
The v0.21.0 artifact lists Motif-Image-6B-Preview on P300X2, but no published media image can actually run it there: the spec's pinned 0.9.0-c180ef7 rejects the model name outright (stale lowercase enum, no P300X2 device config), and the newest stock 0.18.0 image still lacks a (2, 2) mesh preset in tt-metal plus enough trace region for the tp=2 layout. Dev currently hides the pair with an `[[unavailable]]` mark.

Rebased onto dev and reworked to use the declarative overrides in `model_overrides.toml` instead of code and a hand-edited catalog:

- [x] Drop the `[[unavailable]]` mark for Motif on P300x2
- [x] Add a `[[serve_override]]` pinning p300x2 deploys to the patched image `ghcr.io/tenstorrent/tt-studio/studio_images:motif-image-6b-p300x2-20260814-0.18.0-c49bb76` (stock 0.18.0-c49bb76 plus the two one-line fixes, tt-metal#53197 and tt-inference-server#4955). Scoped to p300x2, the board the patch targets and the only one verified; other boards keep the spec image as before
- [x] Regenerate the catalog with `sync_models_from_inference_server.py` from the 0.21.0 artifact (no hand edits) — the only catalog change is P300x2 rejoining Motif's `device_configurations`
- [x] Pull and deploy agree: dev's `media_image_override()` already feeds both `run_container` and the media pre-pull, so the earlier review point about pulling the spec image needlessly is covered by dev's design
- [x] Unit tests for the pin (`MediaImageOverrideTests`), plus `test_sync_models.py` / `test_model_config.py` match the clean-dev baseline
- [x] Hardware verification on p300x2 was done on the original branch: UI deploy flow, warmup healthy, two 1024x1024 generations in ~7s each. The rebased change is data-only, so it was not redeployed on hardware
- [x] Patched image is already in GHCR

Drop the override once a media image ships with both fixes and the spec re-pins (tt-inference-server#4956).
