### PR TITLE
feat: add z-image-turbo for p300x2

### DIFF
--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.18.0",
     "generated_at": "2026-07-23T20:22:38.003837+00:00"
   },
-  "total_models": 56,
+  "total_models": 59,
   "models": [
     {
       "model_name": "distil-large-v3",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.18.0",
     "generated_at": "2026-07-23T20:22:38.003837+00:00"
   },
-  "total_models": 55,
+  "total_models": 56,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -1351,6 +1351,23 @@
       },
       "requires_dev_catalog": true,
       "param_count": 31
+    },
+    {
+      "model_name": "Z-Image-Turbo",
+      "model_type": "IMAGE_GENERATION",
+      "display_model_type": "IMAGE",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "Tongyi-MAI/Z-Image-Turbo",
+      "inference_engine": "media",
+      "status": "FUNCTIONAL",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+      "service_route": "/v1/images/generations",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
     }
   ]
 }


### PR DESCRIPTION
Z-Image-Turbo (Tongyi-MAI) is in the pinned v0.19.0 inference-server artifact for P300X2 but missing from the studio catalog, so it never showed up as deployable.

This adds the catalog entry exactly as a resync from the artifact would emit it — same media image tag FLUX.1-dev already uses (`0.17.0-8c48a10`), no image override, no artifact bump, no `hand_owned` flag (a future resync converges on it).

- [x] Catalog entry for Z-Image-Turbo on P300x2 (`/v1/images/generations`, media engine)
- [x] `shared_config` sync/model-config test suites pass
- [x] Deployed on a Blackhole QuietBox 2 (P300x2, all 4 chips) through the studio deploy flow on the stock pinned image: warmup completed, health endpoint reports Healthy
- [x] Generated a real image through `POST /models/image-generation/` and verified the output JPEG