### PR TITLE
feat: add ssh tunnel engine for remote stacks

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -93,6 +93,13 @@ jobs:
         working-directory: desktop/src-tauri
         run: cargo test
 
+      # SSH tunnel integration tests run against a containerized sshd
+      # (tests/fixtures/sshd) — only the Linux runner has Linux containers.
+      - name: SSH tunnel integration tests
+        if: runner.os == 'Linux'
+        working-directory: desktop/src-tauri
+        run: cargo test --test ssh_tunnel -- --ignored
+
       # Debug + no-bundle keeps this fast and reuses the clippy/test build
       # cache while still exercising the full tauri build path.
       - name: Tauri build (debug, no bundle)

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +83,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +157,23 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bit-set"
@@ -125,10 +206,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -140,6 +239,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -267,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,15 +428,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -330,6 +477,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cookie"
@@ -425,6 +578,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +639,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +707,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -560,6 +767,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +825,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -733,6 +964,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +1044,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +1073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1096,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -859,12 +1188,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -919,6 +1264,7 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1036,6 +1382,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1045,8 +1392,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1070,6 +1419,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1169,6 +1528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1619,39 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -1519,6 +1922,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.11+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +2150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +2208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2221,12 @@ checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1798,6 +2259,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1893,10 +2360,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1905,6 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2131,10 +2657,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
+name = "pageant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb28bd89a207e5cad59072ac4b364b08459d05f90ccfbcdaa920a95857d94430"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.59.0",
+]
 
 [[package]]
 name = "pango"
@@ -2182,6 +2769,36 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2250,6 +2867,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2950,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,10 +3003,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2421,6 +3117,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2564,6 +3290,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.54.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3ee9363fcf66d434d8015d9ae7d879681206981534c21bfdff8a7e34f52cca"
+dependencies = [
+ "aes",
+ "base64ct",
+ "bitflags 2.13.1",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "log",
+ "md5",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs5",
+ "pkcs8",
+ "rand",
+ "rand_core",
+ "ring",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +3436,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +3459,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -2655,6 +3534,31 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2893,6 +3797,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3823,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2992,6 +3917,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3996,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3137,7 +4113,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3208,7 +4184,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3327,7 +4303,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3352,7 +4328,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -3403,6 +4379,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3776,13 +4765,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tt-studio-desktop"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "keyring",
  "reqwest 0.12.28",
+ "russh",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-store",
+ "tempfile",
  "tokio",
 ]
 
@@ -3850,6 +4842,22 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4102,9 +5110,9 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
 ]
 
@@ -4126,7 +5134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.20",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4178,6 +5186,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4200,11 +5218,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -4217,7 +5248,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -4233,6 +5264,17 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4299,6 +5341,15 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
@@ -4322,6 +5373,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4639,7 +5699,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4687,6 +5747,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -27,7 +27,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Health endpoints are plain http on localhost — no TLS backend needed.
 reqwest = { version = "0.12", default-features = false }
-tokio = { version = "1", features = ["macros", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
+russh = { version = "0.54", default-features = false, features = ["ring", "flate2"] }
+async-trait = "0.1.92"
 
 [dev-dependencies]
+tempfile = "3.27.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod hardware;
 mod health;
 mod profiles;
 mod secrets;
+pub mod ssh;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(health::PollerState::default())
+        .manage(ssh::commands::TunnelState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -24,6 +25,9 @@ pub fn run() {
             secrets::clear_ssh_key_passphrase,
             secrets::has_ssh_key_passphrase,
             ssh::known_hosts::trust_host_key,
+            ssh::commands::start_ssh_tunnels,
+            ssh::commands::stop_ssh_tunnels,
+            ssh::commands::get_tunnel_status,
             hardware::detect_hardware,
             health::check_stack_health,
             health::start_health_poll,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub fn run() {
             secrets::set_ssh_key_passphrase,
             secrets::clear_ssh_key_passphrase,
             secrets::has_ssh_key_passphrase,
+            ssh::known_hosts::trust_host_key,
             hardware::detect_hardware,
             health::check_stack_health,
             health::start_health_poll,

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Tauri surface of the tunnel engine.
+//!
+//! `start_ssh_tunnels` turns a saved SSH profile into a running supervisor;
+//! every status change is pushed to the UI as a `tunnel-status` event. When
+//! the tunnel is hard-lost while the window is showing the remote stack,
+//! the window is navigated back to the bundled launcher (the stack page is
+//! unreachable at that point anyway).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, Manager, Url};
+
+use super::known_hosts::KnownHostsVerifier;
+use super::session::{AuthMethod, SshSession, SshTarget};
+use super::tunnel::{Supervisor, SupervisorConfig, TunnelPhase, TunnelStatus};
+use super::{SshError, SshTransport};
+use crate::profiles::{Profile, ProfileKind, SshAuth};
+use crate::secrets;
+
+pub const TUNNEL_EVENT: &str = "tunnel-status";
+const DEFAULT_SSH_PORT: u16 = 22;
+
+/// At most one tunnel supervisor runs at a time (one remote stack per window).
+#[derive(Default)]
+pub struct TunnelState(tokio::sync::Mutex<Option<Supervisor>>);
+
+/// Build the dial target from a saved profile: agent auth is always tried
+/// first, then the profile's key file with the keychain passphrase if one
+/// is stored (see `secrets.rs`).
+fn target_from_profile(profile: &Profile, home: Option<PathBuf>) -> Result<SshTarget, SshError> {
+    if profile.kind != ProfileKind::Ssh {
+        return Err(SshError::Internal {
+            message: "profile is not an SSH profile".into(),
+        });
+    }
+    let host = profile.host.clone().filter(|h| !h.trim().is_empty());
+    let user = profile.user.clone().filter(|u| !u.trim().is_empty());
+    let (Some(host), Some(user)) = (host, user) else {
+        return Err(SshError::Internal {
+            message: "profile is missing host or user".into(),
+        });
+    };
+
+    let mut auth = vec![AuthMethod::Agent];
+    if let Some(SshAuth::Key { path }) = &profile.auth {
+        let passphrase = secrets::load_passphrase(&profile.id).ok();
+        auth.push(AuthMethod::KeyFile {
+            path: expand_tilde(path, home),
+            passphrase,
+        });
+    }
+
+    Ok(SshTarget {
+        host,
+        port: profile.port.unwrap_or(DEFAULT_SSH_PORT),
+        user,
+        auth,
+    })
+}
+
+/// Profiles store key paths the way users type them (`~/.ssh/id_ed25519`).
+fn expand_tilde(path: &str, home: Option<PathBuf>) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Where "back to the launcher" points: the dev server during development,
+/// the bundled app origin in production builds.
+fn launcher_url(app: &AppHandle) -> Option<Url> {
+    if let Some(dev_url) = &app.config().build.dev_url {
+        return Some(dev_url.clone());
+    }
+    #[cfg(windows)]
+    let url = "http://tauri.localhost";
+    #[cfg(not(windows))]
+    let url = "tauri://localhost";
+    Url::parse(url).ok()
+}
+
+/// True when the main window currently shows the remote stack (a plain
+/// http(s) origin) rather than the bundled launcher.
+fn showing_remote_stack(app: &AppHandle) -> bool {
+    let Some(window) = app.get_webview_window("main") else {
+        return false;
+    };
+    let Ok(current) = window.url() else {
+        return false;
+    };
+    let launcher = launcher_url(app);
+    match launcher {
+        Some(l) if l.origin() == current.origin() => false,
+        _ => matches!(current.scheme(), "http" | "https"),
+    }
+}
+
+/// On hard loss while the stack page is showing, bring the user back to the
+/// launcher — the stack's origin is dead, so leaving it up is a blank page.
+fn return_to_launcher_if_lost(app: &AppHandle, status: &TunnelStatus) {
+    if !matches!(status.phase, TunnelPhase::Lost { .. }) || !showing_remote_stack(app) {
+        return;
+    }
+    let Some(url) = launcher_url(app) else { return };
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.navigate(url);
+        }
+    });
+}
+
+#[tauri::command]
+pub async fn start_ssh_tunnels(
+    app: AppHandle,
+    state: tauri::State<'_, TunnelState>,
+    profile: Profile,
+) -> Result<(), SshError> {
+    let home = app.path().home_dir().ok();
+    let target = target_from_profile(&profile, home)?;
+    let verifier = KnownHostsVerifier::for_app(&app)?;
+
+    let connector: super::tunnel::Connector = Arc::new(move || {
+        let target = target.clone();
+        let verifier = verifier.clone();
+        Box::pin(async move {
+            SshSession::connect(&target, verifier)
+                .await
+                .map(|s| Arc::new(s) as Arc<dyn SshTransport>)
+        })
+    });
+
+    let sink_app = app.clone();
+    let sink: super::tunnel::StatusSink = Arc::new(move |status: TunnelStatus| {
+        let _ = sink_app.emit(TUNNEL_EVENT, &status);
+        return_to_launcher_if_lost(&sink_app, &status);
+    });
+
+    let mut guard = state.0.lock().await;
+    if let Some(previous) = guard.take() {
+        previous.stop().await;
+    }
+    *guard = Some(Supervisor::spawn(
+        SupervisorConfig::default(),
+        connector,
+        sink,
+    ));
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_ssh_tunnels(state: tauri::State<'_, TunnelState>) -> Result<(), SshError> {
+    if let Some(supervisor) = state.0.lock().await.take() {
+        supervisor.stop().await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_tunnel_status(
+    state: tauri::State<'_, TunnelState>,
+) -> Result<Option<TunnelStatus>, SshError> {
+    Ok(state.0.lock().await.as_ref().map(|s| s.status()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ssh_profile() -> Profile {
+        Profile {
+            id: "p1".into(),
+            name: "QuietBox".into(),
+            kind: ProfileKind::Ssh,
+            host: Some("qb2.example.com".into()),
+            port: None,
+            user: Some("jashan".into()),
+            auth: Some(SshAuth::Key {
+                path: "~/.ssh/id_ed25519".into(),
+            }),
+            remote_repo_path: None,
+            last_used: None,
+        }
+    }
+
+    #[test]
+    fn target_tries_agent_before_key_file() {
+        let target = target_from_profile(&ssh_profile(), Some(PathBuf::from("/home/u"))).unwrap();
+        assert_eq!(target.host, "qb2.example.com");
+        assert_eq!(target.port, 22);
+        assert!(matches!(target.auth[0], AuthMethod::Agent));
+        match &target.auth[1] {
+            AuthMethod::KeyFile { path, .. } => {
+                assert_eq!(path, &PathBuf::from("/home/u/.ssh/id_ed25519"));
+            }
+            other => panic!("expected key file, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_only_profile_has_single_method() {
+        let mut profile = ssh_profile();
+        profile.auth = Some(SshAuth::Agent);
+        let target = target_from_profile(&profile, None).unwrap();
+        assert_eq!(target.auth.len(), 1);
+        assert!(matches!(target.auth[0], AuthMethod::Agent));
+    }
+
+    #[test]
+    fn local_or_incomplete_profiles_are_rejected() {
+        let mut local = ssh_profile();
+        local.kind = ProfileKind::Local;
+        assert!(target_from_profile(&local, None).is_err());
+
+        let mut no_user = ssh_profile();
+        no_user.user = None;
+        assert!(target_from_profile(&no_user, None).is_err());
+
+        let mut blank_host = ssh_profile();
+        blank_host.host = Some("  ".into());
+        assert!(target_from_profile(&blank_host, None).is_err());
+    }
+
+    #[test]
+    fn tilde_expansion_uses_home_dir() {
+        assert_eq!(
+            expand_tilde("~/.ssh/key", Some(PathBuf::from("/home/u"))),
+            PathBuf::from("/home/u/.ssh/key")
+        );
+        assert_eq!(
+            expand_tilde("/abs/key", Some(PathBuf::from("/home/u"))),
+            PathBuf::from("/abs/key")
+        );
+        assert_eq!(expand_tilde("~/key", None), PathBuf::from("~/key"));
+    }
+}

--- a/desktop/src-tauri/src/ssh/known_hosts.rs
+++ b/desktop/src-tauri/src/ssh/known_hosts.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Trust-on-first-use host key verification.
+//!
+//! Keys live in an app-managed known_hosts file (OpenSSH format, in the app
+//! config dir) — deliberately separate from `~/.ssh/known_hosts` so the
+//! desktop shell never mutates the user's own SSH state. The three outcomes:
+//!
+//! - known & matching → connect proceeds;
+//! - never seen → the connect fails with `unknown_host_key` carrying the
+//!   fingerprint; the UI shows a trust dialog and, on accept, calls the
+//!   `trust_host_key` command and reconnects;
+//! - seen but DIFFERENT → hard fail (`changed_host_key`), never promptable,
+//!   because that is what a machine-in-the-middle looks like.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use russh::keys::{known_hosts, HashAlg, PublicKey};
+use tauri::Manager;
+
+use super::{HostKeyVerifier, SshError};
+
+pub const KNOWN_HOSTS_FILE: &str = "known_hosts";
+
+/// File-backed [`HostKeyVerifier`] over the app-managed known_hosts file.
+pub struct KnownHostsVerifier {
+    path: PathBuf,
+}
+
+impl KnownHostsVerifier {
+    pub fn new(path: PathBuf) -> Arc<Self> {
+        Arc::new(Self { path })
+    }
+
+    /// The verifier used by real connections: `<app config dir>/known_hosts`.
+    pub fn for_app(app: &tauri::AppHandle) -> Result<Arc<Self>, SshError> {
+        Ok(Self::new(app_known_hosts_path(app)?))
+    }
+}
+
+impl HostKeyVerifier for KnownHostsVerifier {
+    fn verify(&self, host: &str, port: u16, key: &PublicKey) -> Result<(), SshError> {
+        // No file yet means first use of any host: plain unknown, not an error.
+        if !self.path.exists() {
+            return Err(unknown_host_key(host, port, key));
+        }
+        match known_hosts::check_known_hosts_path(host, port, key, &self.path) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(unknown_host_key(host, port, key)),
+            Err(russh::keys::Error::KeyChanged { .. }) => Err(SshError::ChangedHostKey {
+                host: host.to_string(),
+                port,
+                fingerprint: fingerprint(key),
+            }),
+            Err(e) => Err(SshError::KnownHosts {
+                message: e.to_string(),
+            }),
+        }
+    }
+}
+
+/// Persist a key the user explicitly accepted in the TOFU dialog.
+pub fn trust(
+    path: &std::path::Path,
+    host: &str,
+    port: u16,
+    public_key: &str,
+) -> Result<(), SshError> {
+    let key: PublicKey = public_key.parse().map_err(|e| SshError::KnownHosts {
+        message: format!("invalid public key: {e}"),
+    })?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| SshError::KnownHosts {
+            message: e.to_string(),
+        })?;
+    }
+    known_hosts::learn_known_hosts_path(host, port, &key, path).map_err(|e| SshError::KnownHosts {
+        message: e.to_string(),
+    })
+}
+
+pub fn fingerprint(key: &PublicKey) -> String {
+    key.fingerprint(HashAlg::Sha256).to_string()
+}
+
+fn unknown_host_key(host: &str, port: u16, key: &PublicKey) -> SshError {
+    SshError::UnknownHostKey {
+        host: host.to_string(),
+        port,
+        key_type: key.algorithm().to_string(),
+        fingerprint: fingerprint(key),
+        public_key: key.to_openssh().unwrap_or_default(),
+    }
+}
+
+fn app_known_hosts_path(app: &tauri::AppHandle) -> Result<PathBuf, SshError> {
+    app.path()
+        .app_config_dir()
+        .map(|dir| dir.join(KNOWN_HOSTS_FILE))
+        .map_err(|e| SshError::KnownHosts {
+            message: format!("no app config dir: {e}"),
+        })
+}
+
+/// Persist a host key the user accepted in the trust dialog, then let the UI
+/// retry the connection.
+#[tauri::command]
+pub fn trust_host_key(
+    app: tauri::AppHandle,
+    host: String,
+    port: u16,
+    public_key: String,
+) -> Result<(), SshError> {
+    trust(&app_known_hosts_path(&app)?, &host, port, &public_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Public host keys are public by definition — these are the published
+    // keys of github.com and gitlab.com, used purely as test fixtures.
+    const KEY_A: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl";
+    const KEY_B: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf";
+
+    fn key(s: &str) -> PublicKey {
+        s.parse().unwrap()
+    }
+
+    fn temp_known_hosts() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("known_hosts");
+        (dir, path)
+    }
+
+    #[test]
+    fn first_contact_reports_unknown_with_fingerprint() {
+        let (_dir, path) = temp_known_hosts();
+        let verifier = KnownHostsVerifier::new(path);
+        let err = verifier.verify("qb2", 22, &key(KEY_A)).unwrap_err();
+        match err {
+            SshError::UnknownHostKey {
+                host,
+                port,
+                key_type,
+                fingerprint,
+                public_key,
+            } => {
+                assert_eq!(host, "qb2");
+                assert_eq!(port, 22);
+                assert_eq!(key_type, "ssh-ed25519");
+                assert!(fingerprint.starts_with("SHA256:"), "{fingerprint}");
+                assert!(public_key.starts_with("ssh-ed25519 "));
+            }
+            other => panic!("expected UnknownHostKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trusted_key_verifies_and_stays_scoped_to_host_and_port() {
+        let (_dir, path) = temp_known_hosts();
+        trust(&path, "qb2", 22, KEY_A).unwrap();
+        let verifier = KnownHostsVerifier::new(path);
+        assert!(verifier.verify("qb2", 22, &key(KEY_A)).is_ok());
+        // Same key from a different host/port is NOT trusted.
+        assert!(matches!(
+            verifier.verify("other-host", 22, &key(KEY_A)),
+            Err(SshError::UnknownHostKey { .. })
+        ));
+        assert!(matches!(
+            verifier.verify("qb2", 2222, &key(KEY_A)),
+            Err(SshError::UnknownHostKey { .. })
+        ));
+    }
+
+    #[test]
+    fn changed_key_is_a_hard_failure() {
+        let (_dir, path) = temp_known_hosts();
+        trust(&path, "qb2", 22, KEY_A).unwrap();
+        let verifier = KnownHostsVerifier::new(path);
+        let err = verifier.verify("qb2", 22, &key(KEY_B)).unwrap_err();
+        assert!(matches!(err, SshError::ChangedHostKey { .. }), "{err:?}");
+        assert!(err.is_fatal());
+    }
+
+    #[test]
+    fn trust_rejects_garbage_keys() {
+        let (_dir, path) = temp_known_hosts();
+        let err = trust(&path, "qb2", 22, "not a key").unwrap_err();
+        assert!(matches!(err, SshError::KnownHosts { .. }));
+        assert!(!path.exists() || std::fs::read_to_string(&path).unwrap().is_empty());
+    }
+
+    #[test]
+    fn trust_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/config/known_hosts");
+        trust(&path, "qb2", 22, KEY_A).unwrap();
+        let verifier = KnownHostsVerifier::new(path);
+        assert!(verifier.verify("qb2", 22, &key(KEY_A)).is_ok());
+    }
+}

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -10,6 +10,7 @@
 //! [`SshTransport`] trait so the russh implementation in `session.rs` can be
 //! swapped for ssh2 or system-ssh without touching the tunnel supervisor.
 
+pub mod known_hosts;
 pub mod session;
 
 use serde::Serialize;

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod known_hosts;
 pub mod session;
+pub mod tunnel;
 
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncWrite};

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -10,6 +10,7 @@
 //! [`SshTransport`] trait so the russh implementation in `session.rs` can be
 //! swapped for ssh2 or system-ssh without touching the tunnel supervisor.
 
+pub(crate) mod commands;
 pub mod known_hosts;
 pub mod session;
 pub mod tunnel;

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! SSH tunnel engine for remote TT-Studio stacks.
+//!
+//! The desktop shell reaches a remote stack by forwarding the stack's ports
+//! over one multiplexed SSH session (direct-tcpip channels behind local TCP
+//! listeners). Everything speaks to the session through the small
+//! [`SshTransport`] trait so the russh implementation in `session.rs` can be
+//! swapped for ssh2 or system-ssh without touching the tunnel supervisor.
+
+pub mod session;
+
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Typed error for every way an SSH connection can fail. Serialized with a
+/// `code` discriminant the UI can switch on (same contract as `SecretError`).
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "code", rename_all = "snake_case")]
+pub enum SshError {
+    /// Hostname didn't resolve.
+    Dns { message: String },
+    /// TCP connect was refused (host up, no sshd on that port).
+    Refused { message: String },
+    /// TCP connect or SSH handshake timed out.
+    Timeout { message: String },
+    /// Protocol/key-exchange failure once the socket was up.
+    Handshake { message: String },
+    /// No usable ssh-agent (socket missing, env unset, agent empty is NOT
+    /// this — an empty agent just falls through to the next auth method).
+    AgentUnavailable { message: String },
+    /// Key file missing, unreadable, or the passphrase didn't decrypt it.
+    KeyFile { path: String, message: String },
+    /// Every configured auth method was tried and rejected by the server.
+    AuthFailed { message: String },
+    /// The server presented a key we have never seen. Carries everything the
+    /// UI needs for a trust-on-first-use prompt.
+    UnknownHostKey {
+        host: String,
+        port: u16,
+        key_type: String,
+        fingerprint: String,
+        /// Full key in OpenSSH format, passed back verbatim to
+        /// `trust_host_key` if the user accepts.
+        public_key: String,
+    },
+    /// The server's key DIFFERS from the one we trusted earlier. Never
+    /// auto-recoverable: could be a reinstalled machine or a MITM.
+    ChangedHostKey {
+        host: String,
+        port: u16,
+        fingerprint: String,
+    },
+    /// The app-managed known_hosts file couldn't be read or written.
+    KnownHosts { message: String },
+    /// The session died after being established.
+    Disconnected { message: String },
+    /// Anything that doesn't fit the buckets above.
+    Internal { message: String },
+}
+
+impl std::fmt::Display for SshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SshError::Dns { message } => write!(f, "DNS lookup failed: {message}"),
+            SshError::Refused { message } => write!(f, "connection refused: {message}"),
+            SshError::Timeout { message } => write!(f, "timed out: {message}"),
+            SshError::Handshake { message } => write!(f, "SSH handshake failed: {message}"),
+            SshError::AgentUnavailable { message } => {
+                write!(f, "ssh-agent unavailable: {message}")
+            }
+            SshError::KeyFile { path, message } => {
+                write!(f, "cannot use key file {path}: {message}")
+            }
+            SshError::AuthFailed { message } => write!(f, "authentication failed: {message}"),
+            SshError::UnknownHostKey {
+                host, fingerprint, ..
+            } => write!(f, "unknown host key for {host}: {fingerprint}"),
+            SshError::ChangedHostKey {
+                host, fingerprint, ..
+            } => write!(
+                f,
+                "HOST KEY CHANGED for {host} (now {fingerprint}) — refusing to connect"
+            ),
+            SshError::KnownHosts { message } => write!(f, "known_hosts error: {message}"),
+            SshError::Disconnected { message } => write!(f, "connection lost: {message}"),
+            SshError::Internal { message } => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for SshError {}
+
+impl SshError {
+    /// Errors where retrying with the same inputs cannot succeed — the
+    /// supervisor stops instead of burning reconnect attempts on them.
+    pub fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            SshError::UnknownHostKey { .. }
+                | SshError::ChangedHostKey { .. }
+                | SshError::AuthFailed { .. }
+                | SshError::KeyFile { .. }
+        )
+    }
+}
+
+impl From<russh::Error> for SshError {
+    fn from(err: russh::Error) -> Self {
+        match err {
+            russh::Error::IO(e) => io_error(&e),
+            russh::Error::Disconnect | russh::Error::HUP => SshError::Disconnected {
+                message: "server closed the connection".into(),
+            },
+            russh::Error::ConnectionTimeout | russh::Error::KeepaliveTimeout => SshError::Timeout {
+                message: "SSH connection timed out".into(),
+            },
+            russh::Error::NoAuthMethod => SshError::AuthFailed {
+                message: "server accepted none of our authentication methods".into(),
+            },
+            russh::Error::UnknownKey => SshError::Handshake {
+                message: "server host key was rejected".into(),
+            },
+            other => SshError::Handshake {
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+impl From<russh::keys::Error> for SshError {
+    fn from(err: russh::keys::Error) -> Self {
+        SshError::Internal {
+            message: err.to_string(),
+        }
+    }
+}
+
+/// Classify a raw socket error into the typed buckets the UI understands.
+pub(crate) fn io_error(e: &std::io::Error) -> SshError {
+    use std::io::ErrorKind;
+    match e.kind() {
+        ErrorKind::ConnectionRefused => SshError::Refused {
+            message: e.to_string(),
+        },
+        ErrorKind::TimedOut => SshError::Timeout {
+            message: e.to_string(),
+        },
+        ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::BrokenPipe => {
+            SshError::Disconnected {
+                message: e.to_string(),
+            }
+        }
+        _ => SshError::Internal {
+            message: e.to_string(),
+        },
+    }
+}
+
+/// Byte stream carried by one forwarded connection.
+pub trait ForwardStream: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T: AsyncRead + AsyncWrite + Send + Unpin> ForwardStream for T {}
+
+/// The seam between the tunnel supervisor and the SSH implementation.
+///
+/// One value represents one authenticated session; the supervisor opens a
+/// direct-tcpip channel per forwarded TCP connection. Implementations must be
+/// cheap to share (`Arc<dyn SshTransport>`) and safe to call concurrently.
+#[async_trait::async_trait]
+pub trait SshTransport: Send + Sync {
+    /// Open a forwarded byte stream to `host:port` as seen from the remote
+    /// machine (direct-tcpip in SSH terms).
+    async fn open_forward(
+        &self,
+        remote_host: &str,
+        remote_port: u16,
+    ) -> Result<Box<dyn ForwardStream>, SshError>;
+
+    /// True once the underlying session is dead. The supervisor polls this
+    /// to trigger reconnects; keepalives make it flip within seconds of a
+    /// silent network drop.
+    fn is_closed(&self) -> bool;
+
+    /// Graceful shutdown. Must be idempotent.
+    async fn close(&self);
+}
+
+/// How the server proved its identity gets checked — implemented by the
+/// app-managed known_hosts store, and by permissive stubs in tests.
+pub trait HostKeyVerifier: Send + Sync {
+    fn verify(&self, host: &str, port: u16, key: &russh::keys::PublicKey) -> Result<(), SshError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_serialize_with_code_discriminant() {
+        let err = SshError::UnknownHostKey {
+            host: "qb2".into(),
+            port: 22,
+            key_type: "ssh-ed25519".into(),
+            fingerprint: "SHA256:abc".into(),
+            public_key: "ssh-ed25519 AAAA".into(),
+        };
+        let json = serde_json::to_value(&err).unwrap();
+        assert_eq!(json["code"], "unknown_host_key");
+        assert_eq!(json["fingerprint"], "SHA256:abc");
+
+        let json = serde_json::to_value(SshError::Refused {
+            message: "x".into(),
+        })
+        .unwrap();
+        assert_eq!(json["code"], "refused");
+    }
+
+    #[test]
+    fn fatal_errors_are_the_non_retryable_ones() {
+        assert!(SshError::AuthFailed {
+            message: String::new()
+        }
+        .is_fatal());
+        assert!(SshError::ChangedHostKey {
+            host: String::new(),
+            port: 22,
+            fingerprint: String::new()
+        }
+        .is_fatal());
+        assert!(!SshError::Refused {
+            message: String::new()
+        }
+        .is_fatal());
+        assert!(!SshError::Disconnected {
+            message: String::new()
+        }
+        .is_fatal());
+    }
+
+    #[test]
+    fn io_errors_classify_by_kind() {
+        use std::io::{Error, ErrorKind};
+        assert!(matches!(
+            io_error(&Error::new(ErrorKind::ConnectionRefused, "no")),
+            SshError::Refused { .. }
+        ));
+        assert!(matches!(
+            io_error(&Error::new(ErrorKind::TimedOut, "slow")),
+            SshError::Timeout { .. }
+        ));
+        assert!(matches!(
+            io_error(&Error::new(ErrorKind::ConnectionReset, "rst")),
+            SshError::Disconnected { .. }
+        ));
+    }
+}

--- a/desktop/src-tauri/src/ssh/session.rs
+++ b/desktop/src-tauri/src/ssh/session.rs
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! russh-backed implementation of [`SshTransport`].
+//!
+//! One [`SshSession`] is one authenticated SSH connection. Auth order is
+//! ssh-agent first (every identity the agent offers), then the profile's key
+//! file (decrypted with the keychain passphrase when one is stored). Host
+//! keys are checked by the injected [`HostKeyVerifier`] during key exchange,
+//! so an untrusted server is rejected before authentication ever starts.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use russh::client::{self, AuthResult, Handle};
+use russh::keys::{self, HashAlg, PrivateKeyWithHashAlg, PublicKey};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+
+use super::{io_error, ForwardStream, HostKeyVerifier, SshError, SshTransport};
+
+const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+/// Keepalives without a reply before russh declares the session dead
+/// (~30 s of silence with the interval above).
+const KEEPALIVE_MAX: usize = 3;
+
+/// Where and how to connect. Cloneable so the tunnel supervisor can redial
+/// with identical parameters on every reconnect attempt.
+#[derive(Clone, Debug)]
+pub struct SshTarget {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    /// Auth methods in the order they will be attempted.
+    pub auth: Vec<AuthMethod>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AuthMethod {
+    /// Try every identity the local ssh-agent offers.
+    Agent,
+    /// A private key file, optionally protected by a passphrase.
+    KeyFile {
+        path: PathBuf,
+        passphrase: Option<String>,
+    },
+}
+
+/// russh event handler: delegates server-key checking to the verifier and
+/// surfaces its typed error (unknown/changed key) as the connect error.
+struct Checker {
+    host: String,
+    port: u16,
+    verifier: Arc<dyn HostKeyVerifier>,
+}
+
+impl client::Handler for Checker {
+    type Error = SshError;
+
+    async fn check_server_key(&mut self, key: &PublicKey) -> Result<bool, Self::Error> {
+        self.verifier.verify(&self.host, self.port, key)?;
+        Ok(true)
+    }
+}
+
+pub struct SshSession {
+    handle: Handle<Checker>,
+}
+
+impl SshSession {
+    /// Connect and authenticate. Fails with a typed [`SshError`] naming the
+    /// exact failure mode (dns / refused / timeout / host key / auth).
+    pub async fn connect(
+        target: &SshTarget,
+        verifier: Arc<dyn HostKeyVerifier>,
+    ) -> Result<Self, SshError> {
+        let stream = dial(&target.host, target.port).await?;
+
+        let config = Arc::new(client::Config {
+            keepalive_interval: Some(KEEPALIVE_INTERVAL),
+            keepalive_max: KEEPALIVE_MAX,
+            ..Default::default()
+        });
+        let checker = Checker {
+            host: target.host.clone(),
+            port: target.port,
+            verifier,
+        };
+        let mut handle = tokio::time::timeout(
+            HANDSHAKE_TIMEOUT,
+            client::connect_stream(config, stream, checker),
+        )
+        .await
+        .map_err(|_| SshError::Timeout {
+            message: format!("SSH handshake with {} timed out", target.host),
+        })??;
+
+        authenticate(&mut handle, target).await?;
+        Ok(Self { handle })
+    }
+}
+
+/// Resolve and TCP-connect, classifying each failure mode separately.
+async fn dial(host: &str, port: u16) -> Result<TcpStream, SshError> {
+    let addrs: Vec<_> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|e| SshError::Dns {
+            message: format!("{host}: {e}"),
+        })?
+        .collect();
+    if addrs.is_empty() {
+        return Err(SshError::Dns {
+            message: format!("{host}: no addresses"),
+        });
+    }
+    let mut last = None;
+    for addr in addrs {
+        match tokio::time::timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr)).await {
+            Ok(Ok(stream)) => return Ok(stream),
+            Ok(Err(e)) => last = Some(io_error(&e)),
+            Err(_) => {
+                last = Some(SshError::Timeout {
+                    message: format!("connecting to {addr} timed out"),
+                })
+            }
+        }
+    }
+    Err(last.unwrap_or(SshError::Internal {
+        message: "no address to connect to".into(),
+    }))
+}
+
+/// Try each configured method in order; collect why each one didn't work so
+/// the final error tells the user the whole story.
+async fn authenticate(handle: &mut Handle<Checker>, target: &SshTarget) -> Result<(), SshError> {
+    let mut attempts: Vec<String> = Vec::new();
+    for method in &target.auth {
+        match method {
+            AuthMethod::Agent => match agent_auth(handle, &target.user).await {
+                Ok(()) => return Ok(()),
+                Err(reason) => attempts.push(format!("agent: {reason}")),
+            },
+            AuthMethod::KeyFile { path, passphrase } => {
+                // A broken key file is fatal (is_fatal) — retrying can't fix
+                // it — but only after the agent has had its chance above.
+                key_auth(handle, &target.user, path, passphrase.as_deref()).await?;
+                return Ok(());
+            }
+        }
+    }
+    Err(SshError::AuthFailed {
+        message: if attempts.is_empty() {
+            "no authentication methods configured".into()
+        } else {
+            attempts.join("; ")
+        },
+    })
+}
+
+/// Authenticate with every identity the local ssh-agent offers. Returns a
+/// human reason (not an [`SshError`]) when the agent path doesn't pan out,
+/// so the caller can fall through to the next method.
+async fn agent_auth(handle: &mut Handle<Checker>, user: &str) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        let agent = keys::agent::client::AgentClient::connect_env()
+            .await
+            .map_err(|e| format!("not available ({e})"))?;
+        agent_auth_with(handle, user, agent).await
+    }
+    #[cfg(windows)]
+    {
+        // OpenSSH-for-Windows service first (named pipe), then Pageant.
+        match keys::agent::client::AgentClient::connect_named_pipe(r"\\.\pipe\openssh-ssh-agent")
+            .await
+        {
+            Ok(agent) => agent_auth_with(handle, user, agent).await,
+            Err(pipe_err) => {
+                if pageant::is_pageant_running().await {
+                    let agent = keys::agent::client::AgentClient::connect_pageant().await;
+                    agent_auth_with(handle, user, agent).await
+                } else {
+                    Err(format!("not available ({pipe_err})"))
+                }
+            }
+        }
+    }
+}
+
+async fn agent_auth_with<S>(
+    handle: &mut Handle<Checker>,
+    user: &str,
+    mut agent: keys::agent::client::AgentClient<S>,
+) -> Result<(), String>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let identities = agent
+        .request_identities()
+        .await
+        .map_err(|e| format!("listing identities failed ({e})"))?;
+    if identities.is_empty() {
+        return Err("agent holds no identities".into());
+    }
+    let count = identities.len();
+    for key in identities {
+        let hash_alg = rsa_hash_for(handle, &key.algorithm()).await;
+        match handle
+            .authenticate_publickey_with(user, key, hash_alg, &mut agent)
+            .await
+        {
+            Ok(AuthResult::Success) => return Ok(()),
+            Ok(AuthResult::Failure { .. }) => continue,
+            Err(e) => return Err(format!("signing via agent failed ({e})")),
+        }
+    }
+    Err(format!("server rejected all {count} agent identities"))
+}
+
+async fn key_auth(
+    handle: &mut Handle<Checker>,
+    user: &str,
+    path: &std::path::Path,
+    passphrase: Option<&str>,
+) -> Result<(), SshError> {
+    let key = keys::load_secret_key(path, passphrase).map_err(|e| SshError::KeyFile {
+        path: path.display().to_string(),
+        message: match e {
+            keys::Error::KeyIsEncrypted => {
+                "key is passphrase-protected and no passphrase is stored".into()
+            }
+            other => other.to_string(),
+        },
+    })?;
+    let hash_alg = rsa_hash_for(handle, &key.algorithm()).await;
+    let key = PrivateKeyWithHashAlg::new(Arc::new(key), hash_alg);
+    match handle.authenticate_publickey(user, key).await? {
+        AuthResult::Success => Ok(()),
+        AuthResult::Failure { .. } => Err(SshError::AuthFailed {
+            message: format!("server rejected key file {}", path.display()),
+        }),
+    }
+}
+
+/// RSA keys need an explicit rsa-sha2-* choice; other algorithms ignore it.
+async fn rsa_hash_for(handle: &Handle<Checker>, algorithm: &keys::Algorithm) -> Option<HashAlg> {
+    if !algorithm.clone().is_rsa() {
+        return None;
+    }
+    handle
+        .best_supported_rsa_hash()
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+}
+
+#[async_trait::async_trait]
+impl SshTransport for SshSession {
+    async fn open_forward(
+        &self,
+        remote_host: &str,
+        remote_port: u16,
+    ) -> Result<Box<dyn ForwardStream>, SshError> {
+        let channel = self
+            .handle
+            .channel_open_direct_tcpip(remote_host, remote_port as u32, "127.0.0.1", 0)
+            .await?;
+        Ok(Box::new(channel.into_stream()))
+    }
+
+    fn is_closed(&self) -> bool {
+        self.handle.is_closed()
+    }
+
+    async fn close(&self) {
+        let _ = self
+            .handle
+            .disconnect(russh::Disconnect::ByApplication, "", "en")
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct AcceptAll;
+    impl HostKeyVerifier for AcceptAll {
+        fn verify(&self, _: &str, _: u16, _: &PublicKey) -> Result<(), SshError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn unresolvable_host_reports_dns_error() {
+        let target = SshTarget {
+            host: "does-not-exist.invalid".into(),
+            port: 22,
+            user: "u".into(),
+            auth: vec![],
+        };
+        let err = SshSession::connect(&target, Arc::new(AcceptAll))
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(err, SshError::Dns { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn closed_port_reports_refused() {
+        // Bind-then-drop guarantees nothing listens on the port.
+        let addr = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap()
+        };
+        let target = SshTarget {
+            host: "127.0.0.1".into(),
+            port: addr.port(),
+            user: "u".into(),
+            auth: vec![],
+        };
+        let err = SshSession::connect(&target, Arc::new(AcceptAll))
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(err, SshError::Refused { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn non_ssh_server_reports_handshake_error() {
+        // A listener that speaks garbage instead of an SSH banner.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut s, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let _ = s.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+            }
+        });
+        let target = SshTarget {
+            host: "127.0.0.1".into(),
+            port: addr.port(),
+            user: "u".into(),
+            auth: vec![],
+        };
+        let err = SshSession::connect(&target, Arc::new(AcceptAll))
+            .await
+            .err()
+            .unwrap();
+        assert!(
+            matches!(
+                err,
+                SshError::Handshake { .. }
+                    | SshError::Disconnected { .. }
+                    | SshError::Timeout { .. }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_key_file_reports_key_file_error() {
+        let mut handle_err = None;
+        // No server needed: load_secret_key fails before any auth traffic,
+        // but key_auth needs a Handle, so exercise via the loader directly.
+        if let Err(e) = keys::load_secret_key("/nonexistent/id_ed25519", None) {
+            handle_err = Some(e.to_string());
+        }
+        assert!(handle_err.is_some());
+    }
+}

--- a/desktop/src-tauri/src/ssh/tunnel.rs
+++ b/desktop/src-tauri/src/ssh/tunnel.rs
@@ -1,0 +1,655 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Local port-forward supervisor.
+//!
+//! Owns one [`SshTransport`] session and a set of local TCP listeners; every
+//! accepted connection becomes a direct-tcpip channel to the same port on
+//! the remote machine. The supervisor task watches session liveness and
+//! redials with exponential backoff (1 s doubling to a 30 s cap). Local
+//! listeners bind the SAME port numbers as the remote services because the
+//! web app derives its URLs from `window.location.hostname` + fixed ports.
+
+use std::future::Future;
+use std::net::{IpAddr, Ipv4Addr};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::{SshError, SshTransport};
+
+/// One local listener → remote endpoint mapping. `local_port` 0 lets the OS
+/// pick (tests only); the bound port is reported back via [`ForwardHealth`].
+#[derive(Clone, Debug)]
+pub struct ForwardSpec {
+    pub local_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16,
+}
+
+/// The TT-Studio stack's port map: frontend 3000, backend 8000, inference
+/// 8001, docker control 8002, agent 8080, ChromaDB 8111, 4000, and the
+/// 7000-7010 model-container range. Same numbers locally and remotely.
+pub fn production_forwards() -> Vec<ForwardSpec> {
+    let fixed = [3000u16, 8000, 8001, 8002, 8080, 8111, 4000];
+    fixed
+        .into_iter()
+        .chain(7000..=7010)
+        .map(|port| ForwardSpec {
+            local_port: port,
+            remote_host: "127.0.0.1".into(),
+            remote_port: port,
+        })
+        .collect()
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum TunnelPhase {
+    /// First dial for this supervisor.
+    Connecting,
+    /// Session up, listeners bound.
+    Connected,
+    /// Session died or dial failed; the supervisor will retry.
+    Reconnecting { attempt: u32, next_delay_secs: u64 },
+    /// Gave up: fatal error or retries exhausted. Terminal.
+    Lost { error: SshError },
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct ForwardHealth {
+    /// Actual bound local port (resolves a 0 in the spec).
+    pub local_port: u16,
+    pub remote_port: u16,
+    /// The listener is bound and accepting.
+    pub active: bool,
+    /// Most recent per-connection failure, if any.
+    pub last_error: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct TunnelStatus {
+    pub phase: TunnelPhase,
+    pub forwards: Vec<ForwardHealth>,
+}
+
+/// Dials one fresh authenticated session. Injected so tests can hand back
+/// fake transports and the Tauri layer can capture profile + verifier.
+pub type Connector = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<Arc<dyn SshTransport>, SshError>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Receives every status change (the Tauri layer turns these into events).
+pub type StatusSink = Arc<dyn Fn(TunnelStatus) + Send + Sync>;
+
+#[derive(Clone, Debug)]
+pub struct SupervisorConfig {
+    pub forwards: Vec<ForwardSpec>,
+    pub bind_addr: IpAddr,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+    /// Consecutive failed dials tolerated before giving up.
+    pub max_attempts: u32,
+}
+
+impl Default for SupervisorConfig {
+    fn default() -> Self {
+        Self {
+            forwards: production_forwards(),
+            bind_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(30),
+            max_attempts: 8,
+        }
+    }
+}
+
+/// How often the supervisor polls [`SshTransport::is_closed`]. Keepalives in
+/// the session make a dead link flip this within ~30 s worst case.
+const LIVENESS_POLL: Duration = Duration::from_millis(500);
+
+pub struct Supervisor {
+    status: Arc<Mutex<TunnelStatus>>,
+    shutdown: watch::Sender<bool>,
+    task: JoinHandle<()>,
+}
+
+impl Supervisor {
+    pub fn spawn(config: SupervisorConfig, connector: Connector, sink: StatusSink) -> Self {
+        let status = Arc::new(Mutex::new(TunnelStatus {
+            phase: TunnelPhase::Connecting,
+            forwards: Vec::new(),
+        }));
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        let task = tokio::spawn(run(config, connector, sink, status.clone(), shutdown_rx));
+        Self {
+            status,
+            shutdown,
+            task,
+        }
+    }
+
+    pub fn status(&self) -> TunnelStatus {
+        self.status.lock().expect("status lock").clone()
+    }
+
+    /// Clean shutdown: closes the session and stops all listeners without
+    /// emitting a `lost` status.
+    pub async fn stop(self) {
+        let _ = self.shutdown.send(true);
+        let _ = self.task.await;
+    }
+}
+
+fn publish(
+    status: &Arc<Mutex<TunnelStatus>>,
+    sink: &StatusSink,
+    update: impl FnOnce(&mut TunnelStatus),
+) {
+    let snapshot = {
+        let mut guard = status.lock().expect("status lock");
+        update(&mut guard);
+        guard.clone()
+    };
+    sink(snapshot);
+}
+
+async fn run(
+    config: SupervisorConfig,
+    connector: Connector,
+    sink: StatusSink,
+    status: Arc<Mutex<TunnelStatus>>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let mut attempt: u32 = 0;
+    let mut delay = config.initial_backoff;
+
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        if attempt == 0 {
+            publish(&status, &sink, |s| {
+                s.phase = TunnelPhase::Connecting;
+                s.forwards.clear();
+            });
+        }
+
+        let transport = tokio::select! {
+            _ = shutdown.changed() => return,
+            result = connector() => match result {
+                Ok(t) => t,
+                Err(e) => {
+                    if e.is_fatal() || attempt >= config.max_attempts {
+                        publish(&status, &sink, |s| {
+                            s.phase = TunnelPhase::Lost { error: e };
+                            s.forwards.clear();
+                        });
+                        return;
+                    }
+                    attempt += 1;
+                    publish(&status, &sink, |s| {
+                        s.phase = TunnelPhase::Reconnecting {
+                            attempt,
+                            next_delay_secs: delay.as_secs(),
+                        };
+                    });
+                    tokio::select! {
+                        _ = shutdown.changed() => return,
+                        _ = tokio::time::sleep(delay) => {}
+                    }
+                    delay = (delay * 2).min(config.max_backoff);
+                    continue;
+                }
+            },
+        };
+
+        // Session is up: bind every listener and start accept loops.
+        let mut accept_tasks: Vec<JoinHandle<()>> = Vec::new();
+        let mut healths: Vec<ForwardHealth> = Vec::new();
+        let mut bind_failure: Option<String> = None;
+        for (idx, spec) in config.forwards.iter().enumerate() {
+            match TcpListener::bind((config.bind_addr, spec.local_port)).await {
+                Ok(listener) => {
+                    let bound = listener
+                        .local_addr()
+                        .map(|a| a.port())
+                        .unwrap_or(spec.local_port);
+                    healths.push(ForwardHealth {
+                        local_port: bound,
+                        remote_port: spec.remote_port,
+                        active: true,
+                        last_error: None,
+                    });
+                    accept_tasks.push(tokio::spawn(accept_loop(
+                        listener,
+                        spec.clone(),
+                        transport.clone(),
+                        status.clone(),
+                        sink.clone(),
+                        idx,
+                    )));
+                }
+                Err(e) => {
+                    let message = format!("bind 127.0.0.1:{}: {e}", spec.local_port);
+                    bind_failure.get_or_insert(message.clone());
+                    healths.push(ForwardHealth {
+                        local_port: spec.local_port,
+                        remote_port: spec.remote_port,
+                        active: false,
+                        last_error: Some(message),
+                    });
+                }
+            }
+        }
+
+        if healths.iter().all(|h| !h.active) {
+            // Nothing usable was bound (ports taken) — retrying won't fix it.
+            for t in &accept_tasks {
+                t.abort();
+            }
+            transport.close().await;
+            publish(&status, &sink, |s| {
+                s.phase = TunnelPhase::Lost {
+                    error: SshError::Internal {
+                        message: bind_failure
+                            .unwrap_or_else(|| "no forward could bind locally".into()),
+                    },
+                };
+                s.forwards = healths;
+            });
+            return;
+        }
+
+        delay = config.initial_backoff;
+        publish(&status, &sink, |s| {
+            s.phase = TunnelPhase::Connected;
+            s.forwards = healths;
+        });
+
+        // Watch the session until it dies or we're told to stop.
+        let session_died = loop {
+            tokio::select! {
+                _ = shutdown.changed() => break false,
+                _ = tokio::time::sleep(LIVENESS_POLL) => {
+                    if transport.is_closed() {
+                        break true;
+                    }
+                }
+            }
+        };
+
+        for t in &accept_tasks {
+            t.abort();
+        }
+        transport.close().await;
+
+        if !session_died {
+            return; // clean shutdown, no status change
+        }
+        attempt = 1;
+        publish(&status, &sink, |s| {
+            s.phase = TunnelPhase::Reconnecting {
+                attempt,
+                next_delay_secs: delay.as_secs(),
+            };
+            s.forwards.clear();
+        });
+        tokio::select! {
+            _ = shutdown.changed() => return,
+            _ = tokio::time::sleep(delay) => {}
+        }
+        delay = (delay * 2).min(config.max_backoff);
+    }
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    spec: ForwardSpec,
+    transport: Arc<dyn SshTransport>,
+    status: Arc<Mutex<TunnelStatus>>,
+    sink: StatusSink,
+    idx: usize,
+) {
+    loop {
+        let mut sock = match listener.accept().await {
+            Ok((sock, _)) => sock,
+            Err(_) => {
+                // Transient accept failure (fd pressure etc.); don't spin.
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                continue;
+            }
+        };
+        let transport = transport.clone();
+        let spec = spec.clone();
+        let status = status.clone();
+        let sink = sink.clone();
+        tokio::spawn(async move {
+            match transport
+                .open_forward(&spec.remote_host, spec.remote_port)
+                .await
+            {
+                Ok(mut stream) => {
+                    let _ = tokio::io::copy_bidirectional(&mut sock, &mut stream).await;
+                }
+                Err(e) => {
+                    publish(&status, &sink, |s| {
+                        if let Some(h) = s.forwards.get_mut(idx) {
+                            h.last_error = Some(e.to_string());
+                        }
+                    });
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::mpsc;
+
+    /// Transport whose forwards are plain TCP connections to a local echo
+    /// server, with liveness controlled by a flag.
+    struct FakeTransport {
+        echo_addr: std::net::SocketAddr,
+        closed: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl SshTransport for FakeTransport {
+        async fn open_forward(
+            &self,
+            _host: &str,
+            _port: u16,
+        ) -> Result<Box<dyn super::super::ForwardStream>, SshError> {
+            let stream = tokio::net::TcpStream::connect(self.echo_addr)
+                .await
+                .map_err(|e| super::super::io_error(&e))?;
+            Ok(Box::new(stream))
+        }
+
+        fn is_closed(&self) -> bool {
+            self.closed.load(Ordering::SeqCst)
+        }
+
+        async fn close(&self) {
+            self.closed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    async fn echo_server() -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    while let Ok(n) = sock.read(&mut buf).await {
+                        if n == 0 || sock.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    fn test_config() -> SupervisorConfig {
+        SupervisorConfig {
+            // High random port: bind 0 and read the real port from status.
+            forwards: vec![ForwardSpec {
+                local_port: 0,
+                remote_host: "127.0.0.1".into(),
+                remote_port: 9999,
+            }],
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(40),
+            max_attempts: 2,
+            ..Default::default()
+        }
+    }
+
+    fn channel_sink() -> (StatusSink, mpsc::UnboundedReceiver<TunnelStatus>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let sink: StatusSink = Arc::new(move |s| {
+            let _ = tx.send(s);
+        });
+        (sink, rx)
+    }
+
+    async fn wait_for(
+        rx: &mut mpsc::UnboundedReceiver<TunnelStatus>,
+        pred: impl Fn(&TunnelStatus) -> bool,
+    ) -> TunnelStatus {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let status = rx.recv().await.expect("status stream ended");
+                if pred(&status) {
+                    return status;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for status")
+    }
+
+    fn connector_to(
+        echo_addr: std::net::SocketAddr,
+        dials: Arc<AtomicU32>,
+        closed_flags: Arc<Mutex<Vec<Arc<AtomicBool>>>>,
+    ) -> Connector {
+        Arc::new(move || {
+            dials.fetch_add(1, Ordering::SeqCst);
+            let closed = Arc::new(AtomicBool::new(false));
+            closed_flags.lock().unwrap().push(closed.clone());
+            let transport: Arc<dyn SshTransport> = Arc::new(FakeTransport { echo_addr, closed });
+            Box::pin(async move { Ok(transport) })
+        })
+    }
+
+    #[tokio::test]
+    async fn forwards_round_trip_through_the_tunnel() {
+        let echo = echo_server().await;
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let flags = Arc::new(Mutex::new(Vec::new()));
+        let sup = Supervisor::spawn(test_config(), connector_to(echo, dials, flags), sink);
+
+        let connected = wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+        let port = connected.forwards[0].local_port;
+        assert_ne!(port, 0, "bound port must be reported");
+
+        let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .unwrap();
+        sock.write_all(b"ping").await.unwrap();
+        let mut buf = [0u8; 4];
+        sock.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"ping");
+
+        sup.stop().await;
+    }
+
+    #[tokio::test]
+    async fn session_death_triggers_reconnect_with_fresh_transport() {
+        let echo = echo_server().await;
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let flags: Arc<Mutex<Vec<Arc<AtomicBool>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sup = Supervisor::spawn(
+            test_config(),
+            connector_to(echo, dials.clone(), flags.clone()),
+            sink,
+        );
+
+        wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+        // Kill the first session out from under the supervisor.
+        flags.lock().unwrap()[0].store(true, Ordering::SeqCst);
+
+        wait_for(&mut rx, |s| {
+            matches!(s.phase, TunnelPhase::Reconnecting { attempt: 1, .. })
+        })
+        .await;
+        let reconnected = wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+        assert_eq!(dials.load(Ordering::SeqCst), 2);
+
+        // The rebuilt tunnel still round-trips.
+        let port = reconnected.forwards[0].local_port;
+        let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .unwrap();
+        sock.write_all(b"again").await.unwrap();
+        let mut buf = [0u8; 5];
+        sock.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"again");
+
+        sup.stop().await;
+    }
+
+    #[tokio::test]
+    async fn fatal_connect_error_stops_without_retries() {
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let dials_in = dials.clone();
+        let connector: Connector = Arc::new(move || {
+            dials_in.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Err(SshError::AuthFailed {
+                    message: "bad key".into(),
+                })
+            })
+        });
+        let sup = Supervisor::spawn(test_config(), connector, sink);
+
+        let lost = wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Lost { .. })).await;
+        assert!(matches!(
+            lost.phase,
+            TunnelPhase::Lost {
+                error: SshError::AuthFailed { .. }
+            }
+        ));
+        assert_eq!(
+            dials.load(Ordering::SeqCst),
+            1,
+            "fatal errors must not retry"
+        );
+        sup.stop().await;
+    }
+
+    #[tokio::test]
+    async fn retryable_errors_back_off_then_give_up() {
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let dials_in = dials.clone();
+        let connector: Connector = Arc::new(move || {
+            dials_in.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Err(SshError::Refused {
+                    message: "nobody home".into(),
+                })
+            })
+        });
+        let sup = Supervisor::spawn(test_config(), connector, sink);
+
+        wait_for(&mut rx, |s| {
+            matches!(s.phase, TunnelPhase::Reconnecting { attempt: 1, .. })
+        })
+        .await;
+        wait_for(&mut rx, |s| {
+            matches!(s.phase, TunnelPhase::Reconnecting { attempt: 2, .. })
+        })
+        .await;
+        wait_for(&mut rx, |s| {
+            matches!(
+                s.phase,
+                TunnelPhase::Lost {
+                    error: SshError::Refused { .. }
+                }
+            )
+        })
+        .await;
+        // max_attempts=2 → initial dial + 2 retries.
+        assert_eq!(dials.load(Ordering::SeqCst), 3);
+        sup.stop().await;
+    }
+
+    #[tokio::test]
+    async fn clean_stop_emits_no_lost_status() {
+        let echo = echo_server().await;
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let flags = Arc::new(Mutex::new(Vec::new()));
+        let sup = Supervisor::spawn(
+            test_config(),
+            connector_to(echo, dials, flags.clone()),
+            sink,
+        );
+        wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+        sup.stop().await;
+        // The transport was closed and no further status arrived.
+        assert!(flags.lock().unwrap()[0].load(Ordering::SeqCst));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn production_map_covers_the_stack_ports() {
+        let forwards = production_forwards();
+        let ports: Vec<u16> = forwards.iter().map(|f| f.local_port).collect();
+        for expected in [3000, 8000, 8001, 8002, 8080, 8111, 4000, 7000, 7010] {
+            assert!(ports.contains(&expected), "missing port {expected}");
+        }
+        assert_eq!(forwards.len(), 7 + 11);
+        // Local and remote port numbers must match — the web app derives its
+        // URLs from window.location.hostname plus these fixed ports.
+        assert!(forwards.iter().all(|f| f.local_port == f.remote_port));
+    }
+
+    #[test]
+    fn status_serializes_for_the_ui() {
+        let status = TunnelStatus {
+            phase: TunnelPhase::Reconnecting {
+                attempt: 3,
+                next_delay_secs: 4,
+            },
+            forwards: vec![ForwardHealth {
+                local_port: 3000,
+                remote_port: 3000,
+                active: true,
+                last_error: None,
+            }],
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["phase"]["state"], "reconnecting");
+        assert_eq!(json["phase"]["attempt"], 3);
+        assert_eq!(json["forwards"][0]["local_port"], 3000);
+
+        let lost = TunnelStatus {
+            phase: TunnelPhase::Lost {
+                error: SshError::ChangedHostKey {
+                    host: "qb2".into(),
+                    port: 22,
+                    fingerprint: "SHA256:x".into(),
+                },
+            },
+            forwards: vec![],
+        };
+        let json = serde_json::to_value(&lost).unwrap();
+        assert_eq!(json["phase"]["state"], "lost");
+        assert_eq!(json["phase"]["error"]["code"], "changed_host_key");
+    }
+}

--- a/desktop/src-tauri/tests/fixtures/sshd/Dockerfile
+++ b/desktop/src-tauri/tests/fixtures/sshd/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.20
+
+# Minimal sshd fixture for the tunnel integration tests: a locked-down
+# pubkey-only sshd plus a busybox httpd on 127.0.0.1:8088 that serves a
+# marker file — the "remote service" the tunnel forwards to. Host keys are
+# generated at image build time so they stay stable across container
+# restarts (the reconnect test depends on that).
+RUN apk add --no-cache openssh busybox-extras \
+    && ssh-keygen -A \
+    && adduser -D -s /bin/sh tunnel \
+    && sed -i 's/^tunnel:!/tunnel:*/' /etc/shadow \
+    && mkdir -p /srv \
+    && echo "tt-studio-tunnel-fixture" > /srv/index.html
+
+COPY sshd_config /etc/ssh/sshd_config
+
+EXPOSE 22
+CMD ["/bin/sh", "-c", "httpd -p 127.0.0.1:8088 -h /srv && exec /usr/sbin/sshd -D -e"]

--- a/desktop/src-tauri/tests/fixtures/sshd/sshd_config
+++ b/desktop/src-tauri/tests/fixtures/sshd/sshd_config
@@ -1,0 +1,14 @@
+# Test-fixture sshd: pubkey-only, forwarding enabled. The authorized_keys
+# file is bind-mounted from the test's temp dir (generated per run), hence
+# StrictModes off — the mount is owned by the host user, not `tunnel`.
+Port 22
+HostKey /etc/ssh/ssh_host_ed25519_key
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+AuthorizedKeysFile /keys/authorized_keys
+StrictModes no
+AllowTcpForwarding yes
+X11Forwarding no
+Subsystem sftp internal-sftp

--- a/desktop/src-tauri/tests/ssh_tunnel.rs
+++ b/desktop/src-tauri/tests/ssh_tunnel.rs
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Integration tests for the SSH tunnel engine against a real containerized
+//! sshd (tests/fixtures/sshd). Marked `#[ignore]` so plain `cargo test`
+//! stays hermetic; CI runs them on Linux with
+//! `cargo test --test ssh_tunnel -- --ignored`, and they also skip
+//! gracefully at runtime when Docker (with Linux containers) is missing.
+//!
+//! The fixture maps a random free host port to the container's sshd, and
+//! every local listener binds port 0 — the tests never touch the live
+//! TT-Studio stack's ports (3000/8000-8002/4000/8080/8111).
+
+use std::net::TcpListener as StdTcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+use tt_studio_desktop_lib::ssh::known_hosts::{trust, KnownHostsVerifier};
+use tt_studio_desktop_lib::ssh::session::{AuthMethod, SshSession, SshTarget};
+use tt_studio_desktop_lib::ssh::tunnel::{
+    Connector, ForwardSpec, StatusSink, Supervisor, SupervisorConfig, TunnelPhase, TunnelStatus,
+};
+use tt_studio_desktop_lib::ssh::{SshError, SshTransport};
+
+const IMAGE: &str = "tt-studio-desktop-sshd-fixture";
+/// Marker served by the httpd inside the fixture container on 127.0.0.1:8088.
+const REMOTE_HTTP_PORT: u16 = 8088;
+const MARKER: &str = "tt-studio-tunnel-fixture";
+
+// ---- fixture management ----
+
+fn docker_has_linux_containers() -> bool {
+    Command::new("docker")
+        .args(["info", "--format", "{{.OSType}}"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "linux")
+        .unwrap_or(false)
+}
+
+/// Build the fixture image once per test binary.
+fn ensure_image() {
+    static BUILD: Once = Once::new();
+    BUILD.call_once(|| {
+        let context = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sshd");
+        let out = Command::new("docker")
+            .args(["build", "-t", IMAGE])
+            .arg(&context)
+            .output()
+            .expect("docker build failed to spawn");
+        assert!(
+            out.status.success(),
+            "docker build failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    });
+}
+
+fn free_port() -> u16 {
+    // Bind-then-drop; the OS hands out a free high port. Tiny race window,
+    // acceptable for tests.
+    StdTcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+struct SshdFixture {
+    name: String,
+    port: u16,
+    /// Holds authorized_keys + the client key pair for this container.
+    keys_dir: tempfile::TempDir,
+}
+
+impl SshdFixture {
+    fn start() -> Self {
+        ensure_image();
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let name = format!(
+            "tt-studio-sshd-test-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        );
+        let keys_dir = tempfile::tempdir().unwrap();
+
+        // Fresh client key pair per container, mounted as authorized_keys.
+        let key_path = keys_dir.path().join("id_ed25519");
+        keygen(&key_path);
+        std::fs::copy(
+            key_path.with_extension("pub"),
+            keys_dir.path().join("authorized_keys"),
+        )
+        .unwrap();
+
+        let port = free_port();
+        let out = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "--name",
+                &name,
+                "-p",
+                &format!("127.0.0.1:{port}:22"),
+                "-v",
+                &format!("{}:/keys:ro", keys_dir.path().display()),
+                IMAGE,
+            ])
+            .output()
+            .expect("docker run failed to spawn");
+        assert!(
+            out.status.success(),
+            "docker run failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let fixture = Self {
+            name,
+            port,
+            keys_dir,
+        };
+        fixture.wait_for_sshd();
+        fixture
+    }
+
+    fn key_path(&self) -> PathBuf {
+        self.keys_dir.path().join("id_ed25519")
+    }
+
+    fn restart(&self) {
+        let out = Command::new("docker")
+            .args(["restart", "-t", "0", &self.name])
+            .output()
+            .expect("docker restart failed to spawn");
+        assert!(out.status.success());
+        self.wait_for_sshd();
+    }
+
+    /// Poll until sshd answers with its banner (docker start is async).
+    fn wait_for_sshd(&self) {
+        for _ in 0..120 {
+            if let Ok(stream) = std::net::TcpStream::connect(("127.0.0.1", self.port)) {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
+                let mut buf = [0u8; 4];
+                use std::io::Read;
+                let mut stream = stream;
+                if stream.read_exact(&mut buf).is_ok() && &buf == b"SSH-" {
+                    return;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        panic!(
+            "sshd fixture {} never came up on port {}",
+            self.name, self.port
+        );
+    }
+
+    fn target(&self) -> SshTarget {
+        SshTarget {
+            host: "127.0.0.1".into(),
+            port: self.port,
+            // Key file only: keeps the test independent of whatever
+            // identities the developer's ssh-agent happens to hold.
+            user: "tunnel".into(),
+            auth: vec![AuthMethod::KeyFile {
+                path: self.key_path(),
+                passphrase: None,
+            }],
+        }
+    }
+}
+
+impl Drop for SshdFixture {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .output();
+    }
+}
+
+fn keygen(path: &Path) {
+    let out = Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-q", "-f"])
+        .arg(path)
+        .output()
+        .expect("ssh-keygen failed to spawn");
+    assert!(
+        out.status.success(),
+        "ssh-keygen failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- helpers shared by the tests ----
+
+fn channel_sink() -> (StatusSink, mpsc::UnboundedReceiver<TunnelStatus>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let sink: StatusSink = Arc::new(move |s| {
+        let _ = tx.send(s);
+    });
+    (sink, rx)
+}
+
+async fn wait_for(
+    rx: &mut mpsc::UnboundedReceiver<TunnelStatus>,
+    what: &str,
+    pred: impl Fn(&TunnelStatus) -> bool,
+) -> TunnelStatus {
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let status = rx.recv().await.expect("status stream ended");
+            if pred(&status) {
+                return status;
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+}
+
+fn connector_for(fixture: &SshdFixture, known_hosts: PathBuf) -> Connector {
+    let target = fixture.target();
+    Arc::new(move || {
+        let target = target.clone();
+        let verifier = KnownHostsVerifier::new(known_hosts.clone());
+        Box::pin(async move {
+            SshSession::connect(&target, verifier)
+                .await
+                .map(|s| Arc::new(s) as Arc<dyn SshTransport>)
+        })
+    })
+}
+
+fn supervisor_config() -> SupervisorConfig {
+    SupervisorConfig {
+        // Local port 0 → high random port; never the live stack's ports.
+        forwards: vec![ForwardSpec {
+            local_port: 0,
+            remote_host: "127.0.0.1".into(),
+            remote_port: REMOTE_HTTP_PORT,
+        }],
+        initial_backoff: Duration::from_millis(500),
+        max_backoff: Duration::from_secs(2),
+        max_attempts: 30,
+        ..Default::default()
+    }
+}
+
+/// TOFU-accept the fixture's host key into `known_hosts` by connecting once,
+/// harvesting the UnknownHostKey error, and persisting the offered key.
+async fn trust_fixture_key(fixture: &SshdFixture, known_hosts: &Path) {
+    let err = SshSession::connect(
+        &fixture.target(),
+        KnownHostsVerifier::new(known_hosts.to_path_buf()),
+    )
+    .await
+    .err()
+    .expect("first contact must fail with an unknown host key");
+    match err {
+        SshError::UnknownHostKey {
+            host,
+            port,
+            fingerprint,
+            public_key,
+            ..
+        } => {
+            assert!(fingerprint.starts_with("SHA256:"));
+            trust(known_hosts, &host, port, &public_key).unwrap();
+        }
+        other => panic!("expected UnknownHostKey, got {other:?}"),
+    }
+}
+
+async fn http_get_through(port: u16) -> String {
+    let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect to forwarded port");
+    sock.write_all(b"GET / HTTP/1.0\r\nHost: fixture\r\n\r\n")
+        .await
+        .unwrap();
+    let mut body = Vec::new();
+    let _ = sock.read_to_end(&mut body).await;
+    String::from_utf8_lossy(&body).to_string()
+}
+
+macro_rules! require_docker {
+    () => {
+        if !docker_has_linux_containers() {
+            eprintln!("skipping: docker with Linux containers is not available");
+            return;
+        }
+    };
+}
+
+// ---- the tests ----
+
+#[tokio::test]
+#[ignore = "needs docker; run with --ignored (desktop-ci does on Linux)"]
+async fn key_auth_tofu_accept_and_forward_round_trip() {
+    require_docker!();
+    let fixture = SshdFixture::start();
+    let tmp = tempfile::tempdir().unwrap();
+    let known_hosts = tmp.path().join("known_hosts");
+
+    // First contact: unknown key → trust it (the TOFU accept path).
+    trust_fixture_key(&fixture, &known_hosts).await;
+
+    // Second connect authenticates with the key file against the now-trusted
+    // host, and the tunnel forwards a real HTTP round trip.
+    let (sink, mut rx) = channel_sink();
+    let sup = Supervisor::spawn(
+        supervisor_config(),
+        connector_for(&fixture, known_hosts),
+        sink,
+    );
+    let connected = wait_for(&mut rx, "connected", |s| {
+        matches!(s.phase, TunnelPhase::Connected)
+    })
+    .await;
+    let local_port = connected.forwards[0].local_port;
+    assert_ne!(local_port, 0);
+
+    let response = http_get_through(local_port).await;
+    assert!(
+        response.contains(MARKER),
+        "expected fixture marker in response, got:\n{response}"
+    );
+    sup.stop().await;
+}
+
+#[tokio::test]
+#[ignore = "needs docker; run with --ignored (desktop-ci does on Linux)"]
+async fn tunnel_reconnects_after_container_restart() {
+    require_docker!();
+    let fixture = SshdFixture::start();
+    let tmp = tempfile::tempdir().unwrap();
+    let known_hosts = tmp.path().join("known_hosts");
+    trust_fixture_key(&fixture, &known_hosts).await;
+
+    let (sink, mut rx) = channel_sink();
+    let sup = Supervisor::spawn(
+        supervisor_config(),
+        connector_for(&fixture, known_hosts),
+        sink,
+    );
+    wait_for(&mut rx, "initial connect", |s| {
+        matches!(s.phase, TunnelPhase::Connected)
+    })
+    .await;
+
+    // Restart the container: the session dies, and because host keys are
+    // baked into the image the reconnect must succeed against the SAME key.
+    fixture.restart();
+    wait_for(&mut rx, "reconnecting status", |s| {
+        matches!(s.phase, TunnelPhase::Reconnecting { .. })
+    })
+    .await;
+    let reconnected = wait_for(&mut rx, "reconnect", |s| {
+        matches!(s.phase, TunnelPhase::Connected)
+    })
+    .await;
+
+    let response = http_get_through(reconnected.forwards[0].local_port).await;
+    assert!(response.contains(MARKER));
+    sup.stop().await;
+}
+
+#[tokio::test]
+#[ignore = "needs docker; run with --ignored (desktop-ci does on Linux)"]
+async fn changed_host_key_is_rejected() {
+    require_docker!();
+    let fixture = SshdFixture::start();
+    let tmp = tempfile::tempdir().unwrap();
+    let known_hosts = tmp.path().join("known_hosts");
+
+    // Record a DIFFERENT (freshly generated) key for the fixture's address —
+    // the TOFU reject path: what a MITM or reinstalled machine looks like.
+    let impostor = tmp.path().join("impostor_ed25519");
+    keygen(&impostor);
+    let impostor_pub = std::fs::read_to_string(impostor.with_extension("pub")).unwrap();
+    trust(&known_hosts, "127.0.0.1", fixture.port, impostor_pub.trim()).unwrap();
+
+    let err = SshSession::connect(
+        &fixture.target(),
+        KnownHostsVerifier::new(known_hosts.clone()),
+    )
+    .await
+    .err()
+    .expect("connect must fail against a changed host key");
+    assert!(
+        matches!(err, SshError::ChangedHostKey { .. }),
+        "expected ChangedHostKey, got {err:?}"
+    );
+    assert!(err.is_fatal());
+
+    // And the supervisor treats it as terminal — no retry storm.
+    let (sink, mut rx) = channel_sink();
+    let sup = Supervisor::spawn(
+        supervisor_config(),
+        connector_for(&fixture, known_hosts),
+        sink,
+    );
+    let lost = wait_for(&mut rx, "lost status", |s| {
+        matches!(s.phase, TunnelPhase::Lost { .. })
+    })
+    .await;
+    assert!(matches!(
+        lost.phase,
+        TunnelPhase::Lost {
+            error: SshError::ChangedHostKey { .. }
+        }
+    ));
+    sup.stop().await;
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,11 @@ import BringUpProgress from "./views/BringUpProgress";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import {
+  describeSshError,
+  TrustHostKeyDialog,
+  TunnelBanner,
+} from "./views/TunnelBanner";
+import {
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -20,14 +25,19 @@ import {
   listProfiles,
   markProfileUsed,
   onStackHealth,
+  onTunnelStatus,
   openStack,
   saveProfile,
   setSshKeyPassphrase,
   startHealthPoll,
+  startSshTunnels,
   stopHealthPoll,
+  stopSshTunnels,
+  trustHostKey,
   type HardwareProbe,
   type Profile,
   type StackHealth,
+  type TunnelStatus,
 } from "./lib/ipc";
 
 // The real TT-Studio frontend is served by the stack itself — the desktop
@@ -51,9 +61,11 @@ const STATUS_STYLE: Record<string, string> = {
 function HealthGate({
   health,
   target,
+  tunnel,
 }: {
   health: StackHealth | null;
   target: Profile | null;
+  tunnel: TunnelStatus | null;
 }) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
@@ -67,6 +79,7 @@ function HealthGate({
             : "Waiting for all services to come up"}
         </p>
       </header>
+      {target && <TunnelBanner status={tunnel} />}
       <ul className="flex w-full max-w-sm flex-col gap-2">
         {(health?.services ?? []).map((s) => (
           <li
@@ -96,6 +109,7 @@ function App() {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [health, setHealth] = useState<StackHealth | null>(null);
   const [bringUp, setBringUp] = useState<BringUpState | null>(null);
+  const [tunnel, setTunnel] = useState<TunnelStatus | null>(null);
   const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const opening = useRef(false);
@@ -126,6 +140,32 @@ function App() {
       stopHealthPoll().catch(() => {});
     };
   }, [screen.name]);
+
+  // For SSH targets: follow tunnel status. The listener is scoped to the
+  // connecting screen, but the tunnel itself keeps running after we navigate
+  // to the stack — it IS the transport to the remote services.
+  useEffect(() => {
+    if (screen.name !== "connecting" || !screen.target) return;
+    let unlisten: (() => void) | undefined;
+    onTunnelStatus(setTunnel).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [screen]);
+
+  // Hard tunnel loss (not the trust prompt) while still on the launcher:
+  // stop the supervisor and drop back to the picker with the reason.
+  useEffect(() => {
+    if (screen.name !== "connecting" || tunnel?.phase.state !== "lost") return;
+    if (tunnel.phase.error.code === "unknown_host_key") return;
+    const message = describeSshError(tunnel.phase.error);
+    stopSshTunnels().catch(() => {});
+    setTunnel(null);
+    setError(message);
+    setScreen({ name: "picker" });
+  }, [screen.name, tunnel]);
 
   // When a bring-up is running (`python run.py --json-events` piped in by the
   // shell), render its NDJSON stream natively instead of the bare checklist.
@@ -172,9 +212,36 @@ function App() {
 
   const connect = useCallback((target: Profile | null) => {
     setHealth(null);
+    setTunnel(null);
     opening.current = false;
-    if (target) markProfileUsed(target.id).catch(() => {});
+    if (target) {
+      markProfileUsed(target.id).catch(() => {});
+      startSshTunnels(target).catch((e) => setError(String(e)));
+    }
     setScreen({ name: "connecting", target });
+  }, []);
+
+  const handleTrustHostKey = useCallback(
+    (target: Profile) => {
+      const phase = tunnel?.phase;
+      if (phase?.state !== "lost" || phase.error.code !== "unknown_host_key")
+        return;
+      const { host, port, public_key } = phase.error;
+      setTunnel(null);
+      trustHostKey(host ?? "", port ?? 22, public_key ?? "")
+        .then(() => startSshTunnels(target))
+        .catch((e) => {
+          setError(String(e));
+          setScreen({ name: "picker" });
+        });
+    },
+    [tunnel],
+  );
+
+  const handleRejectHostKey = useCallback(() => {
+    stopSshTunnels().catch(() => {});
+    setTunnel(null);
+    setScreen({ name: "picker" });
   }, []);
 
   const handleSave = useCallback(
@@ -231,10 +298,24 @@ function App() {
   }
 
   if (screen.name === "connecting") {
+    const target = screen.target;
+    if (
+      target &&
+      tunnel?.phase.state === "lost" &&
+      tunnel.phase.error.code === "unknown_host_key"
+    ) {
+      return (
+        <TrustHostKeyDialog
+          error={tunnel.phase.error}
+          onTrust={() => handleTrustHostKey(target)}
+          onReject={handleRejectHostKey}
+        />
+      );
+    }
     if (bringUp && bringUp.phases.length > 0) {
       return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
     }
-    return <HealthGate health={health} target={screen.target} />;
+    return <HealthGate health={health} target={target} tunnel={tunnel} />;
   }
 
   return (

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -96,6 +96,73 @@ export const onStackHealth = (
 ): Promise<UnlistenFn> =>
   listen<StackHealth>("stack-health", (event) => handler(event.payload));
 
+// ---- ssh tunnels ----
+
+export interface SshErrorPayload {
+  code:
+    | "dns"
+    | "refused"
+    | "timeout"
+    | "handshake"
+    | "agent_unavailable"
+    | "key_file"
+    | "auth_failed"
+    | "unknown_host_key"
+    | "changed_host_key"
+    | "known_hosts"
+    | "disconnected"
+    | "internal";
+  message?: string;
+  host?: string;
+  port?: number;
+  path?: string;
+  key_type?: string;
+  fingerprint?: string;
+  public_key?: string;
+}
+
+export type TunnelPhase =
+  | { state: "connecting" }
+  | { state: "connected" }
+  | { state: "reconnecting"; attempt: number; next_delay_secs: number }
+  | { state: "lost"; error: SshErrorPayload };
+
+export interface ForwardHealth {
+  local_port: number;
+  remote_port: number;
+  active: boolean;
+  last_error?: string;
+}
+
+export interface TunnelStatus {
+  phase: TunnelPhase;
+  forwards: ForwardHealth[];
+}
+
+export const startSshTunnels = (profile: Profile) =>
+  invoke<void>("start_ssh_tunnels", { profile });
+
+export const stopSshTunnels = () => invoke<void>("stop_ssh_tunnels");
+
+export const getTunnelStatus = () =>
+  invoke<TunnelStatus | null>("get_tunnel_status");
+
+export const trustHostKey = (host: string, port: number, publicKey: string) =>
+  invoke<void>("trust_host_key", { host, port, publicKey });
+
+export const onTunnelStatus = (
+  handler: (status: TunnelStatus) => void,
+): Promise<UnlistenFn> =>
+  listen<TunnelStatus>("tunnel-status", (event) => handler(event.payload));
+
+/** Narrow an unknown invoke() rejection into an SshErrorPayload if possible. */
+export function asSshError(e: unknown): SshErrorPayload | null {
+  if (typeof e === "object" && e !== null && "code" in e) {
+    return e as SshErrorPayload;
+  }
+  return null;
+}
+
 // ---- navigation ----
 
 export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/views/TunnelBanner.test.tsx
+++ b/desktop/src/views/TunnelBanner.test.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  describeSshError,
+  describeTunnel,
+  TrustHostKeyDialog,
+  TunnelBanner,
+} from "./TunnelBanner";
+import type { SshErrorPayload, TunnelStatus } from "../lib/ipc";
+
+afterEach(cleanup);
+
+const connected: TunnelStatus = {
+  phase: { state: "connected" },
+  forwards: [
+    { local_port: 3000, remote_port: 3000, active: true },
+    { local_port: 8000, remote_port: 8000, active: true },
+    { local_port: 4000, remote_port: 4000, active: false },
+  ],
+};
+
+const unknownKey: SshErrorPayload = {
+  code: "unknown_host_key",
+  host: "qb2.lan",
+  port: 22,
+  key_type: "ssh-ed25519",
+  fingerprint: "SHA256:abcdef",
+  public_key: "ssh-ed25519 AAAA",
+};
+
+describe("describeTunnel", () => {
+  it("counts only active forwards when connected", () => {
+    expect(describeTunnel(connected)).toBe("SSH tunnel up — forwarding 2 ports");
+  });
+
+  it("shows the reconnect attempt", () => {
+    expect(
+      describeTunnel({
+        phase: { state: "reconnecting", attempt: 3, next_delay_secs: 4 },
+        forwards: [],
+      }),
+    ).toContain("attempt 3");
+  });
+
+  it("explains a lost tunnel with the typed error", () => {
+    expect(
+      describeTunnel({
+        phase: { state: "lost", error: { code: "refused" } },
+        forwards: [],
+      }),
+    ).toContain("connection refused");
+  });
+
+  it("treats a changed host key as a hard, explained failure", () => {
+    const text = describeSshError({
+      code: "changed_host_key",
+      host: "qb2.lan",
+      port: 22,
+      fingerprint: "SHA256:x",
+    });
+    expect(text).toContain("HOST KEY CHANGED");
+    expect(text).toContain("qb2.lan");
+  });
+});
+
+describe("TunnelBanner", () => {
+  it("renders the current phase as a status line", () => {
+    render(<TunnelBanner status={connected} />);
+    expect(screen.getByRole("status").textContent).toContain("SSH tunnel up");
+  });
+});
+
+describe("TrustHostKeyDialog", () => {
+  it("shows the fingerprint and wires both choices", () => {
+    const onTrust = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <TrustHostKeyDialog
+        error={unknownKey}
+        onTrust={onTrust}
+        onReject={onReject}
+      />,
+    );
+    expect(screen.getByText("SHA256:abcdef")).toBeTruthy();
+    expect(screen.getByText("ssh-ed25519")).toBeTruthy();
+    fireEvent.click(screen.getByText("Trust and connect"));
+    expect(onTrust).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+});

--- a/desktop/src/views/TunnelBanner.tsx
+++ b/desktop/src/views/TunnelBanner.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Tunnel status banner + trust-on-first-use host key dialog for SSH
+// connections. Pure views — all IPC stays in App.
+
+import type { SshErrorPayload, TunnelStatus } from "../lib/ipc";
+
+/**
+ * One-line description of the tunnel state for the banner. Exported for
+ * unit tests.
+ */
+export function describeTunnel(status: TunnelStatus | null): string {
+  if (!status) return "Starting SSH tunnel…";
+  switch (status.phase.state) {
+    case "connecting":
+      return "Opening SSH tunnel…";
+    case "connected": {
+      const active = status.forwards.filter((f) => f.active).length;
+      return `SSH tunnel up — forwarding ${active} ports`;
+    }
+    case "reconnecting":
+      return `SSH tunnel dropped — reconnecting (attempt ${status.phase.attempt})…`;
+    case "lost":
+      return `SSH tunnel lost: ${describeSshError(status.phase.error)}`;
+  }
+}
+
+export function describeSshError(error: SshErrorPayload): string {
+  switch (error.code) {
+    case "dns":
+      return "hostname could not be resolved";
+    case "refused":
+      return "connection refused — is sshd running?";
+    case "timeout":
+      return "connection timed out";
+    case "auth_failed":
+      return `authentication failed (${error.message ?? "all methods rejected"})`;
+    case "key_file":
+      return `problem with key file ${error.path ?? ""}: ${error.message ?? ""}`;
+    case "unknown_host_key":
+      return "the machine's host key is not trusted yet";
+    case "changed_host_key":
+      return `HOST KEY CHANGED for ${error.host} — refusing to connect. If the machine was reinstalled, remove it from the app's known_hosts file and reconnect.`;
+    default:
+      return error.message ?? error.code;
+  }
+}
+
+const PHASE_STYLE: Record<string, string> = {
+  connecting: "border-zinc-700 text-zinc-300",
+  connected: "border-emerald-700 text-emerald-300",
+  reconnecting: "border-amber-700 text-amber-300",
+  lost: "border-red-800 text-red-300",
+};
+
+export function TunnelBanner({ status }: { status: TunnelStatus | null }) {
+  const phase = status?.phase.state ?? "connecting";
+  return (
+    <div
+      role="status"
+      className={`w-full max-w-sm rounded-md border bg-zinc-900 px-3 py-2 text-center text-xs ${
+        PHASE_STYLE[phase] ?? PHASE_STYLE.connecting
+      }`}
+    >
+      {describeTunnel(status)}
+    </div>
+  );
+}
+
+interface TrustPromptProps {
+  error: SshErrorPayload; // code === "unknown_host_key"
+  onTrust: () => void;
+  onReject: () => void;
+}
+
+/**
+ * First contact with a machine: show the key fingerprint and let the user
+ * decide. Accepting persists the key; every later connection must match it.
+ */
+export function TrustHostKeyDialog({ error, onTrust, onReject }: TrustPromptProps) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
+      <header className="max-w-md text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Trust this machine?
+        </h1>
+        <p className="mt-2 text-sm text-zinc-400">
+          {error.host}
+          {error.port && error.port !== 22 ? `:${error.port}` : ""} has never
+          been seen before. Verify the fingerprint matches the machine you
+          expect (run <code>ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub</code>{" "}
+          on it) before trusting.
+        </p>
+      </header>
+      <dl className="w-full max-w-md rounded-md border border-zinc-800 bg-zinc-900 p-4 text-sm">
+        <dt className="text-xs uppercase tracking-wide text-zinc-500">
+          Key type
+        </dt>
+        <dd className="mb-3">{error.key_type}</dd>
+        <dt className="text-xs uppercase tracking-wide text-zinc-500">
+          SHA256 fingerprint
+        </dt>
+        <dd className="break-all font-mono text-xs">{error.fingerprint}</dd>
+      </dl>
+      <div className="flex gap-3">
+        <button
+          onClick={onReject}
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onTrust}
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+        >
+          Trust and connect
+        </button>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Milestone D4 of the desktop app: the SSH tunnel engine that lets the launcher front a TT-Studio stack running on a remote machine. Stacked on #1253 (`jashan/desktop-shell`) — retarget to `dev` after that merges.

One russh session multiplexes all forwards as direct-tcpip channels behind local TCP listeners that bind the same port numbers as the remote services (3000, 8000-8002, 8080, 8111, 4000, 7000-7010), since the web app derives its URLs from `window.location.hostname` plus fixed ports. Everything talks to the session through a small `SshTransport` trait, so swapping russh for ssh2 or system-ssh later stays contained to `session.rs`.

- [x] russh session with typed errors per failure mode (dns/refused/timeout/handshake/auth/host key); auth order is ssh-agent (incl. Windows named pipe + Pageant) then key file, with the keychain passphrase from the D2 secrets store
- [x] trust-on-first-use host keys in an app-managed known_hosts file: unknown key surfaces a fingerprint dialog in the launcher; a changed key is a hard fail that is never promptable
- [x] port-forward supervisor: per-listener accept loops, per-tunnel health/last-error, exponential-backoff reconnect (1s doubling to a 30s cap), clean shutdown; fatal errors (auth, host key) stop instead of retrying
- [x] `tunnel-status` events drive a launcher banner; on hard loss while the stack page is showing, the window navigates back to the launcher
- [x] integration tests against a containerized sshd fixture (alpine + busybox httpd): key auth + TOFU accept + HTTP round-trip through the tunnel, reconnect across `docker restart`, changed-key rejection; they skip when docker is unavailable and run on the Linux desktop-ci leg via `--ignored`

Verified locally: cargo test (47 unit tests), the 3 dockerized integration tests, clippy `-D warnings`, rustfmt, `npm test` (38) and `tsc`. Tests bind only OS-assigned high ports, never the real stack's.