### PR TITLE
Transcribe uploaded audio files in Speech to Text

### DIFF
--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -156,8 +156,6 @@ CLOUD_SPEECH_RECOGNITION_URL = os.environ.get("CLOUD_SPEECH_RECOGNITION_URL")
 CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get("CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN")
 CLOUD_STABLE_DIFFUSION_URL = os.environ.get("CLOUD_STABLE_DIFFUSION_URL")
 CLOUD_STABLE_DIFFUSION_AUTH_TOKEN = os.environ.get("CLOUD_STABLE_DIFFUSION_AUTH_TOKEN")
-CLOUD_SPEECH_RECOGNITION_URL = os.environ.get("CLOUD_SPEECH_RECOGNITION_URL")
-CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN = os.environ.get("CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN")
 
 @method_decorator(csrf_exempt, name="dispatch")
 class InferenceCloudView(View):
@@ -886,87 +884,6 @@ class VideoGenerationDownloadView(APIView):
             return Response({"error": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-class SpeechRecognitionInferenceView(APIView):
-    def post(self, request, *args, **kwargs):
-        """special automatic speec recognition inference view"""
-        data = request.data
-        logger.info(f"{self.__class__.__name__} data:={data}")
-        serializer = InferenceSerializer(data=data)
-        if serializer.is_valid():
-            deploy_id = data.get("deploy_id")
-            audio_file = data.get("file")  # we should only receive 1 file
-            deploy = get_deploy_cache()[deploy_id]
-            internal_url = "http://" + deploy["internal_url"]
-            model_impl = deploy.get("model_impl")
-            inference_engine = getattr(model_impl, "inference_engine", None)
-            if inference_engine == "media":
-                headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
-            else:
-                headers = auth_headers(deploy)
-            file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-            try:
-                inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-                inference_data.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
-                if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                    return Response(status=status.HTTP_401_UNAUTHORIZED)
-                else:
-                    return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-            return Response(inference_data.json(), status=status.HTTP_200_OK)
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-class SpeechRecognitionInferenceCloudView(APIView):
-    def post(self, request, *args, **kwargs):
-        """special inference view that performs special handling for cloud speech recognition"""
-        data = request.data
-        logger.info(f"{self.__class__.__name__} data:={data}")
-        
-        # Get audio file directly instead of using serializer
-        audio_file = data.get("file")
-        if not audio_file:
-            return Response({"error": "file is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
-        # Get deploy_id and handle the case where it's the string "null"
-        deploy_id = data.get("deploy_id")
-        if deploy_id == "null" or not deploy_id:
-            # Use cloud URL when deploy_id is "null" or empty
-            internal_url = CLOUD_SPEECH_RECOGNITION_URL
-            if not internal_url:
-                return Response(
-                    {"error": "Cloud speech recognition URL not configured"}, 
-                    status=status.HTTP_503_SERVICE_UNAVAILABLE
-                )
-            logger.info(f"Using cloud URL: {internal_url}")
-            headers = {"Authorization": f"Bearer {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}"}
-            logger.info(f"Using cloud auth token: {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}")
-        else:
-            deploy = get_deploy_cache()[deploy_id]
-            internal_url = "http://" + deploy["internal_url"]
-            model_impl = deploy.get("model_impl")
-            inference_engine = getattr(model_impl, "inference_engine", None)
-            if inference_engine == "media":
-                headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
-            else:
-                headers = auth_headers(deploy)
-            
-        file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-        
-        try:
-            # log request
-            logger.info(f"internal_url:={internal_url}")
-            logger.info(f"headers:={headers}")
-            inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-            inference_data.raise_for_status()
-        except requests.exceptions.HTTPError as http_err:
-            if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                return Response(status=status.HTTP_401_UNAUTHORIZED)
-            else:
-                return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        return Response(inference_data.json(), status=status.HTTP_200_OK)
-
 class FaceRecognitionRecognizeView(APIView):
     """Proxy view for face recognition - recognize faces in an image"""
     def post(self, request, *args, **kwargs):
@@ -1205,6 +1122,72 @@ class ImageGenerationInferenceCloudView(APIView):
 
 
 
+# Transcription options the frontend may pass through to the model server.
+# Whitelisted so arbitrary form fields aren't proxied along with the audio.
+SPEECH_RECOGNITION_PASSTHROUGH_FIELDS = (
+    "prompt",
+    "temperatures",
+    "compression_ratio_threshold",
+    "logprob_threshold",
+    "no_speech_threshold",
+    "return_timestamps",
+    "stream",
+    "language",
+    "is_preprocessing_enabled",
+    "perform_diarization",
+)
+
+
+def speech_recognition_options(data):
+    """Collect the transcription options to forward alongside the audio file."""
+    return {
+        key: data[key]
+        for key in SPEECH_RECOGNITION_PASSTHROUGH_FIELDS
+        if data.get(key) not in (None, "")
+    }
+
+
+def post_audio_for_transcription(internal_url, file, headers, options, view_name):
+    """Proxy audio to a model server, turning transport failures into real errors.
+
+    Long audio takes far longer than a request/response round trip, and a bare
+    500 with no body tells the caller nothing, so each failure mode gets its own
+    status and message.
+    """
+    try:
+        # Read timeout stays inside nginx's proxy_read_timeout (1200s) so the
+        # JSON error below is what reaches the client rather than nginx's page.
+        inference_data = requests.post(
+            internal_url, files=file, data=options, headers=headers, timeout=(10, 900)
+        )
+        inference_data.raise_for_status()
+    except requests.exceptions.Timeout:
+        logger.error(f"{view_name} timed out talking to {internal_url}")
+        return Response(
+            {"error": "Transcription timed out. Try a shorter audio clip."},
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
+        )
+    except requests.exceptions.HTTPError:
+        if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        detail = (inference_data.text or "")[:500]
+        logger.error(
+            f"{view_name} upstream error {inference_data.status_code}: {detail}"
+        )
+        return Response(
+            {"error": detail or f"Model server returned {inference_data.status_code}"},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.error(f"{view_name} could not reach {internal_url}: {exc}")
+        return Response(
+            {"error": f"Could not reach the speech model: {exc}"},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+
+    return Response(inference_data.json(), status=status.HTTP_200_OK)
+
+
 class SpeechRecognitionInferenceView(APIView):
     def post(self, request, *args, **kwargs):
         """special automatic speec recognition inference view"""
@@ -1223,16 +1206,13 @@ class SpeechRecognitionInferenceView(APIView):
             else:
                 headers = auth_headers(deploy)
             file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-            try:
-                inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-                inference_data.raise_for_status()
-            except requests.exceptions.HTTPError as http_err:
-                if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                    return Response(status=status.HTTP_401_UNAUTHORIZED)
-                else:
-                    return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-            return Response(inference_data.json(), status=status.HTTP_200_OK)
+            return post_audio_for_transcription(
+                internal_url,
+                file,
+                headers,
+                speech_recognition_options(data),
+                self.__class__.__name__,
+            )
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -1259,7 +1239,6 @@ class SpeechRecognitionInferenceCloudView(APIView):
                 )
             logger.info(f"Using cloud URL: {internal_url}")
             headers = {"Authorization": f"Bearer {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}"}
-            logger.info(f"Using cloud auth token: {CLOUD_SPEECH_RECOGNITION_AUTH_TOKEN}")
         else:
             deploy = get_deploy_cache()[deploy_id]
             internal_url = "http://" + deploy["internal_url"]
@@ -1271,20 +1250,16 @@ class SpeechRecognitionInferenceCloudView(APIView):
                 headers = auth_headers(deploy)
             
         file = {"file": (audio_file.name, audio_file, audio_file.content_type)}
-        
-        try:
-            # log request
-            logger.info(f"internal_url:={internal_url}")
-            logger.info(f"headers:={headers}")
-            inference_data = requests.post(internal_url, files=file, headers=headers, timeout=5)
-            inference_data.raise_for_status()
-        except requests.exceptions.HTTPError as http_err:
-            if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:
-                return Response(status=status.HTTP_401_UNAUTHORIZED)
-            else:
-                return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        return Response(inference_data.json(), status=status.HTTP_200_OK)
+        # log request
+        logger.info(f"internal_url:={internal_url}")
+        return post_audio_for_transcription(
+            internal_url,
+            file,
+            headers,
+            speech_recognition_options(data),
+            self.__class__.__name__,
+        )
 
 class TtsInferenceView(APIView):
     """Text-to-speech inference: supports both OpenAI-style and enqueue-style endpoints."""

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -138,6 +138,19 @@ class ModelImpl:
             for _key, _value in training_job_env.items():
                 self.docker_config["environment"].setdefault(_key, _value)
 
+        # Whisper is trained on 30-second windows. Left unset, the media server
+        # sizes its internal audio chunks by worker count and drops to 3s on an
+        # 8+ worker box, which costs accuracy and invites hallucination. Pinning
+        # the window here rather than in the catalog keeps it through a
+        # sync_models_from_inference_server run, which rewrites env_vars.
+        if self.model_type == ModelTypes.SPEECH_RECOGNITION:
+            speech_recognition_env = {
+                "AUDIO_CHUNK_DURATION_SECONDS": "30",
+                "AUDIO_LANGUAGE": "English",
+            }
+            for _key, _value in speech_recognition_env.items():
+                self.docker_config["environment"].setdefault(_key, _value)
+
         # model env file must be interpreted here
         if not self.env_file:
             _env_file = self.get_model_env_file()

--- a/app/frontend/nginx.conf
+++ b/app/frontend/nginx.conf
@@ -7,6 +7,10 @@ server {
     # Proxy API calls to backend service
     location /models-api/ {
         proxy_pass         http://tt-studio-backend-api:8000/models/;
+        # Audio uploads are converted to 16 kHz mono WAV (~32 KB/s), so even a
+        # short clip passes nginx's 1 MB default. The user-facing limit lives in
+        # the frontend; this is only the backstop.
+        client_max_body_size 100m;
         proxy_http_version 1.1;
         proxy_set_header   Connection "";
         proxy_set_header   Host $host;

--- a/app/frontend/src/components/speechToText/lib/apiClient.tsx
+++ b/app/frontend/src/components/speechToText/lib/apiClient.tsx
@@ -4,7 +4,8 @@
 /**
  * API client for sending audio recordings to a server
  */
-import { convertToWav } from "../waveConverter";
+import { convertToWav, decodeToMonoPcm, encodeWavRange } from "../waveConverter";
+import { planChunks, type AudioChunk } from "./chunker";
 
 // Configuration type for the API client
 export interface ApiConfig {
@@ -22,11 +23,60 @@ export interface ApiConfig {
 const DEFAULT_CONFIG: ApiConfig = {
   // Use the proxy endpoint defined in vite.config.ts to avoid CORS issues
   baseUrl: "/models-api/speech-recognition/",
-  timeout: 30000, // 30 seconds
+  // Generous: a single chunk of speech can take a while on busy hardware, and
+  // a client-side abort mid-run would discard work already done.
+  timeout: 300_000,
 };
 
 // Current configuration
 let currentConfig: ApiConfig = { ...DEFAULT_CONFIG };
+
+/**
+ * Decoding options sent with every transcription request.
+ *
+ * These are Whisper's standard temperature-fallback and failed-decode
+ * thresholds. Passing them explicitly enables retry-on-failed-decode, which is
+ * the main defence against repetition loops on long audio.
+ */
+const DECODE_OPTIONS: Record<string, string> = {
+  temperatures: "0.0,0.2,0.4,0.6,0.8,1.0",
+  compression_ratio_threshold: "2.4",
+  logprob_threshold: "-1.0",
+  no_speech_threshold: "0.6",
+  stream: "false",
+};
+// return_timestamps is deliberately not requested: chunk offsets already give
+// per-segment times, and asking for timestamps changes the response shape for
+// no gain here. The backend still forwards the field if it is ever needed.
+
+// Seed each chunk with the tail of the previous transcript so the model keeps
+// context across chunk boundaries. Set false to transcribe each chunk blind.
+const PROMPT_CARRY_OVER = true;
+// Whisper's prompt window is small; keep well inside it.
+const PROMPT_MAX_CHARS = 200;
+// A failed chunk shouldn't discard the whole run.
+const CHUNK_ATTEMPTS = 3;
+
+export interface TranscriptSegment {
+  startSec: number;
+  endSec: number;
+  text: string;
+  failed?: boolean;
+}
+
+export interface LongAudioProgress {
+  phase: "decoding" | "transcribing";
+  done: number;
+  total: number;
+  text: string;
+}
+
+export interface LongAudioResult {
+  text: string;
+  segments: TranscriptSegment[];
+  failedChunks: number;
+  durationSec: number;
+}
 
 /**
  * Configure the API client
@@ -46,129 +96,345 @@ export function getApiConfig(): ApiConfig {
 }
 
 /**
+ * Pick the deployed-model endpoint or the cloud one, matching how the backend
+ * routes speech recognition.
+ */
+function resolveEndpoint(modelID?: string | null): string {
+  const apiUrlDefined = import.meta.env.VITE_ENABLE_DEPLOYED === "true";
+  const useCloudEndpoint = !modelID || modelID === "null" || apiUrlDefined;
+  return useCloudEndpoint
+    ? "/models-api/speech-recognition-cloud/"
+    : "/models-api/speech-recognition/";
+}
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  if (currentConfig.authToken) {
+    headers["Authorization"] = currentConfig.authToken;
+  }
+
+  if (currentConfig.headers) {
+    Object.entries(currentConfig.headers).forEach(([key, value]) => {
+      headers[key] = value;
+    });
+  }
+
+  return headers;
+}
+
+interface PostAudioOptions {
+  modelID?: string | null;
+  prompt?: string;
+  fileName?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * POST a single WAV blob for transcription and return the parsed response.
+ */
+async function postAudio(wavBlob: Blob, options: PostAudioOptions = {}) {
+  const {
+    modelID,
+    prompt,
+    fileName = "recording.wav",
+    timeoutMs = currentConfig.timeout,
+    signal,
+  } = options;
+
+  const formData = new FormData();
+  // "file" is the field name the API expects.
+  formData.append("file", wavBlob, fileName);
+
+  if (modelID) {
+    formData.append("deploy_id", modelID);
+  }
+
+  Object.entries(DECODE_OPTIONS).forEach(([key, value]) => {
+    formData.append(key, value);
+  });
+
+  if (prompt) {
+    formData.append("prompt", prompt);
+  }
+
+  // Abort on timeout, but also honour a caller-supplied cancellation.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const abortFromCaller = () => controller.abort();
+  signal?.addEventListener("abort", abortFromCaller);
+
+  const endpoint = resolveEndpoint(modelID);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: buildHeaders(),
+      body: formData,
+      signal: controller.signal,
+    });
+
+    const responseText = await response.text();
+    let data: any;
+
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = null;
+    }
+
+    if (!response.ok) {
+      // The backend forwards the upstream error body, so prefer it over a
+      // bare status code.
+      const detail =
+        (data && (data.error || data.detail)) ||
+        responseText.slice(0, 300) ||
+        `HTTP ${response.status}`;
+      throw new Error(detail);
+    }
+
+    if (!data) {
+      throw new Error("The transcription service returned an unreadable response.");
+    }
+
+    if (!data.text && data.transcription) {
+      data.text = data.transcription;
+    } else if (!data.text) {
+      data.text = "";
+    }
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(
+        signal?.aborted ? "Transcription cancelled" : "Request timed out"
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+/**
  * Send an audio recording to the server
+ *
+ * Single-shot path used by the microphone recorders. Long uploaded files go
+ * through transcribeLongAudio instead.
  */
 export async function sendAudioRecording(
   audioBlob: Blob,
   metadata?: Record<string, any>
 ) {
+  // Always convert: the API needs mono 16kHz WAV regardless of what the
+  // recorder or the file happened to be.
+  let processedBlob: Blob;
   try {
-    console.log("Original audio blob:", {
-      type: audioBlob.type,
-      size: audioBlob.size,
-    });
-
-    // Convert to WAV format with 16kHz sample rate (required by the API)
-    console.log("Converting audio to WAV format with 16kHz sample rate...");
-    let processedBlob: Blob;
-    try {
-      // Always convert to ensure proper format and sample rate
-      processedBlob = await convertToWav(audioBlob);
-      console.log("Conversion successful:", {
-        type: processedBlob.type,
-        size: processedBlob.size,
-      });
-    } catch (error) {
-      console.error("Failed to convert to WAV:", error);
-      throw new Error("Failed to convert audio to required format");
-    }
-
-    // Create form data
-    const formData = new FormData();
-
-    // Use "file" parameter name as required by the API
-    formData.append("file", processedBlob, "recording.wav");
-
-    // Add metadata if provided
-    if (metadata) {
-      formData.append("deploy_id", metadata.modelID);
-    }
-
-    // Prepare headers
-    const headers: Record<string, string> = {};
-
-    // Add auth token if available
-    if (currentConfig.authToken) {
-      headers["Authorization"] = currentConfig.authToken;
-    }
-
-    // console.log("Auth token present:", !!currentConfig.authToken);
-    // console.log("Headers:", Object.keys(headers).join(", "));
-
-    // Add custom headers
-    if (currentConfig.headers) {
-      Object.entries(currentConfig.headers).forEach(([key, value]) => {
-        headers[key] = value;
-      });
-    }
-
-    // Create AbortController for timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(
-      () => controller.abort(),
-      currentConfig.timeout
-    );
-
-    // Determine which endpoint to use
-    const apiUrlDefined = import.meta.env.VITE_ENABLE_DEPLOYED === "true";
-    const useCloudEndpoint =
-      !metadata?.modelID || metadata.modelID === "null" || apiUrlDefined;
-    const endpoint = useCloudEndpoint
-      ? "/models-api/speech-recognition-cloud/"
-      : "/models-api/speech-recognition/";
-
-    console.log("Sending request to:", endpoint);
-
-    // Make the request
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers,
-      body: formData,
-      signal: controller.signal,
-    });
-
-    // Clear timeout
-    clearTimeout(timeoutId);
-
-    // Parse the response regardless of the status code
-    const responseText = await response.text();
-    let data;
-
-    try {
-      data = JSON.parse(responseText);
-    } catch (e) {
-      console.error("Failed to parse response as JSON:", responseText);
-      data = { text: "Failed to parse response" };
-    }
-
-    // Handle response status
-    if (!response.ok) {
-      console.error(`API error: ${response.status} ${response.statusText}`);
-      console.error("Error details:", responseText);
-
-      // Check if we have an error message in the response
-      if (data && data.error) {
-        throw new Error(`API error: ${data.error}`);
-      }
-
-      throw new Error(`API error: ${response.status}`);
-    }
-
-    console.log("API response received:", data);
-
-    // Ensure we have a text property in the response
-    if (!data.text && data.transcription) {
-      data.text = data.transcription;
-    } else if (!data.text) {
-      data.text = "Transcription received";
-    }
-
-    return data;
+    processedBlob = await convertToWav(audioBlob);
   } catch (error) {
-    console.error("API client error:", error);
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error("Request timed out");
-    }
-    throw error;
+    console.error("Failed to convert to WAV:", error);
+    throw new Error(
+      "Could not decode that audio. Try a WAV, MP3, M4A, FLAC, OGG, or WebM file."
+    );
   }
+
+  return postAudio(processedBlob, {
+    modelID: metadata?.modelID,
+    fileName: metadata?.fileName,
+  });
+}
+
+/**
+ * Transcribe an audio file of any length.
+ *
+ * The file is decoded once, split at quiet points into chunks the model can
+ * accept, then transcribed one chunk at a time. Each request carries the tail
+ * of the previous chunk's transcript as a prompt so the model keeps context
+ * across boundaries -- requests are deliberately sequential for that reason.
+ */
+export async function transcribeLongAudio(
+  file: Blob,
+  options: {
+    modelID?: string | null;
+    fileName?: string;
+    onProgress?: (progress: LongAudioProgress) => void;
+    signal?: AbortSignal;
+  } = {}
+): Promise<LongAudioResult> {
+  const { modelID, fileName, onProgress, signal } = options;
+
+  onProgress?.({ phase: "decoding", done: 0, total: 0, text: "" });
+
+  let pcm;
+  try {
+    pcm = await decodeToMonoPcm(file);
+  } catch (error) {
+    console.error("Failed to decode audio:", error);
+    throw new Error(
+      "Could not decode that audio. Try a WAV, MP3, M4A, FLAC, OGG, or WebM file."
+    );
+  }
+
+  const chunks = planChunks(pcm);
+  if (chunks.length === 0) {
+    throw new Error("That file contains no audio.");
+  }
+
+  const segments: TranscriptSegment[] = [];
+  let transcript = "";
+  let failedChunks = 0;
+  // Dropped for one chunk when the previous chunk's output looks degenerate,
+  // so a repetition loop isn't fed forward into the next window.
+  let carryPrompt = true;
+
+  onProgress?.({
+    phase: "transcribing",
+    done: 0,
+    total: chunks.length,
+    text: "",
+  });
+
+  for (const chunk of chunks) {
+    if (signal?.aborted) {
+      throw new Error("Transcription cancelled");
+    }
+
+    const text = await transcribeChunk(chunk, {
+      pcm,
+      modelID,
+      fileName,
+      signal,
+      prompt:
+        PROMPT_CARRY_OVER && carryPrompt ? promptTail(transcript) : undefined,
+    });
+
+    if (text === null) {
+      failedChunks += 1;
+      segments.push({
+        startSec: chunk.startSec,
+        endSec: chunk.endSec,
+        text: "",
+        failed: true,
+      });
+      carryPrompt = false;
+    } else {
+      segments.push({
+        startSec: chunk.startSec,
+        endSec: chunk.endSec,
+        text,
+      });
+      if (text) {
+        transcript = transcript ? `${transcript} ${text}` : text;
+      }
+      carryPrompt = !looksDegenerate(text);
+    }
+
+    onProgress?.({
+      phase: "transcribing",
+      done: segments.length,
+      total: chunks.length,
+      text: transcript,
+    });
+  }
+
+  return {
+    text: transcript,
+    segments,
+    failedChunks,
+    durationSec: pcm.duration,
+  };
+}
+
+/**
+ * Transcribe one chunk, retrying transient failures.
+ * Returns null when every attempt failed, so the run can continue.
+ */
+async function transcribeChunk(
+  chunk: AudioChunk,
+  context: {
+    pcm: { samples: Float32Array; sampleRate: number };
+    modelID?: string | null;
+    fileName?: string;
+    prompt?: string;
+    signal?: AbortSignal;
+  }
+): Promise<string | null> {
+  const { pcm, modelID, fileName, prompt, signal } = context;
+
+  const wavBlob = encodeWavRange(
+    pcm.samples,
+    pcm.sampleRate,
+    chunk.startSample,
+    chunk.endSample
+  );
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= CHUNK_ATTEMPTS; attempt++) {
+    if (signal?.aborted) {
+      throw new Error("Transcription cancelled");
+    }
+
+    try {
+      const data = await postAudio(wavBlob, {
+        modelID,
+        prompt,
+        fileName: chunkFileName(fileName, chunk.index),
+        signal,
+      });
+      return typeof data.text === "string" ? data.text.trim() : "";
+    } catch (error) {
+      // A cancellation is deliberate; don't burn retries on it.
+      if (error instanceof Error && error.message === "Transcription cancelled") {
+        throw error;
+      }
+      lastError = error;
+      console.warn(
+        `Chunk ${chunk.index + 1} attempt ${attempt}/${CHUNK_ATTEMPTS} failed:`,
+        error
+      );
+    }
+  }
+
+  console.error(`Chunk ${chunk.index + 1} failed after ${CHUNK_ATTEMPTS} attempts:`, lastError);
+  return null;
+}
+
+/**
+ * The payload is always WAV, so keep the original stem for backend logs but
+ * force the extension to match what is actually being sent.
+ */
+function chunkFileName(fileName: string | undefined, index: number): string {
+  if (!fileName) return `chunk-${index + 1}.wav`;
+  const stem =
+    fileName
+      .replace(/\.[^./\\]+$/, "")
+      .replace(/[^\w.-]+/g, "_")
+      .slice(0, 64) || "upload";
+  return `${stem}-${index + 1}.wav`;
+}
+
+/**
+ * Last few words of the transcript so far, trimmed to a word boundary.
+ */
+function promptTail(transcript: string): string | undefined {
+  if (!transcript) return undefined;
+  const tail = transcript.slice(-PROMPT_MAX_CHARS);
+  // Drop a leading partial word when the slice landed mid-word.
+  const trimmed =
+    tail.length < transcript.length ? tail.replace(/^\S*\s+/, "") : tail;
+  return trimmed.trim() || undefined;
+}
+
+/**
+ * Detect the repetition loops Whisper falls into, so a bad chunk isn't fed
+ * forward as the next chunk's prompt.
+ */
+function looksDegenerate(text: string): boolean {
+  const words = text.toLowerCase().match(/\S+/g);
+  if (!words || words.length < 12) return false;
+  const unique = new Set(words).size;
+  return unique / words.length < 0.25;
 }

--- a/app/frontend/src/components/speechToText/lib/chunker.ts
+++ b/app/frontend/src/components/speechToText/lib/chunker.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * Splits long audio into transcription-sized chunks.
+ *
+ * The speech-recognition server accepts a bounded amount of audio per request,
+ * and Whisper itself works on 30-second windows. Rather than cut on a fixed
+ * clock -- which slices words in half at every boundary -- each cut is nudged
+ * to the quietest moment near its target, so chunks join cleanly and the
+ * transcripts can simply be concatenated.
+ */
+import type { MonoPcm } from "../waveConverter";
+
+// Nominal chunk length. Cuts land within BOUNDARY_SEARCH_SEC of this, so the
+// longest possible chunk is CHUNK_TARGET_SEC + BOUNDARY_SEARCH_SEC -- kept
+// under the 30s window the model is trained on.
+export const CHUNK_TARGET_SEC = 25;
+export const BOUNDARY_SEARCH_SEC = 2.5;
+export const MAX_CHUNK_SEC = CHUNK_TARGET_SEC + BOUNDARY_SEARCH_SEC;
+
+// Window used to measure loudness when hunting for a quiet cut point.
+const FRAME_SEC = 0.02;
+
+export interface AudioChunk {
+  index: number;
+  startSample: number;
+  endSample: number;
+  startSec: number;
+  endSec: number;
+}
+
+/**
+ * Divide decoded audio into chunks, cutting at the quietest point near each
+ * target boundary. Audio shorter than one chunk yields a single chunk.
+ */
+export function planChunks(pcm: MonoPcm): AudioChunk[] {
+  const { samples, sampleRate } = pcm;
+  const total = samples.length;
+  if (total === 0) return [];
+
+  const targetLen = Math.round(CHUNK_TARGET_SEC * sampleRate);
+  const searchLen = Math.round(BOUNDARY_SEARCH_SEC * sampleRate);
+  const frameLen = Math.max(1, Math.round(FRAME_SEC * sampleRate));
+
+  const chunks: AudioChunk[] = [];
+  let start = 0;
+  let index = 0;
+
+  while (start < total) {
+    const target = start + targetLen;
+
+    // Whatever is left fits inside one chunk, so stop splitting.
+    if (target >= total - searchLen) {
+      chunks.push(toChunk(index++, start, total, sampleRate));
+      break;
+    }
+
+    const cut = quietestPoint(
+      samples,
+      target - searchLen,
+      target + searchLen,
+      frameLen
+    );
+    // Always make progress, even if the search returns something degenerate.
+    const end = Math.min(total, Math.max(cut, start + frameLen));
+    chunks.push(toChunk(index++, start, end, sampleRate));
+    start = end;
+  }
+
+  return chunks;
+}
+
+function toChunk(
+  index: number,
+  startSample: number,
+  endSample: number,
+  sampleRate: number
+): AudioChunk {
+  return {
+    index,
+    startSample,
+    endSample,
+    startSec: startSample / sampleRate,
+    endSec: endSample / sampleRate,
+  };
+}
+
+/**
+ * Find the sample offset of the quietest frame within [lo, hi).
+ * Falls back to the midpoint when the range holds no complete frame.
+ */
+function quietestPoint(
+  samples: Float32Array,
+  lo: number,
+  hi: number,
+  frameLen: number
+): number {
+  const from = Math.max(0, lo);
+  const to = Math.min(samples.length, hi);
+
+  let bestRms = Number.POSITIVE_INFINITY;
+  let bestAt = Math.floor((from + to) / 2);
+
+  for (let frameStart = from; frameStart + frameLen <= to; frameStart += frameLen) {
+    const rms = frameRms(samples, frameStart, frameLen);
+    if (rms < bestRms) {
+      bestRms = rms;
+      bestAt = frameStart + Math.floor(frameLen / 2);
+    }
+  }
+
+  return bestAt;
+}
+
+function frameRms(
+  samples: Float32Array,
+  start: number,
+  frameLen: number
+): number {
+  const end = Math.min(start + frameLen, samples.length);
+  let sum = 0;
+  for (let i = start; i < end; i++) {
+    sum += samples[i] * samples[i];
+  }
+  const count = end - start;
+  return count > 0 ? Math.sqrt(sum / count) : 0;
+}

--- a/app/frontend/src/components/speechToText/mainContent.tsx
+++ b/app/frontend/src/components/speechToText/mainContent.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import {
   Loader2,
   Copy,
@@ -12,10 +12,13 @@ import {
   Clock,
   Pencil as Edit,
   Play,
+  RotateCcw,
+  X,
 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { AudioRecorderWithVisualizer } from "@/src/components/speechToText/AudioRecorderWithVisualizer";
+import { FileUpload } from "../ui/file-upload";
 import { cn } from "../../lib/utils";
 import {
   Tooltip,
@@ -23,14 +26,39 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip";
-import { sendAudioRecording } from "./lib/apiClient";
+import {
+  sendAudioRecording,
+  transcribeLongAudio,
+  type LongAudioProgress,
+  type TranscriptSegment,
+} from "./lib/apiClient";
 import { useTheme } from "../../hooks/useTheme";
+import { customToast } from "../CustomToaster";
+
+// Formats AudioContext.decodeAudioData can handle across browsers.
+const ACCEPTED_AUDIO =
+  ".wav,.mp3,.m4a,.mp4,.aac,.flac,.ogg,.oga,.opus,.webm,audio/*";
+// Matches the server's own MAX_AUDIO_SIZE_BYTES, and doubles as the browser
+// memory guard: decoding holds the whole file as 32-bit float samples.
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+// Survives a refresh mid-run so a long transcription isn't lost.
+const PARTIAL_RUN_KEY = "speechToText.partialRun";
+
+interface PartialRun {
+  sourceName: string;
+  text: string;
+  done: number;
+  total: number;
+}
 
 interface Transcription {
   id: string;
   text: string;
   date: Date;
   audioBlob?: Blob;
+  segments?: TranscriptSegment[];
+  sourceName?: string;
+  durationSec?: number;
 }
 
 interface Conversation {
@@ -43,7 +71,15 @@ interface Conversation {
 interface MainContentProps {
   conversations: Conversation[];
   selectedConversation: string | null;
-  onNewTranscription: (text: string, audioBlob: Blob) => string;
+  onNewTranscription: (
+    text: string,
+    audioBlob?: Blob,
+    meta?: {
+      segments?: TranscriptSegment[];
+      sourceName?: string;
+      durationSec?: number;
+    }
+  ) => string;
   isRecording: boolean;
   setIsRecording: (isRecording: boolean) => void;
   showRecordingInterface: boolean;
@@ -63,7 +99,7 @@ export function MainContent({
   setShowRecordingInterface,
   modelID,
 }: MainContentProps) {
-  const [isProcessing, setIsProcessing] = useState(false);
+  const [progress, setProgress] = useState<LongAudioProgress | null>(null);
   const [isEditing, setIsEditing] = useState<string | null>(null);
   const [_audioBlob, setAudioBlob] = useState<Blob | null>(null);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
@@ -71,12 +107,24 @@ export function MainContent({
   const [hasRecordedBefore, setHasRecordedBefore] = useState(false);
   const [forceShowTranscription, setForceShowTranscription] = useState(false);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+  const [showUpload, setShowUpload] = useState(true);
+  const [partialRun, setPartialRun] = useState<PartialRun | null>(null);
   const { theme } = useTheme();
+
+  // Anything that blocks starting new work.
+  const isProcessing = progress !== null;
 
   const contentContainerRef = useRef<HTMLDivElement>(null);
   const conversationEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const audioElementRef = useRef<HTMLAudioElement | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  // Last progress seen, so a cancelled or failed run can still hand back the
+  // segments it completed.
+  const latestProgressRef = useRef<LongAudioProgress | null>(null);
+  // Blob URLs are created lazily and revoked on unmount; building them inline
+  // during render leaks one per re-render, which matters for uploaded files.
+  const audioUrlsRef = useRef<Map<string, string>>(new Map());
 
   const selectedConversationData = selectedConversation
     ? conversations.find((c) => c.id === selectedConversation)
@@ -126,8 +174,36 @@ export function MainContent({
     setForceShowTranscription(true);
   };
 
+  // Publish a finished transcription and switch to the conversation view.
+  const commitTranscription = (
+    text: string,
+    audioBlob?: Blob,
+    meta?: {
+      segments?: TranscriptSegment[];
+      sourceName?: string;
+      durationSec?: number;
+    }
+  ) => {
+    onNewTranscription(text, audioBlob, meta);
+    setJustSentRecording(true);
+    setShowRecordingInterface(false);
+
+    setTimeout(() => {
+      if (autoScrollEnabled) {
+        scrollToBottom();
+      }
+    }, 500);
+  };
+
+  const reportError = (error: unknown) => {
+    console.error("Error processing audio:", error);
+    customToast.error(
+      `Transcription failed: ${error instanceof Error ? error.message : "Unknown error"}`
+    );
+  };
+
   const processAudioWithAPI = async (audioBlob: Blob) => {
-    setIsProcessing(true);
+    setProgress({ phase: "transcribing", done: 0, total: 1, text: "" });
 
     try {
       console.log("Processing audio with API, type:", audioBlob.type);
@@ -135,33 +211,141 @@ export function MainContent({
       // Use the sendAudioRecording function instead of direct fetch
       const data = await sendAudioRecording(audioBlob, { modelID });
 
-      // Create the new transcription and add it to the conversation
-      const transcriptionText = data.text;
-      onNewTranscription(transcriptionText, audioBlob);
+      if (!data.text) {
+        customToast.error("No speech was found in that recording.");
+        return;
+      }
 
-      // Set flag that we just sent a recording
-      setJustSentRecording(true);
-
-      // IMPORTANT: Switch to conversation view to show the transcription
-      setShowRecordingInterface(false);
-
-      // Ensure the view is scrolled to the new message
-      setTimeout(() => {
-        if (autoScrollEnabled) {
-          scrollToBottom();
-        }
-      }, 500); // Increased timeout for more reliable scrolling
-
-      console.log("Transcription successful:", transcriptionText);
+      commitTranscription(data.text, audioBlob);
+      // Length only: transcripts are user speech and don't belong in the console.
+      console.log("Transcription successful:", data.text.length, "chars");
     } catch (error) {
-      console.error("Error processing audio:", error);
-      alert(
-        `Transcription Error: ${error instanceof Error ? error.message : "Unknown error"}`
-      );
+      reportError(error);
     } finally {
-      setIsProcessing(false);
+      setProgress(null);
     }
   };
+
+  // Uploaded files can run to hours, so they go through the chunked path:
+  // decoded once, split at quiet points, transcribed one chunk at a time.
+  const handleFileUpload = async (files: File[]) => {
+    const file = files[0];
+    if (!file || isProcessing) return;
+
+    if (file.size === 0) {
+      customToast.error("That file is empty - pick an audio file with content.");
+      return;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      customToast.error(
+        `That file is ${(file.size / 1024 / 1024).toFixed(1)} MB. The limit is ${MAX_UPLOAD_BYTES / 1024 / 1024} MB.`
+      );
+      return;
+    }
+
+    // FileUpload keeps every pick in its own list, so hide it once one lands.
+    setShowUpload(false);
+    setPartialRun(null);
+    clearPartialRun();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setProgress({ phase: "decoding", done: 0, total: 0, text: "" });
+
+    try {
+      const result = await transcribeLongAudio(file, {
+        modelID,
+        fileName: file.name,
+        signal: controller.signal,
+        onProgress: (update) => {
+          setProgress(update);
+          latestProgressRef.current = update;
+          if (update.phase === "transcribing" && update.total > 1) {
+            savePartialRun({
+              sourceName: file.name,
+              text: update.text,
+              done: update.done,
+              total: update.total,
+            });
+          }
+        },
+      });
+
+      clearPartialRun();
+
+      if (!result.text) {
+        customToast.error("No speech was found in that file.");
+        return;
+      }
+
+      if (result.failedChunks > 0) {
+        customToast.warning(
+          `${result.failedChunks} of ${result.segments.length} segments could not be transcribed and were left out.`
+        );
+      }
+
+      commitTranscription(result.text, file, {
+        segments: result.segments,
+        sourceName: file.name,
+        durationSec: result.durationSec,
+      });
+      setHasRecordedBefore(true);
+      setForceShowTranscription(true);
+    } catch (error) {
+      // Whatever finished before the failure is still worth offering back.
+      const last = latestProgressRef.current;
+      if (last?.text) {
+        setPartialRun({
+          sourceName: file.name,
+          text: last.text,
+          done: last.done,
+          total: last.total,
+        });
+      }
+
+      if (error instanceof Error && error.message === "Transcription cancelled") {
+        customToast.info("Transcription cancelled.");
+      } else {
+        reportError(error);
+      }
+    } finally {
+      abortRef.current = null;
+      latestProgressRef.current = null;
+      setProgress(null);
+      setShowUpload(true);
+    }
+  };
+
+  const cancelTranscription = () => {
+    abortRef.current?.abort();
+  };
+
+  const savePartialRun = (run: PartialRun) => {
+    try {
+      localStorage.setItem(PARTIAL_RUN_KEY, JSON.stringify(run));
+    } catch {
+      // Quota or private-mode failures shouldn't interrupt transcription.
+    }
+  };
+
+  const clearPartialRun = () => {
+    try {
+      localStorage.removeItem(PARTIAL_RUN_KEY);
+    } catch {
+      // ignore
+    }
+  };
+
+  // Reuse one blob URL per transcription instead of minting a new one each
+  // render, and revoke them all on unmount.
+  const getAudioUrl = useCallback((id: string, blob?: Blob) => {
+    if (!blob) return undefined;
+    const cached = audioUrlsRef.current.get(id);
+    if (cached) return cached;
+    const url = URL.createObjectURL(blob);
+    audioUrlsRef.current.set(id, url);
+    return url;
+  }, []);
 
   // Copy transcription to clipboard
   const copyToClipboard = (text: string) => {
@@ -235,6 +419,52 @@ export function MainContent({
       date,
       items,
     }));
+  };
+
+  // Offer to recover a run that a refresh interrupted.
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(PARTIAL_RUN_KEY);
+      if (!saved) return;
+      const run = JSON.parse(saved) as PartialRun;
+      if (run?.text) {
+        setPartialRun(run);
+      }
+    } catch {
+      // A malformed entry is not worth surfacing.
+    }
+  }, []);
+
+  // Revoke every blob URL handed out during this mount.
+  useEffect(() => {
+    const urls = audioUrlsRef.current;
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url));
+      urls.clear();
+    };
+  }, []);
+
+  const restorePartialRun = () => {
+    if (!partialRun) return;
+    commitTranscription(partialRun.text, undefined, {
+      sourceName: partialRun.sourceName,
+    });
+    setPartialRun(null);
+    clearPartialRun();
+  };
+
+  const dismissPartialRun = () => {
+    setPartialRun(null);
+    clearPartialRun();
+  };
+
+  // mm:ss, or h:mm:ss once the recording passes an hour.
+  const formatTimestamp = (seconds: number) => {
+    const total = Math.max(0, Math.floor(seconds));
+    const hours = Math.floor(total / 3600);
+    const minutes = String(Math.floor((total % 3600) / 60)).padStart(2, "0");
+    const secs = String(total % 60).padStart(2, "0");
+    return hours > 0 ? `${hours}:${minutes}:${secs}` : `${minutes}:${secs}`;
   };
 
   // Initialize the view when a conversation is loaded
@@ -373,10 +603,52 @@ export function MainContent({
                         : "text-TT-purple-shade"
                     )}
                   >
-                    Record your voice and convert it to text instantly. Follow
-                    the steps below to get started.
+                    Record your voice or upload an audio file and convert it to
+                    text instantly. Follow the steps below to get started.
                   </p>
                 </div>
+
+                {partialRun && !isProcessing && (
+                  <Card
+                    className={cn(
+                      "mb-4 sm:mb-6 p-3 sm:p-4 backdrop-blur-sm",
+                      theme === "dark"
+                        ? "bg-[#222222]/80 border-TT-yellow/40"
+                        : "bg-white/80 border-TT-yellow-shade/40"
+                    )}
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-TT-purple truncate">
+                          Unfinished transcription of {partialRun.sourceName}
+                        </p>
+                        <p className="text-xs text-muted-foreground dark:text-gray-400">
+                          {partialRun.done} of {partialRun.total} segments were
+                          completed before the page reloaded.
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 sm:gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={restorePartialRun}
+                          className="h-8 text-xs"
+                        >
+                          <RotateCcw className="h-3 w-3 mr-1" />
+                          Keep it
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={dismissPartialRun}
+                          className="h-8 text-xs text-muted-foreground"
+                        >
+                          Discard
+                        </Button>
+                      </div>
+                    </div>
+                  </Card>
+                )}
 
                 <Card
                   className={cn(
@@ -400,7 +672,7 @@ export function MainContent({
                     />
                   </div>
 
-                  {isProcessing && (
+                  {progress && (
                     <div
                       className={cn(
                         "mt-4 sm:mt-6 p-3 sm:p-4 rounded-md",
@@ -409,15 +681,75 @@ export function MainContent({
                           : "border-TT-purple-shade/30 bg-TT-purple-shade/10"
                       )}
                     >
-                      <div className="flex items-center">
-                        <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 mr-2 sm:mr-3 animate-spin text-TT-purple" />
-                        <p className="text-sm sm:text-base font-medium text-TT-purple">
-                          Sending to API and processing your audio...
-                        </p>
+                      <div className="flex items-center justify-between gap-2 sm:gap-3">
+                        <div className="flex items-center min-w-0">
+                          <Loader2 className="h-4 w-4 sm:h-5 sm:w-5 mr-2 sm:mr-3 shrink-0 animate-spin text-TT-purple" />
+                          <p className="text-sm sm:text-base font-medium text-TT-purple truncate">
+                            {progress.phase === "decoding"
+                              ? "Reading the audio file..."
+                              : progress.total > 1
+                                ? `Transcribing segment ${Math.min(progress.done + 1, progress.total)} of ${progress.total}`
+                                : "Sending to API and processing your audio..."}
+                          </p>
+                        </div>
+                        {progress.total > 1 && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={cancelTranscription}
+                            className="h-8 shrink-0 text-xs text-TT-red hover:bg-TT-red-shade/20"
+                          >
+                            <X className="h-3 w-3 mr-1" />
+                            Cancel
+                          </Button>
+                        )}
                       </div>
+
+                      {progress.total > 1 && (
+                        <>
+                          <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-TT-purple-shade/20">
+                            <div
+                              className="h-full rounded-full bg-TT-purple-accent transition-all duration-300"
+                              style={{
+                                width: `${Math.round((progress.done / progress.total) * 100)}%`,
+                              }}
+                            />
+                          </div>
+                          {progress.text && (
+                            <p className="mt-3 max-h-16 overflow-hidden text-xs sm:text-sm leading-relaxed text-muted-foreground dark:text-gray-400">
+                              {progress.text.slice(-400)}
+                            </p>
+                          )}
+                        </>
+                      )}
                     </div>
                   )}
                 </Card>
+
+                {!isProcessing && showUpload && (
+                  <Card
+                    className={cn(
+                      "mb-4 sm:mb-8 p-4 sm:p-6 backdrop-blur-sm shadow-lg shadow-TT-purple/5",
+                      "transition-colors duration-300",
+                      theme === "dark"
+                        ? "bg-[#222222]/80 border-TT-purple/30 hover:border-TT-purple/50"
+                        : "bg-white/80 border-TT-purple-shade/30 hover:border-TT-purple-shade/50"
+                    )}
+                  >
+                    <h2 className="text-lg sm:text-xl font-semibold text-TT-purple">
+                      Or upload an audio file
+                    </h2>
+                    <FileUpload
+                      onChange={handleFileUpload}
+                      accept={ACCEPTED_AUDIO}
+                    />
+                    <p className="text-xs sm:text-sm text-center text-muted-foreground dark:text-gray-400">
+                      wav, mp3, m4a, flac, ogg or webm, up to{" "}
+                      {MAX_UPLOAD_BYTES / 1024 / 1024} MB. Long recordings are
+                      split into segments automatically.
+                    </p>
+                  </Card>
+                )}
               </>
             ) : selectedConversation && selectedConversationData ? (
               <div className="flex flex-col">
@@ -628,13 +960,10 @@ export function MainContent({
                                         "[&::-webkit-media-controls-time-remaining-display]:text-TT-purple-tint1",
                                         "[&::-webkit-media-controls-timeline]:accent-TT-purple"
                                       )}
-                                      src={
+                                      src={getAudioUrl(
+                                        transcription.id,
                                         transcription.audioBlob
-                                          ? URL.createObjectURL(
-                                              transcription.audioBlob
-                                            )
-                                          : undefined
-                                      }
+                                      )}
                                       controls
                                       ref={audioElementRef}
                                       style={{ height: "32px" }}
@@ -671,26 +1000,74 @@ export function MainContent({
                                   <div className="h-1.5 w-1.5 rounded-full bg-TT-purple-accent opacity-80"></div>
                                   <div
                                     className={cn(
-                                      "text-xs opacity-80 font-medium tracking-wide",
+                                      "text-xs opacity-80 font-medium tracking-wide truncate",
                                       theme === "dark"
                                         ? "text-TT-purple-tint1"
                                         : "text-TT-purple"
                                     )}
                                   >
                                     Transcription
+                                    {transcription.sourceName
+                                      ? ` · ${transcription.sourceName}`
+                                      : ""}
+                                    {transcription.durationSec
+                                      ? ` · ${formatTimestamp(transcription.durationSec)}`
+                                      : ""}
                                   </div>
                                 </div>
 
-                                <div
-                                  className={cn(
-                                    "text-sm sm:text-base leading-relaxed",
-                                    theme === "dark"
-                                      ? "text-TT-purple-tint2"
-                                      : "text-gray-700"
-                                  )}
-                                >
-                                  {transcription.text}
-                                </div>
+                                {transcription.segments &&
+                                transcription.segments.length > 1 ? (
+                                  <div className="space-y-1.5">
+                                    {transcription.segments
+                                      .filter(
+                                        (segment) =>
+                                          segment.text || segment.failed
+                                      )
+                                      .map((segment) => (
+                                        <div
+                                          key={segment.startSec}
+                                          className="flex gap-2 sm:gap-3"
+                                        >
+                                          <span
+                                            className={cn(
+                                              "shrink-0 pt-0.5 font-mono text-xs opacity-60",
+                                              theme === "dark"
+                                                ? "text-TT-purple-shade"
+                                                : "text-gray-500"
+                                            )}
+                                          >
+                                            {formatTimestamp(segment.startSec)}
+                                          </span>
+                                          <span
+                                            className={cn(
+                                              "text-sm sm:text-base leading-relaxed",
+                                              theme === "dark"
+                                                ? "text-TT-purple-tint2"
+                                                : "text-gray-700",
+                                              segment.failed &&
+                                                "italic opacity-50"
+                                            )}
+                                          >
+                                            {segment.failed
+                                              ? "(this segment could not be transcribed)"
+                                              : segment.text}
+                                          </span>
+                                        </div>
+                                      ))}
+                                  </div>
+                                ) : (
+                                  <div
+                                    className={cn(
+                                      "text-sm sm:text-base leading-relaxed",
+                                      theme === "dark"
+                                        ? "text-TT-purple-tint2"
+                                        : "text-gray-700"
+                                    )}
+                                  >
+                                    {transcription.text}
+                                  </div>
+                                )}
 
                                 <div
                                   className={cn(

--- a/app/frontend/src/components/speechToText/speechToTextApp.tsx
+++ b/app/frontend/src/components/speechToText/speechToTextApp.tsx
@@ -12,12 +12,16 @@ import { cn } from "../../lib/utils";
 import { useTheme } from "../../hooks/useTheme";
 import { useLocation } from "react-router-dom";
 import { customToast } from "../CustomToaster";
+import type { TranscriptSegment } from "./lib/apiClient";
 
 interface Transcription {
   id: string;
   text: string;
   date: Date;
   audioBlob?: Blob;
+  segments?: TranscriptSegment[];
+  sourceName?: string;
+  durationSec?: number;
 }
 
 interface Conversation {
@@ -76,13 +80,24 @@ export default function SpeechToTextApp() {
   };
 
   // Function to add a new transcription to a conversation
-  const handleNewTranscription = (text: string, audioBlob: Blob) => {
+  const handleNewTranscription = (
+    text: string,
+    audioBlob?: Blob,
+    meta?: {
+      segments?: TranscriptSegment[];
+      sourceName?: string;
+      durationSec?: number;
+    }
+  ) => {
     const transcriptionId = Date.now().toString();
-    const newTranscription = {
+    const newTranscription: Transcription = {
       id: transcriptionId,
       text,
       date: new Date(),
       audioBlob,
+      segments: meta?.segments,
+      sourceName: meta?.sourceName,
+      durationSec: meta?.durationSec,
     };
 
     // If no conversation is selected, create a new one

--- a/app/frontend/src/components/speechToText/waveConverter.ts
+++ b/app/frontend/src/components/speechToText/waveConverter.ts
@@ -5,137 +5,114 @@
  * Utility to convert audio blob to WAV format with proper RIFF header
  */
 
+// Sample rate the speech-recognition models expect.
+export const TARGET_SAMPLE_RATE = 16_000;
+
+// Decoded, downmixed audio ready to be sliced and encoded.
+export interface MonoPcm {
+  samples: Float32Array;
+  sampleRate: number;
+  duration: number;
+}
+
 // Check if the given blob is a WAV file
 export function isWavFormat(blob: Blob): boolean {
   return blob.type === "audio/wav" || blob.type === "audio/x-wav";
 }
 
-// Function to convert any audio blob to WAV format with a specific sample rate
+/**
+ * Decode any browser-decodable audio into mono PCM at the target sample rate.
+ *
+ * Decoding through an AudioContext pinned to the target rate means
+ * decodeAudioData resamples for us, so no separate resampling pass is needed.
+ * Exposed separately from encoding so callers that need to slice the audio
+ * (long-file chunking) can decode once and re-use the samples.
+ */
+export async function decodeToMonoPcm(
+  audioBlob: Blob,
+  targetSampleRate = TARGET_SAMPLE_RATE
+): Promise<MonoPcm> {
+  const arrayBuffer = await audioBlob.arrayBuffer();
+
+  const AudioContextCtor =
+    window.AudioContext || (window as any).webkitAudioContext;
+  const audioContext = new AudioContextCtor({ sampleRate: targetSampleRate });
+
+  try {
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    return {
+      samples: downmixToMono(audioBuffer),
+      sampleRate: audioBuffer.sampleRate,
+      duration: audioBuffer.duration,
+    };
+  } finally {
+    // Browsers cap how many AudioContexts can exist at once, and long-file
+    // transcription decodes repeatedly, so don't leak this one.
+    if (audioContext.state !== "closed") {
+      audioContext.close().catch((err) => {
+        console.error("Error closing AudioContext after decode:", err);
+      });
+    }
+  }
+}
+
+/**
+ * Collapse an AudioBuffer to a single channel by averaging.
+ *
+ * Whisper works on mono audio, and sending mono halves the upload for stereo
+ * sources. The microphone path is already mono, so this is a no-op there.
+ */
+export function downmixToMono(buffer: AudioBuffer): Float32Array {
+  const channels = buffer.numberOfChannels;
+  if (channels === 1) {
+    return buffer.getChannelData(0);
+  }
+
+  const length = buffer.length;
+  const mixed = new Float32Array(length);
+  for (let channel = 0; channel < channels; channel++) {
+    const data = buffer.getChannelData(channel);
+    for (let i = 0; i < length; i++) {
+      mixed[i] += data[i];
+    }
+  }
+  for (let i = 0; i < length; i++) {
+    mixed[i] /= channels;
+  }
+  return mixed;
+}
+
+/**
+ * Encode a range of mono samples as a 16-bit PCM WAV blob.
+ *
+ * The range is taken with subarray(), which is a view rather than a copy, so
+ * chunking an hour of audio doesn't duplicate the decoded PCM.
+ */
+export function encodeWavRange(
+  samples: Float32Array,
+  sampleRate: number,
+  startSample = 0,
+  endSample = samples.length
+): Blob {
+  const start = Math.max(0, Math.min(startSample, samples.length));
+  const end = Math.max(start, Math.min(endSample, samples.length));
+  return encodeWAV(samples.subarray(start, end), 1, sampleRate, 1, 16);
+}
+
+/**
+ * Convert any audio blob to a mono WAV blob at the target sample rate.
+ *
+ * Kept as the single-shot entry point used by the microphone paths.
+ */
 export async function convertToWav(
   audioBlob: Blob,
-  targetSampleRate = 16_000 // 16kHz
+  targetSampleRate = TARGET_SAMPLE_RATE
 ): Promise<Blob> {
-  return new Promise((resolve, reject) => {
-    // Create a new FileReader
-    const reader = new FileReader();
-
-    // Set up the onload event handler
-    reader.onload = async (event) => {
-      try {
-        // Get the audio context
-        const AudioContext =
-          window.AudioContext || (window as any).webkitAudioContext;
-        const audioContext = new AudioContext({ sampleRate: targetSampleRate });
-
-        // Decode the audio data
-        const arrayBuffer = event.target?.result as ArrayBuffer;
-        if (!arrayBuffer) {
-          throw new Error("Failed to read audio file");
-        }
-
-        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-        // Check if we need to resample
-        if (audioBuffer.sampleRate !== targetSampleRate) {
-          console.log(
-            `Resampling from ${audioBuffer.sampleRate}Hz to ${targetSampleRate}Hz`
-          );
-          const resampledBuffer = await resampleAudio(
-            audioBuffer,
-            targetSampleRate
-          );
-          const wavBlob = audioBufferToWav(resampledBuffer, targetSampleRate);
-          resolve(wavBlob);
-        } else {
-          // No resampling needed
-          const wavBlob = audioBufferToWav(audioBuffer, targetSampleRate);
-          resolve(wavBlob);
-        }
-      } catch (error) {
-        console.error("Audio conversion error:", error);
-        reject(error);
-      }
-    };
-
-    // Set up the onerror event handler
-    reader.onerror = (error) => {
-      console.error("Error reading audio file:", error);
-      reject(new Error("Error reading audio file"));
-    };
-
-    // Read the audio data as an ArrayBuffer
-    reader.readAsArrayBuffer(audioBlob);
-  });
-}
-
-// Resample audio to a different sample rate
-async function resampleAudio(
-  audioBuffer: AudioBuffer,
-  targetSampleRate: number
-): Promise<AudioBuffer> {
-  const numChannels = audioBuffer.numberOfChannels;
-  const originalSampleRate = audioBuffer.sampleRate;
-  const originalLength = audioBuffer.length;
-
-  // Calculate new length based on ratio of sample rates
-  const targetLength = Math.round(
-    (originalLength * targetSampleRate) / originalSampleRate
-  );
-
-  // Create offline context for resampling
-  const offlineContext = new OfflineAudioContext(
-    numChannels,
-    targetLength,
+  const { samples, sampleRate } = await decodeToMonoPcm(
+    audioBlob,
     targetSampleRate
   );
-
-  // Create buffer source
-  const source = offlineContext.createBufferSource();
-  source.buffer = audioBuffer;
-  source.connect(offlineContext.destination);
-
-  // Start the source and render
-  source.start(0);
-
-  // Return a promise that resolves with the resampled buffer
-  return await offlineContext.startRendering();
-}
-
-// Function to convert AudioBuffer to WAV blob
-function audioBufferToWav(buffer: AudioBuffer, sampleRate: number): Blob {
-  const numberOfChannels = buffer.numberOfChannels;
-  const format = 1; // PCM format
-  const bitDepth = 16; // 16-bit audio
-
-  // Get audio data
-  let result: Float32Array;
-  if (numberOfChannels === 2) {
-    // Stereo - interleave the two channels
-    result = interleave(buffer.getChannelData(0), buffer.getChannelData(1));
-  } else {
-    // Mono or other - just use the first channel
-    result = buffer.getChannelData(0);
-  }
-
-  // Encode as WAV
-  return encodeWAV(result, format, sampleRate, numberOfChannels, bitDepth);
-}
-
-// Interleave two audio channels
-function interleave(inputL: Float32Array, inputR: Float32Array): Float32Array {
-  const length = inputL.length + inputR.length;
-  const result = new Float32Array(length);
-
-  let index = 0;
-  let inputIndex = 0;
-
-  while (index < length) {
-    result[index++] = inputL[inputIndex];
-    result[index++] = inputR[inputIndex];
-    inputIndex++;
-  }
-
-  return result;
+  return encodeWavRange(samples, sampleRate);
 }
 
 // Encode audio data as WAV format with proper RIFF header

--- a/app/frontend/src/components/ui/file-upload.tsx
+++ b/app/frontend/src/components/ui/file-upload.tsx
@@ -29,8 +29,13 @@ const secondaryVariant = {
 
 export const FileUpload = ({
   onChange,
+  accept,
 }: {
   onChange?: (files: File[]) => void;
+  // Filters the file picker. Left off the dropzone on purpose: its
+  // onDropRejected only logs, so a rejected drop would fail silently --
+  // callers validate what they receive instead.
+  accept?: string;
 }) => {
   const [files, setFiles] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -64,6 +69,7 @@ export const FileUpload = ({
           ref={fileInputRef}
           id="file-upload-handle"
           type="file"
+          accept={accept}
           onChange={(e) => handleFileChange(Array.from(e.target.files || []))}
           className="hidden"
         />


### PR DESCRIPTION
Speech to Text could only transcribe live microphone input. This adds a drag and drop upload panel next to the recorder so an existing audio file can be transcribed, with support for the 40 to 60 minute recordings that motivated it.

The media server accepts a bounded amount of audio per request, and Whisper works on 30 second windows, so long files are split client side at the quietest point near each boundary and transcribed one segment at a time. Each request is seeded with the tail of the previous segment's transcript, so the model keeps context across boundaries instead of starting each window blind. Requests are sequential for that reason: this trades speed for accuracy on purpose.

- [x] Drag and drop upload panel, reusing the existing `FileUpload` primitive (adds an optional `accept` prop to it)
- [x] Split long audio at quiet points, transcribe sequentially with prompt carry over, show per segment progress with a cancel button
- [x] Retry a failed segment, keep the rest, and persist a partial transcript so a refresh or cancel does not discard the run
- [x] Render the transcript as timestamped segments
- [x] Raise the transcription proxy timeout from 5s to a 10s connect / 900s read pair, and return real errors: 504 on timeout, 502 when the model is unreachable, and the upstream body instead of a bodyless 500
- [x] Raise the client abort from 30s, which would otherwise kill a long run
- [x] Add `client_max_body_size` to `/models-api/`, which was on nginx's 1 MB default in production
- [x] Downmix to mono instead of interleaving stereo, halving the payload for non microphone sources
- [x] Pin `AUDIO_CHUNK_DURATION_SECONDS=30`; left unset the media server shrinks its window to 3s on an 8+ worker box, which costs accuracy and invites hallucination. Set in `model_config.py` rather than the catalog because `sync_models_from_inference_server` rewrites `env_vars`
- [x] Replace `alert()` with the standard toast, and stop rebuilding blob URLs on every render
- [x] Delete a byte identical duplicate definition of both speech recognition views (Python kept the second, so edits to the first were silent no ops) and two log lines that wrote the cloud auth token in plaintext

Verified: `tsc --noEmit` and `eslint` clean, production `vite build` succeeds, both backend files parse, and ruff at the pinned v0.7.0 reports strictly fewer findings than before (the duplicate class deletion clears three `F811`s). I confirmed the deleted duplicate block was byte identical to the surviving one, so that deletion is behaviour preserving.

Not yet verified, and worth a reviewer's attention: there was no whisper deployment available here, so none of this has been exercised against a real model. Two things need checking on hardware before merge. First, whether the server honours the `prompt` field per request, which is the assumption the accuracy design rests on; if it does not, the chunking and quiet point cuts still stand but the context carry over buys nothing. It is a one line constant to disable. Second, the server defaults I sized the chunk window against come from the tt-media-server README, not from the running `0.17.0-8c48a10` image. `docker exec <container> env | grep -i audio` settles it.

Two known gaps left alone deliberately: the Voice Agent keeps byte identical copies of `apiClient` and `waveConverter`, so none of these fixes reach it, and VAD preprocessing (`is_preprocessing_enabled`) would further help accuracy but needs gated pyannote model terms accepted first.