### PR TITLE
feat: add machine-readable NDJSON event stream to the launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ python run.py --purge-all     # wipe containers, volumes, HF-cached models and .
 python run.py --purge-model   # uninstall specific model(s); bare flag opens a picker
 python run.py --logs          # stream all container logs (docker compose logs -f, env-file wired)
 python run.py --info          # re-show the "TT Studio is ready" summary (URLs, mode, hardware)
+python run.py --status --json # one-shot NDJSON state dump (services, HEAD, hardware) — no TUI
+python run.py --json-events   # stream bring-up as NDJSON events (see dev-docs/json-events.md)
 python run.py --no-clear      # start without clearing the terminal; stream full startup detail
 python run.py --report-bug    # bundle logs (logs/tt-studio-logs-ttbr-*.zip) + open a GitHub issue
 python run.py --install-shortcut # add a `tt-studio` shell shortcut (~/.zshrc/~/.bashrc)
@@ -95,7 +97,8 @@ Backend (in `app/backend/`): `./manage.py runserver 0.0.0.0:8000`, and tests via
   [Model interface](dev-docs/model-interface.md),
   [vLLM models](dev-docs/HowToRun_vLLM_Models.md),
   [Launcher terminal design](dev-docs/launcher-terminal-design.md) (read before changing
-  `tt_setup/` terminal output). Also [README](README.md),
+  `tt_setup/` terminal output), [JSON events](dev-docs/json-events.md) (the
+  `--json-events` NDJSON schema). Also [README](README.md),
   [Contributing](CONTRIBUTING.md), [Agent](app/agent/README.md).
 - `.cursor/rules/` — Cursor rules: `general`, `backend`, `frontend`,
   `docker-deployment`, `ai-models`, `project-overview`.

--- a/dev-docs/json-events.md
+++ b/dev-docs/json-events.md
@@ -1,0 +1,85 @@
+# Machine-readable event stream (`--json-events` / `--status --json`)
+
+The launcher can report progress as **NDJSON** (one JSON object per line on
+stdout) so a wrapping program — e.g. a desktop launcher — can render bring-up
+natively instead of scraping the Rich/ANSI terminal output.
+
+Two entry points use it:
+
+```bash
+python run.py --json-events      # full bring-up, streaming events as it runs
+python run.py --status --json    # one-shot state dump (no TUI), then exit
+```
+
+In both modes **stdout carries nothing but events** — the human-facing output
+(panels, spinners, prompts' text) moves to stderr — and the stream is safe to
+read from a PTY or a pipe (no ANSI escapes either way). The implementation
+lives in `tt_setup/console/_events.py`; the phase taps in
+`tt_setup/console/_stepper.py`.
+
+## Envelope
+
+Every line is one JSON object with exactly these keys, in this order:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `v` | int | Schema version. Currently `1`; bumped only on breaking changes. |
+| `ts` | float | Unix timestamp of the event. |
+| `event` | string | Event type (below). |
+| `phase` | string \| null | The setup phase the event belongs to (`Checks`, `Configure`, `Services`, `Build`/`Pull`, `Launch`), or `null` outside any phase. |
+| `detail` | object | Type-specific payload (may be empty). |
+
+Consumers should ignore lines that don't parse as JSON (on the very first run
+of a fresh checkout, the pre-Rich bootstrap prints a few plain setup lines
+before the CLI — and the venv — exist) and tolerate unknown event types and
+extra `detail` keys: additions are non-breaking within `v: 1`.
+
+## Event types
+
+| `event` | When | `detail` |
+| --- | --- | --- |
+| `phase_begin` | A setup phase starts. | `index` (1-based), `total` |
+| `phase_end` | A phase resolves. | `index`, `status` (`"ok"` \| `"failed"`), `duration_s` (omitted on abort paths) |
+| `progress` | Activity inside a phase: the current sub-step (`activity`), a Docker build/pull milestone (`kind`, `service`, `label`), or a phase retitle (`kind: "phase_renamed"`, e.g. Pull → Build fallback). | varies as above |
+| `note` | Informational note (e.g. why the image pull was skipped). | `text` |
+| `warn` | Actionable warning — the same items the terminal recaps in "Needs attention". | `text` |
+| `error` | Something failed. **Always** carries a fix. | `message`, `remediation`, plus context (`service`, `container`, `log`, `exit_code`) when known |
+| `prompt_blocked` | The run needed interactive input; `--json-events` implies non-interactive, so it exits (code 2) instead of hanging. | `prompt`, `remediation` |
+| `ready` | Bring-up finished; the stack is usable. | `urls` (`app`, and unless skipped `fastapi`, `docker_control`), `hardware` (detected label) |
+| `status` | `--status --json` only: the one-shot state dump. | `services` (list of `{name, port, url, healthy}`), `head` (short git SHA), `hardware` |
+
+## Example: a successful bring-up
+
+```json
+{"v": 1, "ts": 1787179000.1, "event": "phase_begin", "phase": "Checks", "detail": {"index": 1, "total": 5}}
+{"v": 1, "ts": 1787179000.2, "event": "progress", "phase": "Checks", "detail": {"activity": "tt-smi"}}
+{"v": 1, "ts": 1787179003.7, "event": "phase_end", "phase": "Checks", "detail": {"index": 1, "status": "ok", "duration_s": 3.5}}
+{"v": 1, "ts": 1787179004.0, "event": "phase_begin", "phase": "Configure", "detail": {"index": 2, "total": 5}}
+{"v": 1, "ts": 1787179060.0, "event": "progress", "phase": "Build", "detail": {"kind": "pulled", "service": "frontend"}}
+{"v": 1, "ts": 1787179095.4, "event": "ready", "phase": null, "detail": {"urls": {"app": "http://localhost:3000", "fastapi": "http://localhost:8001", "docker_control": "http://localhost:8002"}, "hardware": "QuietBox (QB2) · 4 device(s)"}}
+```
+
+And a failure:
+
+```json
+{"v": 1, "ts": 1787179050.0, "event": "error", "phase": "Launch", "detail": {"message": "Inference server didn't start — port 8001 is still taken", "remediation": "lsof -i :8001; python run.py --stop, then re-run", "service": "Inference server", "log": "fastapi.log"}}
+{"v": 1, "ts": 1787179050.1, "event": "phase_end", "phase": "Launch", "detail": {"index": 5, "status": "failed"}}
+```
+
+## Semantics a consumer can rely on
+
+- **Stable envelope.** The five envelope keys, their order, and `v` are the
+  compatibility contract; the stream is valid NDJSON end to end.
+- **Phase roadmap.** A normal run emits `phase_begin`/`phase_end` pairs for the
+  5 phases in order. Phase 4 may begin as `Pull` and be renamed to `Build`
+  (signalled via `progress` / `kind: "phase_renamed"`).
+- **Exactly one terminal outcome.** Success ends with `ready`; failure ends
+  with an `error` (with `remediation`) and/or a `phase_end` with
+  `status: "failed"`, and a non-zero exit code.
+- **Non-interactive.** With `--json-events` the launcher never waits on stdin:
+  any would-be prompt becomes `prompt_blocked` + exit code 2. Pre-answer via
+  `.env` / flags (e.g. `HF_TOKEN`, `--accept-terms`, `-y`).
+- **stderr is human.** Anything on stderr is display output; don't parse it.
+
+Tests: `tests/test_events.py` (emitter + stepper taps) and
+`tests/test_json_stream.py` (end-to-end stream purity, incl. a PTY check).

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -66,6 +66,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | --- | --- |
 | `--stop` | Stop TT Studio: tear down Docker containers and networks, keep the persistent volume. (Deprecated alias: `--cleanup`.) |
 | `--status` | Open the live monitor TUI for a running stack (health, ports, hardware). |
+| `--status --json` | One-shot machine-readable state dump instead of the TUI: a single NDJSON `status` event on stdout with per-service health, the current HEAD, and the hardware label. See [json-events.md](json-events.md). |
 | `--logs` | Stream all container logs (`docker compose logs -f`). Wires up `--env-file` so there are no "variable is not set" warnings; add `--dev` to match a dev bring-up. |
 | `--info` | Re-show the "TT Studio is ready" summary panel (URLs, mode, classified hardware) from live probes — handy after the banner has scrolled away. |
 
@@ -91,6 +92,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | `--no-sudo` | Skip sudo usage for FastAPI setup (may limit functionality). |
 | `--no-browser` | Don't open the frontend in a browser automatically. |
 | `--wait-for-services` | Block until all services report healthy before returning. |
+| `--json-events` | Emit machine-readable NDJSON events on stdout for a wrapping program (e.g. a desktop launcher): phase lifecycle, progress, warnings, errors with remediation, and a final `ready` event. Implies non-interactive — prompts become `prompt_blocked` events — and moves human output to stderr. Schema: [json-events.md](json-events.md). |
 | `--browser-timeout N` | Seconds to wait for the frontend before opening the browser (default `60`). |
 
 ### Developer Tools

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,9 @@ class TestCli(unittest.TestCase):
         from tt_setup import console
         console.set_no_clear(False)
         console.set_verbose(False)
+        # --json-events / --status --json enable the global NDJSON emitter (and
+        # re-point stdout); make sure that never leaks into later tests.
+        console.events.disable()
 
     def test_help_lists_flags(self):
         result = runner.invoke(M.app, ["--help"])
@@ -33,7 +36,7 @@ class TestCli(unittest.TestCase):
         output_without_ansi = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         for flag in ("--dev", "--stop", "--purge-all", "--purge-model", "--help-env",
                      "--no-sudo", "--logs", "--info", "--uninstall", "--switch",
-                     "--build-images", "--no-clear"):
+                     "--build-images", "--no-clear", "--json-events", "--json"):
             self.assertIn(flag, output_without_ansi)
 
     def test_info_flag_dispatches_to_ready_panel(self):
@@ -255,6 +258,45 @@ class TestCli(unittest.TestCase):
         run.assert_called_once()
         self.assertTrue(console.no_clear())
         self.assertTrue(console.is_verbose())
+
+    def test_json_without_status_is_a_usage_error(self):
+        result = runner.invoke(M.app, ["--json"])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_status_json_dispatches_to_json_dump_not_the_tui(self):
+        import tt_setup.monitor as monitor
+        with patch.object(monitor, "run_status_json", return_value=0) as dump, \
+             patch.object(monitor, "run_status") as tui:
+            result = runner.invoke(M.app, ["--status", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        dump.assert_called_once()
+        tui.assert_not_called()
+
+    def test_status_without_json_still_opens_the_tui(self):
+        import tt_setup.monitor as monitor
+        with patch.object(monitor, "run_status", return_value=0) as tui, \
+             patch.object(monitor, "run_status_json") as dump:
+            result = runner.invoke(M.app, ["--status"])
+        self.assertEqual(result.exit_code, 0)
+        tui.assert_called_once()
+        dump.assert_not_called()
+
+    def test_json_events_enables_emitter_and_threads_into_args(self):
+        from tt_setup.cli import _args
+        from tt_setup.console import events
+        with patch.object(_args, "_run") as run:
+            result = runner.invoke(M.app, ["--json-events"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(events.enabled())
+        ns = run.call_args.args[0]
+        self.assertTrue(ns.json_events)
+
+    def test_emitter_stays_off_without_the_flags(self):
+        from tt_setup.cli import _args
+        from tt_setup.console import events
+        with patch.object(_args, "_run"):
+            runner.invoke(M.app, ["--dev"])
+        self.assertFalse(events.enabled())
 
     def test_main_is_callable_entrypoint(self):
         self.assertTrue(callable(M.main))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the NDJSON event emitter (tt_setup/console/_events.py)."""
+import io
+import json
+import sys
+import unittest
+
+from tt_setup.console import _events as events
+
+
+class TestEventEmitter(unittest.TestCase):
+    def tearDown(self):
+        # The emitter is module-global state; never leak it into other tests.
+        events.disable()
+
+    def _enable_buffer(self):
+        buf = io.StringIO()
+        events.enable(stream=buf)
+        return buf
+
+    def test_disabled_by_default_and_emit_is_noop(self):
+        self.assertFalse(events.enabled())
+        # Must not raise (and must write nowhere) while disabled.
+        events.emit("note", detail={"text": "ignored"})
+
+    def test_emit_writes_one_stable_keyed_json_line(self):
+        buf = self._enable_buffer()
+        events.emit("phase_begin", phase="Checks", detail={"index": 1, "total": 5})
+        lines = buf.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        rec = json.loads(lines[0])
+        # Key order is part of the schema contract (stable for consumers).
+        self.assertEqual(list(rec.keys()), ["v", "ts", "event", "phase", "detail"])
+        self.assertEqual(rec["v"], events.SCHEMA_VERSION)
+        self.assertIsInstance(rec["ts"], float)
+        self.assertEqual(rec["event"], "phase_begin")
+        self.assertEqual(rec["phase"], "Checks")
+        self.assertEqual(rec["detail"], {"index": 1, "total": 5})
+
+    def test_phase_defaults_to_null_and_detail_to_empty(self):
+        buf = self._enable_buffer()
+        events.emit("warn")
+        rec = json.loads(buf.getvalue())
+        self.assertIsNone(rec["phase"])
+        self.assertEqual(rec["detail"], {})
+
+    def test_stream_is_parseable_ndjson(self):
+        buf = self._enable_buffer()
+        events.emit("phase_begin", phase="Checks")
+        events.emit("progress", phase="Checks", detail={"activity": "tt-smi"})
+        events.emit("phase_end", phase="Checks", detail={"status": "ok"})
+        records = [json.loads(line) for line in buf.getvalue().splitlines()]
+        self.assertEqual([r["event"] for r in records],
+                         ["phase_begin", "progress", "phase_end"])
+
+    def test_ready_event_carries_urls_and_hardware(self):
+        buf = self._enable_buffer()
+        events.emit_ready(
+            urls={"app": "http://localhost:3000",
+                  "fastapi": "http://localhost:8001",
+                  "docker_control": "http://localhost:8002"},
+            hardware="QuietBox (QB2)")
+        rec = json.loads(buf.getvalue())
+        self.assertEqual(rec["event"], "ready")
+        self.assertEqual(rec["detail"]["urls"]["app"], "http://localhost:3000")
+        self.assertEqual(rec["detail"]["urls"]["fastapi"], "http://localhost:8001")
+        self.assertEqual(rec["detail"]["urls"]["docker_control"], "http://localhost:8002")
+        self.assertEqual(rec["detail"]["hardware"], "QuietBox (QB2)")
+
+    def test_error_event_carries_remediation(self):
+        buf = self._enable_buffer()
+        events.emit_error("inference server didn't start",
+                          remediation="tail -50 fastapi.log", phase="Launch",
+                          service="Inference server")
+        rec = json.loads(buf.getvalue())
+        self.assertEqual(rec["event"], "error")
+        self.assertEqual(rec["phase"], "Launch")
+        self.assertEqual(rec["detail"]["remediation"], "tail -50 fastapi.log")
+        self.assertEqual(rec["detail"]["service"], "Inference server")
+
+    def test_prompt_blocked_event(self):
+        buf = self._enable_buffer()
+        events.emit_prompt_blocked("Enter your HF token",
+                                   remediation="set HF_TOKEN in .env")
+        rec = json.loads(buf.getvalue())
+        self.assertEqual(rec["event"], "prompt_blocked")
+        self.assertEqual(rec["detail"]["prompt"], "Enter your HF token")
+        self.assertIn("HF_TOKEN", rec["detail"]["remediation"])
+
+    def test_non_serializable_detail_degrades_to_str(self):
+        buf = self._enable_buffer()
+        events.emit("note", detail={"obj": object()})
+        rec = json.loads(buf.getvalue())  # default=str keeps the line valid JSON
+        self.assertIsInstance(rec["detail"]["obj"], str)
+
+    def test_broken_stream_never_raises(self):
+        class Broken:
+            def write(self, _):
+                raise BrokenPipeError
+            def flush(self):
+                raise BrokenPipeError
+        events.enable(stream=Broken())
+        events.emit("note", detail={"text": "consumer went away"})  # must not raise
+
+    def test_enable_with_explicit_stream_leaves_stdout_alone(self):
+        before = sys.stdout
+        self._enable_buffer()
+        self.assertIs(sys.stdout, before)
+
+    def test_enable_redirects_stdout_and_disable_restores(self):
+        before = sys.stdout
+        events.enable()
+        try:
+            self.assertIs(sys.stdout, sys.stderr)
+            events.emit("note", detail={"text": "goes to the captured stdout"})
+        finally:
+            events.disable()
+        self.assertIs(sys.stdout, before)
+        self.assertFalse(events.enabled())
+
+    def test_enable_is_idempotent(self):
+        buf = self._enable_buffer()
+        events.enable()  # second call must not steal stdout or reset the stream
+        events.emit("note")
+        self.assertTrue(buf.getvalue())
+
+    def test_plain_strips_rich_markup(self):
+        self.assertEqual(events.plain("[warning]⚠  tt-smi missing[/warning]"),
+                         "⚠  tt-smi missing")
+        self.assertEqual(events.plain("no markup"), "no markup")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -132,5 +132,83 @@ class TestEventEmitter(unittest.TestCase):
         self.assertEqual(events.plain("no markup"), "no markup")
 
 
+class TestStepperEventTaps(unittest.TestCase):
+    """The phase-lifecycle taps in tt_setup/console/_stepper.py."""
+
+    def setUp(self):
+        from tt_setup.console import _stepper as stepper
+        self.stepper = stepper
+        self.buf = io.StringIO()
+        events.enable(stream=self.buf)
+
+    def tearDown(self):
+        events.disable()
+
+    def _records(self):
+        return [json.loads(line) for line in self.buf.getvalue().splitlines()]
+
+    def test_phase_lifecycle_emits_begin_progress_end(self):
+        ph = self.stepper.begin_phase(1, 5, "Checks")
+        ph.set("tt-smi")
+        self.stepper.end_phase(ph)
+        recs = self._records()
+        self.assertEqual([r["event"] for r in recs],
+                         ["phase_begin", "progress", "phase_end"])
+        self.assertTrue(all(r["phase"] == "Checks" for r in recs))
+        self.assertEqual(recs[0]["detail"], {"index": 1, "total": 5})
+        self.assertEqual(recs[1]["detail"], {"activity": "tt-smi"})
+        self.assertEqual(recs[2]["detail"]["status"], "ok")
+        self.assertIn("duration_s", recs[2]["detail"])
+
+    def test_failed_phase_reports_failed_status(self):
+        ph = self.stepper.begin_phase(2, 5, "Configure")
+        ph.fail()
+        self.stepper.end_phase(ph)
+        recs = self._records()
+        self.assertEqual(recs[-1]["event"], "phase_end")
+        self.assertEqual(recs[-1]["detail"]["status"], "failed")
+
+    def test_stop_active_phase_emits_failed_end(self):
+        self.stepper.begin_phase(4, 5, "Build")
+        self.stepper.stop_active_phase()
+        recs = self._records()
+        self.assertEqual(recs[-1]["event"], "phase_end")
+        self.assertEqual(recs[-1]["phase"], "Build")
+        self.assertEqual(recs[-1]["detail"]["status"], "failed")
+
+    def test_stop_with_no_active_phase_emits_nothing(self):
+        self.stepper.stop_active_phase()
+        self.assertEqual(self.buf.getvalue(), "")
+
+    def test_add_note_emits_plain_text_warn(self):
+        self.stepper.add_note("[warning]⚠  tt-smi not installed[/warning]")
+        recs = self._records()
+        self.assertEqual(recs[-1]["event"], "warn")
+        self.assertEqual(recs[-1]["detail"]["text"], "⚠  tt-smi not installed")
+
+    def test_rename_phase_emits_progress(self):
+        self.stepper.begin_phase(4, 5, "Pull")
+        self.stepper.rename_phase(4, "Build")
+        recs = self._records()
+        self.assertEqual(recs[-1]["event"], "progress")
+        self.assertEqual(recs[-1]["phase"], "Build")
+        self.assertEqual(recs[-1]["detail"]["kind"], "phase_renamed")
+        self.stepper.stop_active_phase()
+
+    def test_build_event_emits_progress(self):
+        ph = self.stepper.begin_phase(4, 5, "Build")
+        self.stepper.build_event("built", svc="frontend")
+        self.stepper.end_phase(ph)
+        recs = self._records()
+        built = [r for r in recs if r["event"] == "progress"]
+        self.assertEqual(built[-1]["detail"], {"kind": "built", "service": "frontend"})
+
+    def test_taps_are_silent_when_disabled(self):
+        events.disable()
+        ph = self.stepper.begin_phase(1, 5, "Checks")   # must not raise
+        self.stepper.end_phase(ph)
+        self.assertEqual(self.buf.getvalue(), "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,6 +6,7 @@ import io
 import json
 import sys
 import unittest
+from unittest.mock import patch
 
 from tt_setup.console import _events as events
 
@@ -208,6 +209,69 @@ class TestStepperEventTaps(unittest.TestCase):
         ph = self.stepper.begin_phase(1, 5, "Checks")   # must not raise
         self.stepper.end_phase(ph)
         self.assertEqual(self.buf.getvalue(), "")
+
+
+class TestPromptBlocking(unittest.TestCase):
+    """--json-events implies non-interactive: prompts must never hang the run."""
+
+    def tearDown(self):
+        events.disable()
+
+    def test_prompts_exit_with_prompt_blocked_event_in_machine_mode(self):
+        from tt_setup.console import _prompts
+        buf = io.StringIO()
+        events.enable(stream=buf)
+        attempts = (
+            lambda: _prompts.ask("Enter your HF token"),
+            lambda: _prompts.confirm("Continue?"),
+            lambda: _prompts.secret("Token: "),
+        )
+        for attempt in attempts:
+            with self.assertRaises(SystemExit) as ctx:
+                attempt()
+            self.assertEqual(ctx.exception.code, 2)
+        recs = [json.loads(line) for line in buf.getvalue().splitlines()]
+        self.assertEqual(len(recs), len(attempts))
+        for rec in recs:
+            self.assertEqual(rec["event"], "prompt_blocked")
+            self.assertTrue(rec["detail"]["prompt"])
+            self.assertIn("--json-events", rec["detail"]["remediation"])
+
+    def test_prompts_behave_normally_when_disabled(self):
+        from rich.prompt import Prompt
+        from tt_setup.console import _prompts
+        with patch.object(Prompt, "ask", return_value="answer"):
+            self.assertEqual(_prompts.ask("Question?"), "answer")
+
+
+class TestStatusJsonDump(unittest.TestCase):
+    """`--status --json`: a one-shot state dump through the same emitter."""
+
+    def tearDown(self):
+        events.disable()
+
+    def test_emits_one_status_event_with_services_head_and_hardware(self):
+        from tt_setup import monitor
+        buf = io.StringIO()
+        events.enable(stream=buf)
+        health = {s["health"]: s["name"] == "Frontend" for s in monitor.SERVICES}
+        with patch.object(monitor, "snapshot_health", return_value=health), \
+             patch.object(monitor, "_git_head", return_value="abc1234"), \
+             patch.object(monitor, "_hardware_label",
+                          return_value="QuietBox (QB2) · 2 chips"):
+            rc = monitor.run_status_json()
+        self.assertEqual(rc, 0)
+        lines = buf.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        rec = json.loads(lines[0])
+        self.assertEqual(rec["event"], "status")
+        self.assertEqual(rec["detail"]["head"], "abc1234")
+        self.assertEqual(rec["detail"]["hardware"], "QuietBox (QB2) · 2 chips")
+        by_name = {s["name"]: s for s in rec["detail"]["services"]}
+        self.assertEqual(set(by_name), {s["name"] for s in monitor.SERVICES})
+        self.assertTrue(by_name["Frontend"]["healthy"])
+        self.assertFalse(by_name["Backend"]["healthy"])
+        self.assertEqual(by_name["Frontend"]["port"], 3000)
 
 
 if __name__ == "__main__":

--- a/tests/test_json_stream.py
+++ b/tests/test_json_stream.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""End-to-end tests for the NDJSON stream: a real child process running the
+CLI, asserting stdout is pure, parseable, stable-keyed NDJSON with no ANSI —
+including when stdout is a genuine PTY (where Rich would otherwise colorize).
+
+Uses `--status --json` as the vehicle because it exercises the emitter, the
+stdout/stderr split, and the CLI dispatch without starting or stopping any
+service (its health probes are read-only GETs)."""
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# TT_STUDIO_ROOT is os.getcwd(), so run from the repo root like run.py does.
+_CHILD = ("import sys; sys.argv = ['run.py', '--status', '--json']; "
+          "from tt_setup.cli import main; main()")
+
+
+def _parse_stream(text):
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+class TestJsonStream(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.proc = subprocess.run(
+            [sys.executable, "-c", _CHILD],
+            capture_output=True, text=True, cwd=REPO_ROOT, timeout=120,
+        )
+
+    def test_exits_zero(self):
+        self.assertEqual(self.proc.returncode, 0, self.proc.stderr)
+
+    def test_stdout_is_parseable_ndjson(self):
+        records = _parse_stream(self.proc.stdout)   # raises on any junk line
+        self.assertTrue(records)
+
+    def test_stdout_has_no_ansi_escapes(self):
+        self.assertNotIn("\x1b", self.proc.stdout)
+
+    def test_records_are_stable_keyed(self):
+        for rec in _parse_stream(self.proc.stdout):
+            self.assertEqual(list(rec.keys()), ["v", "ts", "event", "phase", "detail"])
+            self.assertEqual(rec["v"], 1)
+            self.assertIsInstance(rec["ts"], float)
+            self.assertIsInstance(rec["detail"], dict)
+
+    def test_status_dump_shape(self):
+        records = _parse_stream(self.proc.stdout)
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["event"], "status")
+        self.assertIsNone(rec["phase"])
+        detail = rec["detail"]
+        self.assertIn("head", detail)
+        self.assertIn("hardware", detail)
+        names = {s["name"] for s in detail["services"]}
+        self.assertIn("Frontend", names)
+        self.assertIn("Backend", names)
+        for svc in detail["services"]:
+            self.assertEqual(set(svc), {"name", "port", "url", "healthy"})
+            self.assertIsInstance(svc["healthy"], bool)
+
+
+@unittest.skipUnless(hasattr(os, "openpty"), "requires a Unix PTY")
+class TestJsonStreamOnPty(unittest.TestCase):
+    def test_stdout_stays_pure_ndjson_on_a_real_pty(self):
+        # With stdout a genuine terminal, Rich would normally emit color/cursor
+        # escapes — the machine mode must keep them off the event stream.
+        master, slave = os.openpty()
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-c", _CHILD],
+                stdout=slave, stderr=subprocess.DEVNULL, cwd=REPO_ROOT,
+            )
+            os.close(slave)
+            slave = -1
+            chunks = []
+            while True:
+                try:
+                    chunk = os.read(master, 4096)
+                except OSError:   # EIO on Linux once the child side closes
+                    break
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            self.assertEqual(proc.wait(timeout=120), 0)
+        finally:
+            if slave != -1:
+                os.close(slave)
+            os.close(master)
+        # A PTY renders \n as \r\n; normalize before parsing.
+        out = b"".join(chunks).decode("utf-8", errors="replace").replace("\r\n", "\n")
+        self.assertNotIn("\x1b", out)
+        records = _parse_stream(out)
+        self.assertEqual([r["event"] for r in records], ["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tt_setup/cli/_args.py
+++ b/tt_setup/cli/_args.py
@@ -36,6 +36,7 @@ def _entry(
     # ── Lifecycle ────────────────────────────────────────────────────────────
     stop: bool = typer.Option(False, "--stop", help="Stop TT Studio: tear down Docker containers and networks.", rich_help_panel="Lifecycle"),
     status: bool = typer.Option(False, "--status", help="Open the live monitor TUI for a running stack.", rich_help_panel="Lifecycle"),
+    status_json: bool = typer.Option(False, "--json", help="With --status: print a one-shot machine-readable status dump (NDJSON) instead of the TUI.", rich_help_panel="Lifecycle"),
     logs: bool = typer.Option(False, "--logs", help="Stream all container logs (docker compose logs -f).", rich_help_panel="Lifecycle"),
     info: bool = typer.Option(False, "--info", help="Re-show the 'TT Studio is ready' summary (URLs, mode, hardware).", rich_help_panel="Lifecycle"),
     # ── Reset (--purge-all) ──────────────────────────────────────────────────
@@ -53,6 +54,7 @@ def _entry(
     no_sudo: bool = typer.Option(False, "--no-sudo", help="Skip sudo usage (may limit functionality).", rich_help_panel="Advanced"),
     no_browser: bool = typer.Option(False, "--no-browser", help="Skip automatic browser opening.", rich_help_panel="Advanced"),
     wait_for_services: bool = typer.Option(False, "--wait-for-services", help="Wait for all services to be healthy.", rich_help_panel="Advanced"),
+    json_events: bool = typer.Option(False, "--json-events", help="Emit machine-readable NDJSON events on stdout (for a wrapping program, e.g. a desktop launcher). Implies non-interactive: prompts become prompt_blocked events; human output moves to stderr.", rich_help_panel="Advanced"),
     browser_timeout: int = typer.Option(60, "--browser-timeout", help="Seconds to wait for frontend before opening browser.", rich_help_panel="Advanced"),
     # ── Developer Tools ──────────────────────────────────────────────────────
     add_headers: bool = typer.Option(False, "--add-headers", help="Add missing SPDX license headers (excludes frontend).", rich_help_panel="Developer Tools"),
@@ -72,6 +74,14 @@ def _entry(
     set_verbose(verbose or no_clear)   # --no-clear shows full step detail too
     set_no_clear(no_clear)
 
+    if status_json and not status:
+        raise typer.BadParameter("--json requires --status")
+    # Machine-readable modes: stdout becomes pure NDJSON (one JSON object per
+    # line); raw print() and the Rich consoles are re-pointed at stderr.
+    if json_events or (status and status_json):
+        from tt_setup.console import events
+        events.enable()
+
     # --cleanup/--cleanup-all are deprecated aliases for --stop/--purge-all.
     # Warn, then normalize all four onto the internal cleanup/cleanup_all flags.
     if cleanup or cleanup_all:
@@ -90,7 +100,8 @@ def _entry(
         wait_for_services=wait_for_services, browser_timeout=browser_timeout,
         add_headers=add_headers, check_headers=check_headers, auto_deploy=auto_deploy,
         device_id=device_id, fix_docker=fix_docker, configure_env=configure_env,
-        status=status, logs=logs, info=info, report_bug=report_bug,
+        status=status, status_json=status_json, json_events=json_events,
+        logs=logs, info=info, report_bug=report_bug,
         install_shortcut=install_shortcut, accept_terms=accept_terms,
         switch=switch, uninstall=uninstall, purge_model=list(purge_model or []),
     )

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -10,7 +10,7 @@ import subprocess
 import time
 from datetime import datetime
 from tt_setup.startup_checks import check_startup_freshness
-from tt_setup.console import _fmt_duration, add_note, begin_phase, build_note, confirm, console, end_phase, end_run, get_notes, is_verbose, notice_panel, ready_panel, register_setup_phases, rename_phase, show_detail, step, steps_panel, stop_active_phase
+from tt_setup.console import _fmt_duration, add_note, begin_phase, build_note, confirm, console, end_phase, end_run, events, get_notes, is_verbose, notice_panel, ready_panel, register_setup_phases, rename_phase, show_detail, step, steps_panel, stop_active_phase
 from tt_setup.constants import *
 from tt_setup.logging import startup_log
 from tt_setup.shell import check_tt_smi, display_welcome_banner, resolve_hardware_label, run_preflight_checks
@@ -218,6 +218,10 @@ def _run(args):
             return
         
         if args.status:
+            if getattr(args, "status_json", False):
+                # One-shot machine-readable state dump — bypasses the TUI entirely.
+                from tt_setup.monitor import run_status_json
+                sys.exit(run_status_json())
             from tt_setup.monitor import run_status
             sys.exit(run_status(dev_mode=args.dev))
 
@@ -860,6 +864,15 @@ def _run(args):
         # Ready summary — same panel re-viewable later via `python run.py --info`.
         show_ready_panel(args, run_start=run_start, hardware_label=hardware_label,
                          is_deployed_mode=is_deployed_mode)
+
+        # Machine-readable counterpart of the ready panel (--json-events).
+        ready_urls = {"app": "http://localhost:3000"}
+        if not args.skip_fastapi and not is_deployed_mode:
+            ready_urls["fastapi"] = "http://localhost:8001"
+        if not args.skip_docker_control:
+            ready_urls["docker_control"] = "http://localhost:8002"
+        events.emit_ready(urls=ready_urls,
+                          hardware=hardware_label or "No accelerator (remote/cloud mode)")
 
         # Recap actionable notes (HF-access blocks, warnings) that per-phase
         # collapse cleared from the scroll, so they're easy to get back. Full

--- a/tt_setup/console/__init__.py
+++ b/tt_setup/console/__init__.py
@@ -23,6 +23,7 @@ from tt_setup.console._theme import (
     set_no_clear,
     set_verbose,
 )
+from tt_setup.console import _events as events
 from tt_setup.console._stepper import (
     add_note,
     begin_phase,
@@ -56,6 +57,7 @@ from tt_setup.console._prompts import ask, confirm, secret
 from tt_setup.console._steps import download_with_progress, step
 
 __all__ = [
+    "events",
     "TT_THEME", "Console", "console", "_real_console", "real_console", "set_verbose",
     "is_verbose", "set_no_clear", "no_clear", "progress_status", "_fmt_duration",
     "in_phase", "show_detail", "add_note", "get_notes",

--- a/tt_setup/console/_events.py
+++ b/tt_setup/console/_events.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""NDJSON event stream for machine consumers (`--json-events`, `--status --json`).
+
+When enabled, the launcher writes one JSON object per line to stdout so a
+wrapping program (e.g. a desktop launcher) can render progress natively instead
+of scraping the Rich/ANSI terminal output. Every record carries the same
+stable, version-keyed shape:
+
+    {"v": 1, "ts": <unix float>, "event": "<type>", "phase": "<phase or null>",
+     "detail": {...}}
+
+The full schema (event types and their detail payloads) is documented in
+dev-docs/json-events.md. The emitter is OFF by default and every emit is a
+no-op while disabled, so plain interactive runs are byte-for-byte unchanged.
+"""
+
+import json
+import sys
+import time
+
+
+SCHEMA_VERSION = 1
+
+# The recognized event types for schema v1 (see dev-docs/json-events.md).
+EVENT_TYPES = (
+    "phase_begin", "phase_end", "note", "warn", "error", "progress",
+    "prompt_blocked", "ready", "status",
+)
+
+
+_enabled = False
+_stream = None        # where NDJSON lines go (the real stdout, or a test buffer)
+_redirected = False   # True when enable() re-pointed stdout/Rich at stderr
+
+
+def enable(stream=None):
+    """Turn the event stream on.
+
+    With no explicit stream, events claim the process's stdout and everything
+    human-facing — raw print() and the shared Rich consoles — is re-pointed at
+    stderr, so stdout stays pure NDJSON. Passing a stream (tests) writes events
+    there and leaves stdout alone. Idempotent."""
+    global _enabled, _stream, _redirected
+    if _enabled:
+        return
+    _enabled = True
+    if stream is not None:
+        _stream = stream
+        return
+    _stream = sys.stdout
+    sys.stdout = sys.stderr
+    from tt_setup.console._theme import _real_console
+    _real_console.file = sys.stderr
+    _redirected = True
+
+
+def disable():
+    """Turn the event stream off and undo enable()'s stdout/Rich redirection."""
+    global _enabled, _stream, _redirected
+    if _redirected:
+        sys.stdout = _stream
+        from tt_setup.console._theme import _real_console
+        _real_console.file = sys.__stdout__
+        _redirected = False
+    _enabled = False
+    _stream = None
+
+
+def enabled():
+    """True while the NDJSON event stream is active (`--json-events` mode)."""
+    return _enabled
+
+
+def emit(event, phase=None, detail=None):
+    """Write one event line. A no-op while disabled; a failing stream (e.g. the
+    consumer went away mid-run) must never take the launcher down with it."""
+    if not _enabled:
+        return
+    record = {
+        "v": SCHEMA_VERSION,
+        "ts": time.time(),
+        "event": event,
+        "phase": phase,
+        "detail": detail if detail is not None else {},
+    }
+    try:
+        _stream.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+        _stream.flush()
+    except Exception:
+        pass
+
+
+def emit_error(message, remediation, phase=None, **extra):
+    """An `error` event: what went wrong + how to fix it (always actionable)."""
+    emit("error", phase=phase,
+         detail={"message": message, "remediation": remediation, **extra})
+
+
+def emit_prompt_blocked(prompt, remediation):
+    """A `prompt_blocked` event: the run needed interactive input it can't get
+    in --json-events mode; says which prompt and how to pre-answer it."""
+    emit("prompt_blocked", detail={"prompt": prompt, "remediation": remediation})
+
+
+def emit_ready(urls, hardware):
+    """The final `ready` event: service URLs + the detected hardware label."""
+    emit("ready", detail={"urls": urls, "hardware": hardware})
+
+
+def plain(markup):
+    """Rich markup → plain text, for event payloads (they carry no styling)."""
+    try:
+        from rich.text import Text
+        return Text.from_markup(str(markup)).plain
+    except Exception:
+        return str(markup)

--- a/tt_setup/console/_prompts.py
+++ b/tt_setup/console/_prompts.py
@@ -5,8 +5,23 @@
 sticky header."""
 
 from rich.prompt import Confirm, InvalidResponse, Prompt
+from tt_setup.console import _events as events
 from tt_setup.console._theme import console
 from tt_setup.console._stepper import _prompt_guard
+
+
+def _block_if_machine_mode(prompt):
+    """--json-events implies non-interactive: instead of hanging a machine
+    consumer on an invisible prompt, emit a structured prompt_blocked event
+    (with remediation) and exit."""
+    if not events.enabled():
+        return
+    text = events.plain(prompt)
+    events.emit_prompt_blocked(text, remediation=(
+        "this run needs interactive input — answer it once by running "
+        "`python run.py` in a terminal, or pre-configure the value "
+        "(.env / CLI flags) before re-running with --json-events"))
+    raise SystemExit(2)
 
 
 class _YesNoConfirm(Confirm):
@@ -30,6 +45,7 @@ def ask(prompt, default=None, choices=None, password=False):
     `choices`, and a shown default. Pass password=True to mask input. Suspends
     any active phase spinner; lets KeyboardInterrupt propagate so callers can
     print their resume hint."""
+    _block_if_machine_mode(prompt)
     with _prompt_guard():
         return Prompt.ask(prompt, console=console, default=default,
                           choices=choices, password=password)
@@ -38,6 +54,7 @@ def ask(prompt, default=None, choices=None, password=False):
 def confirm(prompt, default=True):
     """Themed yes/no prompt (rich.prompt.Confirm). Suspends any active phase
     spinner; lets KeyboardInterrupt propagate."""
+    _block_if_machine_mode(prompt)
     with _prompt_guard():
         return _YesNoConfirm.ask(prompt, console=console, default=default)
 
@@ -46,6 +63,7 @@ def secret(prompt):
     """Masked input via getpass, with the pinned stepper suspended for the
     duration so it doesn't clash with the (non-Rich) prompt. Returns the raw string."""
     import getpass
+    _block_if_machine_mode(prompt)
     with _prompt_guard():
         return getpass.getpass(prompt)
 

--- a/tt_setup/console/_stepper.py
+++ b/tt_setup/console/_stepper.py
@@ -11,6 +11,7 @@ import threading
 import time
 from rich.rule import Rule
 from rich.text import Text
+from tt_setup.console import _events as events
 from tt_setup.console._theme import _fmt_duration, _real_console, console, is_verbose
 
 
@@ -409,6 +410,15 @@ class _ChecklistController:
 _checklist = _ChecklistController()
 
 
+def _phase_title(index=None):
+    """The registered title for a phase (defaults to the active one), or None.
+    Used to stamp the `phase` field on emitted events."""
+    if index is None:
+        index = _active_phase.index if _active_phase is not None else None
+    p = _checklist._by_index.get(index) if index is not None else None
+    return p.title if p is not None else None
+
+
 def _terminal_lock():
     """The RLock that serializes every raw escape write to the terminal (header
     repaints, the bottom activity row, and step()'s spinner frames), so a
@@ -439,6 +449,8 @@ class _PhaseHandle:
 
     def set(self, activity):
         _checklist.set_activity(self.index, activity)
+        events.emit("progress", phase=_phase_title(self.index),
+                    detail={"activity": activity})
 
     def fail(self):
         self.failed = True
@@ -500,6 +512,7 @@ def add_note(markup):
     """Record an actionable note (Rich markup) to re-show in the end-of-run
     'Needs attention' recap."""
     _notes.append(markup)
+    events.emit("warn", phase=_phase_title(), detail={"text": events.plain(markup)})
 
 
 def get_notes():
@@ -518,6 +531,7 @@ def begin_phase(index, total, title):
     handle = _PhaseHandle(index)
     _IN_PHASE = True
     _active_phase = handle
+    events.emit("phase_begin", phase=title, detail={"index": index, "total": total})
     return handle
 
 
@@ -528,6 +542,11 @@ def end_phase(handle=None):
     if handle is None:
         return
     _checklist.finish_phase(handle.index, handle.failed)
+    p = _checklist._by_index.get(handle.index)
+    detail = {"index": handle.index, "status": "failed" if handle.failed else "ok"}
+    if p is not None and p.start is not None and p.end is not None:
+        detail["duration_s"] = round(p.end - p.start, 3)
+    events.emit("phase_end", phase=_phase_title(handle.index), detail=detail)
     _IN_PHASE = False
     _active_phase = None
 
@@ -536,6 +555,8 @@ def rename_phase(index, title):
     """Retitle a phase mid-run when the plan changes (e.g. a pull that fell back
     to a local build), so the stepper and the final record say what happened."""
     _checklist.set_title(index, title)
+    events.emit("progress", phase=title,
+                detail={"kind": "phase_renamed", "index": index})
 
 
 def end_run():
@@ -546,6 +567,12 @@ def end_run():
 def build_event(kind, svc=None, x=None, y=None, label=None):
     """Feed a Docker build event into the active phase's folded build row."""
     _checklist.build_event(kind, svc=svc, x=x, y=y, label=label)
+    detail = {"kind": kind}
+    if svc:
+        detail["service"] = svc
+    if label:
+        detail["label"] = label
+    events.emit("progress", phase=_phase_title(), detail=detail)
 
 
 def build_log(line):
@@ -557,6 +584,7 @@ def build_note(text, marker="○", style="muted"):
     """Print a calm note in the build body's gutter (aligned with ✓ <svc> lines).
     Pass marker="" for a continuation/hint line under a previous note."""
     _checklist.build_note(text, marker=marker, style=style)
+    events.emit("note", phase=_phase_title(), detail={"text": events.plain(text)})
 
 
 def build_activity(text):
@@ -579,6 +607,9 @@ def stop_active_phase():
     """Reset the scroll region WITHOUT marking the phase — for error/interrupt
     paths, so the sticky header doesn't corrupt a following panel."""
     global _IN_PHASE, _active_phase
+    if _active_phase is not None:
+        events.emit("phase_end", phase=_phase_title(_active_phase.index),
+                    detail={"index": _active_phase.index, "status": "failed"})
     _checklist.stop()
     _IN_PHASE = False
     _active_phase = None

--- a/tt_setup/docker_diag/_diagnostics.py
+++ b/tt_setup/docker_diag/_diagnostics.py
@@ -11,7 +11,7 @@ from rich.table import Table
 from tt_setup.constants import *
 from tt_setup.constants import _COMPOSE_SERVICE_LABEL
 from tt_setup.shell import copy_to_clipboard
-from tt_setup.console import console, notice_panel, show_detail
+from tt_setup.console import console, events, notice_panel, show_detail
 
 
 def _resolve_container_name(prefix):
@@ -351,6 +351,8 @@ def print_container_diagnostics(containers):
             lines,
             border_style="error",
         ))
+        events.emit_error(f"{friendly} container failed: {diagnosis['cause']}",
+                          remediation=diagnosis['action'], container=name)
 
 
 def handle_docker_compose_result(returncode, full_output, use_sudo=False):
@@ -402,6 +404,10 @@ def handle_docker_compose_result(returncode, full_output, use_sudo=False):
     else:
         header_lines.append("[muted]The docker compose build did not complete.[/muted]")
     console.print(notice_panel(header_title, header_lines, border_style="error"))
+    events.emit_error(
+        f"docker compose build failed ({friendly_name or container_name or 'unknown container'})",
+        remediation="cd app && docker compose build --no-cache, then re-run python run.py",
+        exit_code=returncode)
 
     # Check which containers exist/failed
     containers = verify_docker_containers(use_sudo=use_sudo)

--- a/tt_setup/monitor.py
+++ b/tt_setup/monitor.py
@@ -56,6 +56,52 @@ def run_status(dev_mode=False):
     return 0
 
 
+def _git_head():
+    """The checkout's current short HEAD, or 'unknown'."""
+    import subprocess
+    try:
+        return subprocess.run(
+            ["git", "-C", TT_STUDIO_ROOT, "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _hardware_label():
+    """The detected hardware label, probed the same way as the ready panel."""
+    import shutil
+    from tt_setup.docker import detect_tt_hardware
+    from tt_setup.shell import check_tt_smi, resolve_hardware_label
+    tt_status, tt_detail, tt_board = None, "", ""
+    if shutil.which("tt-smi"):
+        tt_status, tt_detail, tt_board = check_tt_smi()
+    label, _ = resolve_hardware_label(tt_status, tt_detail, tt_board, False,
+                                      hw_present=detect_tt_hardware())
+    return label
+
+
+def run_status_json():
+    """Entry point for `--status --json`: a one-shot machine-readable state dump
+    (one NDJSON `status` event on stdout — see dev-docs/json-events.md). Never
+    launches the TUI. Returns an exit code."""
+    from tt_setup.console import events
+    events.enable()   # idempotent; normally already enabled by the CLI callback
+    health = snapshot_health([s["health"] for s in SERVICES])
+    services = [
+        {"name": s["name"], "port": s["port"],
+         "url": f"http://localhost:{s['port']}",
+         "healthy": bool(health.get(s["health"], False))}
+        for s in SERVICES
+    ]
+    events.emit("status", detail={
+        "services": services,
+        "head": _git_head(),
+        "hardware": _hardware_label(),
+    })
+    return 0
+
+
 def _print_text_snapshot():
     """Non-TTY fallback: a single static health table (no live TUI)."""
     from rich.table import Table

--- a/tt_setup/services/_health.py
+++ b/tt_setup/services/_health.py
@@ -15,7 +15,7 @@ except ImportError:
     HAS_REQUESTS = False
 from tt_setup.constants import *
 from tt_setup.docker_diag import _resolve_container_name
-from tt_setup.console import console, notice_panel, progress_status
+from tt_setup.console import console, events, notice_panel, progress_status
 
 
 def probe_service(health_url, timeout=2):
@@ -131,6 +131,9 @@ def report_service_failure(name, log_file, port=None, consequence=None):
         lines.append(f"[muted]  tail -50 {shown_log}[/muted]")
     console.print(notice_panel(f"[error]{name} didn't start — {diagnosis['cause']}[/error]",
                                lines, border_style="error"))
+    events.emit_error(f"{name} didn't start — {diagnosis['cause']}",
+                      remediation="; ".join(diagnosis["actions"]),
+                      service=name, log=shown_log)
     return diagnosis
 
 


### PR DESCRIPTION
Gives the launcher a machine-readable mode so a wrapping program (the upcoming desktop launcher) can render bring-up progress natively instead of scraping Rich/ANSI terminal output.

Two entry points:

- `python run.py --json-events` — streams the bring-up as NDJSON on stdout (one JSON object per line): phase lifecycle, progress, warnings, errors with a remediation string, and a final `ready` event carrying the service URLs (app 3000, FastAPI 8001, docker-control 8002) and the detected hardware label. Implies non-interactive: any code path that would prompt emits a `prompt_blocked` event with remediation and exits instead of hanging the consumer. Human output moves to stderr so stdout stays pure NDJSON.
- `python run.py --status --json` — one-shot state dump (per-service health via the existing snapshot helpers, current HEAD, hardware label) through the same emitter, bypassing the TUI.

Every record has the same version-keyed envelope — `{"v":1,"ts":…,"event":…,"phase":…,"detail":{…}}` — documented in `dev-docs/json-events.md`. The events tap the existing phase stepper (`begin_phase`/`end_phase`/notes) and the failure-diagnosis cards; with the flags off every emit is a no-op, so plain interactive runs are unchanged.

- [x] `tt_setup/console/_events.py`: global NDJSON emitter (off by default, stdout/stderr split on enable)
- [x] Lifecycle taps in the stepper + error events (with remediation) from the service/container diagnosis paths
- [x] `--json-events` (Advanced) and `--status --json` (Lifecycle) flags; prompts become `prompt_blocked` + exit 2 in machine mode
- [x] Schema doc in `dev-docs/json-events.md`; options tables updated
- [x] Verified: full launcher suite green (360 tests, incl. new emitter/tap/CLI units and an end-to-end stream test with a PTY ANSI-purity check); `python run.py --status --json` against a live stack emits valid NDJSON with all six services healthy; `--help` shows both flags in the right panels