### PR TITLE
fix: focus onboarding on the hugging face token

### DIFF
--- a/app/backend/api/hf_access.py
+++ b/app/backend/api/hf_access.py
@@ -11,12 +11,12 @@ import requests
 from typing import List, Dict, Optional
 
 
-# diffusers repos (Wan/FLUX) have no root config.json — check model_index.json instead
+# Only repos that are actually gated on Hugging Face belong here (Qwen and Wan
+# are public). Diffusers repos (FLUX) have no root config.json, so check
+# model_index.json instead.
 HF_GATED_MODELS = [
     ("meta-llama/Llama-3.1-8B-Instruct", "Llama 3.1", "config.json"),
     ("meta-llama/Llama-3.3-70B-Instruct", "Llama 3.3", "config.json"),
-    ("Qwen/Qwen3-32B", "Qwen3-32B", "config.json"),
-    ("Wan-AI/Wan2.2-T2V-A14B-Diffusers", "Wan2.2-T2V", "model_index.json"),
     ("black-forest-labs/FLUX.1-dev", "FLUX.1-dev", "model_index.json"),
 ]
 

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -140,7 +140,7 @@ from model_control.model_utils import (
 from shared_config.model_config import model_implmentations
 from shared_config.logger_config import get_logger
 from shared_config.backend_config import backend_config
-from shared_config.user_config import get_tts_api_key
+from shared_config.user_config import get_tts_api_key, get_tavily_api_key
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
@@ -283,7 +283,9 @@ class AgentStatusView(APIView):
         """Get agent status and discovery information"""
         import time
 
-        tavily_raw = os.environ.get("TAVILY_API_KEY", "")
+        # Read via user_config so a key saved from the Settings dialog takes
+        # effect without restarting the backend container.
+        tavily_raw = get_tavily_api_key() or ""
         tavily_configured = bool(tavily_raw) and tavily_raw != "tavily-api-key-not-configured"
 
         try:

--- a/app/frontend/src/components/HfAccessCheck.tsx
+++ b/app/frontend/src/components/HfAccessCheck.tsx
@@ -34,10 +34,10 @@ const GATED_MODELS_PLACEHOLDER: HfCheckResult[] = [
     url: "https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct",
   },
   {
-    label: "Qwen3-32B",
-    repo: "Qwen/Qwen3-32B",
+    label: "FLUX.1-dev",
+    repo: "black-forest-labs/FLUX.1-dev",
     status: "no_token" as HfCheckStatus,
-    url: "https://huggingface.co/Qwen/Qwen3-32B",
+    url: "https://huggingface.co/black-forest-labs/FLUX.1-dev",
   },
 ];
 

--- a/app/frontend/src/components/welcome/WelcomeDoneStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeDoneStep.tsx
@@ -31,8 +31,9 @@ export default function WelcomeDoneStep({ onFinish, isFinishing }: Props) {
       <div>
         <h2 className="text-2xl font-semibold">You're all set</h2>
         <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">
-          Secrets are saved on the server. You won't see this welcome again on
-          this machine. Edit anything later from the gear icon in the navbar.
+          Your settings are saved on the server, and you won't see this welcome
+          again on this machine. Edit anything later from the gear icon in the
+          navbar.
         </p>
       </div>
 

--- a/app/frontend/src/components/welcome/WelcomeHfCheckStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeHfCheckStep.tsx
@@ -21,7 +21,7 @@ export default function WelcomeHfCheckStep({ onBack, onNext }: Props) {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="space-y-5"
+      className="space-y-5 text-left"
     >
       <div>
         <h2 className="text-2xl font-semibold">Verify model access</h2>

--- a/app/frontend/src/components/welcome/WelcomeHfCheckStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeHfCheckStep.tsx
@@ -27,8 +27,8 @@ export default function WelcomeHfCheckStep({ onBack, onNext }: Props) {
         <h2 className="text-2xl font-semibold">Verify model access</h2>
         <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
           Confirm your Hugging Face token can reach the gated models TT Studio
-          uses out of the box. You can request access in a new tab and continue
-          anyway — this is a soft check.
+          uses out of the box. This is a soft check, so you can request access
+          in a new tab and continue anyway.
         </p>
       </div>
 
@@ -50,7 +50,7 @@ export default function WelcomeHfCheckStep({ onBack, onNext }: Props) {
             </Button>
           )}
           <Button onClick={onNext} disabled={!hasChecked}>
-            {hasChecked && allGranted ? "Continue" : "Continue"}
+            Continue
           </Button>
         </div>
       </div>

--- a/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
@@ -14,7 +14,7 @@ export default function WelcomeIntroStep({ onNext }: Props) {
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="space-y-6"
+      className="space-y-6 text-left"
     >
       <div>
         <h2 className="text-2xl font-semibold">Welcome to TT Studio</h2>
@@ -30,7 +30,7 @@ export default function WelcomeIntroStep({ onNext }: Props) {
           <span className="text-TT-purple">•</span>
           <span>
             A <span className="font-medium">Hugging Face token</span> gives you
-            prioritized model weight downloads, and unlocks gated models like
+            faster model weight downloads, and unlocks gated models like
             the Llama family and FLUX.1-dev.
           </span>
         </li>

--- a/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
@@ -20,8 +20,8 @@ export default function WelcomeIntroStep({ onNext }: Props) {
         <h2 className="text-2xl font-semibold">Welcome to TT Studio</h2>
         <p className="mt-2 text-sm text-stone-500 dark:text-stone-400">
           A quick setup to get your AI models running on Tenstorrent hardware.
-          You can paste API keys now or skip and configure them later from
-          Settings — everything is editable any time.
+          All you need is a Hugging Face token, and even that can wait until
+          later.
         </p>
       </div>
 
@@ -29,29 +29,15 @@ export default function WelcomeIntroStep({ onNext }: Props) {
         <li className="flex items-start gap-2">
           <span className="text-TT-purple">•</span>
           <span>
-            <span className="font-medium">Hugging Face token</span> — used to
-            download gated models like Llama 3 and Qwen.
+            A <span className="font-medium">Hugging Face token</span> gives you
+            prioritized model weight downloads, and unlocks gated models like
+            the Llama family and FLUX.1-dev.
           </span>
         </li>
         <li className="flex items-start gap-2">
           <span className="text-TT-purple">•</span>
           <span>
-            <span className="font-medium">TTS API key</span> — auto-managed;
-            authenticates media / voice (TTS &amp; STT) models for you.
-          </span>
-        </li>
-        <li className="flex items-start gap-2">
-          <span className="text-TT-purple">•</span>
-          <span>
-            <span className="font-medium">Tavily API key</span> — optional;
-            powers the search-enabled agent.
-          </span>
-        </li>
-        <li className="flex items-start gap-2">
-          <span className="text-TT-purple">•</span>
-          <span>
-            <span className="font-medium">JWT secret</span> — auto-generated and
-            persisted for you.
+            You can add or change it any time from Settings.
           </span>
         </li>
       </ul>

--- a/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
@@ -12,7 +12,6 @@ import type { SettingsResponse } from "../../api/settingsApi";
 
 export interface WelcomeSecrets {
   hf_token: string;
-  tavily_api_key: string;
 }
 
 interface Props {
@@ -90,8 +89,6 @@ export default function WelcomeSecretsStep({
   isSaving,
 }: Props) {
   const loading = !current;
-  const jwtMasked = current?.jwt_secret.masked;
-  const ttsMasked = current?.tts_api_key.masked;
   const artifact = current?.artifact;
 
   return (
@@ -102,10 +99,10 @@ export default function WelcomeSecretsStep({
       className="space-y-5"
     >
       <div>
-        <h2 className="text-2xl font-semibold">Set your secrets</h2>
+        <h2 className="text-2xl font-semibold">Add your Hugging Face token</h2>
         <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
-          All values persist on the server. Leave a field blank to skip it for
-          now or keep the existing value.
+          The token is stored on the server. Leave it blank to skip for now or
+          to keep the existing value.
         </p>
       </div>
 
@@ -126,7 +123,7 @@ export default function WelcomeSecretsStep({
           )}
         />
         <p className="text-xs text-stone-500">
-          Required to download gated models.{" "}
+          Speeds up model weight downloads and unlocks gated models.{" "}
           <a
             href="https://huggingface.co/settings/tokens"
             target="_blank"
@@ -135,55 +132,6 @@ export default function WelcomeSecretsStep({
           >
             Generate a token <ExternalLink className="w-3 h-3" />
           </a>
-        </p>
-      </div>
-
-      <div className="space-y-1.5">
-        <Label className="flex items-center gap-1">
-          <Lock className="w-3.5 h-3.5" /> TTS API key
-        </Label>
-        <Input readOnly disabled value={ttsMasked || "Auto-managed"} />
-        <p className="text-xs text-stone-500">
-          Auto-managed for media / voice (TTS &amp; STT) model auth.
-        </p>
-      </div>
-
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-2">
-          <Label htmlFor="tavily_api_key">Tavily API key</Label>
-          {current?.tavily_api_key.set && <SavedBadge />}
-        </div>
-        <RevealInput
-          id="tavily_api_key"
-          value={values.tavily_api_key}
-          onChange={(v) => onChange({ ...values, tavily_api_key: v })}
-          placeholder={fieldPlaceholder(
-            loading,
-            current?.tavily_api_key.set,
-            current?.tavily_api_key.masked,
-            "tvly-..."
-          )}
-        />
-        <p className="text-xs text-stone-500">
-          Optional. Used by the search agent.{" "}
-          <a
-            href="https://tavily.com"
-            target="_blank"
-            rel="noreferrer"
-            className="text-TT-purple inline-flex items-center gap-0.5 hover:underline"
-          >
-            tavily.com <ExternalLink className="w-3 h-3" />
-          </a>
-        </p>
-      </div>
-
-      <div className="space-y-1.5">
-        <Label className="flex items-center gap-1">
-          <Lock className="w-3.5 h-3.5" /> JWT secret
-        </Label>
-        <Input readOnly disabled value={jwtMasked || "Auto-managed"} />
-        <p className="text-xs text-stone-500">
-          Auto-generated and stored for you.
         </p>
       </div>
 

--- a/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
@@ -96,13 +96,13 @@ export default function WelcomeSecretsStep({
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="space-y-5"
+      className="space-y-5 text-left"
     >
       <div>
         <h2 className="text-2xl font-semibold">Add your Hugging Face token</h2>
         <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">
-          The token is stored on the server. Leave it blank to skip for now or
-          to keep the existing value.
+          The token is stored on the server. Leave it blank to set it up later
+          or to keep the existing value.
         </p>
       </div>
 

--- a/app/frontend/src/hooks/useAgentAvailability.ts
+++ b/app/frontend/src/hooks/useAgentAvailability.ts
@@ -64,8 +64,8 @@ export function useAgentAvailability(modelID: string | null | undefined): {
 
       if (modelHasToolCalling && !tavilyConfigured) {
         console.warn(
-          "[TT Studio] Search Agent is disabled — TAVILY_API_KEY is not configured.\n" +
-          "To enable the Search Agent, set a valid TAVILY_API_KEY in your .env file.\n" +
+          "[TT Studio] Search Agent is disabled: no Tavily API key is configured.\n" +
+          "To enable the Search Agent, add a Tavily API key in Settings (gear icon).\n" +
           "Get your API key from: https://app.tavily.com"
         );
       }

--- a/app/frontend/src/pages/WelcomePage.tsx
+++ b/app/frontend/src/pages/WelcomePage.tsx
@@ -24,7 +24,7 @@ import {
   type SettingsResponse,
 } from "../api/settingsApi";
 
-const STEPS = ["Welcome", "Secrets", "Access check", "Done"] as const;
+const STEPS = ["Welcome", "HF token", "Access check", "Done"] as const;
 
 export default function WelcomePage() {
   const navigate = useNavigate();
@@ -32,7 +32,6 @@ export default function WelcomePage() {
   const [stepIndex, setStepIndex] = useState(0);
   const [secrets, setSecrets] = useState<WelcomeSecrets>({
     hf_token: "",
-    tavily_api_key: "",
   });
 
   const { data: current } = useQuery<SettingsResponse>({
@@ -49,7 +48,6 @@ export default function WelcomePage() {
     prefilled.current = true;
     setSecrets({
       hf_token: current.hf_token.value ?? "",
-      tavily_api_key: current.tavily_api_key.value ?? "",
     });
   }, [current]);
 
@@ -59,10 +57,7 @@ export default function WelcomePage() {
       // value is not an update (re-sending the HF token would spuriously
       // flag a redeploy). Blank still means "keep the existing value".
       const body: Record<string, string> = {};
-      for (const key of [
-        "hf_token",
-        "tavily_api_key",
-      ] as const) {
+      for (const key of ["hf_token"] as const) {
         const val = secrets[key].trim();
         if (val !== "" && val !== (current?.[key].value ?? "")) body[key] = val;
       }


### PR DESCRIPTION
Follow-up to the onboarding feedback in Slack. The setup wizard front-loaded too much: auto-managed values the user can't edit, a third-party search key, and an access check that implied public models are gated.

- [x] Secrets step now asks only for the HF token; the auto-managed TTS API key and JWT secret are no longer shown, and the Tavily key is managed from the Settings dialog instead
- [x] HF token copy leads with prioritized weight downloads, with gated-model access as the secondary benefit
- [x] Access check only lists actually gated repos (Llama 3.1, Llama 3.3, FLUX.1-dev); Qwen3-32B and Wan2.2 are public and were removed from both the backend list and the frontend placeholder (verified against the HF API)
- [x] Removed em dashes from wizard copy
- [x] AgentStatusView reads the Tavily key via user_config instead of the container-start env, so a key added later in Settings enables the search agent without a backend restart

Verified with a scripted browser walkthrough of all four wizard steps (single HF field, three access rows, copy sweep), frontend type-check/lint/build, backend api + user_config test suites in a throwaway backend container (same pass/fail set as origin/dev; the failures are pre-existing harness gaps), and a live check that a Tavily key saved via user_config flips tavily_configured with no env var set.