### PR TITLE
chore: bump artifact to v0.20 and add qwen3.6-27b for p300x2

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.19.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.20.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -27,6 +27,7 @@ CODING_AGENT_MODEL_TYPES = (ModelTypes.CHAT, ModelTypes.VLM)
 REASONING_MODELS = {
     "Qwen3-32B": "qwen3",
     "Qwen3.5-9B": "qwen3",
+    "Qwen3.6-27B": "qwen3",
     "gemma-4-31B-it": "gemma4",
 }
 

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,9 +1,9 @@
 {
   "source": {
-    "artifact_version": "0.18.0",
-    "generated_at": "2026-07-23T20:22:38.003837+00:00"
+    "artifact_version": "0.20.0",
+    "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 55,
+  "total_models": 58,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -19,6 +19,7 @@
       ],
       "hf_model_id": "distil-whisper/distil-large-v3",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
@@ -41,6 +42,7 @@
       ],
       "hf_model_id": "black-forest-labs/FLUX.1-dev",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
@@ -63,6 +65,7 @@
       ],
       "hf_model_id": "black-forest-labs/FLUX.1-schnell",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.18.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76",
@@ -90,9 +93,10 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.1-8B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "version": "0.19.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.19.0-b204341-9bd099c",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -117,6 +121,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.3-70B-Instruct",
       "inference_engine": "vLLM",
+      "impl": "llama3-70b-galaxy",
       "status": "COMPLETE",
       "version": "0.16.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
@@ -141,6 +146,7 @@
       ],
       "hf_model_id": "mistralai/Mistral-7B-Instruct-v0.3",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-9b67e09-a91b644",
@@ -165,6 +171,7 @@
       ],
       "hf_model_id": "mobilenetv2",
       "inference_engine": "forge",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.13.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
@@ -186,6 +193,7 @@
       ],
       "hf_model_id": "Qwen/Qwen3-32B",
       "inference_engine": "vLLM",
+      "impl": "qwen3-32b-galaxy",
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
@@ -212,6 +220,7 @@
       ],
       "hf_model_id": "microsoft/speecht5_tts",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.15.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.15.0-25891d3",
@@ -230,6 +239,7 @@
       ],
       "hf_model_id": "stabilityai/stable-diffusion-3.5-large",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
@@ -250,6 +260,7 @@
       ],
       "hf_model_id": "diffusers/stable-diffusion-xl-1.0-inpainting-0.1",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.5.0-fbbbd2da8cfab49ddf43d28dd9c0813a3c3ee2bd",
@@ -270,6 +281,7 @@
       ],
       "hf_model_id": "stabilityai/stable-diffusion-xl-base-1.0",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.11.1",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
@@ -290,6 +302,7 @@
       ],
       "hf_model_id": "stabilityai/stable-diffusion-xl-base-1.0-img-2-img",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.11.1",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.11.1-bac8b34",
@@ -308,6 +321,7 @@
       ],
       "hf_model_id": "vit",
       "inference_engine": "forge",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.13.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
@@ -326,6 +340,7 @@
       ],
       "hf_model_id": "vovnet",
       "inference_engine": "forge",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.13.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
@@ -347,6 +362,7 @@
       ],
       "hf_model_id": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
@@ -369,6 +385,7 @@
       ],
       "hf_model_id": "openai/whisper-large-v3",
       "inference_engine": "media",
+      "impl": null,
       "status": "COMPLETE",
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
@@ -387,6 +404,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-11B-Vision",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-v0.61.1-rc1-5cbc982",
@@ -410,6 +428,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-v0.61.1-rc1-5cbc982",
@@ -434,6 +453,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-1B",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.11.1",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.11.1-84b4c53-222ee06",
@@ -459,6 +479,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-1B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.11.1",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.11.1-84b4c53-222ee06",
@@ -484,6 +505,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-3B",
       "inference_engine": "vLLM",
+      "impl": "tt-transformers",
       "status": "FUNCTIONAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
@@ -508,6 +530,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-3B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.3.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-20edc39-03cb300",
@@ -530,6 +553,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-90B-Vision",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-v0.61.1-rc1-5cbc982",
@@ -553,6 +577,7 @@
       ],
       "hf_model_id": "meta-llama/Llama-3.2-90B-Vision-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-v0.61.1-rc1-5cbc982",
@@ -577,6 +602,7 @@
       ],
       "hf_model_id": "Qwen/Qwen-Image",
       "inference_engine": "media",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-be88351",
@@ -597,6 +623,7 @@
       ],
       "hf_model_id": "Qwen/Qwen-Image-2512",
       "inference_engine": "media",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-be88351",
@@ -618,6 +645,7 @@
       ],
       "hf_model_id": "Qwen/Qwen2.5-72B",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-13f44c5-0edd242",
@@ -644,6 +672,7 @@
       ],
       "hf_model_id": "Qwen/Qwen2.5-72B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-13f44c5-0edd242",
@@ -668,6 +697,7 @@
       ],
       "hf_model_id": "Qwen/Qwen2.5-VL-72B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
@@ -691,6 +721,7 @@
       ],
       "hf_model_id": "Qwen/Qwen3-VL-32B-Instruct",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.14.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.14.0-80180b9-7678b70",
@@ -716,6 +747,7 @@
       ],
       "hf_model_id": "Qwen/QwQ-32B",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.9.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-e95ffa5-48eba14",
@@ -740,6 +772,7 @@
       ],
       "hf_model_id": "resnet-50",
       "inference_engine": "forge",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.13.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
@@ -758,6 +791,7 @@
       ],
       "hf_model_id": "segformer",
       "inference_engine": "forge",
+      "impl": null,
       "status": "FUNCTIONAL",
       "version": "0.13.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.13.0-079a2c2",
@@ -776,6 +810,7 @@
       ],
       "hf_model_id": "arcee-ai/AFM-4.5B",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "EXPERIMENTAL",
       "version": "0.3.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.3.0-ae65ee5-35f023f",
@@ -801,6 +836,7 @@
       ],
       "hf_model_id": "BAAI/bge-large-en-v1.5",
       "inference_engine": "media",
+      "impl": null,
       "status": "EXPERIMENTAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
@@ -825,6 +861,7 @@
       ],
       "hf_model_id": "deepseek-ai/DeepSeek-R1-0528",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "EXPERIMENTAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.12.0-805f43d-a45c614",
@@ -848,384 +885,7 @@
       ],
       "hf_model_id": "efficientnet",
       "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "gemma-3-1b-it",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "N150"
-      ],
-      "hf_model_id": "google/gemma-3-1b-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 1
-    },
-    {
-      "model_name": "gemma-3-27b-it",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "T3K"
-      ],
-      "hf_model_id": "google/gemma-3-27b-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 27
-    },
-    {
-      "model_name": "gemma-3-4b-it",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "google/gemma-3-4b-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 4
-    },
-    {
-      "model_name": "gpt-oss-20b",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "T3K"
-      ],
-      "hf_model_id": "openai/gpt-oss-20b",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e867533-8f36910",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "VLLM_ENABLE_RESPONSES_API_STORE": "1",
-        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": "1"
-      },
-      "param_count": 20
-    },
-    {
-      "model_name": "medgemma-27b-it",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "T3K"
-      ],
-      "hf_model_id": "google/medgemma-27b-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 27
-    },
-    {
-      "model_name": "medgemma-4b-it",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "google/medgemma-4b-it",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 4
-    },
-    {
-      "model_name": "Qwen2.5-7B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "N150X4",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-7B",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-5b5db8a-e771fff",
-      "service_route": "/v1/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 7
-    },
-    {
-      "model_name": "Qwen2.5-7B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "N150X4",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-7B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-5b5db8a-e771fff",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 7
-    },
-    {
-      "model_name": "Qwen2.5-Coder-32B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY_T3K",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-17a5973-aa4ae1e",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 32
-    },
-    {
-      "model_name": "Qwen2.5-VL-32B-Instruct",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-VL-32B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 32
-    },
-    {
-      "model_name": "Qwen2.5-VL-3B-Instruct",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-VL-3B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 3
-    },
-    {
-      "model_name": "Qwen2.5-VL-7B-Instruct",
-      "model_type": "VLM",
-      "display_model_type": "VLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen2.5-VL-7B-Instruct",
-      "inference_engine": "vLLM",
-      "status": "EXPERIMENTAL",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 7
-    },
-    {
-      "model_name": "Qwen3-4B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "Qwen/Qwen3-4B",
-      "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "2048",
-        "VLLM__MAX_MODEL_LENGTH": "2048",
-        "VLLM__MIN_MODEL_LENGTH": "32"
-      },
-      "param_count": 4
-    },
-    {
-      "model_name": "Qwen3-Embedding-4B",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "GALAXY",
-        "N150",
-        "N300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-Embedding-4B",
-      "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "1024",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "1",
-        "MAX_BATCH_SIZE": "1",
-        "DEFAULT_THROTTLE_LEVEL": "0"
-      },
-      "param_count": 4
-    },
-    {
-      "model_name": "Qwen3-Embedding-8B",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "GALAXY",
-        "N150",
-        "N300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-Embedding-8B",
-      "inference_engine": "media",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-      "service_route": "/enqueue",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "1024",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "1"
-      },
-      "param_count": 8
-    },
-    {
-      "model_name": "unet",
-      "model_type": "CNN",
-      "display_model_type": "CNN",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "unet",
-      "inference_engine": "forge",
+      "impl": null,
       "status": "EXPERIMENTAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
@@ -1266,6 +926,133 @@
       "param_count": null
     },
     {
+      "model_name": "gemma-3-1b-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "N150"
+      ],
+      "hf_model_id": "google/gemma-3-1b-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 1
+    },
+    {
+      "model_name": "gemma-3-27b-it",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "T3K"
+      ],
+      "hf_model_id": "google/gemma-3-27b-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 27
+    },
+    {
+      "model_name": "gemma-3-4b-it",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "google/gemma-3-4b-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 4
+    },
+    {
+      "model_name": "gemma-4-31B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/gemma-4-31B-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "GEMMA4_PAGE_BLOCK_SIZE": "64",
+        "GEMMA4_MAX_TOKENS_ALL_USERS": "49152"
+      },
+      "param_count": 31,
+      "requires_dev_catalog": true
+    },
+    {
+      "model_name": "gpt-oss-20b",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "T3K"
+      ],
+      "hf_model_id": "openai/gpt-oss-20b",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e867533-8f36910",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ENABLE_RESPONSES_API_STORE": "1",
+        "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": "1"
+      },
+      "param_count": 20
+    },
+    {
       "model_name": "Llama-3.1-8B",
       "hand_owned": true,
       "model_type": "TRAINING",
@@ -1295,6 +1082,253 @@
         "REQUEST_PROCESSING_TIMEOUT_SECONDS": 100000
       },
       "param_count": null
+    },
+    {
+      "model_name": "medgemma-27b-it",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "T3K"
+      ],
+      "hf_model_id": "google/medgemma-27b-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-0b10c51-3499ffa",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 27
+    },
+    {
+      "model_name": "medgemma-4b-it",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "google/medgemma-4b-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c254ee3-c4f2327",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 4
+    },
+    {
+      "model_name": "Qwen2.5-7B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "N150X4",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-7B",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-5b5db8a-e771fff",
+      "service_route": "/v1/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 7
+    },
+    {
+      "model_name": "Qwen2.5-7B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "N150X4",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-7B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-5b5db8a-e771fff",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 7
+    },
+    {
+      "model_name": "Qwen2.5-Coder-32B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY_T3K",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-17a5973-aa4ae1e",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 32
+    },
+    {
+      "model_name": "Qwen2.5-VL-32B-Instruct",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-VL-32B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 32
+    },
+    {
+      "model_name": "Qwen2.5-VL-3B-Instruct",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-VL-3B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 3
+    },
+    {
+      "model_name": "Qwen2.5-VL-7B-Instruct",
+      "model_type": "VLM",
+      "display_model_type": "VLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen2.5-VL-7B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.9.0-c18569e-b2894d3",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 7
+    },
+    {
+      "model_name": "Qwen3-4B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "Qwen/Qwen3-4B",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "2048",
+        "VLLM__MAX_MODEL_LENGTH": "2048",
+        "VLLM__MIN_MODEL_LENGTH": "32"
+      },
+      "param_count": 4
+    },
+    {
+      "model_name": "Qwen3-Embedding-8B",
+      "model_type": "EMBEDDING",
+      "display_model_type": "EMBEDDING",
+      "device_configurations": [
+        "GALAXY",
+        "N150",
+        "N300",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-Embedding-8B",
+      "inference_engine": "media",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
+      "service_route": "/enqueue",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "1024",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "1"
+      },
+      "param_count": 8
     },
     {
       "model_name": "Qwen3.5-9B",
@@ -1327,17 +1361,18 @@
       }
     },
     {
-      "model_name": "gemma-4-31B-it",
+      "model_name": "Qwen3.6-27B",
       "model_type": "CHAT",
       "display_model_type": "LLM",
       "device_configurations": [
         "P300x2"
       ],
-      "hf_model_id": "google/gemma-4-31B-it",
+      "hf_model_id": "Qwen/Qwen3.6-27B",
       "inference_engine": "vLLM",
+      "impl": null,
       "status": "EXPERIMENTAL",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.18.0-c49bb76-6b4a3a7",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.20.0-de59f8a-03fa3af",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -1345,12 +1380,31 @@
         "VLLM_RPC_TIMEOUT": "900000",
         "VLLM_TARGET_DEVICE": "tt",
         "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-        "GEMMA4_PAGE_BLOCK_SIZE": "64",
-        "GEMMA4_MAX_TOKENS_ALL_USERS": "49152"
+        "TT_QWEN35_TEXT_VER": "qwen36_blackhole",
+        "HF_MODEL": "Qwen/Qwen3.6-27B",
+        "TT_MESH_GRAPH_DESC_PATH": "../../tt-metal/tt_metal/fabric/mesh_graph_descriptors/p300_x2_mesh_graph_descriptor.textproto",
+        "QWEN36_MAX_TOKENS_ALL_USERS": "525312"
       },
-      "requires_dev_catalog": true,
-      "param_count": 31
+      "param_count": 27
+    },
+    {
+      "model_name": "unet",
+      "model_type": "CNN",
+      "display_model_type": "CNN",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "unet",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
     }
   ]
 }

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1462,7 +1462,7 @@
       "param_count": 27,
       "requires_dev_catalog": true,
       "inference_artifact_ref": {
-        "P300x2": "stisi/feat-qwen38-27b-dev-spec"
+        "P300x2": "tt-studio/qwen3.8-27b-p300x2"
       }
     },
     {

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1357,7 +1357,7 @@
       "param_count": 9,
       "requires_dev_catalog": true,
       "inference_artifact_ref": {
-        "P150": "stisi/feat-qwen35-9b-blackhole-devicespec"
+        "P150": "tt-studio/qwen3.5-9b-p150"
       }
     },
     {


### PR DESCRIPTION
## Summary
This PR bumps the inference server artifact version to v0.20.0 which introduces a new model: Qwen3.6-27B on the BH QB2 (P300x2). Supporting code changes are made to enable turning on or off reasoning for the model for app integrations.