### PR TITLE
feat: add custom dataset upload, preview, and management for training

### DIFF
--- a/app/backend/training_control/urls.py
+++ b/app/backend/training_control/urls.py
@@ -7,6 +7,8 @@ from . import views
 
 urlpatterns = [
     path("catalog/", views.TrainingCatalogView.as_view(), name="training-catalog"),
+    path("datasets/custom/", views.CustomDatasetsView.as_view(), name="training-custom-datasets"),
+    path("datasets/custom/<str:name>/", views.CustomDatasetDetailView.as_view(), name="training-custom-dataset-detail"),
     path("jobs/", views.TrainingJobsListView.as_view(), name="training-jobs-list"),
     path("jobs/<str:job_id>/", views.TrainingJobDetailView.as_view(), name="training-job-detail"),
     path("jobs/<str:job_id>/metrics/", views.TrainingJobMetricsView.as_view(), name="training-job-metrics"),

--- a/app/backend/training_control/views.py
+++ b/app/backend/training_control/views.py
@@ -5,18 +5,26 @@ import json
 import os
 
 import requests
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from model_control.model_utils import get_deploy_cache
+from shared_config.backend_config import backend_config
 from shared_config.logger_config import get_logger
 from shared_config.model_type_config import ModelTypes
 
 logger = get_logger(__name__)
 
 PROXY_TIMEOUT = 120
+
+# Shared training host-volume root under the persistent storage volume. Custom
+# datasets live in a subdirectory of it.
+TRAINING_VOLUME_SUBDIR = "training_volume"
+CUSTOM_DATASETS_SUBDIR = os.path.join(TRAINING_VOLUME_SUBDIR, "custom_datasets")
+MAX_DATASET_UPLOAD_BYTES = 100 * 1024 * 1024
+MAX_DATASET_PREVIEW_BYTES = 25 * 1024 * 1024
 
 # tt-media-server authenticates with `Authorization: Bearer <API_KEY>`.
 # Not the JWT used for vLLM/LLM inference endpoints.
@@ -136,9 +144,224 @@ def _proxy_post(url, body=None):
         return JsonResponse({"error": str(e)}, status=500)
 
 
+def _custom_datasets_dir():
+    """Container-internal path to the custom-datasets directory (created if absent).
+
+    Ensures both the shared ``training_volume`` root and the ``custom_datasets``
+    subdir exist with sticky world-writable permissions. The root matters because
+    the training container (uid 1000) and the host user running run.py also create
+    entries directly under ``training_volume``; without the sticky bit that dir
+    would be left root-owned and unwritable to them. The chmod is applied on every
+    call (not just on creation) so the permissions self-heal regardless of which
+    component created the directory first.
+    """
+    volume_dir = os.path.join(
+        backend_config.persistent_storage_volume, TRAINING_VOLUME_SUBDIR
+    )
+    internal_dir = os.path.join(
+        backend_config.persistent_storage_volume, CUSTOM_DATASETS_SUBDIR
+    )
+    for path in (volume_dir, internal_dir):
+        try:
+            os.makedirs(path, exist_ok=True)
+            os.chmod(path, 0o1777)
+        except OSError as e:
+            logger.warning("Could not prepare training dir %s: %s", path, e)
+    return internal_dir
+
+
+def _safe_dataset_filename(name):
+    """
+    Strips any directory components to prevent path traversal and requires a
+    ``.json`` extension (the only format the preview/loader understands).
+    """
+    if not name:
+        return None
+    base = os.path.basename(name.replace("\\", "/")).strip()
+    if not base or base in (".", "..") or base.startswith("."):
+        return None
+    if not base.lower().endswith(".json"):
+        return None
+    return base
+
+
 # ---------------------------------------------------------------------------
 # Views
 # ---------------------------------------------------------------------------
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CustomDatasetsView(View):
+    """Manage user-uploaded custom datasets on the shared training volume.
+
+    GET  /training/datasets/custom/  → list uploaded datasets
+    POST /training/datasets/custom/  → upload a dataset JSON file (multipart)
+    """
+
+    def get(self, request, *args, **kwargs):
+        directory = _custom_datasets_dir()
+        datasets = []
+        try:
+            for entry in sorted(os.listdir(directory)):
+                path = os.path.join(directory, entry)
+                if not os.path.isfile(path) or not entry.lower().endswith(".json"):
+                    continue
+                try:
+                    stat = os.stat(path)
+                except OSError:
+                    continue
+                datasets.append(
+                    {
+                        "id": entry,
+                        "name": entry,
+                        "size_bytes": stat.st_size,
+                        "modified_at": int(stat.st_mtime),
+                    }
+                )
+        except OSError as e:
+            logger.exception("Could not list custom datasets in %s", directory)
+            return JsonResponse({"error": str(e)}, status=500)
+        return JsonResponse({"datasets": datasets}, status=200)
+
+    def post(self, request, *args, **kwargs):
+        upload = request.FILES.get("file")
+        if upload is None:
+            return JsonResponse(
+                {"error": "No file provided. Send a multipart 'file' field."},
+                status=400,
+            )
+
+        filename = _safe_dataset_filename(upload.name)
+        if filename is None:
+            return JsonResponse(
+                {"error": "Invalid filename. Only .json dataset files are accepted."},
+                status=400,
+            )
+
+        if upload.size and upload.size > MAX_DATASET_UPLOAD_BYTES:
+            limit_mb = MAX_DATASET_UPLOAD_BYTES // (1024 * 1024)
+            return JsonResponse(
+                {"error": f"File is too large. The limit is {limit_mb} MB."},
+                status=400,
+            )
+
+        raw = upload.read()
+        try:
+            json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return JsonResponse(
+                {"error": "File is not valid JSON."}, status=400
+            )
+
+        directory = _custom_datasets_dir()
+        dest = os.path.join(directory, filename)
+        if os.path.exists(dest):
+            return JsonResponse(
+                {
+                    "error": (
+                        f'A dataset named "{filename}" already exists. '
+                        "Rename the file or delete the existing dataset first."
+                    )
+                },
+                status=409,
+            )
+        try:
+            with open(dest, "wb") as f:
+                f.write(raw)
+        except OSError as e:
+            logger.exception("Could not save custom dataset to %s", dest)
+            return JsonResponse({"error": str(e)}, status=500)
+
+        try:
+            stat = os.stat(dest)
+            size_bytes = stat.st_size
+            modified_at = int(stat.st_mtime)
+        except OSError:
+            size_bytes = len(raw)
+            modified_at = None
+
+        return JsonResponse(
+            {
+                "id": filename,
+                "name": filename,
+                "size_bytes": size_bytes,
+                "modified_at": modified_at,
+            },
+            status=201,
+        )
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CustomDatasetDetailView(View):
+    """Read back or delete a single user-uploaded custom dataset.
+
+    GET    /training/datasets/custom/<name>/ → raw JSON contents of the dataset
+    DELETE /training/datasets/custom/<name>/ → remove the dataset from the volume
+
+    GET returns the file's raw bytes with an ``application/json`` content type so
+    the frontend can parse and preview it the same way it previews a freshly
+    selected local file.
+    """
+
+    def get(self, request, name, *args, **kwargs):
+        filename = _safe_dataset_filename(name)
+        if filename is None:
+            return JsonResponse(
+                {"error": "Invalid dataset name. Only .json datasets are supported."},
+                status=400,
+            )
+
+        directory = _custom_datasets_dir()
+        path = os.path.join(directory, filename)
+        if not os.path.isfile(path):
+            return JsonResponse({"error": "Dataset not found."}, status=404)
+
+        try:
+            size = os.path.getsize(path)
+        except OSError as e:
+            logger.exception("Could not stat custom dataset %s", path)
+            return JsonResponse({"error": str(e)}, status=500)
+
+        if size > MAX_DATASET_PREVIEW_BYTES:
+            limit_mb = MAX_DATASET_PREVIEW_BYTES // (1024 * 1024)
+            return JsonResponse(
+                {
+                    "error": (
+                        f"Dataset is too large to preview. The limit is {limit_mb} MB."
+                    )
+                },
+                status=413,
+            )
+
+        try:
+            with open(path, "rb") as f:
+                raw = f.read()
+        except OSError as e:
+            logger.exception("Could not read custom dataset %s", path)
+            return JsonResponse({"error": str(e)}, status=500)
+
+        return HttpResponse(raw, content_type="application/json")
+
+    def delete(self, request, name, *args, **kwargs):
+        filename = _safe_dataset_filename(name)
+        if filename is None:
+            return JsonResponse(
+                {"error": "Invalid dataset name. Only .json datasets are supported."},
+                status=400,
+            )
+
+        directory = _custom_datasets_dir()
+        path = os.path.join(directory, filename)
+        if not os.path.isfile(path):
+            return JsonResponse({"error": "Dataset not found."}, status=404)
+
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.exception("Could not delete custom dataset %s", path)
+            return JsonResponse({"error": str(e)}, status=500)
+
+        return JsonResponse({"id": filename, "name": filename, "deleted": True}, status=200)
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/app/frontend/src/api/trainingApi.ts
+++ b/app/frontend/src/api/trainingApi.ts
@@ -128,6 +128,68 @@ export async function fetchTrainingCatalog(): Promise<CatalogEntry[]> {
   return extractModels(data);
 }
 
+// ---------------------------------------------------------------------------
+// Custom (user-uploaded) datasets
+// ---------------------------------------------------------------------------
+
+// A dataset JSON file the user uploaded, stored under the shared training volume
+// at training_volume/custom_datasets/. These are offered as choices in the New
+// Training Job dialog. The training server does not yet accept arbitrary
+// datasets, so selecting one still trains on the default (sst2) recipe — see
+// DEFAULT_DATASET_LOADER.
+export interface CustomDataset {
+  id: string;
+  name: string;
+  size_bytes?: number;
+  modified_at?: number | null;
+}
+
+// Dataset the training server actually uses when a custom dataset is selected.
+// Custom datasets aren't supported by the inference/training server yet, so jobs
+// fall back to this built-in recipe while still showing the user's choice. Value
+// matches the dataset `id` exposed by the training container's /v1/catalog.
+export const DEFAULT_DATASET_LOADER = "SST2";
+
+export async function fetchCustomDatasets(): Promise<CustomDataset[]> {
+  const { data } = await axios.get(`${TRAINING_API}/datasets/custom/`);
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.datasets)) return data.datasets;
+  return [];
+}
+
+// Fetch the raw JSON contents of a previously uploaded custom dataset so it can
+// be parsed and previewed client-side (same path as a freshly selected file).
+// Returns the file text; `responseType: "text"` + a passthrough transform keep
+// axios from parsing/normalizing the JSON so the shared parser sees it verbatim.
+export async function fetchCustomDatasetContent(id: string): Promise<string> {
+  const { data } = await axios.get<string>(
+    `${TRAINING_API}/datasets/custom/${encodeURIComponent(id)}/`,
+    { responseType: "text", transformResponse: [(value) => value] },
+  );
+  return typeof data === "string" ? data : JSON.stringify(data);
+}
+
+export async function uploadCustomDataset(
+  file: File,
+): Promise<CustomDataset> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const { data } = await axios.post(
+    `${TRAINING_API}/datasets/custom/`,
+    formData,
+    { headers: { "Content-Type": "multipart/form-data" } },
+  );
+  return data;
+}
+
+// Delete a previously uploaded custom dataset, removing the file from the shared
+// training volume.
+export async function deleteCustomDataset(id: string): Promise<void> {
+  await axios.delete(
+    `${TRAINING_API}/datasets/custom/${encodeURIComponent(id)}/`,
+  );
+}
+
 export interface TrainingCatalog {
   models: CatalogEntry[];
   datasets: CatalogEntry[];

--- a/app/frontend/src/components/training/DatasetPreview.tsx
+++ b/app/frontend/src/components/training/DatasetPreview.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useMemo, useState } from "react";
+import { Table2, Braces } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import { formatCellValue, type DatasetPreview as DatasetPreviewData } from "./datasetPreview";
+
+interface DatasetPreviewProps {
+  preview: DatasetPreviewData;
+  /** How many rows to render in the preview. */
+  maxRows?: number;
+}
+
+type ViewMode = "table" | "json";
+
+export function DatasetPreview({ preview, maxRows = 5 }: DatasetPreviewProps) {
+  const [view, setView] = useState<ViewMode>("table");
+
+  const sampleRows = useMemo(
+    () => preview.rows.slice(0, maxRows),
+    [preview.rows, maxRows],
+  );
+
+  const shownCount = sampleRows.length;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Showing {shownCount.toLocaleString()} of{" "}
+          {preview.totalRows.toLocaleString()} rows &middot;{" "}
+          {preview.columns.length.toLocaleString()} columns
+        </p>
+        <div className="flex items-center rounded-md border border-gray-200 p-0.5 dark:border-gray-700">
+          <Button
+            type="button"
+            variant={view === "table" ? "secondary" : "ghost"}
+            size="sm"
+            className="h-7 gap-1.5 px-2.5"
+            onClick={() => setView("table")}
+          >
+            <Table2 className="h-4 w-4" />
+            Table
+          </Button>
+          <Button
+            type="button"
+            variant={view === "json" ? "secondary" : "ghost"}
+            size="sm"
+            className="h-7 gap-1.5 px-2.5"
+            onClick={() => setView("json")}
+          >
+            <Braces className="h-4 w-4" />
+            JSON
+          </Button>
+        </div>
+      </div>
+
+      {view === "table" ? (
+        <div className="max-h-96 overflow-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <Table>
+            <TableHeader className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800">
+              <TableRow>
+                {preview.columns.map((col) => (
+                  <TableHead
+                    key={col}
+                    className="whitespace-nowrap font-mono text-xs"
+                  >
+                    {col}
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sampleRows.map((row, idx) => (
+                <TableRow key={idx}>
+                  {preview.columns.map((col) => {
+                    const text = formatCellValue(row[col]);
+                    return (
+                      <TableCell
+                        key={col}
+                        className="max-w-xs align-top text-xs"
+                        title={text}
+                      >
+                        <span className="line-clamp-3 whitespace-pre-wrap break-words">
+                          {text}
+                        </span>
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <pre
+          className={cn(
+            "max-h-96 overflow-auto rounded-lg border border-gray-200 bg-gray-50 p-4 text-left text-xs leading-relaxed",
+            "dark:border-gray-700 dark:bg-gray-900/50",
+          )}
+        >
+          <code>{JSON.stringify(sampleRows, null, 2)}</code>
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/training/DatasetPreviewPanel.tsx
+++ b/app/frontend/src/components/training/DatasetPreviewPanel.tsx
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  FileJson,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  UploadCloud,
+} from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Progress } from "../ui/progress";
+import { Button } from "../ui/button";
+import { cn } from "../../lib/utils";
+import { DatasetUploadField } from "./DatasetUploadField";
+import { DatasetPreview } from "./DatasetPreview";
+import {
+  parseDatasetFile,
+  DatasetParseError,
+  type DatasetPreview as DatasetPreviewData,
+} from "./datasetPreview";
+import {
+  deleteCustomDataset,
+  fetchCustomDatasetContent,
+  fetchCustomDatasets,
+  uploadCustomDataset,
+  formatTrainingTimestamp,
+  type CustomDataset,
+} from "../../api/trainingApi";
+import { customToast } from "../CustomToaster";
+
+// Guard against reading arbitrarily large files into memory for a client-side
+// preview. 25 MB is generous for a JSON dataset sample.
+const MAX_FILE_BYTES = 25 * 1024 * 1024;
+
+type Phase = "idle" | "reading" | "parsing" | "ready" | "error";
+
+// What the current preview is showing: a freshly selected local file (which can
+// still be uploaded) or a dataset already stored on the server (already saved,
+// so the "Save for Training" action is disallowed).
+type PreviewSource = "file" | "existing";
+
+interface DatasetPreviewPanelProps {
+  // Notified after a dataset is successfully uploaded to the server so parents
+  // (e.g. the training dialog) can refresh their custom-dataset list.
+  onUploaded?: () => void;
+}
+
+function formatBytes(bytes?: number): string {
+  if (bytes === undefined || bytes === null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function DatasetPreviewPanel({ onUploaded }: DatasetPreviewPanelProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<DatasetPreviewData | null>(null);
+  const [previewSource, setPreviewSource] = useState<PreviewSource | null>(null);
+  const [previewName, setPreviewName] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploaded, setUploaded] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const readerRef = useRef<FileReader | null>(null);
+
+  // Previously uploaded datasets discovered on the shared training volume.
+  const [datasets, setDatasets] = useState<CustomDataset[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const refreshDatasets = useCallback(async () => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const list = await fetchCustomDatasets();
+      setDatasets(list);
+    } catch {
+      setListError("Failed to load uploaded datasets.");
+    } finally {
+      setListLoading(false);
+    }
+  }, []);
+
+  // Search the custom_datasets directory whenever the panel mounts so returning
+  // to the training tab always reflects what has already been uploaded.
+  useEffect(() => {
+    void refreshDatasets();
+  }, [refreshDatasets]);
+
+  const reset = useCallback(() => {
+    readerRef.current?.abort();
+    readerRef.current = null;
+    setFile(null);
+    setPhase("idle");
+    setProgress(0);
+    setError(null);
+    setPreview(null);
+    setPreviewSource(null);
+    setPreviewName(null);
+    setUploading(false);
+    setUploaded(false);
+    setSelectedId(null);
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      await uploadCustomDataset(file);
+      setUploaded(true);
+      customToast.success(`Uploaded "${file.name}" for training`);
+      onUploaded?.();
+      void refreshDatasets();
+    } catch (err) {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Failed to upload dataset";
+      customToast.error(message);
+    } finally {
+      setUploading(false);
+    }
+  }, [file, onUploaded, refreshDatasets]);
+
+  const handleFileSelected = useCallback((selected: File) => {
+    readerRef.current?.abort();
+    setSelectedId(null);
+    setFile(selected);
+    setPreview(null);
+    setPreviewSource(null);
+    setPreviewName(selected.name);
+    setError(null);
+    setProgress(0);
+    setUploaded(false);
+
+    if (selected.size > MAX_FILE_BYTES) {
+      setPhase("error");
+      setError(
+        `File is too large to preview (${(selected.size / (1024 * 1024)).toFixed(1)} MB). The limit is ${MAX_FILE_BYTES / (1024 * 1024)} MB.`,
+      );
+      return;
+    }
+
+    setPhase("reading");
+
+    const reader = new FileReader();
+    readerRef.current = reader;
+
+    reader.onprogress = (event) => {
+      if (event.lengthComputable) {
+        setProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+
+    reader.onerror = () => {
+      setPhase("error");
+      setError("Failed to read the file.");
+      readerRef.current = null;
+    };
+
+    reader.onload = () => {
+      setProgress(100);
+      setPhase("parsing");
+      // Defer parsing so the "Parsing…" state paints before the (potentially
+      // blocking) JSON.parse runs on the main thread.
+      setTimeout(() => {
+        try {
+          const text = String(reader.result ?? "");
+          const parsed = parseDatasetFile(text);
+          setPreview(parsed);
+          setPreviewSource("file");
+          setPhase("ready");
+        } catch (err) {
+          const message =
+            err instanceof DatasetParseError
+              ? err.message
+              : "Could not parse the dataset file.";
+          setPhase("error");
+          setError(message);
+        } finally {
+          readerRef.current = null;
+        }
+      }, 0);
+    };
+
+    reader.readAsText(selected);
+  }, []);
+
+  // Delete the dataset currently being previewed, removing it from the training
+  // volume, then clear the preview and refresh the list.
+  const handleDelete = useCallback(async () => {
+    if (!selectedId) return;
+    const name = previewName ?? selectedId;
+    setDeleting(true);
+    try {
+      await deleteCustomDataset(selectedId);
+      customToast.success(`Removed "${name}"`);
+      reset();
+      await refreshDatasets();
+      onUploaded?.();
+    } catch (err) {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data
+          ?.error || "Failed to delete dataset";
+      customToast.error(message);
+    } finally {
+      setDeleting(false);
+    }
+  }, [selectedId, previewName, reset, refreshDatasets, onUploaded]);
+
+  // Preview a dataset that is already stored on the server. It is already saved,
+  // so uploading it again is disallowed (no "Save for Training" button).
+  // Clicking the dataset that is already being previewed collapses the preview.
+  const handleSelectExisting = useCallback(
+    async (dataset: CustomDataset) => {
+    if (selectedId === dataset.id) {
+      reset();
+      return;
+    }
+    readerRef.current?.abort();
+    readerRef.current = null;
+    setFile(null);
+    setUploaded(false);
+    setError(null);
+    setProgress(0);
+    setPreview(null);
+    setPreviewSource(null);
+    setPreviewName(dataset.name);
+    setSelectedId(dataset.id);
+    setPhase("parsing");
+
+    try {
+      const text = await fetchCustomDatasetContent(dataset.id);
+      const parsed = parseDatasetFile(text);
+      setPreview(parsed);
+      setPreviewSource("existing");
+      setPhase("ready");
+    } catch (err) {
+      let message = "Could not load the dataset.";
+      if (err instanceof DatasetParseError) {
+        message = err.message;
+      } else {
+        const apiError = (err as { response?: { data?: { error?: string } } })
+          ?.response?.data?.error;
+        if (apiError) message = apiError;
+      }
+      setPhase("error");
+      setError(message);
+    }
+    },
+    [selectedId, reset],
+  );
+
+  const isBusy = phase === "reading" || phase === "parsing";
+  const canSave = phase === "ready" && preview && previewSource === "file";
+
+  // The preview belongs to a stored dataset when a list item is selected;
+  // otherwise it belongs to a freshly picked local file. Used to place the
+  // preview/busy/error blocks above (existing) or below (new upload) the
+  // "or upload new" divider.
+  const existingContext = selectedId !== null;
+
+  const previewArea = (
+    <>
+      {isBusy && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {phase === "reading"
+              ? "Reading file…"
+              : selectedId
+                ? "Loading dataset…"
+                : "Parsing…"}
+          </div>
+          <Progress value={phase === "parsing" ? 100 : progress} />
+        </div>
+      )}
+
+      {phase === "error" && error && (
+        <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm dark:border-red-700 dark:bg-red-900/20">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+          <p className="text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {phase === "ready" && preview && (
+        <>
+          {previewName && (
+            <div className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+              <FileJson className="h-4 w-4 text-gray-400" />
+              <span className="truncate">{previewName}</span>
+            </div>
+          )}
+          <DatasetPreview preview={preview} />
+        </>
+      )}
+
+      {phase === "ready" && preview && (
+        <div className="flex items-center justify-between gap-3 border-t border-gray-100 pt-4 dark:border-gray-800">
+          {previewSource === "existing" ? (
+            <>
+              <span className="flex items-center gap-1.5 text-sm text-green-600 dark:text-green-400">
+                <CheckCircle2 className="h-4 w-4" />
+                Already saved for training
+              </span>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="mr-2 h-4 w-4" />
+                )}
+                Remove dataset
+              </Button>
+            </>
+          ) : (
+            <div className="ml-auto flex items-center gap-3">
+              {uploaded && (
+                <span className="flex items-center gap-1.5 text-sm text-green-600 dark:text-green-400">
+                  <CheckCircle2 className="h-4 w-4" />
+                  Available for training
+                </span>
+              )}
+              <Button
+                onClick={handleUpload}
+                disabled={uploading || uploaded || !canSave}
+              >
+                {uploading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <UploadCloud className="mr-2 h-4 w-4" />
+                )}
+                {uploaded ? "Uploaded" : "Save for Training"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">Custom Dataset Upload</CardTitle>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Upload a dataset JSON file, or select a previously uploaded one to
+          preview its contents.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Previously uploaded datasets */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Uploaded datasets
+            </h3>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 px-2"
+              onClick={() => void refreshDatasets()}
+              disabled={listLoading}
+            >
+              <RefreshCw
+                className={cn("h-3.5 w-3.5", listLoading && "animate-spin")}
+              />
+              Refresh
+            </Button>
+          </div>
+
+          {listError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{listError}</p>
+          )}
+
+          {listLoading && datasets.length === 0 ? (
+            <div className="flex items-center gap-2 rounded-lg border border-dashed border-gray-200 px-4 py-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading datasets…
+            </div>
+          ) : datasets.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-gray-200 px-4 py-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              No datasets uploaded yet.
+            </div>
+          ) : (
+            <ul className="max-h-56 space-y-1 overflow-auto rounded-lg border border-gray-200 p-1 dark:border-gray-700">
+              {datasets.map((dataset) => {
+                const isSelected = selectedId === dataset.id;
+                return (
+                  <li key={dataset.id}>
+                    <button
+                      type="button"
+                      onClick={() => void handleSelectExisting(dataset)}
+                      disabled={isBusy}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors",
+                        "hover:bg-gray-100 dark:hover:bg-gray-800",
+                        "disabled:cursor-not-allowed disabled:opacity-60",
+                        isSelected &&
+                          "bg-gray-100 ring-1 ring-inset ring-gray-300 dark:bg-gray-800 dark:ring-gray-600",
+                      )}
+                    >
+                      <FileJson className="h-4 w-4 shrink-0 text-gray-400" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-gray-800 dark:text-gray-100">
+                          {dataset.name}
+                        </span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400">
+                          {[
+                            formatBytes(dataset.size_bytes),
+                            dataset.modified_at
+                              ? formatTrainingTimestamp(dataset.modified_at)
+                              : "",
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")}
+                        </span>
+                      </span>
+                      {isSelected && (
+                        <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {/* Preview for a previously uploaded dataset renders here, above the
+              "or upload new" divider. */}
+          {existingContext && previewArea}
+        </div>
+
+        <div className="flex items-center gap-3 pt-1">
+          <div className="h-px flex-1 bg-gray-100 dark:bg-gray-800" />
+          <span className="text-xs font-medium uppercase tracking-wide text-gray-400">
+            or upload new
+          </span>
+          <div className="h-px flex-1 bg-gray-100 dark:bg-gray-800" />
+        </div>
+
+        <DatasetUploadField
+          file={file}
+          onFileSelected={handleFileSelected}
+          onClear={reset}
+          disabled={isBusy}
+        />
+
+        {/* Preview for a freshly selected local file renders here, below the
+            upload field. */}
+        {!existingContext && previewArea}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/frontend/src/components/training/DatasetUploadField.tsx
+++ b/app/frontend/src/components/training/DatasetUploadField.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+import { FileJson, UploadCloud, X } from "lucide-react";
+
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+
+interface DatasetUploadFieldProps {
+  /** Currently selected file, if any (controlled by the parent). */
+  file: File | null;
+  /** Called with the chosen file when the user drops or selects one. */
+  onFileSelected: (file: File) => void;
+  /** Clear the current selection. */
+  onClear: () => void;
+  /** Disable interaction (e.g. while a file is being read/parsed). */
+  disabled?: boolean;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function DatasetUploadField({
+  file,
+  onFileSelected,
+  onClear,
+  disabled = false,
+}: DatasetUploadFieldProps) {
+  const onDrop = useCallback(
+    (accepted: File[]) => {
+      const next = accepted[0];
+      if (next) onFileSelected(next);
+    },
+    [onFileSelected],
+  );
+
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    onDrop,
+    multiple: false,
+    disabled,
+    noClick: true,
+    noKeyboard: true,
+    accept: { "application/json": [".json"] },
+  });
+
+  if (file) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+        <div className="flex min-w-0 items-center gap-3">
+          <FileJson className="h-5 w-5 shrink-0 text-TT-purple-accent" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+              {file.name}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {formatBytes(file.size)}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          disabled={disabled}
+        >
+          <X className="mr-1 h-4 w-4" />
+          Remove
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      {...getRootProps()}
+      className={cn(
+        "flex flex-col items-center justify-center rounded-lg border-2 border-dashed px-6 py-10 text-center transition-colors",
+        isDragActive
+          ? "border-TT-purple-accent bg-TT-purple-accent/5"
+          : "border-gray-300 dark:border-gray-600",
+        disabled
+          ? "cursor-not-allowed opacity-60"
+          : "cursor-pointer hover:border-TT-purple-accent/70",
+      )}
+      onClick={() => {
+        if (!disabled) open();
+      }}
+    >
+      <input {...getInputProps()} />
+      <UploadCloud className="mb-3 h-8 w-8 text-gray-400 dark:text-gray-500" />
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        {isDragActive
+          ? "Drop the JSON file here"
+          : "Drag & drop a dataset JSON file here"}
+      </p>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        or click to browse. Expected: a JSON array of objects (.json)
+      </p>
+    </div>
+  );
+}

--- a/app/frontend/src/components/training/TrainingConfigDialog.tsx
+++ b/app/frontend/src/components/training/TrainingConfigDialog.tsx
@@ -34,10 +34,19 @@ import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import {
   fetchTrainingCatalogFull,
+  fetchCustomDatasets,
   createTrainingJob,
+  DEFAULT_DATASET_LOADER,
   type CatalogEntry,
+  type CustomDataset,
 } from "../../api/trainingApi";
 import { customToast } from "../CustomToaster";
+
+// Custom datasets share the dataset dropdown with the built-in catalog entries.
+// Prefixing their select value lets us distinguish them at submit time so we can
+// fall back to the default recipe (the training server can't consume arbitrary
+// datasets yet) while still showing the user's selection.
+const CUSTOM_DATASET_PREFIX = "custom:";
 
 // Default hyperparameters mirror the reference gemma_sst2 single-chip recipe:
 // https://github.com/tenstorrent/tt-blacksmith/blob/main/blacksmith/experiments/torch/gemma/single_chip/gemma_sst2.yaml
@@ -72,6 +81,7 @@ export function TrainingConfigDialog({
 }: TrainingConfigDialogProps) {
   const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
   const [datasets, setDatasets] = useState<CatalogEntry[]>([]);
+  const [customDatasets, setCustomDatasets] = useState<CustomDataset[]>([]);
   const [device, setDevice] = useState<string | undefined>(undefined);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -98,12 +108,18 @@ export function TrainingConfigDialog({
   useEffect(() => {
     if (!open) return;
     setCatalogLoading(true);
-    fetchTrainingCatalogFull()
-      .then(({ models, datasets: datasetEntries, device: catalogDevice }) => {
-        setCatalog(models);
-        setDatasets(datasetEntries);
-        setDevice(catalogDevice);
-      })
+    Promise.all([fetchTrainingCatalogFull(), fetchCustomDatasets()])
+      .then(
+        ([
+          { models, datasets: datasetEntries, device: catalogDevice },
+          custom,
+        ]) => {
+          setCatalog(models);
+          setDatasets(datasetEntries);
+          setCustomDatasets(custom);
+          setDevice(catalogDevice);
+        },
+      )
       .catch(() => customToast.error("Failed to load training catalog"))
       .finally(() => setCatalogLoading(false));
   }, [open]);
@@ -124,10 +140,15 @@ export function TrainingConfigDialog({
     }
     setSubmitting(true);
     try {
+      // Custom datasets can't be consumed by the training server yet, so a job
+      // that selects one still trains on the default (sst2) recipe. The UI keeps
+      // showing the user's custom selection regardless.
+      const isCustom = values.dataset.startsWith(CUSTOM_DATASET_PREFIX);
+      const datasetLoader = isCustom ? DEFAULT_DATASET_LOADER : values.dataset;
       // Map form fields to the container's `TrainingRequest` schema. Field names
       // must match exactly (e.g. `dataset_loader`, `lora_r`) or they are dropped.
       await createTrainingJob({
-        dataset_loader: values.dataset,
+        dataset_loader: datasetLoader,
         device_type: device,
         learning_rate: values.learning_rate,
         batch_size: values.batch_size,
@@ -245,6 +266,21 @@ export function TrainingConfigDialog({
                             {entry.name}
                           </SelectItem>
                         ))}
+                        {customDatasets.length > 0 && (
+                          <>
+                            <div className="px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                              Custom Datasets
+                            </div>
+                            {customDatasets.map((ds) => (
+                              <SelectItem
+                                key={`${CUSTOM_DATASET_PREFIX}${ds.id}`}
+                                value={`${CUSTOM_DATASET_PREFIX}${ds.id}`}
+                              >
+                                {ds.name}
+                              </SelectItem>
+                            ))}
+                          </>
+                        )}
                       </SelectContent>
                     </Select>
                     <FormMessage />

--- a/app/frontend/src/components/training/datasetPreview.ts
+++ b/app/frontend/src/components/training/datasetPreview.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Client-side parsing + validation for training dataset preview. No backend is
+// involved: the file is read in the browser, parsed, and a small sample is shown
+// to the user before they wire it into a training job.
+
+export type DatasetRow = Record<string, unknown>;
+
+export interface DatasetPreview {
+  /** All parsed rows (kept in memory for the preview only). */
+  rows: DatasetRow[];
+  /** Column keys, in first-seen order across the sampled rows. */
+  columns: string[];
+  /** Total number of rows in the file. */
+  totalRows: number;
+}
+
+/** A parse failure with a user-facing message. */
+export class DatasetParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DatasetParseError";
+  }
+}
+
+// Only include object rows when deriving columns; scan at most this many rows so
+// a very wide/long file does not stall the UI thread while building headers.
+const MAX_ROWS_FOR_COLUMN_DERIVATION = 200;
+
+function isPlainObject(value: unknown): value is DatasetRow {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+/**
+ * Parse the text contents of a dataset file into a preview.
+ *
+ * Supported shape (per the current feature scope): a JSON array of objects,
+ * e.g. `[{ "prompt": "...", "completion": "..." }, ...]`.
+ *
+ * Throws {@link DatasetParseError} with a friendly message for anything else.
+ */
+export function parseDatasetFile(text: string): DatasetPreview {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new DatasetParseError("The file is empty.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new DatasetParseError(`The file is not valid JSON: ${detail}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new DatasetParseError(
+      "Expected a JSON array of objects at the top level (e.g. [{ ... }, { ... }]).",
+    );
+  }
+
+  if (parsed.length === 0) {
+    throw new DatasetParseError("The dataset array is empty.");
+  }
+
+  const nonObjectIndex = parsed.findIndex((row) => !isPlainObject(row));
+  if (nonObjectIndex !== -1) {
+    throw new DatasetParseError(
+      `Every item must be an object. Item at index ${nonObjectIndex} is not an object.`,
+    );
+  }
+
+  const rows = parsed as DatasetRow[];
+  const columns = deriveColumns(rows);
+
+  return { rows, columns, totalRows: rows.length };
+}
+
+/** Collect column keys in first-seen order across the sampled rows. */
+export function deriveColumns(rows: DatasetRow[]): string[] {
+  const seen = new Set<string>();
+  const limit = Math.min(rows.length, MAX_ROWS_FOR_COLUMN_DERIVATION);
+  for (let i = 0; i < limit; i++) {
+    for (const key of Object.keys(rows[i])) {
+      seen.add(key);
+    }
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Render a single cell value for the table view. Objects/arrays are stringified;
+ * primitives are shown as-is; null/undefined render as an empty string.
+ */
+export function formatCellValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}

--- a/app/frontend/src/pages/TrainingPage.tsx
+++ b/app/frontend/src/pages/TrainingPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../api/trainingApi";
 import { customToast } from "../components/CustomToaster";
 import { TrainingConfigDialog } from "../components/training/TrainingConfigDialog";
+import { DatasetPreviewPanel } from "../components/training/DatasetPreviewPanel";
 
 const STATUS_STYLES: Record<
   string,
@@ -291,6 +292,19 @@ export default function TrainingPage() {
             )}
           </CardContent>
         </Card>
+
+        {/* Dataset management */}
+        <div className="pt-2 text-left">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Dataset Management
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Upload and preview datasets for fine-tuning
+          </p>
+        </div>
+
+        {/* Custom dataset upload & preview */}
+        <DatasetPreviewPanel />
       </div>
 
       {/* New Job Dialog */}


### PR DESCRIPTION
Lets users upload JSON datasets from the Training page, preview them in a table/JSON view, and list or delete previously uploaded datasets. Uploaded datasets are stored on the shared training volume and offered as choices in the New Training Job dialog.
