### PR TITLE
feat: add NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 for p300x2

### DIFF
--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -52,17 +52,21 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
 
 def tool_calling_launch_flags(model_name: str = "", hf_model_id: str = "") -> Optional[str]:
     """The vLLM flags a container must be launched with for coding-agent tool
-    calling, or None if the model family has no known tool-call parser."""
+    calling and/or reasoning splitting, or None if the model family needs
+    neither. A registered reasoning parser no longer requires a tool-call
+    parser: reasoning models without a known tool format (e.g. NemotronH)
+    still need --reasoning-parser so thinking ends up in reasoning_content
+    instead of leaking into the reply."""
     from shared_config.coding_agent_config import get_reasoning_parser
 
     parser = tool_call_parser_for(model_name, hf_model_id)
-    if not parser:
-        return None
-    flags = f"--enable-auto-tool-choice --tool-call-parser {parser}"
     reasoning = get_reasoning_parser(model_name)
+    parts = []
+    if parser:
+        parts.append(f"--enable-auto-tool-choice --tool-call-parser {parser}")
     if reasoning:
-        flags += f" --reasoning-parser {reasoning}"
-    return flags
+        parts.append(f"--reasoning-parser {reasoning}")
+    return " ".join(parts) if parts else None
 
 
 def resolve_deploy_image(

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -28,6 +28,10 @@ REASONING_MODELS = {
     "Qwen3-32B": "qwen3",
     "Qwen3.5-9B": "qwen3",
     "gemma-4-31B-it": "gemma4",
+    # NemotronH hybrids pre-fill `<think>\n` in the assistant turn; the
+    # completion format (`...reasoning...</think>answer`) is exactly the
+    # DeepSeek-R1 contract, so vLLM's deepseek_r1 parser splits it correctly.
+    "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4": "deepseek_r1",
 }
 
 # Suffix that selects thinking mode for a reasoning model over the gateway,

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1351,6 +1351,40 @@
       },
       "requires_dev_catalog": true,
       "param_count": 31
+    },
+    {
+      "model_name": "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      "hand_owned": true,
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      "inference_engine": "vLLM",
+      "status": "EXPERIMENTAL",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-studio/studio_images:nemotron35-lightning-30b-blackhole-0.20.0-PENDING",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "HF_MODEL": "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+        "MESH_DEVICE": "P300x2",
+        "ARCH_NAME": "blackhole",
+        "NEMOTRON_BLOCK_SIZE": "64",
+        "NEMOTRON_MAX_MODEL_LEN": "1048576",
+        "NEMOTRON_TT_CONFIG": "{\"trace_region_size\": 536870912, \"fabric_config\": \"FABRIC_1D_RING\"}",
+        "NEMOTRON_ADDITIONAL_SERVER_ARGS": "--hf-overrides '{\"quantization_config\":null}' --reasoning-parser deepseek_r1"
+      },
+      "param_count": 30,
+      "requires_dev_catalog": true,
+      "inference_artifact_ref": {
+        "P300x2": "autoport/nemotron-3.5-lightning-30b-a3b-nvfp4"
+      }
     }
   ]
 }


### PR DESCRIPTION
Makes NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 deployable and usable in the chat UI on a P300x2 board (4 chips).

The model was brought up via the tt-metal autoport pipeline on a QuietBox2 (branch `agentic-research/hous/multigoal-claude` + local autoport commits): full 52-layer NemotronH hybrid (23× Mamba-2, 6× NoPE-GQA attention, 23× sigmoid-routed MoE), TP=4 over `MeshShape(1,4)` with `FABRIC_1D_RING`, serving through the TT vLLM plugin at the model's full advertised **1,048,576-token context** (7.47/29.9 GB per-device DRAM at 1M — 3× headroom). Serving numbers: TTFT 109 ms, 64.9 t/s/user single-user (zero vLLM-specific decode overhead vs standalone), 309.8 tok/s aggregate at batch 32. All ten bringup stages completed with the runner's verification gates green (no degenerate output, context contract verified at every stage).

The model is an instruct/reasoning hybrid whose chat template pre-fills `<think>\n` (thinking on by default). Its completion format is exactly the DeepSeek-R1 contract, so it's registered in `REASONING_MODELS` with the `deepseek_r1` parser — verified on-device: chat `message.content` carries only the final answer, thinking goes to `reasoning_content`.

One backend change of note: `tool_calling_launch_flags` previously only emitted `--reasoning-parser` when the model also had a known tool-call parser. Nemotron has no verified tool-call format (per the function's own policy, unknown families get no tool parser rather than risking a wrong one), but it still needs the reasoning parser or thinking leaks into replies — so the reasoning flag is now decoupled from tool-parser availability. No behavior change for existing models (every current reasoning model also has a tool parser).

- [x] Add the catalog entry, P300x2 only so it allocates all 4 chips
- [x] Register it as a reasoning model (`deepseek_r1`) so it gets a thinking variant and clean replies
- [x] Decouple `--reasoning-parser` from tool-call-parser availability
- [ ] Build & publish the serving image to `tt-studio/studio_images` (blocked: no GHCR credentials on the bringup box; `docker_image` tag is a PENDING placeholder — the autoport currently serves via the external-server path from a tt-metal checkout, exactly as the TTI release workflow ran it)
- [ ] Push the tt-metal autoport branch referenced by `inference_artifact_ref` (same credential gap)
- [x] Served on the P300x2 box, confirmed healthy through the same inference path the UI uses (OpenAI-compatible chat completions on :8000)
- [x] Checked the server runs with `--reasoning-parser deepseek_r1` and `--hf-overrides '{"quantization_config":null}'` (the autoport loads NVFP4 weights itself)
- [x] Confirmed the weights load from the normal Hugging Face cache with no re-download

Marked EXPERIMENTAL. No tool calling for now — the NemotronH tool-call format has not been verified against any vLLM parser, and a wrong parser can break startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
