### PR TITLE
fix: fix stale model dropdown after reset, warmup clock reset on refresh, and fake video eta

### DIFF
--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -359,6 +359,22 @@ class ModelHealthView(APIView):
                 # the container's stdout. Best-effort: if anything fails we still
                 # return the basic 202 so the badge logic is unaffected.
                 content["phase"] = _get_startup_phase(deploy_id)
+                # Anchor the frontend's warmup clock to the deploy start time so
+                # it survives page refreshes. Server-computed to avoid client
+                # clock skew; omitted if deployed_at is missing/unparseable.
+                if content["phase"] is not None:
+                    deployed_at = deploy.get("deployed_at")
+                    if deployed_at:
+                        try:
+                            started = datetime.datetime.fromisoformat(deployed_at)
+                            if started.tzinfo is None:
+                                started = started.replace(tzinfo=datetime.timezone.utc)
+                            now = datetime.datetime.now(datetime.timezone.utc)
+                            content["phase"]["elapsed_seconds"] = max(
+                                0.0, (now - started).total_seconds()
+                            )
+                        except (ValueError, TypeError):
+                            pass
                 # Bound the per-deploy progress state to currently-tracked deploys so it can't accumulate.
                 from .download_progress import prune_state
                 prune_state(set(get_deploy_cache().keys()))

--- a/app/frontend/src/components/HealthBadge.tsx
+++ b/app/frontend/src/components/HealthBadge.tsx
@@ -42,6 +42,9 @@ export interface StartupPhase {
   phases?: string[];
   phase_labels?: Record<string, string>;
   phase_base_pct?: Record<string, number>;
+  // Server-computed seconds since the deploy started; anchors the warmup
+  // clock so it survives page refreshes.
+  elapsed_seconds?: number | null;
 }
 
 interface HealthBadgeProps {

--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import axios from "axios";
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { Layers, Cpu, ArrowLeft, ChevronDown } from "lucide-react";
 import ElevatedCard from "./ui/elevated-card";
@@ -14,6 +14,7 @@ import { FirstStepForm } from "./FirstStepForm";
 import { ChipConfigStep } from "./ChipConfigStep";
 import { VoiceAgentSolutionStep } from "./VoiceAgentSolutionStep";
 import { useActiveDeploymentsContext } from "../providers/ActiveDeploymentsContext";
+import { useRefresh } from "../hooks/useRefresh";
 import type { ChipStatus } from "../types/chipStatus";
 import {
   autoPlacement,
@@ -106,6 +107,19 @@ export default function StepperDemo() {
   useEffect(() => {
     fetchChipStatus();
   }, [deploymentSignature, fetchChipStatus]);
+
+  // Refetch chip-status when a board reset completes (the NavBar reset dialog
+  // bumps these), so the model dropdown drops stale "in use by X" entries
+  // immediately instead of waiting for the idle poll or a page refresh.
+  const { refreshTrigger, resetAllNonce } = useRefresh();
+  const skipInitialRefreshRef = useRef(true);
+  useEffect(() => {
+    if (skipInitialRefreshRef.current) {
+      skipInitialRefreshRef.current = false;
+      return;
+    }
+    fetchChipStatus();
+  }, [refreshTrigger, resetAllNonce, fetchChipStatus]);
 
   // Overlay reserved devices onto chip-status so the model list greys out
   // configurations a pending deploy already claimed — before the backend

--- a/app/frontend/src/components/models/ModelPreparingBanner.tsx
+++ b/app/frontend/src/components/models/ModelPreparingBanner.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import { X, Zap, ScrollText, Download, Check, Clock } from "lucide-react";
 import { Button } from "../ui/button";
 import type { ModelRow } from "../../types/models";
@@ -58,11 +58,23 @@ function formatBytes(n?: number | null): string {
   return `${v.toFixed(decimals)} ${units[u]}`;
 }
 
-// Wall-clock seconds since the row mounted (i.e. since warmup became visible).
-function useElapsedSeconds(): number {
+// Seconds since the deploy started. Anchored to the server's elapsed_seconds
+// when available (so the clock survives page refreshes); otherwise falls back
+// to time-since-mount. Wall-clock (Date.now) based so backgrounded tabs don't
+// undercount.
+function useElapsedSeconds(serverElapsed?: number | null): number {
+  const anchorRef = useRef<number>(Date.now());
   const [seconds, setSeconds] = useState(0);
   useEffect(() => {
-    const id = setInterval(() => setSeconds((s) => s + 1), 1000);
+    if (serverElapsed != null && serverElapsed >= 0) {
+      anchorRef.current = Date.now() - serverElapsed * 1000;
+    }
+  }, [serverElapsed]);
+  useEffect(() => {
+    const tick = () =>
+      setSeconds(Math.max(0, Math.floor((Date.now() - anchorRef.current) / 1000)));
+    tick();
+    const id = setInterval(tick, 1000);
     return () => clearInterval(id);
   }, []);
   return seconds;
@@ -283,7 +295,7 @@ function PreparingRow({
   const haveSize =
     phase?.downloaded_bytes != null || phase?.total_bytes != null;
   const indeterminate = isDownloading && !haveSize;
-  const elapsed = useElapsedSeconds();
+  const elapsed = useElapsedSeconds(phase?.elapsed_seconds);
 
   return (
     <div className="w-full">

--- a/app/frontend/src/components/videoGen/VideoGenChat.tsx
+++ b/app/frontend/src/components/videoGen/VideoGenChat.tsx
@@ -6,7 +6,6 @@ import { useEffect } from "react";
 import * as ScrollArea from "@radix-ui/react-scroll-area";
 import { Button } from "../ui/button";
 import { User, Video, ChevronDown, Download, ArrowLeft } from "lucide-react";
-import { Progress } from "../ui/progress";
 import VideoInputArea from "./VideoInputArea";
 import type { VideoGenChatProps } from "./types/chat";
 import { useVideoChat } from "./hooks/useVideoChat";
@@ -149,25 +148,19 @@ const VideoGenChat: React.FC<VideoGenChatProps> = ({
                     <p className="text-sm font-medium">
                       {!progress || progress.phase === "queued"
                         ? "Queued…"
-                        : progress.percent >= 99
-                          ? "Finishing up…"
-                          : "Generating your video…"}
+                        : "Generating your video…"}
                     </p>
-                    <Progress
-                      value={progress?.percent ?? 0}
-                      className="mt-2 bg-gray-300 dark:bg-[#1a1c2a]"
-                      indicatorClassName="bg-[#7C68FA]"
-                    />
-                    {progress && progress.phase === "in_progress" ? (
-                      <p className="mt-1 text-xs text-gray-500 dark:text-white/60">
-                        {formatClock(progress.elapsedSeconds)} / ~
-                        {formatClock(progress.estimatedSeconds)}
-                      </p>
-                    ) : (
-                      <p className="mt-1 text-xs text-gray-500 dark:text-white/60">
-                        Waiting for the model…
-                      </p>
-                    )}
+                    {/* Generation time isn't known ahead of time, so show an
+                        activity bar plus the true elapsed clock instead of a
+                        percentage against a made-up estimate. */}
+                    <div className="relative mt-2 h-2 w-full overflow-hidden rounded-full bg-gray-300 dark:bg-[#1a1c2a]">
+                      <div className="absolute inset-0 rounded-full bg-gradient-to-r from-[#7C68FA]/30 via-[#7C68FA] to-[#7C68FA]/30 animate-pulse" />
+                    </div>
+                    <p className="mt-1 text-xs text-gray-500 dark:text-white/60">
+                      {progress
+                        ? formatClock(progress.elapsedSeconds)
+                        : "Waiting for the model…"}
+                    </p>
                   </div>
                 </div>
               </div>

--- a/app/frontend/src/components/videoGen/hooks/useVideoChat.ts
+++ b/app/frontend/src/components/videoGen/hooks/useVideoChat.ts
@@ -2,17 +2,13 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import { VideoMessage, VideoGenProgress } from "../types/chat";
+import { VideoMessage, VideoGenPhase, VideoGenProgress } from "../types/chat";
 import {
   submitVideoGeneration,
   getVideoStatus,
   downloadVideo,
 } from "../api/videoGeneration";
 
-// Visual fill rate for the progress bar. The server's terminal status always
-// decides when the video is actually ready; this only paces the bar. Tune as
-// more real durations are observed.
-const ESTIMATED_VIDEO_GEN_SECONDS = 255;
 const POLL_INTERVAL_MS = 2000;
 const MAX_GENERATION_MS = 15 * 60 * 1000;
 
@@ -34,7 +30,8 @@ export const useVideoChat = (modelID: string) => {
   // Timers / loop guards, kept in refs so cleanup is reliable.
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const tickTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const startedAtRef = useRef<number | null>(null); // ms epoch when in_progress first seen
+  const startedAtRef = useRef<number | null>(null); // ms epoch when the job was submitted
+  const phaseRef = useRef<VideoGenPhase>("queued");
 
   const clearTimers = useCallback(() => {
     if (pollTimerRef.current) {
@@ -57,17 +54,11 @@ export const useVideoChat = (modelID: string) => {
     []
   );
 
-  // Recompute the elapsed timer + bar percentage from the in_progress start anchor.
+  // Recompute the elapsed clock from the submit-time anchor.
   const updateElapsed = useCallback(() => {
     if (startedAtRef.current == null) return;
     const elapsedSeconds = Math.max(0, (Date.now() - startedAtRef.current) / 1000);
-    const percent = Math.min(elapsedSeconds / ESTIMATED_VIDEO_GEN_SECONDS, 0.99) * 100;
-    setProgress({
-      phase: "in_progress",
-      elapsedSeconds,
-      estimatedSeconds: ESTIMATED_VIDEO_GEN_SECONDS,
-      percent,
-    });
+    setProgress({ phase: phaseRef.current, elapsedSeconds });
   }, []);
 
   const finishGeneration = useCallback(() => {
@@ -88,12 +79,8 @@ export const useVideoChat = (modelID: string) => {
       setTextInput("");
 
       setIsGenerating(true);
-      setProgress({
-        phase: "queued",
-        elapsedSeconds: 0,
-        estimatedSeconds: ESTIMATED_VIDEO_GEN_SECONDS,
-        percent: 0,
-      });
+      phaseRef.current = "queued";
+      setProgress({ phase: "queued", elapsedSeconds: 0 });
 
       try {
         const result = await submitVideoGeneration(input, modelID);
@@ -108,6 +95,11 @@ export const useVideoChat = (modelID: string) => {
         const { jobId } = result;
         const submittedAt = Date.now();
 
+        // Anchor the elapsed clock at submit so it reports the true generation
+        // time, even if the job jumps straight from queued to completed.
+        startedAtRef.current = submittedAt;
+        tickTimerRef.current = setInterval(updateElapsed, 1000);
+
         const stop = (message: string) => {
           finishGeneration();
           appendBot(message);
@@ -121,11 +113,10 @@ export const useVideoChat = (modelID: string) => {
           try {
             const phase = await getVideoStatus(jobId, modelID);
 
-            // Start the elapsed clock + bar only once the job is actually running.
-            if (phase === "in_progress" && startedAtRef.current == null) {
-              startedAtRef.current = Date.now();
+            // Advance the label once the job is actually running.
+            if (phase === "in_progress" && phaseRef.current === "queued") {
+              phaseRef.current = "in_progress";
               updateElapsed();
-              tickTimerRef.current = setInterval(updateElapsed, 1000);
             }
 
             if (phase === "completed") {

--- a/app/frontend/src/components/videoGen/types/chat.ts
+++ b/app/frontend/src/components/videoGen/types/chat.ts
@@ -24,6 +24,4 @@ export type VideoGenPhase =
 export interface VideoGenProgress {
   phase: VideoGenPhase;
   elapsedSeconds: number;
-  estimatedSeconds: number;
-  percent: number;
 }


### PR DESCRIPTION
Three UI-feedback fixes around deploy and monitoring flows.

After a board reset, the model dropdown kept showing "in use by X" until a page refresh — the chip-status poller never listened to the reset dialog's refresh signals. The warmup card's elapsed clock was counted from component mount, so refreshing the page reset it to 0:00. And video generation paced its progress bar against a hardcoded ~4:15 estimate that had nothing to do with the real generation time.

- [x] Refetch chip status when a board reset completes, so the dropdown updates immediately (only the chip-status data refreshes, nothing else)
- [x] Add server-computed `elapsed_seconds` (from the deploy record's `deployed_at`) to the startup-phase payload and anchor the warmup clock to it; falls back to the old mount-based counter if absent
- [x] Drop the hardcoded 255s video estimate: show the true elapsed time from submit with an activity bar, and keep displaying the video the moment the job completes

Verified with the dev stack up (backend/frontend health checks green): the elapsed computation was checked against the live deploy cache in the backend container, and each flow was walked through in a scripted browser session against the real frontend with mocked API responses — dropdown clears after reset without a reload, warmup clock resumes at the true elapsed time across a page refresh, and the video appears as soon as the status flips to completed with no fake countdown. A real board reset / video-model deploy wasn't exercised since the box's hardware was occupied by a live deployment. Frontend lint and type-check pass on the touched files.