### PR TITLE
ci: allow release PR titles in commitlint check

### DIFF
--- a/.claude/skills/draft-release-notes/SKILL.md
+++ b/.claude/skills/draft-release-notes/SKILL.md
@@ -25,6 +25,11 @@ branch.
 
 If the user names a branch, use it. Don't guess a version — ask if unclear.
 
+The release PR into `main` is titled `Rc vX.Y.Z` (the **Lint PR title** check is
+skipped for `rc-*` head branches) or `release: vX.Y.Z` — see CONTRIBUTING →
+Release Process. Step 2 relies on that `Rc vX.Y.Z` merge-commit title as the
+cutoff.
+
 ## Step 1 — Study the previous releases (match the style, don't invent it)
 
 Read the **most recent two or three** published release descriptions so the new

--- a/.claude/skills/feature-branch-pr/SKILL.md
+++ b/.claude/skills/feature-branch-pr/SKILL.md
@@ -142,20 +142,38 @@ untracked dirs.
 ### 7. Commit with a human message
 
 Imperative, specific, professional. Describe what changed and why, as a
-teammate would. No AI attribution, no `Co-Authored-By` AI trailers.
+teammate would. No AI attribution, no `Co-Authored-By` AI trailers. Use the same
+Conventional Commits form as the PR title (step 8) so a squash-merge reads cleanly
+either way.
 
 ```
-git commit -m "Hide board reset button while a model is deployed"
+git commit -m "fix: hide board reset button while a model is deployed"
 ```
 
 ### 8. Push and open the PR against dev
 
+The PR title **must** follow [Conventional Commits](https://www.conventionalcommits.org/)
+— `<type>(<optional scope>): <subject>`. CI (`Validate PR Title`) rejects anything
+else, and since the repo squash-merges, this title becomes the commit message on
+`dev`. Allowed types are listed in [CONTRIBUTING.md](../../../CONTRIBUTING.md#allowed-types):
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`,
+`revert`, `release`. The subject after the type still has to read like a teammate
+wrote it — lowercase, imperative, specific:
+
+```
+fix: hide board reset button while a model is deployed
+feat(ui): add Wan2.2 video model to the deploy list
+```
+
 ```bash
 git push -u origin <username>/<short-kebab-feature>
 gh pr create --base dev \
-  --title "<human, professional title>" \
+  --title "<type>(<scope>): <human, specific subject>" \
   --body "<what changed, why, and how it was verified>"
 ```
+
+(`release: vX.Y.Z` and the bare `Rc vX.Y.Z` title are for `rc-*` release PRs into
+`main` only — not for feature work.)
 
 PR description guidance: keep it short and human — a few plain sentences on
 what changed and why, then a simple to-do list of the changes (and how they
@@ -189,3 +207,5 @@ git checkout "$ORIG"
   create.
 - **Don't** mention Claude / Claude Code / AI tooling, or add AI co-author
   trailers, in commits, PR text, or review comments.
+- **Don't** open a PR with a prose title (`Hide board reset button...`) — commitlint
+  fails it. Prefix a Conventional Commits type: `fix: hide board reset button...`.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,11 @@
 # Enforce Conventional Commits on PR titles.
 # Since we squash-merge to dev, the PR title becomes the commit message,
 # so validating the title is sufficient.
+#
+# Release branches are exempt: `rc-*` and `tt_qb2_launch_branch` PRs into `main`
+# are conventionally titled `Rc vX.Y.Z` (what `gh pr create --fill` produces from
+# the branch name). `release: vX.Y.Z` is also accepted if you prefer a
+# conventional title — see commitlint.config.js and CONTRIBUTING (Release Process).
 
 name: Lint PR Title
 
@@ -30,6 +35,17 @@ jobs:
         run: npm install --save-dev @commitlint/cli@^19.7.1 @commitlint/config-conventional@^19.7.1
 
       - name: Lint PR title
+        if: >-
+          !startsWith(github.head_ref, 'rc-') &&
+          github.head_ref != 'tt_qb2_launch_branch'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: echo "$PR_TITLE" | npx commitlint
+
+      - name: Release PR — conventional title not required
+        if: >-
+          startsWith(github.head_ref, 'rc-') ||
+          github.head_ref == 'tt_qb2_launch_branch'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: echo "Release branch $HEAD_REF - skipping conventional title check."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ We use **[Conventional Commits](https://www.conventionalcommits.org/)** for all 
 | `ci`       | Changes to CI configuration files and scripts     |
 | `chore`    | Other changes that don't modify src or test files |
 | `revert`   | Reverts a previous commit                         |
+| `release`  | Release PR from a `rc-vX.Y.Z` branch into `main`  |
 
 ### **Examples**
 
@@ -53,6 +54,7 @@ fix: stop board reset button crashing on reset-all
 docs: update CONTRIBUTING with commit convention
 ci: add commitlint workflow for PR titles
 refactor(api): simplify model-loading endpoint
+release: v2.10.0
 feat(ui)!: redesign dashboard layout
 ```
 
@@ -116,6 +118,14 @@ We actively welcome your pull requests! To ensure quality contributions, any cod
 
   - When `dev` is stable and ready for release, a **release cut branch** is created from `main`.
   - **Naming convention:** `rc-vx.x.x` (e.g., `rc-v1.2.0`).
+
+- **Release PR title:**
+
+  - Release PRs may be titled `Rc vX.Y.Z` — the **Lint PR title** check is skipped for
+    `rc-*` and `tt_qb2_launch_branch` head branches, since that title comes straight from
+    `gh pr create --fill`.
+  - `release: vX.Y.Z` is also valid if you'd rather keep `main`'s squashed history fully
+    conventional.
 
 - **Feature Inclusion:**
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,4 +2,26 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  rules: {
+    // config-conventional's default types plus `release`, used for
+    // rc-vX.Y.Z -> main pull requests (e.g. "release: v2.10.0").
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert",
+        "release",
+      ],
+    ],
+  },
 };


### PR DESCRIPTION
The PR title check rejects release PRs. `rc-* -> main` PRs are titled `Rc vX.Y.Z` (what `gh pr create --fill` produces from the branch name), which has no conventional type or subject, so it fails — see #1247. The check landed after the last few releases, so release PRs were never accounted for.

This exempts release branches from the check and adds a `release` type for anyone who'd rather use a conventional title. The two skills and CONTRIBUTING that tell people how to title a PR predate the check too, so they're updated to match what CI actually enforces.

- [x] Skip the title check for `rc-*` and `tt_qb2_launch_branch` head branches (still inside the same job, so the check reports green rather than disappearing)
- [x] Add `release` to commitlint's `type-enum`, so `release: v2.10.0` is valid
- [x] Document both in CONTRIBUTING (allowed types + Release Process)
- [x] feature-branch-pr skill: require a conventional PR title — its example title would have failed the check
- [x] draft-release-notes skill: note the release PR title convention it depends on
- [x] Verified with commitlint 19.7.1 locally: `release: v2.10.0` and `chore(release): v2.10.0` pass (both failed on the old config), prose titles still fail; workflow YAML parses and both skill frontmatters still load

App health checks are N/A — CI config and docs only.