### PR TITLE
feat: add desktop shell profiles, picker, health gating, and bring-up rendering

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -47,6 +47,7 @@ jobs:
             librsvg2-dev \
             libxdo-dev \
             libssl-dev \
+            libdbus-1-dev \
             build-essential \
             curl \
             wget \

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -77,6 +77,10 @@ jobs:
         working-directory: desktop
         run: npm run build
 
+      - name: Launcher unit tests
+        working-directory: desktop
+        run: npm test
+
       - name: Check Rust formatting
         working-directory: desktop/src-tauri
         run: cargo fmt --check

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -15,12 +15,237 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.12",
         "@tauri-apps/cli": "^2.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react-swc": "^3.7.1",
+        "jsdom": "^30.0.1",
         "tailwindcss": "^4.1.12",
         "typescript": "^5.6.3",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^4.1.11"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -463,6 +688,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -930,6 +1173,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.16.1",
@@ -1737,6 +1987,79 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1786,12 +2109,255 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1802,6 +2368,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
@@ -1816,6 +2389,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1859,6 +2452,26 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1899,6 +2512,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -1914,6 +2547,47 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2200,6 +2874,26 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2209,6 +2903,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -2228,6 +2929,40 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2278,6 +3013,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2301,6 +3061,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -2349,6 +3126,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2357,6 +3147,13 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2367,6 +3164,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
@@ -2389,6 +3207,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2406,6 +3241,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2418,6 +3309,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/vite": {
@@ -2494,6 +3395,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
     "tauri": "tauri"
   },
   "dependencies": {
@@ -18,11 +19,15 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "@tauri-apps/cli": "^2.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react-swc": "^3.7.1",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.6.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.11"
   }
 }

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -343,6 +343,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -364,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -377,7 +387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -506,6 +516,16 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -1675,6 +1695,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2619,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,7 +3061,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3655,6 +3726,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tt-studio-desktop"
 version = "0.1.0"
 dependencies = [
+ "keyring",
  "serde",
  "serde_json",
  "tauri",
@@ -4211,6 +4283,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4242,11 +4323,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4280,6 +4378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,6 +4394,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4304,10 +4414,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4322,6 +4444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,6 +4460,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4346,6 +4480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4496,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4510,6 +4656,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -3153,6 +3153,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6708afbe549f176b712066e71648ba8fafba20789453718260c7ca356733cb0c"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,7 +3399,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3555,7 +3599,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3603,6 +3659,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-store",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2499,6 +2499,38 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2551,6 +2583,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2776,6 +2814,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3140,7 +3190,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3727,11 +3777,13 @@ name = "tt-studio-desktop"
 version = "0.1.0"
 dependencies = [
  "keyring",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-store",
+ "tokio",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,5 +15,6 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,5 +16,12 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
+# sync-secret-service links libdbus on Linux (libdbus-1-dev in CI); no
+# secret-service daemon at runtime degrades to a typed error, not a crash.
+keyring = { version = "3", features = [
+    "apple-native",
+    "windows-native",
+    "sync-secret-service",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,3 +25,9 @@ keyring = { version = "3", features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Health endpoints are plain http on localhost — no TLS backend needed.
+reqwest = { version = "0.12", default-features = false }
+tokio = { version = "1", features = ["macros", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/desktop/src-tauri/src/hardware.rs
+++ b/desktop/src-tauri/src/hardware.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Tenstorrent hardware presence probe.
+//!
+//! The first-run picker uses this to choose its default: a machine with a
+//! Tenstorrent accelerator pre-selects "run locally", anything else defaults
+//! to connecting over SSH. Full deployment needs `/dev/tenstorrent`, which
+//! only exists on Linux hosts with the driver loaded.
+
+use serde::Serialize;
+use std::path::Path;
+
+/// Device node the tt-kmd driver exposes on Linux.
+pub const TENSTORRENT_DEV: &str = "/dev/tenstorrent";
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DefaultMode {
+    Local,
+    Ssh,
+}
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HardwareProbe {
+    pub accelerator_present: bool,
+    pub default_mode: DefaultMode,
+}
+
+/// Pure gating logic: local mode only makes sense on Linux with the device
+/// node present; everything else should steer the picker to SSH.
+pub fn probe_at(is_linux: bool, dev_path: &Path) -> HardwareProbe {
+    let accelerator_present = is_linux && dev_path.exists();
+    HardwareProbe {
+        accelerator_present,
+        default_mode: if accelerator_present {
+            DefaultMode::Local
+        } else {
+            DefaultMode::Ssh
+        },
+    }
+}
+
+#[tauri::command]
+pub fn detect_hardware() -> HardwareProbe {
+    probe_at(cfg!(target_os = "linux"), Path::new(TENSTORRENT_DEV))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_with_device_defaults_to_local() {
+        let dir = std::env::temp_dir();
+        let probe = probe_at(true, &dir); // any existing path stands in for /dev/tenstorrent
+        assert!(probe.accelerator_present);
+        assert_eq!(probe.default_mode, DefaultMode::Local);
+    }
+
+    #[test]
+    fn linux_without_device_defaults_to_ssh() {
+        let probe = probe_at(true, Path::new("/nonexistent/tenstorrent-test-path"));
+        assert!(!probe.accelerator_present);
+        assert_eq!(probe.default_mode, DefaultMode::Ssh);
+    }
+
+    #[test]
+    fn non_linux_defaults_to_ssh_even_if_path_exists() {
+        let dir = std::env::temp_dir();
+        let probe = probe_at(false, &dir);
+        assert!(!probe.accelerator_present);
+        assert_eq!(probe.default_mode, DefaultMode::Ssh);
+    }
+
+    #[test]
+    fn probe_serializes_for_the_ui() {
+        let json = serde_json::to_value(probe_at(true, Path::new("/nope"))).unwrap();
+        assert_eq!(json["accelerator_present"], false);
+        assert_eq!(json["default_mode"], "ssh");
+    }
+}

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Stack health poller.
+//!
+//! Read-only GETs against the TT-Studio services' health endpoints. The
+//! launcher gates "open the stack" on the overall result: `ready` is true
+//! only when every service reports healthy. A background poller pushes each
+//! snapshot to the UI as a `stack-health` Tauri event.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::Emitter;
+
+pub const HEALTH_EVENT: &str = "stack-health";
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceStatus {
+    /// Responded 2xx.
+    Up,
+    /// Responded, but not 2xx.
+    Down,
+    /// No response at all (connection refused, timeout, DNS).
+    Unreachable,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct ServiceHealth {
+    pub name: String,
+    pub url: String,
+    pub status: ServiceStatus,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StackHealth {
+    pub services: Vec<ServiceHealth>,
+    pub ready: bool,
+}
+
+/// Health-check URLs, injectable so tests can point them at a stub server.
+#[derive(Clone, Debug)]
+pub struct Endpoints {
+    pub frontend: String,
+    pub backend_up: String,
+    pub backend_models: String,
+    pub inference: String,
+    pub docker_control: String,
+}
+
+impl Endpoints {
+    pub fn local_default() -> Self {
+        Self {
+            frontend: "http://localhost:3000/".into(),
+            backend_up: "http://localhost:8000/up/".into(),
+            backend_models: "http://localhost:8000/models/health/".into(),
+            inference: "http://localhost:8001/health".into(),
+            docker_control: "http://localhost:8002/api/v1/health".into(),
+        }
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .expect("reqwest client construction cannot fail with static config")
+}
+
+async fn check(client: &reqwest::Client, name: &str, url: &str) -> ServiceHealth {
+    let status = match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => ServiceStatus::Up,
+        Ok(_) => ServiceStatus::Down,
+        Err(_) => ServiceStatus::Unreachable,
+    };
+    ServiceHealth {
+        name: name.to_string(),
+        url: url.to_string(),
+        status,
+    }
+}
+
+pub async fn poll_once(client: &reqwest::Client, eps: &Endpoints) -> StackHealth {
+    let (frontend, backend, models, inference, docker_control) = tokio::join!(
+        check(client, "frontend", &eps.frontend),
+        check(client, "backend", &eps.backend_up),
+        check(client, "backend models", &eps.backend_models),
+        check(client, "inference server", &eps.inference),
+        check(client, "docker control", &eps.docker_control),
+    );
+    let services = vec![frontend, backend, models, inference, docker_control];
+    let ready = services.iter().all(|s| s.status == ServiceStatus::Up);
+    StackHealth { services, ready }
+}
+
+/// Managed state guarding against a second concurrent poll loop.
+#[derive(Default)]
+pub struct PollerState {
+    running: Arc<AtomicBool>,
+}
+
+#[tauri::command]
+pub async fn check_stack_health() -> StackHealth {
+    poll_once(&client(), &Endpoints::local_default()).await
+}
+
+/// Start the background poller (idempotent). Emits a `stack-health` event
+/// every couple of seconds until `stop_health_poll`.
+#[tauri::command]
+pub fn start_health_poll(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, PollerState>,
+) -> Result<(), String> {
+    if state.running.swap(true, Ordering::SeqCst) {
+        return Ok(()); // already polling
+    }
+    let running = state.running.clone();
+    tauri::async_runtime::spawn(async move {
+        let client = client();
+        let eps = Endpoints::local_default();
+        while running.load(Ordering::SeqCst) {
+            let health = poll_once(&client, &eps).await;
+            if app.emit(HEALTH_EVENT, &health).is_err() {
+                break; // app is shutting down
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub fn stop_health_poll(state: tauri::State<'_, PollerState>) {
+    state.running.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// Minimal stub HTTP server: responds to each path with a fixed status
+    /// code. The accept thread lives until the test binary exits.
+    fn stub_server(routes: HashMap<&'static str, u16>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let path = request.split_whitespace().nth(1).unwrap_or("/").to_string();
+                let code = routes.get(path.as_str()).copied().unwrap_or(404);
+                let response =
+                    format!("HTTP/1.1 {code} X\r\ncontent-length: 0\r\nconnection: close\r\n\r\n");
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    fn endpoints_for(base: &str) -> Endpoints {
+        Endpoints {
+            frontend: format!("{base}/"),
+            backend_up: format!("{base}/up/"),
+            backend_models: format!("{base}/models/health/"),
+            inference: format!("{base}/health"),
+            docker_control: format!("{base}/api/v1/health"),
+        }
+    }
+
+    fn all_ok_routes() -> HashMap<&'static str, u16> {
+        HashMap::from([
+            ("/", 200),
+            ("/up/", 200),
+            ("/models/health/", 200),
+            ("/health", 200),
+            ("/api/v1/health", 200),
+        ])
+    }
+
+    #[tokio::test]
+    async fn ready_when_every_service_is_up() {
+        let base = stub_server(all_ok_routes());
+        let health = poll_once(&client(), &endpoints_for(&base)).await;
+        assert!(health.ready);
+        assert_eq!(health.services.len(), 5);
+        assert!(health
+            .services
+            .iter()
+            .all(|s| s.status == ServiceStatus::Up));
+    }
+
+    #[tokio::test]
+    async fn one_failing_service_blocks_ready() {
+        let mut routes = all_ok_routes();
+        routes.insert("/health", 503); // inference server unhappy
+        let base = stub_server(routes);
+        let health = poll_once(&client(), &endpoints_for(&base)).await;
+        assert!(!health.ready);
+        let inference = health
+            .services
+            .iter()
+            .find(|s| s.name == "inference server")
+            .unwrap();
+        assert_eq!(inference.status, ServiceStatus::Down);
+        // The others still report up — the UI shows per-service detail.
+        assert_eq!(
+            health
+                .services
+                .iter()
+                .filter(|s| s.status == ServiceStatus::Up)
+                .count(),
+            4
+        );
+    }
+
+    #[tokio::test]
+    async fn unreachable_stack_reports_unreachable_not_down() {
+        // Bind-then-drop guarantees nothing is listening on the port.
+        let addr = {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap()
+        };
+        let health = poll_once(&client(), &endpoints_for(&format!("http://{addr}"))).await;
+        assert!(!health.ready);
+        assert!(health
+            .services
+            .iter()
+            .all(|s| s.status == ServiceStatus::Unreachable));
+    }
+
+    /// Opt-in check against a locally running stack (read-only GETs):
+    /// `cargo test -- --ignored live_stack`.
+    #[tokio::test]
+    #[ignore = "needs a running TT-Studio stack on localhost"]
+    async fn live_stack_poll() {
+        let health = poll_once(&client(), &Endpoints::local_default()).await;
+        for s in &health.services {
+            println!("{:<18} {} -> {:?}", s.name, s.url, s.status);
+        }
+        println!("ready: {}", health.ready);
+    }
+
+    #[test]
+    fn health_serializes_for_the_ui() {
+        let health = StackHealth {
+            services: vec![ServiceHealth {
+                name: "frontend".into(),
+                url: "http://localhost:3000/".into(),
+                status: ServiceStatus::Up,
+            }],
+            ready: false,
+        };
+        let json = serde_json::to_value(&health).unwrap();
+        assert_eq!(json["services"][0]["status"], "up");
+        assert_eq!(json["ready"], false);
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -3,11 +3,19 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 mod commands;
+mod profiles;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![commands::open_stack])
+        .plugin(tauri_plugin_store::Builder::new().build())
+        .invoke_handler(tauri::generate_handler![
+            commands::open_stack,
+            profiles::list_profiles,
+            profiles::save_profile,
+            profiles::delete_profile,
+            profiles::mark_profile_used,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod commands;
 mod hardware;
+mod health;
 mod profiles;
 mod secrets;
 
@@ -11,6 +12,7 @@ mod secrets;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
+        .manage(health::PollerState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -21,6 +23,9 @@ pub fn run() {
             secrets::clear_ssh_key_passphrase,
             secrets::has_ssh_key_passphrase,
             hardware::detect_hardware,
+            health::check_stack_health,
+            health::start_health_poll,
+            health::stop_health_poll,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 mod commands;
+mod hardware;
 mod profiles;
 mod secrets;
 
@@ -19,6 +20,7 @@ pub fn run() {
             secrets::set_ssh_key_passphrase,
             secrets::clear_ssh_key_passphrase,
             secrets::has_ssh_key_passphrase,
+            hardware::detect_hardware,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod commands;
 mod profiles;
+mod secrets;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -15,6 +16,9 @@ pub fn run() {
             profiles::save_profile,
             profiles::delete_profile,
             profiles::mark_profile_used,
+            secrets::set_ssh_key_passphrase,
+            secrets::clear_ssh_key_passphrase,
+            secrets::has_ssh_key_passphrase,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/profiles.rs
+++ b/desktop/src-tauri/src/profiles.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Connection profiles for the desktop shell.
+//!
+//! A profile describes a machine that runs (or will run) a TT-Studio stack:
+//! either this machine (`local`) or a remote one reached over SSH (`ssh`).
+//! Profiles persist via tauri-plugin-store in `profiles.json` in the app
+//! config dir. Secret material (passphrases, passwords) is never stored
+//! here — see `secrets.rs` for the OS-keychain side.
+
+use serde::{Deserialize, Serialize};
+use tauri::Wry;
+use tauri_plugin_store::StoreExt;
+
+const STORE_FILE: &str = "profiles.json";
+const PROFILES_KEY: &str = "profiles";
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileKind {
+    Local,
+    Ssh,
+}
+
+/// How to authenticate an SSH profile. Key passphrases live in the OS
+/// keychain keyed by profile id, never in the profile itself.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(tag = "method", rename_all = "snake_case")]
+pub enum SshAuth {
+    Agent,
+    Key { path: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Profile {
+    pub id: String,
+    pub name: String,
+    pub kind: ProfileKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<SshAuth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_repo_path: Option<String>,
+    /// Unix seconds of the last successful connect, for sorting the picker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used: Option<f64>,
+}
+
+// ---- pure CRUD over a profile list (unit-tested, no Tauri involved) ----
+
+pub fn parse_profiles(value: Option<&serde_json::Value>) -> Vec<Profile> {
+    // Tolerate a corrupt or missing store rather than wedging the picker.
+    value
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Insert or replace by id. New profiles append; existing ones keep position.
+pub fn upsert(profiles: &mut Vec<Profile>, profile: Profile) {
+    match profiles.iter_mut().find(|p| p.id == profile.id) {
+        Some(slot) => *slot = profile,
+        None => profiles.push(profile),
+    }
+}
+
+pub fn remove(profiles: &mut Vec<Profile>, id: &str) -> bool {
+    let before = profiles.len();
+    profiles.retain(|p| p.id != id);
+    profiles.len() != before
+}
+
+pub fn touch(profiles: &mut [Profile], id: &str, now: f64) -> bool {
+    match profiles.iter_mut().find(|p| p.id == id) {
+        Some(p) => {
+            p.last_used = Some(now);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Most-recently-used first; never-used profiles keep insertion order at the end.
+pub fn sort_recent_first(profiles: &mut [Profile]) {
+    profiles.sort_by(|a, b| {
+        b.last_used
+            .unwrap_or(0.0)
+            .partial_cmp(&a.last_used.unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+}
+
+// ---- Tauri commands wiring the pure layer to tauri-plugin-store ----
+
+fn read_store(app: &tauri::AppHandle<Wry>) -> Result<Vec<Profile>, String> {
+    let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
+    Ok(parse_profiles(store.get(PROFILES_KEY).as_ref()))
+}
+
+fn write_store(app: &tauri::AppHandle<Wry>, profiles: &[Profile]) -> Result<(), String> {
+    let store = app.store(STORE_FILE).map_err(|e| e.to_string())?;
+    let value = serde_json::to_value(profiles).map_err(|e| e.to_string())?;
+    store.set(PROFILES_KEY, value);
+    store.save().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn list_profiles(app: tauri::AppHandle<Wry>) -> Result<Vec<Profile>, String> {
+    let mut profiles = read_store(&app)?;
+    sort_recent_first(&mut profiles);
+    Ok(profiles)
+}
+
+#[tauri::command]
+pub fn save_profile(app: tauri::AppHandle<Wry>, profile: Profile) -> Result<Vec<Profile>, String> {
+    if profile.id.trim().is_empty() {
+        return Err("profile id must not be empty".to_string());
+    }
+    if profile.name.trim().is_empty() {
+        return Err("profile name must not be empty".to_string());
+    }
+    let mut profiles = read_store(&app)?;
+    upsert(&mut profiles, profile);
+    write_store(&app, &profiles)?;
+    Ok(profiles)
+}
+
+#[tauri::command]
+pub fn delete_profile(app: tauri::AppHandle<Wry>, id: String) -> Result<Vec<Profile>, String> {
+    let mut profiles = read_store(&app)?;
+    remove(&mut profiles, &id);
+    write_store(&app, &profiles)?;
+    Ok(profiles)
+}
+
+#[tauri::command]
+pub fn mark_profile_used(app: tauri::AppHandle<Wry>, id: String) -> Result<(), String> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_secs_f64();
+    let mut profiles = read_store(&app)?;
+    if touch(&mut profiles, &id, now) {
+        write_store(&app, &profiles)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssh_profile(id: &str, name: &str) -> Profile {
+        Profile {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: ProfileKind::Ssh,
+            host: Some("qb2.example.com".to_string()),
+            port: Some(22),
+            user: Some("jashan".to_string()),
+            auth: Some(SshAuth::Key {
+                path: "~/.ssh/id_ed25519".to_string(),
+            }),
+            remote_repo_path: Some("~/tt-studio".to_string()),
+            last_used: None,
+        }
+    }
+
+    #[test]
+    fn profile_round_trips_through_json() {
+        let profile = ssh_profile("p1", "QuietBox");
+        let json = serde_json::to_value(&profile).unwrap();
+        assert_eq!(json["kind"], "ssh");
+        assert_eq!(json["auth"]["method"], "key");
+        assert_eq!(json["auth"]["path"], "~/.ssh/id_ed25519");
+        let back: Profile = serde_json::from_value(json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn local_profile_omits_ssh_fields() {
+        let profile = Profile {
+            id: "local".to_string(),
+            name: "This machine".to_string(),
+            kind: ProfileKind::Local,
+            host: None,
+            port: None,
+            user: None,
+            auth: None,
+            remote_repo_path: None,
+            last_used: None,
+        };
+        let json = serde_json::to_value(&profile).unwrap();
+        assert!(json.get("host").is_none());
+        assert!(json.get("auth").is_none());
+        let back: Profile = serde_json::from_value(json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn agent_auth_round_trips() {
+        let json = serde_json::json!({ "method": "agent" });
+        let auth: SshAuth = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(auth, SshAuth::Agent);
+        assert_eq!(serde_json::to_value(&auth).unwrap(), json);
+    }
+
+    #[test]
+    fn parse_profiles_tolerates_missing_and_corrupt_values() {
+        assert!(parse_profiles(None).is_empty());
+        assert!(parse_profiles(Some(&serde_json::json!("not a list"))).is_empty());
+        assert!(parse_profiles(Some(&serde_json::json!([{ "bogus": true }]))).is_empty());
+        let good = serde_json::to_value(vec![ssh_profile("p1", "QuietBox")]).unwrap();
+        assert_eq!(parse_profiles(Some(&good)).len(), 1);
+    }
+
+    #[test]
+    fn upsert_appends_new_and_replaces_existing() {
+        let mut profiles = vec![];
+        upsert(&mut profiles, ssh_profile("p1", "QuietBox"));
+        upsert(&mut profiles, ssh_profile("p2", "Lab box"));
+        assert_eq!(profiles.len(), 2);
+        upsert(&mut profiles, ssh_profile("p1", "QuietBox (renamed)"));
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].name, "QuietBox (renamed)");
+    }
+
+    #[test]
+    fn remove_deletes_by_id() {
+        let mut profiles = vec![ssh_profile("p1", "a"), ssh_profile("p2", "b")];
+        assert!(remove(&mut profiles, "p1"));
+        assert_eq!(profiles.len(), 1);
+        assert!(!remove(&mut profiles, "nope"));
+        assert_eq!(profiles.len(), 1);
+    }
+
+    #[test]
+    fn touch_sets_last_used_only_for_known_ids() {
+        let mut profiles = vec![ssh_profile("p1", "a")];
+        assert!(touch(&mut profiles, "p1", 1000.0));
+        assert_eq!(profiles[0].last_used, Some(1000.0));
+        assert!(!touch(&mut profiles, "ghost", 2000.0));
+    }
+
+    #[test]
+    fn sort_puts_most_recent_first() {
+        let mut profiles = vec![
+            ssh_profile("never", "never used"),
+            ssh_profile("old", "old"),
+            ssh_profile("new", "new"),
+        ];
+        touch(&mut profiles, "old", 100.0);
+        touch(&mut profiles, "new", 200.0);
+        sort_recent_first(&mut profiles);
+        let ids: Vec<&str> = profiles.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, ["new", "old", "never"]);
+    }
+}

--- a/desktop/src-tauri/src/secrets.rs
+++ b/desktop/src-tauri/src/secrets.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! OS-keychain storage for SSH key passphrases.
+//!
+//! The only secret the desktop shell ever persists is the passphrase of an
+//! SSH private key, keyed by connection-profile id. Passwords are never
+//! persisted anywhere. On platforms without a usable keychain (e.g. headless
+//! Linux with no secret-service daemon) every operation degrades to a typed
+//! `keychain_unavailable` error the UI can explain instead of crashing.
+
+use serde::Serialize;
+
+const SERVICE: &str = "com.tenstorrent.tt-studio";
+
+/// Typed error surfaced to the UI. `code` tells the frontend which case it
+/// is; `message` carries platform detail for display/logging.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum SecretError {
+    /// No keychain backend is reachable (headless Linux without a
+    /// secret-service daemon, locked keychain, etc.). The UI should offer
+    /// ssh-agent auth or per-session passphrase entry instead.
+    KeychainUnavailable {
+        message: String,
+    },
+    NotFound,
+    Other {
+        message: String,
+    },
+}
+
+impl From<keyring::Error> for SecretError {
+    fn from(err: keyring::Error) -> Self {
+        match err {
+            keyring::Error::NoEntry => SecretError::NotFound,
+            keyring::Error::NoStorageAccess(e) => SecretError::KeychainUnavailable {
+                message: e.to_string(),
+            },
+            keyring::Error::PlatformFailure(e) => SecretError::KeychainUnavailable {
+                message: e.to_string(),
+            },
+            other => SecretError::Other {
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+fn entry_for(profile_id: &str) -> Result<keyring::Entry, SecretError> {
+    // One keychain entry per profile; the profile id is not secret.
+    keyring::Entry::new(SERVICE, &format!("ssh-key-passphrase:{profile_id}"))
+        .map_err(SecretError::from)
+}
+
+pub fn store_passphrase(profile_id: &str, passphrase: &str) -> Result<(), SecretError> {
+    entry_for(profile_id)?
+        .set_password(passphrase)
+        .map_err(SecretError::from)
+}
+
+pub fn load_passphrase(profile_id: &str) -> Result<String, SecretError> {
+    entry_for(profile_id)?
+        .get_password()
+        .map_err(SecretError::from)
+}
+
+pub fn forget_passphrase(profile_id: &str) -> Result<(), SecretError> {
+    match entry_for(profile_id)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(SecretError::from(e)),
+    }
+}
+
+// ---- Tauri commands ----
+//
+// The passphrase is write-only from the UI's point of view: the frontend can
+// set, clear, and probe existence, but never read it back — only the future
+// SSH connector (Rust side) consumes it via `load_passphrase`.
+
+#[tauri::command]
+pub fn set_ssh_key_passphrase(profile_id: String, passphrase: String) -> Result<(), SecretError> {
+    store_passphrase(&profile_id, &passphrase)
+}
+
+#[tauri::command]
+pub fn clear_ssh_key_passphrase(profile_id: String) -> Result<(), SecretError> {
+    forget_passphrase(&profile_id)
+}
+
+#[tauri::command]
+pub fn has_ssh_key_passphrase(profile_id: String) -> Result<bool, SecretError> {
+    match load_passphrase(&profile_id) {
+        Ok(_) => Ok(true),
+        Err(SecretError::NotFound) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Once;
+
+    use keyring::credential::{Credential, CredentialApi, CredentialBuilderApi};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Shared in-memory credential store so tests never touch (or require) a
+    /// real keychain daemon. keyring's built-in mock keeps state per Entry,
+    /// which can't exercise our create-entry-per-call functions.
+    static VAULT: Mutex<Option<HashMap<(String, String), String>>> = Mutex::new(None);
+
+    #[derive(Debug)]
+    struct MemCredential {
+        service: String,
+        user: String,
+    }
+
+    impl CredentialApi for MemCredential {
+        fn set_password(&self, password: &str) -> keyring::Result<()> {
+            let mut vault = VAULT.lock().unwrap();
+            vault
+                .get_or_insert_with(HashMap::new)
+                .insert((self.service.clone(), self.user.clone()), password.into());
+            Ok(())
+        }
+
+        fn get_password(&self) -> keyring::Result<String> {
+            let vault = VAULT.lock().unwrap();
+            vault
+                .as_ref()
+                .and_then(|v| v.get(&(self.service.clone(), self.user.clone())))
+                .cloned()
+                .ok_or(keyring::Error::NoEntry)
+        }
+
+        fn set_secret(&self, secret: &[u8]) -> keyring::Result<()> {
+            self.set_password(&String::from_utf8_lossy(secret))
+        }
+
+        fn get_secret(&self) -> keyring::Result<Vec<u8>> {
+            self.get_password().map(String::into_bytes)
+        }
+
+        fn delete_credential(&self) -> keyring::Result<()> {
+            let mut vault = VAULT.lock().unwrap();
+            vault
+                .get_or_insert_with(HashMap::new)
+                .remove(&(self.service.clone(), self.user.clone()))
+                .map(|_| ())
+                .ok_or(keyring::Error::NoEntry)
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct MemBuilder;
+
+    impl CredentialBuilderApi for MemBuilder {
+        fn build(
+            &self,
+            _target: Option<&str>,
+            service: &str,
+            user: &str,
+        ) -> keyring::Result<Box<Credential>> {
+            Ok(Box::new(MemCredential {
+                service: service.into(),
+                user: user.into(),
+            }))
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn use_mock_keyring() {
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| {
+            keyring::set_default_credential_builder(Box::new(MemBuilder));
+        });
+    }
+
+    #[test]
+    fn passphrase_round_trip_and_forget() {
+        use_mock_keyring();
+        store_passphrase("p1", "hunter2").unwrap();
+        assert_eq!(load_passphrase("p1").unwrap(), "hunter2");
+        forget_passphrase("p1").unwrap();
+        assert_eq!(load_passphrase("p1"), Err(SecretError::NotFound));
+    }
+
+    #[test]
+    fn forget_is_idempotent_for_missing_entries() {
+        use_mock_keyring();
+        assert_eq!(forget_passphrase("never-stored"), Ok(()));
+    }
+
+    #[test]
+    fn entries_are_scoped_per_profile() {
+        use_mock_keyring();
+        store_passphrase("a", "secret-a").unwrap();
+        store_passphrase("b", "secret-b").unwrap();
+        assert_eq!(load_passphrase("a").unwrap(), "secret-a");
+        assert_eq!(load_passphrase("b").unwrap(), "secret-b");
+        forget_passphrase("a").unwrap();
+        assert_eq!(load_passphrase("b").unwrap(), "secret-b");
+    }
+
+    #[test]
+    fn keyring_errors_map_to_typed_errors() {
+        assert_eq!(
+            SecretError::from(keyring::Error::NoEntry),
+            SecretError::NotFound
+        );
+        let unavailable = SecretError::from(keyring::Error::NoStorageAccess(
+            "no secret-service daemon".into(),
+        ));
+        assert!(matches!(
+            unavailable,
+            SecretError::KeychainUnavailable { .. }
+        ));
+        // Serialized shape is the UI contract: a discriminant the frontend
+        // can switch on plus a human message.
+        let json = serde_json::to_value(&unavailable).unwrap();
+        assert_eq!(json["code"], "keychain_unavailable");
+        assert!(json["message"].as_str().unwrap().contains("daemon"));
+        assert_eq!(
+            serde_json::to_value(SecretError::NotFound).unwrap()["code"],
+            "not_found"
+        );
+    }
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2,50 +2,216 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import ConnectionPicker from "./views/ConnectionPicker";
+import ProfileEditor from "./views/ProfileEditor";
+import {
+  asSecretError,
+  deleteProfile,
+  detectHardware,
+  listProfiles,
+  markProfileUsed,
+  onStackHealth,
+  openStack,
+  saveProfile,
+  setSshKeyPassphrase,
+  startHealthPoll,
+  stopHealthPoll,
+  type HardwareProbe,
+  type Profile,
+  type StackHealth,
+} from "./lib/ipc";
 
 // The real TT-Studio frontend is served by the stack itself — the desktop
 // shell navigates this window to it rather than bundling it (the web app
 // derives URLs from window.location, so it must load from its own origin).
 const STACK_URL = "http://localhost:3000";
 
-function App() {
-  const [error, setError] = useState<string | null>(null);
-  const [opening, setOpening] = useState(false);
+type Screen =
+  | { name: "loading" }
+  | { name: "picker" }
+  | { name: "editor"; profile?: Profile }
+  | { name: "connecting"; target: Profile | null };
 
-  const openStack = async () => {
-    setOpening(true);
-    setError(null);
+const STATUS_STYLE: Record<string, string> = {
+  up: "bg-emerald-500",
+  down: "bg-red-500",
+  unreachable: "bg-zinc-600",
+};
+
+/** Per-service health checklist shown while waiting for the stack. */
+function HealthGate({
+  health,
+  target,
+}: {
+  health: StackHealth | null;
+  target: Profile | null;
+}) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
+      <header className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {target ? `Connecting to ${target.name}` : "Starting TT-Studio"}
+        </h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          {health?.ready
+            ? "All services are up — opening TT-Studio…"
+            : "Waiting for all services to come up"}
+        </p>
+      </header>
+      <ul className="flex w-full max-w-sm flex-col gap-2">
+        {(health?.services ?? []).map((s) => (
+          <li
+            key={s.name}
+            className="flex items-center justify-between rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm"
+          >
+            <span>{s.name}</span>
+            <span className="flex items-center gap-2 text-xs text-zinc-400">
+              {s.status}
+              <span
+                className={`h-2 w-2 rounded-full ${STATUS_STYLE[s.status] ?? "bg-zinc-600"}`}
+              />
+            </span>
+          </li>
+        ))}
+        {!health && (
+          <li className="text-center text-sm text-zinc-500">Checking…</li>
+        )}
+      </ul>
+    </main>
+  );
+}
+
+function App() {
+  const [screen, setScreen] = useState<Screen>({ name: "loading" });
+  const [hardware, setHardware] = useState<HardwareProbe | null>(null);
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [health, setHealth] = useState<StackHealth | null>(null);
+  const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const opening = useRef(false);
+
+  useEffect(() => {
+    Promise.all([detectHardware(), listProfiles()])
+      .then(([hw, saved]) => {
+        setHardware(hw);
+        setProfiles(saved);
+        setScreen({ name: "picker" });
+      })
+      .catch((e) => {
+        setError(String(e));
+        setScreen({ name: "picker" });
+      });
+  }, []);
+
+  // While connecting: poll stack health, and navigate once everything is up.
+  useEffect(() => {
+    if (screen.name !== "connecting") return;
+    let unlisten: (() => void) | undefined;
+    onStackHealth(setHealth).then((fn) => {
+      unlisten = fn;
+    });
+    startHealthPoll().catch((e) => setError(String(e)));
+    return () => {
+      unlisten?.();
+      stopHealthPoll().catch(() => {});
+    };
+  }, [screen.name]);
+
+  useEffect(() => {
+    if (screen.name !== "connecting" || !health?.ready || opening.current)
+      return;
+    opening.current = true;
+    stopHealthPoll()
+      .catch(() => {})
+      .then(() => openStack(STACK_URL))
+      .catch((e) => {
+        opening.current = false;
+        setError(String(e));
+      });
+  }, [screen.name, health]);
+
+  const connect = useCallback((target: Profile | null) => {
+    setHealth(null);
+    opening.current = false;
+    if (target) markProfileUsed(target.id).catch(() => {});
+    setScreen({ name: "connecting", target });
+  }, []);
+
+  const handleSave = useCallback(
+    async (profile: Profile, passphrase: string | null) => {
+      try {
+        setProfiles(await saveProfile(profile));
+      } catch (e) {
+        setError(String(e));
+        return;
+      }
+      if (passphrase !== null) {
+        try {
+          await setSshKeyPassphrase(profile.id, passphrase);
+          setKeychainWarning(null);
+        } catch (e) {
+          const secretErr = asSecretError(e);
+          setKeychainWarning(
+            secretErr?.code === "keychain_unavailable"
+              ? "No OS keychain is available on this machine, so the passphrase was not saved — use ssh-agent or enter it when connecting."
+              : `Couldn't save the passphrase: ${secretErr?.message ?? e}`,
+          );
+        }
+      }
+      setScreen({ name: "picker" });
+    },
+    [],
+  );
+
+  const handleDelete = useCallback(async (profile: Profile) => {
     try {
-      await invoke("open_stack", { url: STACK_URL });
-      // On success the window navigates away from the launcher entirely.
+      setProfiles(await deleteProfile(profile.id));
     } catch (e) {
       setError(String(e));
-      setOpening(false);
     }
-  };
+  }, []);
+
+  if (screen.name === "loading") {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-zinc-950 text-sm text-zinc-500">
+        Loading…
+      </main>
+    );
+  }
+
+  if (screen.name === "editor") {
+    return (
+      <ProfileEditor
+        initial={screen.profile}
+        keychainWarning={keychainWarning}
+        onSave={handleSave}
+        onCancel={() => setScreen({ name: "picker" })}
+      />
+    );
+  }
+
+  if (screen.name === "connecting") {
+    return <HealthGate health={health} target={screen.target} />;
+  }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 text-zinc-100">
-      <h1 className="text-3xl font-semibold tracking-tight">TT-Studio</h1>
-      <p className="text-sm text-zinc-400">Desktop launcher</p>
-      <button
-        type="button"
-        onClick={openStack}
-        disabled={opening}
-        className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 disabled:opacity-50"
-      >
-        {opening ? "Opening…" : "Open TT-Studio"}
-      </button>
-      <p className="text-xs text-zinc-500">{STACK_URL}</p>
-      {error && (
-        <p className="max-w-md text-center text-xs text-red-400">
-          Couldn&apos;t open the stack: {error}. Is TT-Studio running? Start it
-          with <code className="text-zinc-300">python run.py</code>.
+    <>
+      <ConnectionPicker
+        hardware={hardware}
+        profiles={profiles}
+        onConnectLocal={() => connect(null)}
+        onConnectSsh={connect}
+        onAddMachine={() => setScreen({ name: "editor" })}
+        onEditProfile={(profile) => setScreen({ name: "editor", profile })}
+        onDeleteProfile={handleDelete}
+      />
+      {(error || keychainWarning) && (
+        <p className="fixed inset-x-0 bottom-4 mx-auto max-w-md rounded-md bg-zinc-900 px-4 py-2 text-center text-xs text-amber-400">
+          {error ?? keychainWarning}
         </p>
       )}
-    </main>
+    </>
   );
 }
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -3,8 +3,16 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import BringUpProgress from "./views/BringUpProgress";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
+import {
+  initialBringUpState,
+  parseEventLine,
+  reduceEvent,
+  type BringUpState,
+} from "./lib/events";
 import {
   asSecretError,
   deleteProfile,
@@ -87,6 +95,7 @@ function App() {
   const [hardware, setHardware] = useState<HardwareProbe | null>(null);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [health, setHealth] = useState<StackHealth | null>(null);
+  const [bringUp, setBringUp] = useState<BringUpState | null>(null);
   const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const opening = useRef(false);
@@ -117,6 +126,36 @@ function App() {
       stopHealthPoll().catch(() => {});
     };
   }, [screen.name]);
+
+  // When a bring-up is running (`python run.py --json-events` piped in by the
+  // shell), render its NDJSON stream natively instead of the bare checklist.
+  useEffect(() => {
+    if (screen.name !== "connecting") return;
+    let unlisten: (() => void) | undefined;
+    listen<string>("bringup-line", ({ payload }) => {
+      const event = parseEventLine(payload);
+      if (!event) return;
+      setBringUp((prev) => reduceEvent(prev ?? initialBringUpState(), event));
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+      setBringUp(null);
+    };
+  }, [screen.name]);
+
+  const handleBringUpReady = useCallback((appUrl: string) => {
+    if (opening.current) return;
+    opening.current = true;
+    stopHealthPoll()
+      .catch(() => {})
+      .then(() => openStack(appUrl))
+      .catch((e) => {
+        opening.current = false;
+        setError(String(e));
+      });
+  }, []);
 
   useEffect(() => {
     if (screen.name !== "connecting" || !health?.ready || opening.current)
@@ -192,6 +231,9 @@ function App() {
   }
 
   if (screen.name === "connecting") {
+    if (bringUp && bringUp.phases.length > 0) {
+      return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
+    }
     return <HealthGate health={health} target={screen.target} />;
   }
 

--- a/desktop/src/lib/events.test.ts
+++ b/desktop/src/lib/events.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from "vitest";
+import {
+  initialBringUpState,
+  parseEventLine,
+  reduceEvent,
+  reduceStream,
+} from "./events";
+
+// Fixture streams mirroring dev-docs/json-events.md.
+
+export const SUCCESS_STREAM = [
+  `{"v": 1, "ts": 1.0, "event": "phase_begin", "phase": "Checks", "detail": {"index": 1, "total": 5}}`,
+  `{"v": 1, "ts": 1.1, "event": "progress", "phase": "Checks", "detail": {"activity": "tt-smi"}}`,
+  `{"v": 1, "ts": 3.5, "event": "phase_end", "phase": "Checks", "detail": {"index": 1, "status": "ok", "duration_s": 2.5}}`,
+  `{"v": 1, "ts": 4.0, "event": "phase_begin", "phase": "Pull", "detail": {"index": 2, "total": 5}}`,
+  `{"v": 1, "ts": 4.5, "event": "progress", "phase": "Build", "detail": {"kind": "phase_renamed"}}`,
+  `{"v": 1, "ts": 5.0, "event": "progress", "phase": "Build", "detail": {"kind": "pulled", "service": "frontend"}}`,
+  `{"v": 1, "ts": 6.0, "event": "note", "phase": "Build", "detail": {"text": "image pull skipped (cached)"}}`,
+  `{"v": 1, "ts": 7.0, "event": "phase_end", "phase": "Build", "detail": {"index": 2, "status": "ok", "duration_s": 3.0}}`,
+  `{"v": 1, "ts": 8.0, "event": "warn", "phase": null, "detail": {"text": "HF_TOKEN not set — gated models unavailable"}}`,
+  `{"v": 1, "ts": 9.0, "event": "ready", "phase": null, "detail": {"urls": {"app": "http://localhost:3000", "fastapi": "http://localhost:8001"}, "hardware": "QuietBox (QB2) · 4 device(s)"}}`,
+].join("\n");
+
+export const FAILURE_STREAM = [
+  `{"v": 1, "ts": 1.0, "event": "phase_begin", "phase": "Launch", "detail": {"index": 5, "total": 5}}`,
+  `{"v": 1, "ts": 2.0, "event": "error", "phase": "Launch", "detail": {"message": "Inference server didn't start — port 8001 is still taken", "remediation": "lsof -i :8001; python run.py --stop, then re-run", "service": "Inference server", "log": "fastapi.log"}}`,
+  `{"v": 1, "ts": 2.1, "event": "phase_end", "phase": "Launch", "detail": {"index": 5, "status": "failed"}}`,
+].join("\n");
+
+export const PROMPT_BLOCKED_STREAM = [
+  `{"v": 1, "ts": 1.0, "event": "phase_begin", "phase": "Configure", "detail": {"index": 2, "total": 5}}`,
+  `{"v": 1, "ts": 2.0, "event": "prompt_blocked", "phase": "Configure", "detail": {"prompt": "Enter your Hugging Face token", "remediation": "set HF_TOKEN in .env, then re-run"}}`,
+].join("\n");
+
+describe("parseEventLine", () => {
+  it("parses a valid v1 envelope", () => {
+    const event = parseEventLine(
+      `{"v": 1, "ts": 2.5, "event": "note", "phase": "Checks", "detail": {"text": "hi"}}`,
+    );
+    expect(event).toEqual({
+      v: 1,
+      ts: 2.5,
+      event: "note",
+      phase: "Checks",
+      detail: { text: "hi" },
+    });
+  });
+
+  it("returns null for non-JSON bootstrap lines and blanks", () => {
+    expect(parseEventLine("Creating venv…")).toBeNull();
+    expect(parseEventLine("")).toBeNull();
+    expect(parseEventLine("   ")).toBeNull();
+  });
+
+  it("returns null for JSON that is not a v1 event envelope", () => {
+    expect(parseEventLine(`[1, 2, 3]`)).toBeNull();
+    expect(parseEventLine(`"just a string"`)).toBeNull();
+    expect(parseEventLine(`{"v": 2, "event": "note"}`)).toBeNull();
+    expect(parseEventLine(`{"v": 1, "ts": 1.0}`)).toBeNull();
+  });
+
+  it("tolerates a missing or malformed detail", () => {
+    const event = parseEventLine(`{"v": 1, "ts": 1.0, "event": "note"}`);
+    expect(event?.detail).toEqual({});
+    expect(event?.phase).toBeNull();
+  });
+});
+
+describe("reduceEvent / reduceStream", () => {
+  it("folds a successful bring-up into ok phases and ready state", () => {
+    const state = reduceStream(SUCCESS_STREAM);
+    expect(state.totalPhases).toBe(5);
+    expect(state.phases.map((p) => [p.name, p.status])).toEqual([
+      ["Checks", "ok"],
+      ["Build", "ok"], // renamed from Pull mid-phase
+    ]);
+    expect(state.phases[0].durationS).toBe(2.5);
+    expect(state.notes).toEqual(["image pull skipped (cached)"]);
+    expect(state.warnings).toEqual([
+      "HF_TOKEN not set — gated models unavailable",
+    ]);
+    expect(state.errors).toEqual([]);
+    expect(state.ready?.urls.app).toBe("http://localhost:3000");
+    expect(state.ready?.hardware).toContain("QuietBox");
+  });
+
+  it("tracks the running phase's activity from progress events", () => {
+    const state = reduceStream(
+      SUCCESS_STREAM.split("\n").slice(0, 2).join("\n"),
+    );
+    expect(state.phases[0].status).toBe("running");
+    expect(state.phases[0].activity).toBe("tt-smi");
+  });
+
+  it("folds a failure into an error card and a failed phase", () => {
+    const state = reduceStream(FAILURE_STREAM);
+    expect(state.phases).toEqual([
+      expect.objectContaining({ name: "Launch", status: "failed" }),
+    ]);
+    expect(state.errors).toHaveLength(1);
+    expect(state.errors[0].message).toContain("port 8001");
+    expect(state.errors[0].remediation).toContain("--stop");
+    expect(state.errors[0].service).toBe("Inference server");
+    expect(state.errors[0].log).toBe("fastapi.log");
+    expect(state.ready).toBeNull();
+  });
+
+  it("captures prompt_blocked with its remediation", () => {
+    const state = reduceStream(PROMPT_BLOCKED_STREAM);
+    expect(state.promptBlocked?.prompt).toContain("Hugging Face");
+    expect(state.promptBlocked?.remediation).toContain("HF_TOKEN");
+  });
+
+  it("ignores unknown event types (non-breaking within v1)", () => {
+    const before = initialBringUpState();
+    const after = reduceEvent(before, {
+      v: 1,
+      ts: 1,
+      event: "totally_new_thing",
+      phase: null,
+      detail: { anything: true },
+    });
+    expect(after).toEqual(before);
+  });
+
+  it("skips unparseable lines mixed into the stream", () => {
+    const state = reduceStream(
+      `pre-bootstrap chatter\n${FAILURE_STREAM}\nmore chatter`,
+    );
+    expect(state.errors).toHaveLength(1);
+  });
+});

--- a/desktop/src/lib/events.ts
+++ b/desktop/src/lib/events.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Types and reducer for the launcher's machine-readable bring-up stream
+// (`python run.py --json-events`). Mirrors the NDJSON schema documented in
+// dev-docs/json-events.md: one JSON object per line with a stable envelope
+// {v, ts, event, phase, detail}. Consumers must skip unparseable lines and
+// tolerate unknown event types / extra detail keys (non-breaking within v1).
+
+export type BringUpEventType =
+  | "phase_begin"
+  | "phase_end"
+  | "progress"
+  | "note"
+  | "warn"
+  | "error"
+  | "prompt_blocked"
+  | "ready"
+  | "status";
+
+export interface BringUpEvent {
+  v: number;
+  ts: number;
+  event: BringUpEventType | (string & {});
+  phase: string | null;
+  detail: Record<string, unknown>;
+}
+
+/**
+ * Parse one NDJSON line. Returns null for anything that isn't a v1 event
+ * envelope — e.g. the plain bootstrap lines a fresh checkout prints before
+ * the CLI exists — so callers can simply filter.
+ */
+export function parseEventLine(line: string): BringUpEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return null;
+  const obj = value as Record<string, unknown>;
+  if (obj.v !== 1 || typeof obj.event !== "string") return null;
+  return {
+    v: 1,
+    ts: typeof obj.ts === "number" ? obj.ts : 0,
+    event: obj.event,
+    phase: typeof obj.phase === "string" ? obj.phase : null,
+    detail:
+      typeof obj.detail === "object" && obj.detail !== null
+        ? (obj.detail as Record<string, unknown>)
+        : {},
+  };
+}
+
+// ---- reducer: fold the event stream into renderable bring-up state ----
+
+export type PhaseStatus = "running" | "ok" | "failed";
+
+export interface PhaseState {
+  name: string;
+  index: number;
+  status: PhaseStatus;
+  durationS?: number;
+  /** Latest sub-step reported via progress events while running. */
+  activity?: string;
+}
+
+export interface BringUpError {
+  message: string;
+  remediation?: string;
+  service?: string;
+  log?: string;
+}
+
+export interface ReadyInfo {
+  urls: Record<string, string>;
+  hardware?: string;
+}
+
+export interface BringUpState {
+  phases: PhaseState[];
+  totalPhases: number | null;
+  notes: string[];
+  warnings: string[];
+  errors: BringUpError[];
+  promptBlocked: { prompt: string; remediation?: string } | null;
+  ready: ReadyInfo | null;
+}
+
+export function initialBringUpState(): BringUpState {
+  return {
+    phases: [],
+    totalPhases: null,
+    notes: [],
+    warnings: [],
+    errors: [],
+    promptBlocked: null,
+    ready: null,
+  };
+}
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" ? v : undefined;
+
+/** Fold one event into the state. Returns a new state object. */
+export function reduceEvent(
+  state: BringUpState,
+  event: BringUpEvent,
+): BringUpState {
+  const d = event.detail;
+  switch (event.event) {
+    case "phase_begin": {
+      const phase: PhaseState = {
+        name: event.phase ?? `Phase ${state.phases.length + 1}`,
+        index:
+          typeof d.index === "number" ? d.index : state.phases.length + 1,
+        status: "running",
+      };
+      return {
+        ...state,
+        totalPhases:
+          typeof d.total === "number" ? d.total : state.totalPhases,
+        phases: [...state.phases, phase],
+      };
+    }
+    case "phase_end": {
+      const phases = state.phases.map((p) =>
+        p.name === event.phase && p.status === "running"
+          ? {
+              ...p,
+              status: (d.status === "ok" ? "ok" : "failed") as PhaseStatus,
+              durationS:
+                typeof d.duration_s === "number" ? d.duration_s : undefined,
+              activity: undefined,
+            }
+          : p,
+      );
+      return { ...state, phases };
+    }
+    case "progress": {
+      // A retitle (Pull → Build fallback) renames the running phase; any
+      // other progress updates its current activity line.
+      if (d.kind === "phase_renamed" && event.phase) {
+        const phases = state.phases.map((p) =>
+          p.status === "running" ? { ...p, name: event.phase as string } : p,
+        );
+        return { ...state, phases };
+      }
+      const activity =
+        str(d.activity) ??
+        (str(d.kind) && str(d.service)
+          ? `${d.kind}: ${d.service}`
+          : str(d.label));
+      if (!activity) return state;
+      const phases = state.phases.map((p) =>
+        p.status === "running" && (event.phase === null || p.name === event.phase)
+          ? { ...p, activity }
+          : p,
+      );
+      return { ...state, phases };
+    }
+    case "note":
+      return str(d.text)
+        ? { ...state, notes: [...state.notes, d.text as string] }
+        : state;
+    case "warn":
+      return str(d.text)
+        ? { ...state, warnings: [...state.warnings, d.text as string] }
+        : state;
+    case "error":
+      return {
+        ...state,
+        errors: [
+          ...state.errors,
+          {
+            message: str(d.message) ?? "Bring-up failed",
+            remediation: str(d.remediation),
+            service: str(d.service),
+            log: str(d.log),
+          },
+        ],
+      };
+    case "prompt_blocked":
+      return {
+        ...state,
+        promptBlocked: {
+          prompt: str(d.prompt) ?? "The launcher needs interactive input",
+          remediation: str(d.remediation),
+        },
+      };
+    case "ready":
+      return {
+        ...state,
+        ready: {
+          urls:
+            typeof d.urls === "object" && d.urls !== null
+              ? (d.urls as Record<string, string>)
+              : {},
+          hardware: str(d.hardware),
+        },
+      };
+    default:
+      // Unknown event types are non-breaking within v1 — ignore.
+      return state;
+  }
+}
+
+/** Convenience for tests and replay: fold a whole NDJSON document. */
+export function reduceStream(ndjson: string): BringUpState {
+  return ndjson
+    .split("\n")
+    .map(parseEventLine)
+    .filter((e): e is BringUpEvent => e !== null)
+    .reduce(reduceEvent, initialBringUpState());
+}

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Typed wrappers around the Tauri IPC surface exposed by src-tauri. Keep the
+// shapes in sync with the Rust structs (profiles.rs, hardware.rs, health.rs,
+// secrets.rs) — serde uses snake_case throughout.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type ProfileKind = "local" | "ssh";
+
+export type SshAuth = { method: "agent" } | { method: "key"; path: string };
+
+export interface Profile {
+  id: string;
+  name: string;
+  kind: ProfileKind;
+  host?: string;
+  port?: number;
+  user?: string;
+  auth?: SshAuth;
+  remote_repo_path?: string;
+  last_used?: number;
+}
+
+export interface HardwareProbe {
+  accelerator_present: boolean;
+  default_mode: ProfileKind;
+}
+
+export type ServiceStatus = "up" | "down" | "unreachable";
+
+export interface ServiceHealth {
+  name: string;
+  url: string;
+  status: ServiceStatus;
+}
+
+export interface StackHealth {
+  services: ServiceHealth[];
+  ready: boolean;
+}
+
+export interface SecretError {
+  code: "keychain_unavailable" | "not_found" | "other";
+  message?: string;
+}
+
+// ---- profiles ----
+
+export const listProfiles = () => invoke<Profile[]>("list_profiles");
+
+export const saveProfile = (profile: Profile) =>
+  invoke<Profile[]>("save_profile", { profile });
+
+export const deleteProfile = (id: string) =>
+  invoke<Profile[]>("delete_profile", { id });
+
+export const markProfileUsed = (id: string) =>
+  invoke<void>("mark_profile_used", { id });
+
+// ---- secrets (write-only from the UI; reads stay in Rust) ----
+
+export const setSshKeyPassphrase = (profileId: string, passphrase: string) =>
+  invoke<void>("set_ssh_key_passphrase", { profileId, passphrase });
+
+export const clearSshKeyPassphrase = (profileId: string) =>
+  invoke<void>("clear_ssh_key_passphrase", { profileId });
+
+export const hasSshKeyPassphrase = (profileId: string) =>
+  invoke<boolean>("has_ssh_key_passphrase", { profileId });
+
+/** Narrow an unknown invoke() rejection into a SecretError when possible. */
+export function asSecretError(e: unknown): SecretError | null {
+  if (typeof e === "object" && e !== null && "code" in e) {
+    return e as SecretError;
+  }
+  return null;
+}
+
+// ---- hardware & health ----
+
+export const detectHardware = () => invoke<HardwareProbe>("detect_hardware");
+
+export const checkStackHealth = () =>
+  invoke<StackHealth>("check_stack_health");
+
+export const startHealthPoll = () => invoke<void>("start_health_poll");
+
+export const stopHealthPoll = () => invoke<void>("stop_health_poll");
+
+export const onStackHealth = (
+  handler: (health: StackHealth) => void,
+): Promise<UnlistenFn> =>
+  listen<StackHealth>("stack-health", (event) => handler(event.payload));
+
+// ---- navigation ----
+
+export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/views/BringUpProgress.test.tsx
+++ b/desktop/src/views/BringUpProgress.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import BringUpProgress from "./BringUpProgress";
+import { reduceStream } from "../lib/events";
+import {
+  FAILURE_STREAM,
+  PROMPT_BLOCKED_STREAM,
+  SUCCESS_STREAM,
+} from "../lib/events.test";
+
+afterEach(cleanup);
+
+describe("BringUpProgress", () => {
+  it("renders the phase stepper with notes and warnings for a success", () => {
+    const state = reduceStream(SUCCESS_STREAM);
+    const onReady = vi.fn();
+    render(<BringUpProgress state={state} onReady={onReady} />);
+
+    expect(screen.getByTestId("phase-Checks").textContent).toContain("1/5");
+    // The Pull phase was renamed to Build mid-run.
+    expect(screen.getByTestId("phase-Build")).toBeTruthy();
+    expect(screen.queryByTestId("phase-Pull")).toBeNull();
+    expect(screen.getByText("image pull skipped (cached)")).toBeTruthy();
+    expect(screen.getByTestId("bringup-warning").textContent).toContain(
+      "HF_TOKEN",
+    );
+    expect(screen.getByText(/opening/i)).toBeTruthy();
+  });
+
+  it("calls onReady with the app url once the launcher reports ready", () => {
+    const onReady = vi.fn();
+    render(
+      <BringUpProgress state={reduceStream(SUCCESS_STREAM)} onReady={onReady} />,
+    );
+    expect(onReady).toHaveBeenCalledWith("http://localhost:3000");
+  });
+
+  it("does not call onReady while still running or after a failure", () => {
+    const onReady = vi.fn();
+    const { unmount } = render(
+      <BringUpProgress state={reduceStream(FAILURE_STREAM)} onReady={onReady} />,
+    );
+    expect(onReady).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("renders an error card with remediation on failure", () => {
+    const state = reduceStream(FAILURE_STREAM);
+    render(<BringUpProgress state={state} onReady={() => {}} />);
+
+    const card = screen.getByTestId("bringup-error");
+    expect(card.textContent).toContain("port 8001");
+    expect(card.textContent).toContain("python run.py --stop");
+    expect(card.textContent).toContain("fastapi.log");
+    expect(screen.getByTestId("phase-Launch").textContent).toContain("✕");
+  });
+
+  it("explains a blocked prompt with its remediation", () => {
+    const state = reduceStream(PROMPT_BLOCKED_STREAM);
+    render(<BringUpProgress state={state} onReady={() => {}} />);
+
+    const card = screen.getByTestId("bringup-prompt-blocked");
+    expect(card.textContent).toContain("Hugging Face");
+    expect(card.textContent).toContain("HF_TOKEN");
+  });
+});

--- a/desktop/src/views/BringUpProgress.tsx
+++ b/desktop/src/views/BringUpProgress.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Native rendering of the launcher's bring-up stream (--json-events): a
+// phase stepper, notes/warnings, error cards with remediation, and the
+// ready → open-the-stack transition. Pure view over BringUpState.
+
+import { useEffect } from "react";
+import type { BringUpState, PhaseState } from "../lib/events";
+
+function PhaseRow({ phase, total }: { phase: PhaseState; total: number | null }) {
+  const icon =
+    phase.status === "ok" ? (
+      <span className="text-emerald-400">✓</span>
+    ) : phase.status === "failed" ? (
+      <span className="text-red-400">✕</span>
+    ) : (
+      <span className="inline-block h-3 w-3 animate-spin rounded-full border border-zinc-500 border-t-transparent" />
+    );
+  return (
+    <li
+      data-testid={`phase-${phase.name}`}
+      className="flex items-center gap-3 rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm"
+    >
+      <span className="w-4 text-center">{icon}</span>
+      <span className="text-xs text-zinc-500">
+        {phase.index}
+        {total ? `/${total}` : ""}
+      </span>
+      <span className="font-medium">{phase.name}</span>
+      {phase.status === "running" && phase.activity && (
+        <span className="truncate text-xs text-zinc-400">
+          {phase.activity}
+        </span>
+      )}
+      {phase.durationS !== undefined && (
+        <span className="ml-auto text-xs text-zinc-500">
+          {phase.durationS.toFixed(1)}s
+        </span>
+      )}
+    </li>
+  );
+}
+
+interface Props {
+  state: BringUpState;
+  /** Called once the launcher reports ready and the app URL is known. */
+  onReady: (appUrl: string) => void;
+}
+
+function BringUpProgress({ state, onReady }: Props) {
+  const appUrl = state.ready?.urls.app;
+  useEffect(() => {
+    if (appUrl) onReady(appUrl);
+  }, [appUrl, onReady]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 py-10 text-zinc-100">
+      <header className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Starting TT-Studio
+        </h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          {state.ready
+            ? `Ready${state.ready.hardware ? ` on ${state.ready.hardware}` : ""} — opening…`
+            : state.errors.length > 0
+              ? "Bring-up hit a problem"
+              : "Setting up services on the machine"}
+        </p>
+      </header>
+
+      <ol className="flex w-full max-w-md flex-col gap-2">
+        {state.phases.map((phase) => (
+          <PhaseRow key={phase.name} phase={phase} total={state.totalPhases} />
+        ))}
+      </ol>
+
+      {(state.notes.length > 0 || state.warnings.length > 0) && (
+        <section className="flex w-full max-w-md flex-col gap-1">
+          {state.notes.map((note, i) => (
+            <p key={`n${i}`} className="text-xs text-zinc-400">
+              {note}
+            </p>
+          ))}
+          {state.warnings.map((warning, i) => (
+            <p
+              key={`w${i}`}
+              data-testid="bringup-warning"
+              className="text-xs text-amber-400"
+            >
+              ⚠ {warning}
+            </p>
+          ))}
+        </section>
+      )}
+
+      {state.errors.map((err, i) => (
+        <section
+          key={i}
+          data-testid="bringup-error"
+          className="w-full max-w-md rounded-lg border border-red-900 bg-red-950/40 p-4"
+        >
+          <p className="text-sm font-medium text-red-300">
+            {err.service ? `${err.service}: ` : ""}
+            {err.message}
+          </p>
+          {err.remediation && (
+            <p className="mt-2 text-xs text-red-200/80">
+              Try:{" "}
+              <code className="rounded bg-zinc-900 px-1 py-0.5">
+                {err.remediation}
+              </code>
+            </p>
+          )}
+          {err.log && (
+            <p className="mt-1 text-xs text-red-200/60">Log: {err.log}</p>
+          )}
+        </section>
+      ))}
+
+      {state.promptBlocked && (
+        <section
+          data-testid="bringup-prompt-blocked"
+          className="w-full max-w-md rounded-lg border border-amber-900 bg-amber-950/40 p-4"
+        >
+          <p className="text-sm font-medium text-amber-300">
+            The launcher needs input it can't ask for here
+          </p>
+          <p className="mt-1 text-xs text-amber-200/80">
+            {state.promptBlocked.prompt}
+          </p>
+          {state.promptBlocked.remediation && (
+            <p className="mt-2 text-xs text-amber-200/80">
+              Try:{" "}
+              <code className="rounded bg-zinc-900 px-1 py-0.5">
+                {state.promptBlocked.remediation}
+              </code>
+            </p>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}
+
+export default BringUpProgress;

--- a/desktop/src/views/ConnectionPicker.test.tsx
+++ b/desktop/src/views/ConnectionPicker.test.tsx
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ConnectionPicker, { defaultSelection } from "./ConnectionPicker";
+import type { HardwareProbe, Profile } from "../lib/ipc";
+
+const withHardware: HardwareProbe = {
+  accelerator_present: true,
+  default_mode: "local",
+};
+const noHardware: HardwareProbe = {
+  accelerator_present: false,
+  default_mode: "ssh",
+};
+
+const qb2: Profile = {
+  id: "qb2",
+  name: "Lab QuietBox",
+  kind: "ssh",
+  host: "qb2.lan",
+  port: 22,
+  user: "tt",
+  auth: { method: "agent" },
+  last_used: 200,
+};
+const older: Profile = {
+  id: "older",
+  name: "Old box",
+  kind: "ssh",
+  host: "old.lan",
+  auth: { method: "key", path: "~/.ssh/id_ed25519" },
+  last_used: 100,
+};
+
+const noop = {
+  onConnectLocal: () => {},
+  onConnectSsh: () => {},
+  onAddMachine: () => {},
+  onEditProfile: () => {},
+  onDeleteProfile: () => {},
+};
+
+afterEach(cleanup);
+
+describe("defaultSelection (picker gating)", () => {
+  it("pre-selects local when an accelerator is present", () => {
+    expect(defaultSelection(withHardware, [qb2])).toBe("local");
+    expect(defaultSelection(withHardware, [])).toBe("local");
+  });
+
+  it("falls back to the most recently used ssh profile without hardware", () => {
+    expect(defaultSelection(noHardware, [older, qb2])).toBe("qb2");
+  });
+
+  it("selects nothing on a fresh install with no hardware", () => {
+    expect(defaultSelection(noHardware, [])).toBeNull();
+    expect(defaultSelection(null, [])).toBeNull();
+  });
+});
+
+describe("ConnectionPicker", () => {
+  it("offers 'run on this machine' only when hardware is detected", () => {
+    const { unmount } = render(
+      <ConnectionPicker hardware={withHardware} profiles={[]} {...noop} />,
+    );
+    expect(screen.getByTestId("connect-local")).toBeTruthy();
+    unmount();
+
+    render(<ConnectionPicker hardware={noHardware} profiles={[]} {...noop} />);
+    expect(screen.queryByTestId("connect-local")).toBeNull();
+    expect(screen.getByTestId("picker-empty")).toBeTruthy();
+  });
+
+  it("connects a saved ssh machine with one click", () => {
+    const onConnectSsh = vi.fn();
+    render(
+      <ConnectionPicker
+        hardware={noHardware}
+        profiles={[qb2]}
+        {...noop}
+        onConnectSsh={onConnectSsh}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("connect-qb2"));
+    expect(onConnectSsh).toHaveBeenCalledWith(qb2);
+  });
+
+  it("shows host, user, and auth detail for ssh profiles", () => {
+    render(
+      <ConnectionPicker hardware={noHardware} profiles={[older]} {...noop} />,
+    );
+    expect(screen.getByText("Old box")).toBeTruthy();
+    expect(screen.getByText(/old\.lan/)).toBeTruthy();
+    expect(screen.getByText(/key ~\/\.ssh\/id_ed25519/)).toBeTruthy();
+  });
+
+  it("always offers adding a machine", () => {
+    const onAddMachine = vi.fn();
+    render(
+      <ConnectionPicker
+        hardware={withHardware}
+        profiles={[]}
+        {...noop}
+        onAddMachine={onAddMachine}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("add-machine"));
+    expect(onAddMachine).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/views/ConnectionPicker.tsx
+++ b/desktop/src/views/ConnectionPicker.tsx
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// First-run connection picker: run TT-Studio on this machine (when a
+// Tenstorrent accelerator is present) or connect to a remote machine over
+// SSH. Pure view — all IPC stays in App.
+
+import type { HardwareProbe, Profile } from "../lib/ipc";
+
+/**
+ * What the picker should pre-select on load: `"local"` when the machine has
+ * an accelerator, otherwise the most recently used SSH profile's id, or null
+ * when there is nothing to select yet (fresh install, no hardware).
+ * Exported for unit tests.
+ */
+export function defaultSelection(
+  hardware: HardwareProbe | null,
+  profiles: Profile[],
+): "local" | string | null {
+  if (hardware?.accelerator_present) return "local";
+  const ssh = profiles.filter((p) => p.kind === "ssh");
+  if (ssh.length === 0) return null;
+  const mostRecent = [...ssh].sort(
+    (a, b) => (b.last_used ?? 0) - (a.last_used ?? 0),
+  )[0];
+  return mostRecent.id;
+}
+
+export function describeAuth(profile: Profile): string {
+  if (!profile.auth || profile.auth.method === "agent") return "ssh-agent";
+  return `key ${profile.auth.path}`;
+}
+
+interface Props {
+  hardware: HardwareProbe | null;
+  profiles: Profile[];
+  onConnectLocal: () => void;
+  onConnectSsh: (profile: Profile) => void;
+  onAddMachine: () => void;
+  onEditProfile: (profile: Profile) => void;
+  onDeleteProfile: (profile: Profile) => void;
+}
+
+function ConnectionPicker({
+  hardware,
+  profiles,
+  onConnectLocal,
+  onConnectSsh,
+  onAddMachine,
+  onEditProfile,
+  onDeleteProfile,
+}: Props) {
+  const selected = defaultSelection(hardware, profiles);
+  const sshProfiles = profiles.filter((p) => p.kind === "ssh");
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-zinc-950 px-6 text-zinc-100">
+      <header className="text-center">
+        <h1 className="text-3xl font-semibold tracking-tight">TT-Studio</h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          Where do you want to run it?
+        </p>
+      </header>
+
+      <section className="flex w-full max-w-md flex-col gap-3">
+        {hardware?.accelerator_present && (
+          <button
+            type="button"
+            onClick={onConnectLocal}
+            data-testid="connect-local"
+            className={`flex items-center justify-between rounded-lg border px-4 py-3 text-left transition-colors ${
+              selected === "local"
+                ? "border-purple-500 bg-purple-500/10"
+                : "border-zinc-800 bg-zinc-900 hover:border-zinc-600"
+            }`}
+          >
+            <span>
+              <span className="block text-sm font-medium">
+                Run on this machine
+              </span>
+              <span className="block text-xs text-zinc-400">
+                Tenstorrent accelerator detected
+              </span>
+            </span>
+            <span className="text-xs font-medium text-purple-400">
+              Recommended
+            </span>
+          </button>
+        )}
+
+        {sshProfiles.map((profile) => (
+          <div
+            key={profile.id}
+            data-testid={`profile-${profile.id}`}
+            className={`flex items-center justify-between gap-3 rounded-lg border px-4 py-3 ${
+              selected === profile.id
+                ? "border-purple-500 bg-purple-500/10"
+                : "border-zinc-800 bg-zinc-900"
+            }`}
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{profile.name}</p>
+              <p className="truncate text-xs text-zinc-400">
+                {profile.user ? `${profile.user}@` : ""}
+                {profile.host}
+                {profile.port && profile.port !== 22 ? `:${profile.port}` : ""}
+                {" · "}
+                {describeAuth(profile)}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => onEditProfile(profile)}
+                className="rounded-md px-2 py-1 text-xs text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => onDeleteProfile(profile)}
+                className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-800 hover:text-red-400"
+              >
+                Remove
+              </button>
+              <button
+                type="button"
+                onClick={() => onConnectSsh(profile)}
+                data-testid={`connect-${profile.id}`}
+                className="rounded-md bg-purple-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-purple-500"
+              >
+                Connect
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {!hardware?.accelerator_present && sshProfiles.length === 0 && (
+          <p
+            data-testid="picker-empty"
+            className="rounded-lg border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-400"
+          >
+            No Tenstorrent hardware found on this machine. Add a machine that
+            has one to connect over SSH.
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={onAddMachine}
+          data-testid="add-machine"
+          className="rounded-lg border border-zinc-700 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-zinc-500 hover:text-zinc-100"
+        >
+          + Add machine
+        </button>
+      </section>
+    </main>
+  );
+}
+
+export default ConnectionPicker;

--- a/desktop/src/views/ProfileEditor.tsx
+++ b/desktop/src/views/ProfileEditor.tsx
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Add/edit form for an SSH connection profile. Pure view: the caller
+// persists the profile and stores the optional key passphrase in the OS
+// keychain (never in the profile itself).
+
+import { useState } from "react";
+import type { Profile, SshAuth } from "../lib/ipc";
+
+interface Props {
+  /** When set, edit this profile; otherwise create a new one. */
+  initial?: Profile;
+  /** Shown when the OS keychain is unavailable (e.g. headless Linux). */
+  keychainWarning?: string | null;
+  onSave: (profile: Profile, passphrase: string | null) => void;
+  onCancel: () => void;
+}
+
+function newId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `profile-${Math.random().toString(36).slice(2)}`;
+}
+
+function ProfileEditor({ initial, keychainWarning, onSave, onCancel }: Props) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [host, setHost] = useState(initial?.host ?? "");
+  const [port, setPort] = useState(initial?.port ?? 22);
+  const [user, setUser] = useState(initial?.user ?? "");
+  const [authMethod, setAuthMethod] = useState<"agent" | "key">(
+    initial?.auth?.method ?? "agent",
+  );
+  const [keyPath, setKeyPath] = useState(
+    initial?.auth?.method === "key" ? initial.auth.path : "",
+  );
+  const [passphrase, setPassphrase] = useState("");
+  const [repoPath, setRepoPath] = useState(initial?.remote_repo_path ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = () => {
+    if (!name.trim()) return setError("Give this machine a name.");
+    if (!host.trim()) return setError("Hostname is required.");
+    if (authMethod === "key" && !keyPath.trim())
+      return setError("Choose the SSH private key to use.");
+    const auth: SshAuth =
+      authMethod === "agent"
+        ? { method: "agent" }
+        : { method: "key", path: keyPath.trim() };
+    onSave(
+      {
+        id: initial?.id ?? newId(),
+        name: name.trim(),
+        kind: "ssh",
+        host: host.trim(),
+        port,
+        user: user.trim() || undefined,
+        auth,
+        remote_repo_path: repoPath.trim() || undefined,
+        last_used: initial?.last_used,
+      },
+      authMethod === "key" && passphrase ? passphrase : null,
+    );
+  };
+
+  const field =
+    "w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-purple-500 focus:outline-none";
+  const label = "block text-xs font-medium text-zinc-400";
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-zinc-950 px-6 text-zinc-100">
+      <form
+        className="flex w-full max-w-md flex-col gap-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        <header>
+          <h1 className="text-xl font-semibold tracking-tight">
+            {initial ? "Edit machine" : "Add machine"}
+          </h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            A remote machine with Tenstorrent hardware, reached over SSH.
+          </p>
+        </header>
+
+        <div>
+          <label className={label} htmlFor="pe-name">
+            Name
+          </label>
+          <input
+            id="pe-name"
+            className={field}
+            placeholder="Lab QuietBox"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label className={label} htmlFor="pe-host">
+              Host
+            </label>
+            <input
+              id="pe-host"
+              className={field}
+              placeholder="qb2.lan"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+            />
+          </div>
+          <div className="w-24">
+            <label className={label} htmlFor="pe-port">
+              Port
+            </label>
+            <input
+              id="pe-port"
+              className={field}
+              type="number"
+              min={1}
+              max={65535}
+              value={port}
+              onChange={(e) => setPort(Number(e.target.value) || 22)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={label} htmlFor="pe-user">
+            User
+          </label>
+          <input
+            id="pe-user"
+            className={field}
+            placeholder="tenstorrent"
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+          />
+        </div>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className={label}>Authentication</legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="auth"
+              checked={authMethod === "agent"}
+              onChange={() => setAuthMethod("agent")}
+            />
+            ssh-agent (recommended)
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="auth"
+              checked={authMethod === "key"}
+              onChange={() => setAuthMethod("key")}
+            />
+            Private key file
+          </label>
+          {authMethod === "key" && (
+            <div className="ml-6 flex flex-col gap-2">
+              <input
+                aria-label="Private key path"
+                className={field}
+                placeholder="~/.ssh/id_ed25519"
+                value={keyPath}
+                onChange={(e) => setKeyPath(e.target.value)}
+              />
+              <input
+                aria-label="Key passphrase"
+                className={field}
+                type="password"
+                placeholder="Key passphrase (stored in the OS keychain)"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+              />
+              {keychainWarning && (
+                <p className="text-xs text-amber-400">{keychainWarning}</p>
+              )}
+            </div>
+          )}
+        </fieldset>
+
+        <div>
+          <label className={label} htmlFor="pe-repo">
+            TT-Studio path on the remote (optional)
+          </label>
+          <input
+            id="pe-repo"
+            className={field}
+            placeholder="~/tt-studio"
+            value={repoPath}
+            onChange={(e) => setRepoPath(e.target.value)}
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="save-profile"
+            className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}
+
+export default ProfileEditor;

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
@@ -20,5 +21,8 @@ export default defineConfig({
   },
   build: {
     target: "es2021",
+  },
+  test: {
+    environment: "jsdom",
   },
 });


### PR DESCRIPTION
Builds the shared desktop shell on top of the Tauri scaffold: connection profiles, a first-run picker (run locally vs connect over SSH), stack health gating, and native rendering of the launcher's `--json-events` NDJSON stream (schema in dev-docs/json-events.md on #1250).

Stacked on #1252; retarget/rebase to `dev` after it merges.

- [x] Connection profile model + CRUD via tauri-plugin-store (`profiles.json` in the app config dir); no secret material in the store
- [x] SSH key passphrases in the OS keychain via `keyring` (secret-service on Linux — `libdbus-1-dev` added to CI); headless machines get a typed `keychain_unavailable` error the UI explains instead of a crash; passphrases are write-only from the webview
- [x] Hardware probe: `/dev/tenstorrent` on Linux (path injectable for tests) decides whether the picker defaults to local or SSH
- [x] Health poller: read-only GETs to frontend `:3000/`, backend `:8000/up/` + `/models/health/`, inference `:8001/health`, docker-control `:8002/api/v1/health`; per-service status pushed as `stack-health` Tauri events; "open the stack" gates on all-green
- [x] Picker + profile editor views with typed IPC wrappers (`src/lib/ipc.ts`)
- [x] Bring-up progress view: phase stepper, notes/warnings, error cards with remediation, prompt_blocked card, ready → navigate transition; NDJSON parser/reducer in `src/lib/events.ts` tolerates bootstrap chatter and unknown event types
- [x] Vitest suite (32 tests: parser/reducer with success, failure, and prompt_blocked fixture streams; picker gating; event rendering) wired into desktop-ci

Verified: `cargo test` (24 tests incl. a stub-HTTP-server health suite), `cargo clippy -D warnings`, `cargo fmt --check`, `npm test`, `npm run type-check`, `npm run build` all pass. The poller was also run against this machine's real ports (stack currently stopped — every service correctly reports `unreachable` and `ready` stays false); an opt-in `--ignored live_stack` test keeps that check runnable.