### PR TITLE
feat(desktop): native white-box mode — spawn run.py and stream bring-up

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -770,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2592,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3406,6 +3435,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3825,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-store",
+ "tempfile",
  "tokio",
 ]
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2068,6 +2068,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2577,6 +2578,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3319,6 +3344,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +3891,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-store",
  "tempfile",
  "tokio",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,3 +31,4 @@ tokio = { version = "1", features = ["macros", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
+tauri-plugin-dialog = "2"
 # sync-secret-service links libdbus on Linux (libdbus-1-dev in CI); no
 # secret-service daemon at runtime degrades to a typed error, not a crash.
 keyring = { version = "3", features = [

--- a/desktop/src-tauri/src/hardware.rs
+++ b/desktop/src-tauri/src/hardware.rs
@@ -7,7 +7,9 @@
 //! The first-run picker uses this to choose its default: a machine with a
 //! Tenstorrent accelerator pre-selects "run locally", anything else defaults
 //! to connecting over SSH. Full deployment needs `/dev/tenstorrent`, which
-//! only exists on Linux hosts with the driver loaded.
+//! only exists on Linux hosts with the driver loaded. The platform rides
+//! along so the picker can explain *why* local mode is unavailable (wrong
+//! OS vs. missing device/driver).
 
 use serde::Serialize;
 use std::path::Path;
@@ -23,16 +25,41 @@ pub enum DefaultMode {
 }
 
 #[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Platform {
+    Linux,
+    Macos,
+    Windows,
+    Other,
+}
+
+impl Platform {
+    pub fn current() -> Self {
+        if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else if cfg!(target_os = "macos") {
+            Platform::Macos
+        } else if cfg!(target_os = "windows") {
+            Platform::Windows
+        } else {
+            Platform::Other
+        }
+    }
+}
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HardwareProbe {
+    pub platform: Platform,
     pub accelerator_present: bool,
     pub default_mode: DefaultMode,
 }
 
 /// Pure gating logic: local mode only makes sense on Linux with the device
 /// node present; everything else should steer the picker to SSH.
-pub fn probe_at(is_linux: bool, dev_path: &Path) -> HardwareProbe {
-    let accelerator_present = is_linux && dev_path.exists();
+pub fn probe(platform: Platform, dev_path: &Path) -> HardwareProbe {
+    let accelerator_present = platform == Platform::Linux && dev_path.exists();
     HardwareProbe {
+        platform,
         accelerator_present,
         default_mode: if accelerator_present {
             DefaultMode::Local
@@ -44,7 +71,7 @@ pub fn probe_at(is_linux: bool, dev_path: &Path) -> HardwareProbe {
 
 #[tauri::command]
 pub fn detect_hardware() -> HardwareProbe {
-    probe_at(cfg!(target_os = "linux"), Path::new(TENSTORRENT_DEV))
+    probe(Platform::current(), Path::new(TENSTORRENT_DEV))
 }
 
 #[cfg(test)]
@@ -54,14 +81,17 @@ mod tests {
     #[test]
     fn linux_with_device_defaults_to_local() {
         let dir = std::env::temp_dir();
-        let probe = probe_at(true, &dir); // any existing path stands in for /dev/tenstorrent
+        let probe = probe(Platform::Linux, &dir); // any existing path stands in for /dev/tenstorrent
         assert!(probe.accelerator_present);
         assert_eq!(probe.default_mode, DefaultMode::Local);
     }
 
     #[test]
     fn linux_without_device_defaults_to_ssh() {
-        let probe = probe_at(true, Path::new("/nonexistent/tenstorrent-test-path"));
+        let probe = probe(
+            Platform::Linux,
+            Path::new("/nonexistent/tenstorrent-test-path"),
+        );
         assert!(!probe.accelerator_present);
         assert_eq!(probe.default_mode, DefaultMode::Ssh);
     }
@@ -69,14 +99,17 @@ mod tests {
     #[test]
     fn non_linux_defaults_to_ssh_even_if_path_exists() {
         let dir = std::env::temp_dir();
-        let probe = probe_at(false, &dir);
-        assert!(!probe.accelerator_present);
-        assert_eq!(probe.default_mode, DefaultMode::Ssh);
+        for platform in [Platform::Macos, Platform::Windows, Platform::Other] {
+            let probe = probe(platform, &dir);
+            assert!(!probe.accelerator_present);
+            assert_eq!(probe.default_mode, DefaultMode::Ssh);
+        }
     }
 
     #[test]
     fn probe_serializes_for_the_ui() {
-        let json = serde_json::to_value(probe_at(true, Path::new("/nope"))).unwrap();
+        let json = serde_json::to_value(probe(Platform::Macos, Path::new("/nope"))).unwrap();
+        assert_eq!(json["platform"], "macos");
         assert_eq!(json["accelerator_present"], false);
         assert_eq!(json["default_mode"], "ssh");
     }

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -259,6 +259,95 @@ pub async fn restart_stack(
     spawn_bring_up(&app, &state, &path)
 }
 
+// ---- quit flow ----
+
+/// Ask whether quitting should also stop the stack. The host services
+/// detach and ignore SIGHUP on purpose, so "keep running in the background"
+/// is the truthful default; "stop the stack" runs `run.py --stop` first.
+///
+/// Called from the CloseRequested handler with the close already prevented;
+/// every branch ends in `app.exit(0)`.
+pub fn confirm_quit(app: &tauri::AppHandle<Wry>) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+    let app = app.clone();
+    app.clone()
+        .dialog()
+        .message(
+            "TT-Studio's services keep running in the background — you can \
+             reopen the app (or the browser) and pick up where you left off.\n\n\
+             Stop the stack before quitting?",
+        )
+        .title("Quit TT-Studio")
+        // "Stop the stack" is the affirmative (Ok) button so that dismissing
+        // the dialog (Esc / close) maps to the safe default: keep running.
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Stop the stack".to_string(),
+            "Keep running".to_string(),
+        ))
+        .show(move |stop_stack| {
+            if stop_stack {
+                stop_stack_then_exit(&app);
+            } else {
+                app.exit(0);
+            }
+        });
+}
+
+/// Kill any in-flight bring-up, run `run.py --stop` in the known checkout
+/// (progress streamed as `stop-line` events for whoever is still listening),
+/// then exit. Exits immediately if there is no checkout to stop.
+fn stop_stack_then_exit(app: &tauri::AppHandle<Wry>) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let state: tauri::State<LauncherState> = app.state();
+
+        // Free the child slot: signal a running bring-up and give its
+        // reader thread a moment to reap it.
+        kill_child(&state.child);
+        for _ in 0..50 {
+            if state.child.lock().map(|g| g.is_none()).unwrap_or(true) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        let checkout = state
+            .checkout
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .or_else(|| default_existing_checkout(&app));
+        let (Some(checkout), Ok(logs)) = (checkout, log_dir(&app)) else {
+            app.exit(0);
+            return;
+        };
+
+        let line_app = app.clone();
+        let exit_app = app.clone();
+        let spawned = spawn_streaming(
+            &stop_spec(&checkout, logs.join("stop.log")),
+            state.child.clone(),
+            move |line| {
+                let _ = line_app.emit(STOP_LINE_EVENT, &line);
+            },
+            move |_code| {
+                exit_app.exit(0);
+            },
+        );
+        if spawned.is_err() {
+            app.exit(0);
+        }
+    });
+}
+
+/// Attached-but-never-spawned sessions still deserve a working "stop the
+/// stack": fall back to the configured/managed checkout (never cloning).
+fn default_existing_checkout(app: &tauri::AppHandle<Wry>) -> Option<PathBuf> {
+    let configured = stack_checkout::configured_path(app).ok().flatten();
+    let home = app.path().home_dir().ok()?;
+    stack_checkout::existing(configured.as_deref(), &stack_checkout::managed_dir(&home))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -43,11 +43,14 @@ pub struct SpawnSpec {
 }
 
 /// Full bring-up. `--no-browser` because the desktop window is the browser;
-/// `--json-events` for the machine-readable stream (implies non-interactive).
+/// `--json-events` for the machine-readable stream (implies non-interactive);
+/// `--no-sudo` because a GUI child can never answer a sudo password prompt —
+/// anything that genuinely needs root becomes a `prompt_blocked`/`error`
+/// event pointing the user at a one-time terminal run instead of a hang.
 pub fn bring_up_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
     SpawnSpec {
         program: PYTHON.to_string(),
-        args: ["run.py", "--no-browser", "--json-events"]
+        args: ["run.py", "--no-browser", "--json-events", "--no-sudo"]
             .map(String::from)
             .to_vec(),
         cwd: checkout.to_path_buf(),
@@ -264,7 +267,10 @@ mod tests {
     fn bring_up_spec_runs_run_py_with_json_events_from_the_checkout() {
         let spec = bring_up_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
         assert_eq!(spec.program, "python3");
-        assert_eq!(spec.args, ["run.py", "--no-browser", "--json-events"]);
+        assert_eq!(
+            spec.args,
+            ["run.py", "--no-browser", "--json-events", "--no-sudo"]
+        );
         // run.py derives TT_STUDIO_ROOT from cwd — this is the contract.
         assert_eq!(spec.cwd, Path::new("/tmp/stack"));
     }

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -211,6 +211,51 @@ pub fn bring_up_running(state: tauri::State<'_, LauncherState>) -> bool {
     state.child.lock().map(|g| g.is_some()).unwrap_or(false)
 }
 
+/// The UI attached to an already-healthy local stack (no bring-up spawned).
+/// Recorded so quitting can still offer to stop that stack.
+#[tauri::command]
+pub fn mark_local_attach(state: tauri::State<'_, LauncherState>) {
+    state.local_stack.store(true, Ordering::SeqCst);
+}
+
+/// Explicit restart: `run.py --stop` (streamed as `stop-line` events), then
+/// a fresh bring-up. Never triggered automatically — only by the launcher
+/// UI's "Restart stack" action.
+#[tauri::command]
+pub async fn restart_stack(
+    app: tauri::AppHandle<Wry>,
+    state: tauri::State<'_, LauncherState>,
+    checkout: String,
+) -> Result<u32, String> {
+    let path = checked_checkout(&checkout)?;
+    let logs = log_dir(&app)?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let line_app = app.clone();
+    spawn_streaming(
+        &stop_spec(&path, logs.join("stop.log")),
+        state.child.clone(),
+        move |line| {
+            let _ = line_app.emit(STOP_LINE_EVENT, &line);
+        },
+        move |code| {
+            let _ = tx.send(code);
+        },
+    )?;
+    let code = tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|_| "run.py --stop ended without reporting an exit code".to_string())?;
+    if code != Some(0) {
+        return Err(format!(
+            "run.py --stop failed (exit {}) — not starting a new bring-up",
+            code.map_or("signal".to_string(), |c| c.to_string())
+        ));
+    }
+
+    spawn_bring_up(&app, &state, &path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Native white-box launcher: spawn `python run.py` inside a checkout and
+//! stream its NDJSON events to the UI.
+//!
+//! `run.py --json-events` keeps stdout machine-readable (one JSON object per
+//! line) and moves all human output to stderr. So: stdout is read
+//! line-buffered and each line is forwarded verbatim as a `bringup-line`
+//! Tauri event (the frontend owns parsing — see src/lib/events.ts), while
+//! stderr goes to a rotating log file in the app data dir for bug reports.
+//!
+//! Two contract details worth keeping in mind:
+//! - `run.py` derives TT_STUDIO_ROOT from its cwd, so the child's cwd must
+//!   be the checkout root.
+//! - The bootstrap re-execs (execve) into `.tt_studio_run_venv`; PID and the
+//!   stdout pipe survive that, so it's still one child from our side.
+
+use crate::state::{ChildSlot, LauncherState};
+use crate::{stack_checkout, state};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::Ordering;
+use tauri::{Emitter, Manager, Wry};
+
+pub const BRINGUP_LINE_EVENT: &str = "bringup-line";
+pub const BRINGUP_EXIT_EVENT: &str = "bringup-exit";
+pub const STOP_LINE_EVENT: &str = "stop-line";
+
+const PYTHON: &str = "python3";
+
+/// Everything needed to spawn one launcher child.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpawnSpec {
+    pub program: String,
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+    pub stderr_log: PathBuf,
+    pub envs: Vec<(String, String)>,
+}
+
+/// Full bring-up. `--no-browser` because the desktop window is the browser;
+/// `--json-events` for the machine-readable stream (implies non-interactive).
+pub fn bring_up_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
+    SpawnSpec {
+        program: PYTHON.to_string(),
+        args: ["run.py", "--no-browser", "--json-events"]
+            .map(String::from)
+            .to_vec(),
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// `run.py --stop`: stop containers, keep the persistent volume.
+pub fn stop_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
+    SpawnSpec {
+        program: PYTHON.to_string(),
+        args: ["run.py", "--stop"].map(String::from).to_vec(),
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// One-deep rotation: keep the previous run's stderr as `<name>.1`.
+pub fn rotate_log(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if path.exists() {
+        let mut rotated = path.as_os_str().to_owned();
+        rotated.push(".1");
+        std::fs::rename(path, PathBuf::from(rotated))?;
+    }
+    Ok(())
+}
+
+/// Spawn the child described by `spec`, park it in `slot`, and stream its
+/// stdout line by line to `on_line` from a reader thread. When stdout hits
+/// EOF the same thread reaps the child and calls `on_exit` with its exit
+/// code (None if killed by signal). Errors if `slot` is already occupied.
+pub fn spawn_streaming(
+    spec: &SpawnSpec,
+    slot: ChildSlot,
+    on_line: impl Fn(String) + Send + 'static,
+    on_exit: impl FnOnce(Option<i32>) + Send + 'static,
+) -> Result<u32, String> {
+    let mut guard = slot.lock().map_err(|e| e.to_string())?;
+    if guard.is_some() {
+        return Err("a launcher process is already running".to_string());
+    }
+
+    rotate_log(&spec.stderr_log).map_err(|e| format!("couldn't prepare stderr log: {e}"))?;
+    let log = File::create(&spec.stderr_log).map_err(|e| e.to_string())?;
+
+    let mut child = Command::new(&spec.program)
+        .args(&spec.args)
+        .current_dir(&spec.cwd)
+        .envs(spec.envs.iter().map(|(k, v)| (k, v)))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(log))
+        .spawn()
+        .map_err(|e| format!("failed to spawn {}: {e}", spec.program))?;
+
+    let pid = child.id();
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "child has no stdout pipe".to_string())?;
+    *guard = Some(child);
+    drop(guard);
+
+    let reaper_slot = slot.clone();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(line) => on_line(line),
+                Err(_) => break,
+            }
+        }
+        // EOF: take the child back out of the slot and reap it.
+        let child = reaper_slot.lock().ok().and_then(|mut s| s.take());
+        let code = child.and_then(|mut c| c.wait().ok()).and_then(|s| s.code());
+        on_exit(code);
+    });
+
+    Ok(pid)
+}
+
+/// Signal the running child, if any. The reader thread reaps it on EOF.
+pub fn kill_child(slot: &ChildSlot) -> bool {
+    match slot.lock() {
+        Ok(mut guard) => match guard.as_mut() {
+            Some(child) => child.kill().is_ok(),
+            None => false,
+        },
+        Err(_) => false,
+    }
+}
+
+// ---- Tauri commands ----
+
+fn log_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("logs"))
+}
+
+fn checked_checkout(checkout: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(checkout);
+    if !stack_checkout::is_valid_checkout(&path) {
+        return Err(format!(
+            "{checkout} is not a tt-studio checkout (no run.py)"
+        ));
+    }
+    Ok(path)
+}
+
+fn spawn_bring_up(
+    app: &tauri::AppHandle<Wry>,
+    state: &state::LauncherState,
+    checkout: &Path,
+) -> Result<u32, String> {
+    let spec = bring_up_spec(checkout, log_dir(app)?.join("bringup.log"));
+    *state.checkout.lock().map_err(|e| e.to_string())? = Some(checkout.to_path_buf());
+    state.local_stack.store(true, Ordering::SeqCst);
+    let line_app = app.clone();
+    let exit_app = app.clone();
+    spawn_streaming(
+        &spec,
+        state.child.clone(),
+        move |line| {
+            let _ = line_app.emit(BRINGUP_LINE_EVENT, &line);
+        },
+        move |code| {
+            let _ = exit_app.emit(BRINGUP_EXIT_EVENT, code);
+        },
+    )
+}
+
+/// Start `run.py --no-browser --json-events` in the given checkout and
+/// stream its stdout as `bringup-line` events; `bringup-exit` carries the
+/// exit code when it ends.
+#[tauri::command]
+pub fn start_bring_up(
+    app: tauri::AppHandle<Wry>,
+    state: tauri::State<'_, LauncherState>,
+    checkout: String,
+) -> Result<u32, String> {
+    let path = checked_checkout(&checkout)?;
+    spawn_bring_up(&app, &state, &path)
+}
+
+/// Kill the running launcher child (if any). Returns whether a signal was
+/// actually sent.
+#[tauri::command]
+pub fn stop_bring_up(state: tauri::State<'_, LauncherState>) -> bool {
+    kill_child(&state.child)
+}
+
+#[tauri::command]
+pub fn bring_up_running(state: tauri::State<'_, LauncherState>) -> bool {
+    state.child.lock().map(|g| g.is_some()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bring_up_spec_runs_run_py_with_json_events_from_the_checkout() {
+        let spec = bring_up_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
+        assert_eq!(spec.program, "python3");
+        assert_eq!(spec.args, ["run.py", "--no-browser", "--json-events"]);
+        // run.py derives TT_STUDIO_ROOT from cwd — this is the contract.
+        assert_eq!(spec.cwd, Path::new("/tmp/stack"));
+    }
+
+    #[test]
+    fn stop_spec_runs_run_py_stop() {
+        let spec = stop_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
+        assert_eq!(spec.args, ["run.py", "--stop"]);
+        assert_eq!(spec.cwd, Path::new("/tmp/stack"));
+    }
+
+    #[test]
+    fn rotate_keeps_one_previous_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("logs").join("bringup.log");
+
+        rotate_log(&log).unwrap(); // nothing to rotate, just mkdir
+        std::fs::write(&log, "first run").unwrap();
+        rotate_log(&log).unwrap();
+        assert!(!log.exists());
+        let rotated = dir.path().join("logs").join("bringup.log.1");
+        assert_eq!(std::fs::read_to_string(&rotated).unwrap(), "first run");
+
+        std::fs::write(&log, "second run").unwrap();
+        rotate_log(&log).unwrap();
+        assert_eq!(std::fs::read_to_string(&rotated).unwrap(), "second run");
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,15 +5,18 @@
 mod commands;
 mod hardware;
 mod health;
+pub mod launcher;
 mod profiles;
 mod secrets;
-mod stack_checkout;
+pub mod stack_checkout;
+pub mod state;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(health::PollerState::default())
+        .manage(state::LauncherState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -29,6 +32,9 @@ pub fn run() {
             health::stop_health_poll,
             stack_checkout::resolve_stack_checkout,
             stack_checkout::set_stack_checkout_path,
+            launcher::start_bring_up,
+            launcher::stop_bring_up,
+            launcher::bring_up_running,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,8 +13,29 @@ pub mod state;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    use std::sync::atomic::Ordering;
+    use tauri::Manager;
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(tauri_plugin_dialog::init())
+        // Quit dialog: only when this session started or attached to a local
+        // stack is there anything to ask about — the host services detach
+        // and survive the app on purpose, so the default is to leave them.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let app = window.app_handle();
+                let launcher_state: tauri::State<state::LauncherState> = app.state();
+                if !launcher_state.local_stack.load(Ordering::SeqCst) {
+                    return; // nothing local: close normally
+                }
+                api.prevent_close();
+                if launcher_state.quitting.swap(true, Ordering::SeqCst) {
+                    return; // quit flow already in flight
+                }
+                launcher::confirm_quit(app);
+            }
+        })
         .manage(health::PollerState::default())
         .manage(state::LauncherState::default())
         .invoke_handler(tauri::generate_handler![

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub fn run() {
             launcher::start_bring_up,
             launcher::stop_bring_up,
             launcher::bring_up_running,
+            launcher::mark_local_attach,
+            launcher::restart_stack,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod hardware;
 mod health;
 mod profiles;
 mod secrets;
+mod stack_checkout;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -26,6 +27,8 @@ pub fn run() {
             health::check_stack_health,
             health::start_health_poll,
             health::stop_health_poll,
+            stack_checkout::resolve_stack_checkout,
+            stack_checkout::set_stack_checkout_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/stack_checkout.rs
+++ b/desktop/src-tauri/src/stack_checkout.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Locating (or creating) the tt-studio checkout that native mode runs.
+//!
+//! Native white-box mode drives `python run.py` inside a real tt-studio
+//! checkout. Resolution order:
+//!
+//! 1. A user-configured path (settings store) — must already be a checkout.
+//! 2. The managed checkout at `~/.local/share/tt-studio/stack`.
+//! 3. If neither exists, shallow-clone the latest `v*` release tag of
+//!    tenstorrent/tt-studio into the managed location.
+//!
+//! A directory counts as a checkout when `run.py` sits at its root — that is
+//! the entrypoint the launcher spawns, and `run.py` derives TT_STUDIO_ROOT
+//! from its cwd.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tauri::{Manager, Wry};
+use tauri_plugin_store::StoreExt;
+
+pub const REPO_URL: &str = "https://github.com/tenstorrent/tt-studio";
+const SETTINGS_STORE: &str = "settings.json";
+const STACK_PATH_KEY: &str = "stack_checkout_path";
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckoutSource {
+    /// The user pointed the app at an existing checkout.
+    Configured,
+    /// The managed checkout already existed.
+    Managed,
+    /// Freshly cloned into the managed location.
+    Cloned,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StackCheckout {
+    pub path: PathBuf,
+    pub source: CheckoutSource,
+}
+
+/// A directory is a usable checkout iff `run.py` sits at its root.
+pub fn is_valid_checkout(path: &Path) -> bool {
+    path.join("run.py").is_file()
+}
+
+/// Managed checkout location under the user's home directory.
+pub fn managed_dir(home: &Path) -> PathBuf {
+    home.join(".local")
+        .join("share")
+        .join("tt-studio")
+        .join("stack")
+}
+
+/// Numeric components of a plain release tag (`v2.10.0` → `[2, 10, 0]`).
+/// Pre-releases and anything non-numeric are rejected — the managed clone
+/// should only ever track a real release.
+fn release_tag_key(tag: &str) -> Option<Vec<u64>> {
+    let rest = tag.strip_prefix('v')?;
+    rest.split('.')
+        .map(|part| part.parse::<u64>().ok())
+        .collect()
+}
+
+/// Pick the highest release tag out of `git ls-remote --tags` output.
+pub fn latest_v_tag(ls_remote: &str) -> Option<String> {
+    ls_remote
+        .lines()
+        .filter_map(|line| line.split('\t').nth(1))
+        .filter_map(|r| r.strip_prefix("refs/tags/"))
+        .filter(|tag| !tag.ends_with("^{}"))
+        .filter_map(|tag| release_tag_key(tag).map(|key| (key, tag.to_string())))
+        .max()
+        .map(|(_, tag)| tag)
+}
+
+fn git(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.first().unwrap_or(&""),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Find an existing checkout without touching the network. Used where a
+/// clone would be inappropriate (e.g. deciding what `--stop` should run in).
+pub fn existing(configured: Option<&Path>, managed: &Path) -> Option<PathBuf> {
+    if let Some(path) = configured {
+        if is_valid_checkout(path) {
+            return Some(path.to_path_buf());
+        }
+    }
+    is_valid_checkout(managed).then(|| managed.to_path_buf())
+}
+
+/// Resolve the checkout to run, cloning the latest release into `managed`
+/// when nothing exists yet. Runs git synchronously — call off the main
+/// thread.
+pub fn resolve(
+    configured: Option<&Path>,
+    managed: &Path,
+    repo_url: &str,
+) -> Result<StackCheckout, String> {
+    if let Some(path) = configured {
+        // An explicit setting that doesn't point at a checkout is a user
+        // error to surface, not something to silently fall through.
+        if !is_valid_checkout(path) {
+            return Err(format!(
+                "configured stack path {} has no run.py — point the setting at a tt-studio checkout or clear it",
+                path.display()
+            ));
+        }
+        return Ok(StackCheckout {
+            path: path.to_path_buf(),
+            source: CheckoutSource::Configured,
+        });
+    }
+
+    if is_valid_checkout(managed) {
+        return Ok(StackCheckout {
+            path: managed.to_path_buf(),
+            source: CheckoutSource::Managed,
+        });
+    }
+
+    let occupied = managed.is_dir()
+        && managed
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(true);
+    if occupied || managed.is_file() {
+        return Err(format!(
+            "{} exists but is not a tt-studio checkout (no run.py) — remove it or configure a checkout path",
+            managed.display()
+        ));
+    }
+
+    let tags = git(&["ls-remote", "--tags", repo_url])?;
+    let tag =
+        latest_v_tag(&tags).ok_or_else(|| format!("no release tags (v*) found at {repo_url}"))?;
+
+    if let Some(parent) = managed.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let managed_str = managed
+        .to_str()
+        .ok_or_else(|| "managed checkout path is not valid UTF-8".to_string())?;
+    git(&[
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        &tag,
+        repo_url,
+        managed_str,
+    ])?;
+
+    if !is_valid_checkout(managed) {
+        return Err(format!(
+            "cloned {tag} into {} but run.py is missing — clone looks broken",
+            managed.display()
+        ));
+    }
+    Ok(StackCheckout {
+        path: managed.to_path_buf(),
+        source: CheckoutSource::Cloned,
+    })
+}
+
+// ---- Tauri commands ----
+
+pub fn configured_path(app: &tauri::AppHandle<Wry>) -> Result<Option<PathBuf>, String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(STACK_PATH_KEY)
+        .and_then(|v| v.as_str().map(PathBuf::from)))
+}
+
+fn default_managed_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+    let home = app.path().home_dir().map_err(|e| e.to_string())?;
+    Ok(managed_dir(&home))
+}
+
+/// Resolve (and if needed clone) the checkout native mode should use.
+#[tauri::command]
+pub async fn resolve_stack_checkout(app: tauri::AppHandle<Wry>) -> Result<StackCheckout, String> {
+    let configured = configured_path(&app)?;
+    let managed = default_managed_dir(&app)?;
+    tauri::async_runtime::spawn_blocking(move || resolve(configured.as_deref(), &managed, REPO_URL))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Set (or with `None`, clear) the user-configured checkout path.
+#[tauri::command]
+pub fn set_stack_checkout_path(
+    app: tauri::AppHandle<Wry>,
+    path: Option<String>,
+) -> Result<(), String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    match path {
+        Some(p) => {
+            if !is_valid_checkout(Path::new(&p)) {
+                return Err(format!("{p} is not a tt-studio checkout (no run.py)"));
+            }
+            store.set(STACK_PATH_KEY, serde_json::Value::String(p));
+        }
+        None => {
+            store.delete(STACK_PATH_KEY);
+        }
+    }
+    store.save().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn run(dir: &Path, cmd: &[&str]) {
+        let output = Command::new(cmd[0])
+            .args(&cmd[1..])
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("spawn {cmd:?}: {e}"));
+        assert!(
+            output.status.success(),
+            "{cmd:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Local bare repo with run.py, tagged v0.1.0 and (one commit later)
+    /// v0.10.0, plus tags resolve() must ignore. Returns a clone URL.
+    fn fixture_repo(base: &Path) -> String {
+        let bare = base.join("origin.git");
+        let work = base.join("work");
+        fs::create_dir_all(&bare).unwrap();
+        run(
+            base,
+            &["git", "init", "-q", "--bare", bare.to_str().unwrap()],
+        );
+        run(
+            base,
+            &[
+                "git",
+                "clone",
+                "-q",
+                bare.to_str().unwrap(),
+                work.to_str().unwrap(),
+            ],
+        );
+        run(&work, &["git", "config", "user.email", "ci@example.com"]);
+        run(&work, &["git", "config", "user.name", "CI"]);
+        fs::write(work.join("run.py"), "# release v0.1.0\n").unwrap();
+        run(&work, &["git", "add", "run.py"]);
+        run(&work, &["git", "commit", "-q", "-m", "v0.1.0"]);
+        run(&work, &["git", "tag", "v0.1.0"]);
+        run(&work, &["git", "tag", "v1.0.0-rc1"]); // pre-release: ignored
+        run(&work, &["git", "tag", "not-a-version"]);
+        fs::write(work.join("run.py"), "# release v0.10.0\n").unwrap();
+        run(&work, &["git", "commit", "-q", "-am", "v0.10.0"]);
+        run(&work, &["git", "tag", "v0.10.0"]);
+        run(
+            &work,
+            &["git", "push", "-q", "--tags", "origin", "HEAD:main"],
+        );
+        bare.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn checkout_validity_hinges_on_run_py() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_valid_checkout(dir.path()));
+        fs::write(dir.path().join("run.py"), "").unwrap();
+        assert!(is_valid_checkout(dir.path()));
+    }
+
+    #[test]
+    fn latest_tag_picks_highest_release_numerically() {
+        let output = "\
+aaa\trefs/tags/not-a-version
+bbb\trefs/tags/v2.9.1
+ccc\trefs/tags/v2.10.0
+ccc\trefs/tags/v2.10.0^{}
+ddd\trefs/tags/v2.10.0-rc1
+eee\trefs/tags/v2.2.0
+";
+        assert_eq!(latest_v_tag(output).as_deref(), Some("v2.10.0"));
+        assert_eq!(latest_v_tag(""), None);
+        assert_eq!(latest_v_tag("aaa\trefs/tags/v3-rc"), None);
+    }
+
+    #[test]
+    fn configured_checkout_wins_but_must_be_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let configured = dir.path().join("mine");
+        fs::create_dir_all(&configured).unwrap();
+        let managed = dir.path().join("managed");
+
+        // Configured but missing run.py: hard error, no fallthrough.
+        let err = resolve(Some(&configured), &managed, "unused").unwrap_err();
+        assert!(err.contains("no run.py"), "{err}");
+
+        fs::write(configured.join("run.py"), "").unwrap();
+        let checkout = resolve(Some(&configured), &managed, "unused").unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Configured);
+        assert_eq!(checkout.path, configured);
+    }
+
+    #[test]
+    fn existing_managed_checkout_is_reused_without_git() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        fs::create_dir_all(&managed).unwrap();
+        fs::write(managed.join("run.py"), "").unwrap();
+        // repo_url is bogus on purpose — no network/git should be needed.
+        let checkout = resolve(None, &managed, "file:///nonexistent").unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Managed);
+        assert_eq!(existing(None, &managed), Some(managed));
+    }
+
+    #[test]
+    fn occupied_non_checkout_managed_dir_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        fs::create_dir_all(&managed).unwrap();
+        fs::write(managed.join("junk.txt"), "").unwrap();
+        let err = resolve(None, &managed, "unused").unwrap_err();
+        assert!(err.contains("not a tt-studio checkout"), "{err}");
+    }
+
+    #[test]
+    fn missing_managed_dir_clones_the_latest_release_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = fixture_repo(dir.path());
+        let managed = dir.path().join("data").join("stack");
+
+        let checkout = resolve(None, &managed, &url).unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Cloned);
+        // v0.10.0 outranks v0.1.0 numerically (not lexically) and the
+        // pre-release/junk tags were skipped.
+        let contents = fs::read_to_string(managed.join("run.py")).unwrap();
+        assert!(contents.contains("v0.10.0"), "{contents}");
+
+        // A second resolve reuses the clone.
+        let again = resolve(None, &managed, &url).unwrap();
+        assert_eq!(again.source, CheckoutSource::Managed);
+    }
+
+    #[test]
+    fn existing_prefers_configured_over_managed() {
+        let dir = tempfile::tempdir().unwrap();
+        let configured = dir.path().join("mine");
+        let managed = dir.path().join("managed");
+        for p in [&configured, &managed] {
+            fs::create_dir_all(p).unwrap();
+            fs::write(p.join("run.py"), "").unwrap();
+        }
+        assert_eq!(existing(Some(&configured), &managed), Some(configured));
+        assert_eq!(
+            existing(Some(Path::new("/nope")), &managed),
+            Some(managed.clone())
+        );
+        assert_eq!(existing(None, Path::new("/nope")), None);
+    }
+}

--- a/desktop/src-tauri/src/state.rs
+++ b/desktop/src-tauri/src/state.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Shared state for the native launcher's child process.
+//!
+//! At most one `run.py` child (bring-up or `--stop`) runs at a time. The
+//! child lives in a shared slot: the spawner puts it there, the stdout
+//! reader thread takes it back out to reap it on EOF, and `kill` signals it
+//! in place. `run.py` bootstrap re-execs (execve) into its own venv, so PID
+//! and stdout survive — the slot always holds "the" launcher process.
+
+use std::path::PathBuf;
+use std::process::Child;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+/// Slot holding the currently running launcher child, shared between the
+/// spawner, the reader/reaper thread, and kill/quit paths.
+pub type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+#[derive(Default)]
+pub struct LauncherState {
+    pub child: ChildSlot,
+    /// Checkout the last child was spawned in; quit-time `--stop` reuses it.
+    pub checkout: Mutex<Option<PathBuf>>,
+    /// True once this session started a bring-up or attached to the local
+    /// stack — gates the "stop the stack?" quit dialog.
+    pub local_stack: AtomicBool,
+    /// True while the quit flow (dialog or `--stop`) is in flight, so a
+    /// second close request doesn't start it again.
+    pub quitting: AtomicBool,
+}

--- a/desktop/src-tauri/tests/fixtures/fake_run.py
+++ b/desktop/src-tauri/tests/fixtures/fake_run.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+"""Fake run.py for the desktop launcher's integration tests.
+
+Emits canned `--json-events` NDJSON streams on stdout (schema per
+dev-docs/json-events.md) selected by the FAKE_RUN_SCENARIO env var:
+success (default), failure, prompt_blocked, slow. `--stop` in argv takes a
+plain-text teardown path and exits 0. Human chatter goes to stderr, like the
+real launcher.
+
+Mirrors run.py's TT_STUDIO_ROOT-from-cwd contract: refuses to run (exit 3)
+when the current directory doesn't contain run.py, so a spawner with the
+wrong cwd fails loudly in tests.
+"""
+
+import json
+import os
+import sys
+import time
+
+
+def emit(event, phase=None, detail=None, ts=1000.0):
+    line = {"v": 1, "ts": ts, "event": event, "phase": phase, "detail": detail or {}}
+    print(json.dumps(line), flush=True)
+
+
+def main():
+    if not os.path.isfile(os.path.join(os.getcwd(), "run.py")):
+        print("fake_run: cwd is not a checkout (no run.py)", file=sys.stderr)
+        return 3
+
+    print("human-facing chatter belongs on stderr", file=sys.stderr)
+
+    if "--stop" in sys.argv:
+        print("stopping containers (fake)", flush=True)
+        return 0
+
+    scenario = os.environ.get("FAKE_RUN_SCENARIO", "success")
+
+    if scenario == "success":
+        emit("phase_begin", "Checks", {"index": 1, "total": 2})
+        emit("progress", "Checks", {"activity": "tt-smi"})
+        emit("phase_end", "Checks", {"index": 1, "status": "ok", "duration_s": 0.1})
+        emit("phase_begin", "Launch", {"index": 2, "total": 2})
+        emit("phase_end", "Launch", {"index": 2, "status": "ok", "duration_s": 0.2})
+        emit(
+            "ready",
+            None,
+            {
+                "urls": {"app": "http://localhost:3000"},
+                "hardware": "Fake QuietBox · 2 device(s)",
+            },
+        )
+        return 0
+
+    if scenario == "failure":
+        emit("phase_begin", "Launch", {"index": 1, "total": 1})
+        emit(
+            "error",
+            "Launch",
+            {
+                "message": "Inference server didn't start — port 8001 is still taken",
+                "remediation": "lsof -i :8001; python run.py --stop, then re-run",
+                "service": "Inference server",
+                "log": "fastapi.log",
+            },
+        )
+        emit("phase_end", "Launch", {"index": 1, "status": "failed"})
+        return 1
+
+    if scenario == "prompt_blocked":
+        emit("phase_begin", "Configure", {"index": 1, "total": 2})
+        emit(
+            "prompt_blocked",
+            "Configure",
+            {
+                "prompt": "A Hugging Face token is required for gated models",
+                "remediation": "set HF_TOKEN in .env, or run: python run.py",
+            },
+        )
+        return 2
+
+    if scenario == "slow":
+        # Drip progress long enough for a test to observe and kill us.
+        emit("phase_begin", "Checks", {"index": 1, "total": 5})
+        for i in range(240):
+            emit("progress", "Checks", {"activity": "step %d" % i})
+            time.sleep(0.25)
+        return 0
+
+    print("fake_run: unknown scenario %r" % scenario, file=sys.stderr)
+    return 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/src-tauri/tests/launcher_spawn.rs
+++ b/desktop/src-tauri/tests/launcher_spawn.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Integration tests for launcher::spawn_streaming, driven against
+//! tests/fixtures/fake_run.py — a stand-in run.py that emits the canned
+//! `--json-events` NDJSON streams (success incl. ready, failure with
+//! remediation, prompt_blocked, slow progress). No real bring-up anywhere.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
+use tt_studio_desktop_lib::launcher::{
+    bring_up_spec, kill_child, spawn_streaming, stop_spec, SpawnSpec,
+};
+use tt_studio_desktop_lib::state::ChildSlot;
+
+const STREAM_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The spec builders hardcode `python3` (the Linux target); CI runners may
+/// only have `python` on PATH, so tests pick whichever answers.
+fn python() -> String {
+    if let Ok(p) = std::env::var("PYTHON") {
+        return p;
+    }
+    for candidate in ["python3", "python"] {
+        let works = std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if works {
+            return candidate.to_string();
+        }
+    }
+    panic!("no python interpreter on PATH (set PYTHON to override)");
+}
+
+/// A temp "checkout": fake_run.py copied in as run.py, so the fixture's
+/// cwd assertion doubles as a test of the spawner's cwd contract.
+fn fake_checkout(dir: &Path) -> PathBuf {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake_run.py");
+    std::fs::copy(&fixture, dir.join("run.py")).unwrap();
+    dir.to_path_buf()
+}
+
+enum Msg {
+    Line(String),
+    Exit(Option<i32>),
+}
+
+fn spawn(spec: &SpawnSpec, slot: &ChildSlot) -> mpsc::Receiver<Msg> {
+    let (tx, rx) = mpsc::channel();
+    let line_tx = tx.clone();
+    spawn_streaming(
+        spec,
+        slot.clone(),
+        move |line| {
+            let _ = line_tx.send(Msg::Line(line));
+        },
+        move |code| {
+            let _ = tx.send(Msg::Exit(code));
+        },
+    )
+    .expect("spawn failed");
+    rx
+}
+
+/// Drain the stream until the exit notification, collecting stdout lines.
+fn wait_exit(rx: &mpsc::Receiver<Msg>, lines: &mut Vec<String>) -> Option<i32> {
+    loop {
+        match rx.recv_timeout(STREAM_TIMEOUT).expect("launcher timed out") {
+            Msg::Line(line) => lines.push(line),
+            Msg::Exit(code) => return code,
+        }
+    }
+}
+
+fn scenario_spec(dir: &Path, scenario: &str) -> SpawnSpec {
+    let checkout = fake_checkout(dir);
+    let mut spec = bring_up_spec(&checkout, dir.join("logs").join("bringup.log"));
+    spec.program = python();
+    spec.envs
+        .push(("FAKE_RUN_SCENARIO".to_string(), scenario.to_string()));
+    spec
+}
+
+fn event_type(line: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    Some(value.get("event")?.as_str()?.to_string())
+}
+
+#[test]
+fn success_stream_ends_in_ready_and_a_clean_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "success");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(0));
+
+    // Every stdout line is valid NDJSON (stderr noise went to the log file).
+    let events: Vec<String> = lines.iter().filter_map(|l| event_type(l)).collect();
+    assert_eq!(events.len(), lines.len(), "non-JSON on stdout: {lines:?}");
+    assert_eq!(events.first().map(String::as_str), Some("phase_begin"));
+    assert_eq!(events.last().map(String::as_str), Some("ready"));
+
+    // The child is reaped: slot free again.
+    assert!(slot.lock().unwrap().is_none());
+
+    // stderr was captured to the log file, not mixed into the stream.
+    let log = std::fs::read_to_string(spec.stderr_log.clone()).unwrap();
+    assert!(log.contains("stderr"), "{log}");
+}
+
+#[test]
+fn failure_stream_carries_remediation_and_nonzero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "failure");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(1));
+
+    let error_line = lines
+        .iter()
+        .find(|l| event_type(l).as_deref() == Some("error"))
+        .expect("no error event in failure stream");
+    assert!(error_line.contains("remediation"), "{error_line}");
+    assert!(error_line.contains("port 8001"), "{error_line}");
+}
+
+#[test]
+fn blocked_prompt_exits_2_instead_of_hanging() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "prompt_blocked");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    // stdin is null and the fixture never reads it — if the spawner ever
+    // left a prompt attached, this would hit the 60s stream timeout.
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(2));
+    assert!(lines
+        .iter()
+        .any(|l| event_type(l).as_deref() == Some("prompt_blocked")));
+}
+
+#[test]
+fn kill_terminates_a_slow_bring_up_and_frees_the_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "slow");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    // Wait until the child demonstrably streams, then kill it mid-phase.
+    match rx.recv_timeout(STREAM_TIMEOUT).expect("no first line") {
+        Msg::Line(_) => {}
+        Msg::Exit(code) => panic!("slow child exited early: {code:?}"),
+    }
+    assert!(kill_child(&slot), "kill reported no child to signal");
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_ne!(code, Some(0), "killed child reported success");
+    assert!(
+        slot.lock().unwrap().is_none(),
+        "child not reaped after kill"
+    );
+
+    // The slot is genuinely reusable: run the (fake) --stop path in it.
+    let mut stop = stop_spec(dir.path(), dir.path().join("logs").join("stop.log"));
+    stop.program = python();
+    let stop_rx = spawn(&stop, &slot);
+    let mut stop_lines = Vec::new();
+    assert_eq!(wait_exit(&stop_rx, &mut stop_lines), Some(0));
+    assert!(stop_lines.iter().any(|l| l.contains("stopping")));
+}
+
+#[test]
+fn second_spawn_while_running_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "slow");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+    match rx.recv_timeout(STREAM_TIMEOUT).expect("no first line") {
+        Msg::Line(_) => {}
+        Msg::Exit(code) => panic!("slow child exited early: {code:?}"),
+    }
+
+    let err = spawn_streaming(&spec, slot.clone(), |_| {}, |_| {}).unwrap_err();
+    assert!(err.contains("already running"), "{err}");
+
+    kill_child(&slot);
+    let mut lines = Vec::new();
+    wait_exit(&rx, &mut lines);
+}
+
+#[test]
+fn stderr_log_rotates_between_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "success");
+    let slot = ChildSlot::default();
+
+    let rx = spawn(&spec, &slot);
+    wait_exit(&rx, &mut Vec::new());
+    let rx = spawn(&spec, &slot);
+    wait_exit(&rx, &mut Vec::new());
+
+    assert!(spec.stderr_log.exists());
+    let rotated = spec.stderr_log.with_extension("log.1");
+    assert!(rotated.exists(), "previous run's log was not kept");
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import BringUpProgress from "./views/BringUpProgress";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import {
+  applyExit,
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -151,16 +152,25 @@ function App() {
   // shell), render its NDJSON stream natively instead of the bare checklist.
   useEffect(() => {
     if (screen.name !== "connecting") return;
-    let unlisten: (() => void) | undefined;
+    let unlistenLine: (() => void) | undefined;
+    let unlistenExit: (() => void) | undefined;
     listen<string>("bringup-line", ({ payload }) => {
       const event = parseEventLine(payload);
       if (!event) return;
       setBringUp((prev) => reduceEvent(prev ?? initialBringUpState(), event));
     }).then((fn) => {
-      unlisten = fn;
+      unlistenLine = fn;
+    });
+    // If the child dies without a terminal event (crash, kill, blocked
+    // prompt before the stream existed), surface that instead of spinning.
+    listen<number | null>("bringup-exit", ({ payload }) => {
+      setBringUp((prev) => applyExit(prev ?? initialBringUpState(), payload));
+    }).then((fn) => {
+      unlistenExit = fn;
     });
     return () => {
-      unlisten?.();
+      unlistenLine?.();
+      unlistenExit?.();
       setBringUp(null);
     };
   }, [screen.name]);
@@ -299,7 +309,12 @@ function App() {
   }
 
   if (screen.name === "connecting") {
-    if (bringUp && bringUp.phases.length > 0) {
+    if (
+      bringUp &&
+      (bringUp.phases.length > 0 ||
+        bringUp.errors.length > 0 ||
+        bringUp.promptBlocked)
+    ) {
       return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
     }
     if (prep) {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,14 +15,19 @@ import {
 } from "./lib/events";
 import {
   asSecretError,
+  checkStackHealth,
   deleteProfile,
   detectHardware,
   listProfiles,
+  markLocalAttach,
   markProfileUsed,
   onStackHealth,
   openStack,
+  resolveStackCheckout,
+  restartStack,
   saveProfile,
   setSshKeyPassphrase,
+  startBringUp,
   startHealthPoll,
   stopHealthPoll,
   type HardwareProbe,
@@ -39,7 +44,9 @@ type Screen =
   | { name: "loading" }
   | { name: "picker" }
   | { name: "editor"; profile?: Profile }
-  | { name: "connecting"; target: Profile | null };
+  // bringUpOnly: a restart is in flight — services may briefly still look
+  // healthy, so only the bring-up's own ready event may open the stack.
+  | { name: "connecting"; target: Profile | null; bringUpOnly?: boolean };
 
 const STATUS_STYLE: Record<string, string> = {
   up: "bg-emerald-500",
@@ -98,6 +105,10 @@ function App() {
   const [bringUp, setBringUp] = useState<BringUpState | null>(null);
   const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /** One-line status while native mode prepares (checkout clone, --stop). */
+  const [prep, setPrep] = useState<string | null>(null);
+  /** Whether a local stack already answers its health checks (picker info). */
+  const [stackUp, setStackUp] = useState(false);
   const opening = useRef(false);
 
   useEffect(() => {
@@ -113,9 +124,18 @@ function App() {
       });
   }, []);
 
+  // On the picker, take one health snapshot so it can say whether a local
+  // stack is already running (read-only GETs).
+  useEffect(() => {
+    if (screen.name !== "picker") return;
+    checkStackHealth()
+      .then((h) => setStackUp(h.ready))
+      .catch(() => setStackUp(false));
+  }, [screen.name]);
+
   // While connecting: poll stack health, and navigate once everything is up.
   useEffect(() => {
-    if (screen.name !== "connecting") return;
+    if (screen.name !== "connecting" || screen.bringUpOnly) return;
     let unlisten: (() => void) | undefined;
     onStackHealth(setHealth).then((fn) => {
       unlisten = fn;
@@ -158,7 +178,12 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (screen.name !== "connecting" || !health?.ready || opening.current)
+    if (
+      screen.name !== "connecting" ||
+      screen.bringUpOnly ||
+      !health?.ready ||
+      opening.current
+    )
       return;
     opening.current = true;
     stopHealthPoll()
@@ -175,6 +200,49 @@ function App() {
     opening.current = false;
     if (target) markProfileUsed(target.id).catch(() => {});
     setScreen({ name: "connecting", target });
+  }, []);
+
+  // Native mode: attach if the stack is already healthy, otherwise resolve
+  // the checkout (cloning on first use) and spawn the bring-up.
+  const connectLocal = useCallback(async () => {
+    setHealth(null);
+    opening.current = false;
+    setScreen({ name: "connecting", target: null });
+    try {
+      const current = await checkStackHealth();
+      if (current.ready) {
+        // Already running: no bring-up — the health poller opens the stack.
+        await markLocalAttach();
+        return;
+      }
+      setPrep("Preparing the TT-Studio checkout (first run clones it)…");
+      const checkout = await resolveStackCheckout();
+      await startBringUp(checkout.path);
+    } catch (e) {
+      setError(String(e));
+      setScreen({ name: "picker" });
+    } finally {
+      setPrep(null);
+    }
+  }, []);
+
+  // Explicit "Restart stack": run.py --stop, then a fresh bring-up. Health
+  // polling is suppressed (bringUpOnly) so the old, still-draining services
+  // can't re-open the stack mid-restart.
+  const handleRestart = useCallback(async () => {
+    setHealth(null);
+    opening.current = false;
+    setScreen({ name: "connecting", target: null, bringUpOnly: true });
+    setPrep("Stopping the current stack…");
+    try {
+      const checkout = await resolveStackCheckout();
+      await restartStack(checkout.path);
+    } catch (e) {
+      setError(String(e));
+      setScreen({ name: "picker" });
+    } finally {
+      setPrep(null);
+    }
   }, []);
 
   const handleSave = useCallback(
@@ -234,6 +302,16 @@ function App() {
     if (bringUp && bringUp.phases.length > 0) {
       return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
     }
+    if (prep) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 px-6 text-zinc-100">
+          <span className="inline-block h-5 w-5 animate-spin rounded-full border border-zinc-500 border-t-transparent" />
+          <p data-testid="native-prep" className="text-sm text-zinc-400">
+            {prep}
+          </p>
+        </main>
+      );
+    }
     return <HealthGate health={health} target={screen.target} />;
   }
 
@@ -242,7 +320,9 @@ function App() {
       <ConnectionPicker
         hardware={hardware}
         profiles={profiles}
-        onConnectLocal={() => connect(null)}
+        stackUp={stackUp}
+        onConnectLocal={connectLocal}
+        onRestartStack={handleRestart}
         onConnectSsh={connect}
         onAddMachine={() => setScreen({ name: "editor" })}
         onEditProfile={(profile) => setScreen({ name: "editor", profile })}

--- a/desktop/src/lib/events.test.ts
+++ b/desktop/src/lib/events.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  applyExit,
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -132,5 +133,30 @@ describe("reduceEvent / reduceStream", () => {
       `pre-bootstrap chatter\n${FAILURE_STREAM}\nmore chatter`,
     );
     expect(state.errors).toHaveLength(1);
+  });
+});
+
+describe("applyExit (child died — was the stream self-explanatory?)", () => {
+  it("leaves a ready or already-explained stream alone", () => {
+    const ready = reduceStream(SUCCESS_STREAM);
+    expect(applyExit(ready, 0)).toBe(ready);
+    const failed = reduceStream(FAILURE_STREAM);
+    expect(applyExit(failed, 1)).toBe(failed);
+    const blocked = reduceStream(PROMPT_BLOCKED_STREAM);
+    expect(applyExit(blocked, 2)).toBe(blocked);
+  });
+
+  it("turns a bare exit 2 into a prompt-blocked card", () => {
+    const state = applyExit(initialBringUpState(), 2);
+    expect(state.promptBlocked?.remediation).toBe("python run.py");
+  });
+
+  it("turns an unexplained crash or kill into an error card", () => {
+    const crashed = applyExit(initialBringUpState(), 1);
+    expect(crashed.errors[0].message).toContain("exited with code 1");
+    expect(crashed.errors[0].remediation).toBe("python run.py");
+
+    const killed = applyExit(initialBringUpState(), null);
+    expect(killed.errors[0].message).toContain("interrupted");
   });
 });

--- a/desktop/src/lib/events.ts
+++ b/desktop/src/lib/events.ts
@@ -210,6 +210,49 @@ export function reduceEvent(
   }
 }
 
+/** What the prompt-blocked card tells the user to run in a terminal. */
+export const ONE_TIME_SETUP_COMMAND = "python run.py";
+
+/**
+ * Fold the child's exit code into the state. A healthy stream carries its
+ * own terminal event (ready / error / prompt_blocked); this fills the gap
+ * when the process dies without one — a crash, a kill, or exit code 2 from
+ * a prompt hit before the event stream existed — so the UI never waits on a
+ * dead child. No-op when the stream already explained itself.
+ */
+export function applyExit(
+  state: BringUpState,
+  code: number | null,
+): BringUpState {
+  if (state.ready || code === 0) return state;
+  // Exit code 2 is the --json-events contract for "needed interactive input".
+  if (code === 2) {
+    return state.promptBlocked
+      ? state
+      : {
+          ...state,
+          promptBlocked: {
+            prompt: "The launcher needed interactive input before it could report why.",
+            remediation: ONE_TIME_SETUP_COMMAND,
+          },
+        };
+  }
+  if (state.errors.length > 0) return state;
+  return {
+    ...state,
+    errors: [
+      ...state.errors,
+      {
+        message:
+          code === null
+            ? "Bring-up was interrupted before it finished"
+            : `Bring-up exited with code ${code}`,
+        remediation: ONE_TIME_SETUP_COMMAND,
+      },
+    ],
+  };
+}
+
 /** Convenience for tests and replay: fold a whole NDJSON document. */
 export function reduceStream(ndjson: string): BringUpState {
   return ndjson

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -96,6 +96,39 @@ export const onStackHealth = (
 ): Promise<UnlistenFn> =>
   listen<StackHealth>("stack-health", (event) => handler(event.payload));
 
+// ---- native launcher (stack checkout + run.py child) ----
+
+export interface StackCheckout {
+  path: string;
+  source: "configured" | "managed" | "cloned";
+}
+
+/** May shallow-clone the latest release on first use — can take a while. */
+export const resolveStackCheckout = () =>
+  invoke<StackCheckout>("resolve_stack_checkout");
+
+export const setStackCheckoutPath = (path: string | null) =>
+  invoke<void>("set_stack_checkout_path", { path });
+
+export const startBringUp = (checkout: string) =>
+  invoke<number>("start_bring_up", { checkout });
+
+export const stopBringUp = () => invoke<boolean>("stop_bring_up");
+
+export const bringUpRunning = () => invoke<boolean>("bring_up_running");
+
+/** Raw NDJSON lines from `run.py --json-events` (parse with events.ts). */
+export const onBringUpLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("bringup-line", (event) => handler(event.payload));
+
+/** Exit code of the bring-up child; null when killed by a signal. */
+export const onBringUpExit = (
+  handler: (code: number | null) => void,
+): Promise<UnlistenFn> =>
+  listen<number | null>("bringup-exit", (event) => handler(event.payload));
+
 // ---- navigation ----
 
 export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -117,6 +117,13 @@ export const stopBringUp = () => invoke<boolean>("stop_bring_up");
 
 export const bringUpRunning = () => invoke<boolean>("bring_up_running");
 
+/** Record that the UI attached to an already-running local stack. */
+export const markLocalAttach = () => invoke<void>("mark_local_attach");
+
+/** `run.py --stop`, then a fresh bring-up. Explicit user action only. */
+export const restartStack = (checkout: string) =>
+  invoke<number>("restart_stack", { checkout });
+
 /** Raw NDJSON lines from `run.py --json-events` (parse with events.ts). */
 export const onBringUpLine = (
   handler: (line: string) => void,

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -25,7 +25,10 @@ export interface Profile {
   last_used?: number;
 }
 
+export type Platform = "linux" | "macos" | "windows" | "other";
+
 export interface HardwareProbe {
+  platform: Platform;
   accelerator_present: boolean;
   default_mode: ProfileKind;
 }

--- a/desktop/src/views/BringUpProgress.test.tsx
+++ b/desktop/src/views/BringUpProgress.test.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import BringUpProgress from "./BringUpProgress";
 import { reduceStream } from "../lib/events";
@@ -66,5 +66,27 @@ describe("BringUpProgress", () => {
     const card = screen.getByTestId("bringup-prompt-blocked");
     expect(card.textContent).toContain("Hugging Face");
     expect(card.textContent).toContain("HF_TOKEN");
+    expect(card.textContent).toContain("one-time setup");
+  });
+
+  it("copies the remediation command to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    try {
+      render(
+        <BringUpProgress
+          state={reduceStream(PROMPT_BLOCKED_STREAM)}
+          onReady={() => {}}
+        />,
+      );
+      const button = screen.getByTestId("copy-remediation");
+      fireEvent.click(button);
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining("HF_TOKEN"),
+      );
+      await waitFor(() => expect(button.textContent).toBe("Copied"));
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/desktop/src/views/BringUpProgress.tsx
+++ b/desktop/src/views/BringUpProgress.tsx
@@ -6,8 +6,39 @@
 // phase stepper, notes/warnings, error cards with remediation, and the
 // ready → open-the-stack transition. Pure view over BringUpState.
 
-import { useEffect } from "react";
-import type { BringUpState, PhaseState } from "../lib/events";
+import { useEffect, useState } from "react";
+import {
+  ONE_TIME_SETUP_COMMAND,
+  type BringUpState,
+  type PhaseState,
+} from "../lib/events";
+
+/** A remediation command with a copy-to-clipboard affordance. */
+function Remediation({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard
+      ?.writeText(command)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  };
+  return (
+    <span className="inline-flex items-center gap-2">
+      <code className="rounded bg-zinc-900 px-1 py-0.5">{command}</code>
+      <button
+        type="button"
+        onClick={copy}
+        data-testid="copy-remediation"
+        className="rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-300 transition-colors hover:border-zinc-500 hover:text-zinc-100"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </span>
+  );
+}
 
 function PhaseRow({ phase, total }: { phase: PhaseState; total: number | null }) {
   const icon =
@@ -107,10 +138,7 @@ function BringUpProgress({ state, onReady }: Props) {
           </p>
           {err.remediation && (
             <p className="mt-2 text-xs text-red-200/80">
-              Try:{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5">
-                {err.remediation}
-              </code>
+              Try: <Remediation command={err.remediation} />
             </p>
           )}
           {err.log && (
@@ -130,14 +158,12 @@ function BringUpProgress({ state, onReady }: Props) {
           <p className="mt-1 text-xs text-amber-200/80">
             {state.promptBlocked.prompt}
           </p>
-          {state.promptBlocked.remediation && (
-            <p className="mt-2 text-xs text-amber-200/80">
-              Try:{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5">
-                {state.promptBlocked.remediation}
-              </code>
-            </p>
-          )}
+          <p className="mt-2 text-xs text-amber-200/80">
+            Run the one-time setup in a terminal, then relaunch:{" "}
+            <Remediation
+              command={state.promptBlocked.remediation ?? ONE_TIME_SETUP_COMMAND}
+            />
+          </p>
         </section>
       )}
     </main>

--- a/desktop/src/views/ConnectionPicker.test.tsx
+++ b/desktop/src/views/ConnectionPicker.test.tsx
@@ -4,14 +4,24 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import ConnectionPicker, { defaultSelection } from "./ConnectionPicker";
+import ConnectionPicker, {
+  defaultSelection,
+  noLocalReason,
+} from "./ConnectionPicker";
 import type { HardwareProbe, Profile } from "../lib/ipc";
 
 const withHardware: HardwareProbe = {
+  platform: "linux",
   accelerator_present: true,
   default_mode: "local",
 };
 const noHardware: HardwareProbe = {
+  platform: "linux",
+  accelerator_present: false,
+  default_mode: "ssh",
+};
+const onMac: HardwareProbe = {
+  platform: "macos",
   accelerator_present: false,
   default_mode: "ssh",
 };
@@ -132,6 +142,33 @@ describe("ConnectionPicker", () => {
     expect(screen.getByText("Old box")).toBeTruthy();
     expect(screen.getByText(/old\.lan/)).toBeTruthy();
     expect(screen.getByText(/key ~\/\.ssh\/id_ed25519/)).toBeTruthy();
+  });
+
+  it("explains why local mode is unavailable, per platform", () => {
+    // Linux without the device node: point at the driver setup.
+    expect(noLocalReason(noHardware)).toContain("/dev/tenstorrent");
+    expect(noLocalReason(noHardware)).toContain("python run.py");
+    // Non-Linux: native mode is out entirely, steer to SSH.
+    expect(noLocalReason(onMac)).toContain("macOS");
+    expect(noLocalReason(onMac)).toContain("SSH");
+    // Hardware present (or still probing): no card.
+    expect(noLocalReason(withHardware)).toBeNull();
+    expect(noLocalReason(null)).toBeNull();
+
+    const first = render(
+      <ConnectionPicker hardware={onMac} profiles={[qb2]} {...noop} />,
+    );
+    expect(screen.getByTestId("no-local-card").textContent).toContain(
+      "macOS",
+    );
+    // Saved SSH profiles are still front and center.
+    expect(screen.getByTestId("connect-qb2")).toBeTruthy();
+    first.unmount();
+
+    render(
+      <ConnectionPicker hardware={withHardware} profiles={[]} {...noop} />,
+    );
+    expect(screen.queryByTestId("no-local-card")).toBeNull();
   });
 
   it("always offers adding a machine", () => {

--- a/desktop/src/views/ConnectionPicker.test.tsx
+++ b/desktop/src/views/ConnectionPicker.test.tsx
@@ -36,7 +36,9 @@ const older: Profile = {
 };
 
 const noop = {
+  stackUp: false,
   onConnectLocal: () => {},
+  onRestartStack: () => {},
   onConnectSsh: () => {},
   onAddMachine: () => {},
   onEditProfile: () => {},
@@ -72,6 +74,41 @@ describe("ConnectionPicker", () => {
     render(<ConnectionPicker hardware={noHardware} profiles={[]} {...noop} />);
     expect(screen.queryByTestId("connect-local")).toBeNull();
     expect(screen.getByTestId("picker-empty")).toBeTruthy();
+  });
+
+  it("offers restart only when a local stack is already up", () => {
+    const onRestartStack = vi.fn();
+    const { unmount } = render(
+      <ConnectionPicker
+        hardware={withHardware}
+        profiles={[]}
+        {...noop}
+        stackUp
+        onRestartStack={onRestartStack}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("restart-stack"));
+    expect(onRestartStack).toHaveBeenCalled();
+    expect(screen.getByText(/already running/)).toBeTruthy();
+    unmount();
+
+    // Stack down → no restart affordance.
+    const second = render(
+      <ConnectionPicker hardware={withHardware} profiles={[]} {...noop} />,
+    );
+    expect(screen.queryByTestId("restart-stack")).toBeNull();
+    second.unmount();
+
+    // No hardware → no restart even if something answers on the ports.
+    render(
+      <ConnectionPicker
+        hardware={noHardware}
+        profiles={[]}
+        {...noop}
+        stackUp
+      />,
+    );
+    expect(screen.queryByTestId("restart-stack")).toBeNull();
   });
 
   it("connects a saved ssh machine with one click", () => {

--- a/desktop/src/views/ConnectionPicker.tsx
+++ b/desktop/src/views/ConnectionPicker.tsx
@@ -27,6 +27,26 @@ export function defaultSelection(
   return mostRecent.id;
 }
 
+/**
+ * Why local mode is unavailable, phrased for the picker — distinguishing
+ * "wrong OS" (native mode is Linux-only) from "Linux but no device node"
+ * (card missing or driver not set up). Null when local mode is offered.
+ * Exported for unit tests.
+ */
+export function noLocalReason(hardware: HardwareProbe | null): string | null {
+  if (!hardware || hardware.accelerator_present) return null;
+  if (hardware.platform === "linux") {
+    return "No Tenstorrent accelerator was found on this machine (/dev/tenstorrent is missing). If a card is installed, finish the one-time driver setup in a terminal with python run.py; otherwise connect to a machine that has one over SSH.";
+  }
+  const os =
+    hardware.platform === "macos"
+      ? "macOS"
+      : hardware.platform === "windows"
+        ? "Windows"
+        : "this OS";
+  return `Running models locally needs a Linux machine with a Tenstorrent accelerator — TT-Studio can't run natively on ${os}. Connect to a Linux machine over SSH instead.`;
+}
+
 export function describeAuth(profile: Profile): string {
   if (!profile.auth || profile.auth.method === "agent") return "ssh-agent";
   return `key ${profile.auth.path}`;
@@ -70,6 +90,15 @@ function ConnectionPicker({
       </header>
 
       <section className="flex w-full max-w-md flex-col gap-3">
+        {noLocalReason(hardware) && (
+          <p
+            data-testid="no-local-card"
+            className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3 text-xs leading-relaxed text-zinc-400"
+          >
+            {noLocalReason(hardware)}
+          </p>
+        )}
+
         {hardware?.accelerator_present && (
           <button
             type="button"
@@ -162,8 +191,8 @@ function ConnectionPicker({
             data-testid="picker-empty"
             className="rounded-lg border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-400"
           >
-            No Tenstorrent hardware found on this machine. Add a machine that
-            has one to connect over SSH.
+            No machines yet — add one that has a Tenstorrent accelerator to
+            connect over SSH.
           </p>
         )}
 

--- a/desktop/src/views/ConnectionPicker.tsx
+++ b/desktop/src/views/ConnectionPicker.tsx
@@ -35,7 +35,11 @@ export function describeAuth(profile: Profile): string {
 interface Props {
   hardware: HardwareProbe | null;
   profiles: Profile[];
+  /** A local stack already answers its health checks. */
+  stackUp: boolean;
   onConnectLocal: () => void;
+  /** Explicit stop-then-bring-up; never triggered automatically. */
+  onRestartStack: () => void;
   onConnectSsh: (profile: Profile) => void;
   onAddMachine: () => void;
   onEditProfile: (profile: Profile) => void;
@@ -45,7 +49,9 @@ interface Props {
 function ConnectionPicker({
   hardware,
   profiles,
+  stackUp,
   onConnectLocal,
+  onRestartStack,
   onConnectSsh,
   onAddMachine,
   onEditProfile,
@@ -80,13 +86,28 @@ function ConnectionPicker({
                 Run on this machine
               </span>
               <span className="block text-xs text-zinc-400">
-                Tenstorrent accelerator detected
+                {stackUp
+                  ? "Stack already running — connect attaches to it"
+                  : "Tenstorrent accelerator detected"}
               </span>
             </span>
             <span className="text-xs font-medium text-purple-400">
               Recommended
             </span>
           </button>
+        )}
+
+        {hardware?.accelerator_present && stackUp && (
+          <div className="flex items-center justify-end px-1">
+            <button
+              type="button"
+              onClick={onRestartStack}
+              data-testid="restart-stack"
+              className="rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+            >
+              Restart stack
+            </button>
+          </div>
         )}
 
         {sshProfiles.map((profile) => (


### PR DESCRIPTION
Third slice of the desktop app (D3), stacked on #1253 (\`jashan/desktop-shell\`), which is stacked on #1252 — retarget to \`dev\` after those merge. This makes the QuietBox story real: double-click the app on a Linux box with a Tenstorrent card and it finds (or clones) a tt-studio checkout, runs \`python run.py --no-browser --json-events --no-sudo\`, renders the bring-up natively from the NDJSON stream (dev-docs/json-events.md, #1250), and opens the stack when it's ready. If a stack is already healthy it just attaches — no bring-up spawned.

- [x] Checkout resolution: user-configured path → managed \`~/.local/share/tt-studio/stack\` → shallow-clone of the latest \`v*\` release tag (unit-tested against a local bare-repo fixture, no network in tests)
- [x] Spawner: cwd = checkout root (run.py derives TT_STUDIO_ROOT from cwd), stdout forwarded line-by-line as \`bringup-line\` events, stderr to a rotating log in the app data dir, child survives the venv re-exec as one process
- [x] Attach-first: one health snapshot before spawning anything; picker gets an explicit "Restart stack" action (\`--stop\` then bring-up) that is never triggered automatically
- [x] Prompts can't hang the GUI: \`--no-sudo\` by default, \`prompt_blocked\`/exit-code-2 render a "run one-time setup in a terminal: python run.py" card with a copy button
- [x] Quit dialog: "Keep running" (default — the host services detach and survive the app on purpose) vs "Stop the stack" (runs \`run.py --stop\`, then exits); dialog dismissal maps to keep-running
- [x] SSH fallback polish: the picker now explains *why* local mode is unavailable (non-Linux vs Linux-without-\`/dev/tenstorrent\`)
- [x] Verified: cargo fmt/clippy \`-D warnings\`/test (34 unit + 6 integration), vitest (41), debug tauri build; integration tests drive the spawner against \`tests/fixtures/fake_run.py\` covering success-to-ready, failure-with-remediation, prompt_blocked, and kill/cleanup — no real bring-up was run anywhere
- [x] Attach detection checked read-only against a live local stack (per-service statuses correct)