### PR TITLE
feat(desktop): ssh remote bring-up and one-click connect flow

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -93,12 +93,13 @@ jobs:
         working-directory: desktop/src-tauri
         run: cargo test
 
-      # SSH tunnel integration tests run against a containerized sshd
-      # (tests/fixtures/sshd) — only the Linux runner has Linux containers.
-      - name: SSH tunnel integration tests
+      # SSH integration tests (tunnels + remote bring-up e2e) run against a
+      # containerized sshd (tests/fixtures/sshd) — only the Linux runner has
+      # Linux containers.
+      - name: SSH integration tests
         if: runner.os == 'Linux'
         working-directory: desktop/src-tauri
-        run: cargo test --test ssh_tunnel -- --ignored
+        run: cargo test --test ssh_tunnel --test ssh_remote_bringup -- --ignored
 
       # Debug + no-bundle keeps this fast and reuses the clippy/test build
       # cache while still exercising the full tauri build path.

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -65,7 +65,7 @@ impl Endpoints {
     }
 }
 
-fn client() -> reqwest::Client {
+pub(crate) fn client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,7 +5,8 @@
 mod commands;
 mod hardware;
 mod health;
-mod profiles;
+pub mod profiles;
+pub mod remote;
 mod secrets;
 pub mod ssh;
 
@@ -28,6 +29,7 @@ pub fn run() {
             ssh::commands::start_ssh_tunnels,
             ssh::commands::stop_ssh_tunnels,
             ssh::commands::get_tunnel_status,
+            remote::classify_remote_stack,
             hardware::detect_hardware,
             health::check_stack_health,
             health::start_health_poll,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(health::PollerState::default())
         .manage(ssh::commands::TunnelState::default())
+        .manage(remote::RemoteState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -30,6 +31,8 @@ pub fn run() {
             ssh::commands::stop_ssh_tunnels,
             ssh::commands::get_tunnel_status,
             remote::classify_remote_stack,
+            remote::start_remote_bring_up,
+            remote::cancel_remote_bring_up,
             hardware::detect_hardware,
             health::check_stack_health,
             health::start_health_poll,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,11 @@ pub fn run() {
         .manage(health::PollerState::default())
         .manage(ssh::commands::TunnelState::default())
         .manage(remote::RemoteState::default())
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                ssh::commands::on_close_requested(window, api);
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -33,6 +38,8 @@ pub fn run() {
             remote::classify_remote_stack,
             remote::start_remote_bring_up,
             remote::cancel_remote_bring_up,
+            remote::get_active_remote,
+            remote::quit_app,
             hardware::detect_hardware,
             health::check_stack_health,
             health::start_health_poll,

--- a/desktop/src-tauri/src/profiles.rs
+++ b/desktop/src-tauri/src/profiles.rs
@@ -86,6 +86,18 @@ pub fn touch(profiles: &mut [Profile], id: &str, now: f64) -> bool {
     }
 }
 
+/// Record the repo path a connect actually validated (found `run.py` at) so
+/// later connects and the quit-time stop use it without re-deriving defaults.
+pub fn set_repo_path(profiles: &mut [Profile], id: &str, path: &str) -> bool {
+    match profiles.iter_mut().find(|p| p.id == id) {
+        Some(p) if p.remote_repo_path.as_deref() != Some(path) => {
+            p.remote_repo_path = Some(path.to_string());
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Most-recently-used first; never-used profiles keep insertion order at the end.
 pub fn sort_recent_first(profiles: &mut [Profile]) {
     profiles.sort_by(|a, b| {
@@ -137,6 +149,15 @@ pub fn delete_profile(app: tauri::AppHandle<Wry>, id: String) -> Result<Vec<Prof
     remove(&mut profiles, &id);
     write_store(&app, &profiles)?;
     Ok(profiles)
+}
+
+/// Persist a validated repo path (no-op for unknown ids or unchanged paths).
+pub fn persist_repo_path(app: &tauri::AppHandle<Wry>, id: &str, path: &str) -> Result<(), String> {
+    let mut profiles = read_store(app)?;
+    if set_repo_path(&mut profiles, id, path) {
+        write_store(app, &profiles)?;
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -246,6 +267,19 @@ mod tests {
         assert!(touch(&mut profiles, "p1", 1000.0));
         assert_eq!(profiles[0].last_used, Some(1000.0));
         assert!(!touch(&mut profiles, "ghost", 2000.0));
+    }
+
+    #[test]
+    fn set_repo_path_updates_only_on_change() {
+        let mut profiles = vec![ssh_profile("p1", "a")];
+        // ssh_profile seeds "~/tt-studio"; same value is a no-op.
+        assert!(!set_repo_path(&mut profiles, "p1", "~/tt-studio"));
+        assert!(set_repo_path(&mut profiles, "p1", "/opt/tt-studio"));
+        assert_eq!(
+            profiles[0].remote_repo_path.as_deref(),
+            Some("/opt/tt-studio")
+        );
+        assert!(!set_repo_path(&mut profiles, "ghost", "/x"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -398,6 +398,68 @@ fn stderr_log_file(app: &tauri::AppHandle) -> Option<std::fs::File> {
     std::fs::File::create(dir.join(BRINGUP_STDERR_LOG)).ok()
 }
 
+// ---- quitting: optionally stop the remote stack on the way out ----
+
+/// Output lines from `run.py --stop` while the quit dialog streams it.
+pub const REMOTE_STOP_EVENT: &str = "remote-stop-line";
+
+/// The profile the current SSH connection belongs to, for the quit dialog's
+/// "Stop the stack on <host>" wording. `None` on local connections.
+#[tauri::command]
+pub fn get_active_remote(
+    tunnels: tauri::State<'_, crate::ssh::commands::TunnelState>,
+) -> Option<Profile> {
+    tunnels.active_profile()
+}
+
+/// Leave the app. With `stop_stack`, first run `run.py --stop` on the active
+/// remote machine, streaming its output as `remote-stop-line` events; a stop
+/// that fails returns the error WITHOUT quitting so the user can decide to
+/// quit anyway. Without it (or with no active remote), just disconnect.
+#[tauri::command]
+pub async fn quit_app(
+    app: tauri::AppHandle,
+    tunnels: tauri::State<'_, crate::ssh::commands::TunnelState>,
+    remote: tauri::State<'_, RemoteState>,
+    stop_stack: bool,
+) -> Result<(), SshError> {
+    // A quit aborts any in-flight bring-up either way.
+    remote.cancel().await;
+    if stop_stack {
+        if let Some(profile) = tunnels.active_profile() {
+            use tauri::Emitter;
+            let session = connect_session(&app, &profile).await?;
+            let command = stop_command(&repo_path(&profile));
+            let line_app = app.clone();
+            let exit = session
+                .exec_stream(
+                    &command,
+                    |line| {
+                        let _ = line_app.emit(REMOTE_STOP_EVENT, line);
+                    },
+                    |_| {},
+                )
+                .await;
+            session.close().await;
+            match exit {
+                Ok(Some(0)) => {}
+                Ok(code) => {
+                    return Err(SshError::Internal {
+                        message: match code {
+                            Some(code) => format!("run.py --stop exited with code {code}"),
+                            None => "run.py --stop ended without an exit code".to_string(),
+                        },
+                    })
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    tunnels.shutdown().await;
+    app.exit(0);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -270,6 +270,12 @@ pub async fn classify_remote_stack(
     };
     session.close().await;
 
+    // The probe just validated (or refuted) the repo path; on success, write
+    // the resolved value back so the profile stops relying on the default.
+    if run_py_exists {
+        let _ = crate::profiles::persist_repo_path(&app, &profile.id, &path);
+    }
+
     Ok(classify(
         local.ready,
         run_py_exists,

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Remote TT-Studio stack detection over an established SSH tunnel set.
+//!
+//! Once the tunnels are up (all local listeners bound the stack's real
+//! ports), the connect flow asks one question: attach to a running stack, or
+//! bring one up? Answered by combining
+//!
+//! - the local health poller aimed at the forwarded ports (a healthy answer
+//!   means the remote stack is fully up — attach), and
+//! - one-shot probes over `ssh exec`: `test -f <repo>/run.py` (is there a
+//!   checkout at the profile's repo path?), `python3 --version` (can run.py
+//!   even run there?), and `python3 run.py --status --json` (which services
+//!   are up — distinguishes down from partial).
+//!
+//! NOTE: callers must verify the tunnel's forwards actually bound before
+//! classifying — with port 3000 taken locally, the health poll would be
+//! talking to whatever local server squats on it, not the remote stack.
+
+use serde::Serialize;
+use tauri::Manager;
+
+use crate::health;
+use crate::profiles::Profile;
+use crate::ssh::exec::{quote_path, ExecOutput};
+use crate::ssh::known_hosts::KnownHostsVerifier;
+use crate::ssh::session::SshSession;
+use crate::ssh::{SshError, SshTransport};
+
+/// Where a checkout lives when the profile doesn't say.
+pub const DEFAULT_REPO_PATH: &str = "~/tt-studio";
+
+/// `run.py` needs a modern interpreter; older ones fail with a confusing
+/// SyntaxError instead of a clear message, so we gate up front.
+pub const MIN_PYTHON: (u32, u32) = (3, 12);
+
+/// The repo path this profile's stack lives at (falls back to the default).
+pub fn repo_path(profile: &Profile) -> String {
+    profile
+        .remote_repo_path
+        .clone()
+        .filter(|p| !p.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_REPO_PATH.to_string())
+}
+
+// ---- the exact commands run on the remote machine ----
+
+pub fn probe_run_py_command(path: &str) -> String {
+    format!("test -f {}/run.py", quote_path(path))
+}
+
+/// `2>&1` because some interpreters print the version banner to stderr.
+pub fn python_version_command() -> &'static str {
+    "python3 --version 2>&1"
+}
+
+pub fn status_command(path: &str) -> String {
+    format!("cd {} && python3 run.py --status --json", quote_path(path))
+}
+
+pub fn bring_up_command(path: &str) -> String {
+    format!(
+        "cd {} && python3 run.py --no-browser --json-events",
+        quote_path(path)
+    )
+}
+
+pub fn stop_command(path: &str) -> String {
+    format!("cd {} && python3 run.py --stop 2>&1", quote_path(path))
+}
+
+// ---- probe parsing ----
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PythonProbe {
+    Found { major: u32, minor: u32, raw: String },
+    Missing { message: String },
+}
+
+impl PythonProbe {
+    pub fn meets_minimum(&self) -> bool {
+        matches!(self, PythonProbe::Found { major, minor, .. }
+            if (*major, *minor) >= MIN_PYTHON)
+    }
+}
+
+/// Interpret `python3 --version 2>&1` output. A non-zero exit is "no usable
+/// python3" (127 from the shell when the binary is absent).
+pub fn parse_python_probe(output: &ExecOutput) -> PythonProbe {
+    let raw = output.stdout.trim().to_string();
+    if !output.success() {
+        return PythonProbe::Missing {
+            message: if raw.is_empty() {
+                "python3 not found on the remote machine".to_string()
+            } else {
+                raw
+            },
+        };
+    }
+    let mut parts = raw
+        .strip_prefix("Python ")
+        .unwrap_or("")
+        .split('.')
+        .map(|p| p.parse::<u32>());
+    match (parts.next(), parts.next()) {
+        (Some(Ok(major)), Some(Ok(minor))) => PythonProbe::Found { major, minor, raw },
+        _ => PythonProbe::Missing {
+            message: format!("could not parse python version from {raw:?}"),
+        },
+    }
+}
+
+/// One service row from the `status` event of `run.py --status --json`.
+pub type ServiceUp = (String, bool);
+
+/// Pull the service list out of a `--status --json` stdout dump: NDJSON
+/// lines, one of which is the `status` event. Unparseable lines are skipped
+/// (same contract as the frontend's event parser).
+pub fn parse_status_services(stdout: &str) -> Option<Vec<ServiceUp>> {
+    for line in stdout.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if value["event"] != "status" {
+            continue;
+        }
+        let services = value["detail"]["services"].as_array()?;
+        return Some(
+            services
+                .iter()
+                .filter_map(|s| {
+                    Some((
+                        s["name"].as_str()?.to_string(),
+                        s["healthy"].as_bool().unwrap_or(false),
+                    ))
+                })
+                .collect(),
+        );
+    }
+    None
+}
+
+// ---- classification ----
+
+/// What the connect flow should do next, serialized for the launcher UI
+/// (tagged the same way as `SshError`).
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StackClassification {
+    /// Every service answers over the tunnel — attach directly.
+    Healthy,
+    /// Some services are up; bring-up will finish the job.
+    Partial {
+        healthy: Vec<String>,
+        unhealthy: Vec<String>,
+    },
+    /// Nothing is running — full bring-up.
+    Down,
+    /// No `run.py` at the profile's repo path: the UI shows clone
+    /// instructions (remote auto-clone is out of scope).
+    NoCheckout { path: String },
+    /// No usable python3 on the remote machine.
+    PythonMissing { message: String },
+    /// python3 exists but is older than run.py supports.
+    PythonTooOld { found: String, required: String },
+}
+
+impl StackClassification {
+    /// True when the right next step is running the bring-up command.
+    pub fn needs_bring_up(&self) -> bool {
+        matches!(
+            self,
+            StackClassification::Partial { .. } | StackClassification::Down
+        )
+    }
+}
+
+/// Pure decision over the probe results (unit-tested; the Tauri command and
+/// the e2e test both feed it real probes).
+pub fn classify(
+    local_ready: bool,
+    run_py_exists: bool,
+    python: &PythonProbe,
+    services: Option<&[ServiceUp]>,
+    path: &str,
+) -> StackClassification {
+    if local_ready {
+        // The stack answers end to end through the tunnel; nothing else
+        // matters (an old python can't stop an already-running stack).
+        return StackClassification::Healthy;
+    }
+    if !run_py_exists {
+        return StackClassification::NoCheckout {
+            path: path.to_string(),
+        };
+    }
+    match python {
+        PythonProbe::Missing { message } => {
+            return StackClassification::PythonMissing {
+                message: message.clone(),
+            }
+        }
+        PythonProbe::Found { raw, .. } if !python.meets_minimum() => {
+            return StackClassification::PythonTooOld {
+                found: raw.clone(),
+                required: format!("{}.{}", MIN_PYTHON.0, MIN_PYTHON.1),
+            }
+        }
+        PythonProbe::Found { .. } => {}
+    }
+    let (healthy, unhealthy): (Vec<_>, Vec<_>) = services
+        .unwrap_or(&[])
+        .iter()
+        .cloned()
+        .partition(|(_, up)| *up);
+    if healthy.is_empty() {
+        // Also the fallback when --status --json isn't available on the
+        // remote checkout: bring-up sorts that out either way.
+        StackClassification::Down
+    } else {
+        StackClassification::Partial {
+            healthy: healthy.into_iter().map(|(n, _)| n).collect(),
+            unhealthy: unhealthy.into_iter().map(|(n, _)| n).collect(),
+        }
+    }
+}
+
+// ---- the Tauri command tying it together ----
+
+async fn connect_session(
+    app: &tauri::AppHandle,
+    profile: &Profile,
+) -> Result<SshSession, SshError> {
+    let home = app.path().home_dir().ok();
+    let target = crate::ssh::commands::target_from_profile(profile, home)?;
+    let verifier = KnownHostsVerifier::for_app(app)?;
+    SshSession::connect(&target, verifier).await
+}
+
+/// Probe the remote machine (over one short-lived exec session) and the
+/// forwarded ports, and say whether to attach, bring up, or bail with a
+/// specific error card. Call only after the tunnel reports every essential
+/// forward bound — see the module docs.
+#[tauri::command]
+pub async fn classify_remote_stack(
+    app: tauri::AppHandle,
+    profile: Profile,
+) -> Result<StackClassification, SshError> {
+    let session = connect_session(&app, &profile).await?;
+    let path = repo_path(&profile);
+
+    let local = health::poll_once(&health::client(), &health::Endpoints::local_default()).await;
+    let run_py_exists = session
+        .exec_capture(&probe_run_py_command(&path))
+        .await?
+        .success();
+    let python = parse_python_probe(&session.exec_capture(python_version_command()).await?);
+
+    let services = if run_py_exists && python.meets_minimum() && !local.ready {
+        let out = session.exec_capture(&status_command(&path)).await?;
+        if out.success() {
+            parse_status_services(&out.stdout)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    session.close().await;
+
+    Ok(classify(
+        local.ready,
+        run_py_exists,
+        &python,
+        services.as_deref(),
+        &path,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn out(exit_code: Option<u32>, stdout: &str) -> ExecOutput {
+        ExecOutput {
+            exit_code,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn py(major: u32, minor: u32) -> PythonProbe {
+        PythonProbe::Found {
+            major,
+            minor,
+            raw: format!("Python {major}.{minor}.0"),
+        }
+    }
+
+    #[test]
+    fn python_probe_parses_versions_and_failures() {
+        assert_eq!(
+            parse_python_probe(&out(Some(0), "Python 3.12.3\n")),
+            PythonProbe::Found {
+                major: 3,
+                minor: 12,
+                raw: "Python 3.12.3".into()
+            }
+        );
+        assert!(matches!(
+            parse_python_probe(&out(Some(127), "sh: python3: not found\n")),
+            PythonProbe::Missing { .. }
+        ));
+        assert!(matches!(
+            parse_python_probe(&out(Some(0), "garbage")),
+            PythonProbe::Missing { .. }
+        ));
+    }
+
+    #[test]
+    fn python_minimum_is_3_12() {
+        assert!(py(3, 12).meets_minimum());
+        assert!(py(3, 13).meets_minimum());
+        assert!(py(4, 0).meets_minimum());
+        assert!(!py(3, 11).meets_minimum());
+        assert!(!py(2, 7).meets_minimum());
+    }
+
+    #[test]
+    fn status_services_parse_from_the_ndjson_dump() {
+        let stdout = concat!(
+            "not json at all\n",
+            r#"{"v":1,"ts":1.0,"event":"note","phase":null,"detail":{"text":"x"}}"#,
+            "\n",
+            r#"{"v":1,"ts":2.0,"event":"status","phase":null,"detail":{"services":[{"name":"frontend","port":3000,"url":"http://localhost:3000","healthy":true},{"name":"backend","port":8000,"healthy":false}],"head":"abc1234","hardware":"P300"}}"#,
+            "\n",
+        );
+        assert_eq!(
+            parse_status_services(stdout).unwrap(),
+            vec![
+                ("frontend".to_string(), true),
+                ("backend".to_string(), false)
+            ]
+        );
+        assert_eq!(parse_status_services("plain text\n"), None);
+    }
+
+    #[test]
+    fn healthy_tunnelled_stack_always_attaches() {
+        // Even with a hostile-looking remote (no checkout, no python): if
+        // every service answers through the tunnel, attach.
+        let missing = PythonProbe::Missing {
+            message: "nope".into(),
+        };
+        assert_eq!(
+            classify(true, false, &missing, None, "~/tt-studio"),
+            StackClassification::Healthy
+        );
+    }
+
+    #[test]
+    fn missing_run_py_is_an_invalid_path_error() {
+        let c = classify(false, false, &py(3, 12), None, "~/elsewhere");
+        assert_eq!(
+            c,
+            StackClassification::NoCheckout {
+                path: "~/elsewhere".into()
+            }
+        );
+        assert!(!c.needs_bring_up());
+    }
+
+    #[test]
+    fn old_or_missing_python_blocks_bring_up() {
+        assert_eq!(
+            classify(false, true, &py(3, 11), None, "~/tt-studio"),
+            StackClassification::PythonTooOld {
+                found: "Python 3.11.0".into(),
+                required: "3.12".into()
+            }
+        );
+        let missing = PythonProbe::Missing {
+            message: "python3 not found".into(),
+        };
+        assert!(matches!(
+            classify(false, true, &missing, None, "~/tt-studio"),
+            StackClassification::PythonMissing { .. }
+        ));
+    }
+
+    #[test]
+    fn service_mix_distinguishes_partial_from_down() {
+        let services = vec![
+            ("frontend".to_string(), true),
+            ("backend".to_string(), false),
+        ];
+        let c = classify(false, true, &py(3, 12), Some(&services), "~/tt-studio");
+        assert_eq!(
+            c,
+            StackClassification::Partial {
+                healthy: vec!["frontend".into()],
+                unhealthy: vec!["backend".into()],
+            }
+        );
+        assert!(c.needs_bring_up());
+
+        let all_down = vec![("frontend".to_string(), false)];
+        assert_eq!(
+            classify(false, true, &py(3, 12), Some(&all_down), "~/tt-studio"),
+            StackClassification::Down
+        );
+        // No status output at all (old checkout without the flag) → Down.
+        assert_eq!(
+            classify(false, true, &py(3, 12), None, "~/tt-studio"),
+            StackClassification::Down
+        );
+    }
+
+    #[test]
+    fn classification_serializes_with_kind_discriminant() {
+        let json = serde_json::to_value(StackClassification::NoCheckout {
+            path: "~/tt-studio".into(),
+        })
+        .unwrap();
+        assert_eq!(json["kind"], "no_checkout");
+        assert_eq!(json["path"], "~/tt-studio");
+        let json = serde_json::to_value(StackClassification::Healthy).unwrap();
+        assert_eq!(json["kind"], "healthy");
+    }
+
+    #[test]
+    fn remote_commands_quote_the_repo_path() {
+        assert_eq!(
+            probe_run_py_command("~/tt-studio"),
+            "test -f \"$HOME\"/'tt-studio'/run.py"
+        );
+        assert_eq!(
+            status_command("/opt/tt studio"),
+            "cd '/opt/tt studio' && python3 run.py --status --json"
+        );
+        assert_eq!(
+            bring_up_command("~/tt-studio"),
+            "cd \"$HOME\"/'tt-studio' && python3 run.py --no-browser --json-events"
+        );
+        assert_eq!(
+            stop_command("~/tt-studio"),
+            "cd \"$HOME\"/'tt-studio' && python3 run.py --stop 2>&1"
+        );
+    }
+
+    #[test]
+    fn repo_path_falls_back_to_default() {
+        let mut profile = Profile {
+            id: "p".into(),
+            name: "n".into(),
+            kind: crate::profiles::ProfileKind::Ssh,
+            host: Some("h".into()),
+            port: None,
+            user: Some("u".into()),
+            auth: None,
+            remote_repo_path: None,
+            last_used: None,
+        };
+        assert_eq!(repo_path(&profile), DEFAULT_REPO_PATH);
+        profile.remote_repo_path = Some("  ".into());
+        assert_eq!(repo_path(&profile), DEFAULT_REPO_PATH);
+        profile.remote_repo_path = Some("/opt/tt-studio".into());
+        assert_eq!(repo_path(&profile), "/opt/tt-studio");
+    }
+}

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -279,6 +279,119 @@ pub async fn classify_remote_stack(
     ))
 }
 
+// ---- remote bring-up: `run.py --json-events` streamed over ssh exec ----
+
+/// Raw NDJSON lines from the remote bring-up, one event payload per line —
+/// the same event name the native launcher path uses, so the frontend's
+/// parser/reducer (`lib/events.ts`) is shared unchanged.
+pub const BRINGUP_LINE_EVENT: &str = "bringup-line";
+/// Fired once when the remote bring-up command finishes (or dies).
+pub const BRINGUP_EXIT_EVENT: &str = "bringup-exit";
+/// Where the remote command's stderr (human display output) is kept.
+pub const BRINGUP_STDERR_LOG: &str = "remote-bringup.log";
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct BringUpExit {
+    /// Remote exit code; `None` when the channel closed without one (killed
+    /// session, network drop) — pair with `error` for the reason if known.
+    pub exit_code: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// At most one remote bring-up runs at a time. Holds the session so
+/// cancellation can close it, which ends the exec stream.
+#[derive(Default)]
+pub struct RemoteState {
+    bring_up: tokio::sync::Mutex<Option<BringUpHandle>>,
+}
+
+struct BringUpHandle {
+    session: std::sync::Arc<SshSession>,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+impl RemoteState {
+    /// Tear down any in-flight bring-up without emitting an exit event.
+    pub(crate) async fn cancel(&self) {
+        if let Some(handle) = self.bring_up.lock().await.take() {
+            handle.task.abort();
+            handle.session.close().await;
+        }
+    }
+}
+
+/// Start `python3 run.py --no-browser --json-events` on the remote machine
+/// and stream its stdout to the launcher as `bringup-line` events; stderr
+/// (the human-facing display output) goes to `remote-bringup.log` in the app
+/// log dir. Replaces any bring-up already running.
+#[tauri::command]
+pub async fn start_remote_bring_up(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, RemoteState>,
+    profile: Profile,
+) -> Result<(), SshError> {
+    let session = std::sync::Arc::new(connect_session(&app, &profile).await?);
+    let command = bring_up_command(&repo_path(&profile));
+    let mut stderr_log = stderr_log_file(&app);
+
+    let task_session = session.clone();
+    let task = tauri::async_runtime::spawn(async move {
+        use std::io::Write;
+        use tauri::Emitter;
+        let line_app = app.clone();
+        let result = task_session
+            .exec_stream(
+                &command,
+                |line| {
+                    let _ = line_app.emit(BRINGUP_LINE_EVENT, line);
+                },
+                |chunk| {
+                    if let Some(f) = &mut stderr_log {
+                        let _ = f.write_all(chunk);
+                    }
+                },
+            )
+            .await;
+        task_session.close().await;
+        let exit = match result {
+            Ok(exit_code) => BringUpExit {
+                exit_code,
+                error: None,
+            },
+            Err(e) => BringUpExit {
+                exit_code: None,
+                error: Some(e.to_string()),
+            },
+        };
+        let _ = app.emit(BRINGUP_EXIT_EVENT, &exit);
+    });
+
+    let mut guard = state.bring_up.lock().await;
+    if let Some(previous) = guard.take() {
+        previous.task.abort();
+        previous.session.close().await;
+    }
+    *guard = Some(BringUpHandle { session, task });
+    Ok(())
+}
+
+/// Stop a running remote bring-up by closing its SSH session (ends the exec
+/// channel; sshd tears the remote process group down with it). Idempotent.
+#[tauri::command]
+pub async fn cancel_remote_bring_up(state: tauri::State<'_, RemoteState>) -> Result<(), SshError> {
+    state.cancel().await;
+    Ok(())
+}
+
+/// Fresh log file per bring-up; failures to create it degrade to discarding
+/// stderr rather than blocking the bring-up.
+fn stderr_log_file(app: &tauri::AppHandle) -> Option<std::fs::File> {
+    let dir = app.path().app_log_dir().ok()?;
+    std::fs::create_dir_all(&dir).ok()?;
+    std::fs::File::create(dir.join(BRINGUP_STDERR_LOG)).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -448,6 +561,25 @@ mod tests {
             stop_command("~/tt-studio"),
             "cd \"$HOME\"/'tt-studio' && python3 run.py --stop 2>&1"
         );
+    }
+
+    #[test]
+    fn bring_up_exit_serializes_for_the_ui() {
+        let json = serde_json::to_value(BringUpExit {
+            exit_code: Some(2),
+            error: None,
+        })
+        .unwrap();
+        assert_eq!(json["exit_code"], 2);
+        assert!(json.get("error").is_none());
+
+        let json = serde_json::to_value(BringUpExit {
+            exit_code: None,
+            error: Some("connection lost".into()),
+        })
+        .unwrap();
+        assert!(json["exit_code"].is_null());
+        assert_eq!(json["error"], "connection lost");
     }
 
     #[test]

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -32,7 +32,10 @@ pub struct TunnelState(tokio::sync::Mutex<Option<Supervisor>>);
 /// Build the dial target from a saved profile: agent auth is always tried
 /// first, then the profile's key file with the keychain passphrase if one
 /// is stored (see `secrets.rs`).
-fn target_from_profile(profile: &Profile, home: Option<PathBuf>) -> Result<SshTarget, SshError> {
+pub(crate) fn target_from_profile(
+    profile: &Profile,
+    home: Option<PathBuf>,
+) -> Result<SshTarget, SshError> {
     if profile.kind != ProfileKind::Ssh {
         return Err(SshError::Internal {
             message: "profile is not an SSH profile".into(),

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -27,7 +27,30 @@ const DEFAULT_SSH_PORT: u16 = 22;
 
 /// At most one tunnel supervisor runs at a time (one remote stack per window).
 #[derive(Default)]
-pub struct TunnelState(tokio::sync::Mutex<Option<Supervisor>>);
+pub struct TunnelState {
+    supervisor: tokio::sync::Mutex<Option<Supervisor>>,
+    /// The profile the running tunnels belong to. Drives the quit dialog:
+    /// while set, closing the window offers stop-vs-disconnect first.
+    active: std::sync::Mutex<Option<Profile>>,
+}
+
+impl TunnelState {
+    pub(crate) fn active_profile(&self) -> Option<Profile> {
+        self.active.lock().expect("active profile lock").clone()
+    }
+
+    fn set_active(&self, profile: Option<Profile>) {
+        *self.active.lock().expect("active profile lock") = profile;
+    }
+
+    /// Stop the supervisor (if any) and forget the active profile.
+    pub(crate) async fn shutdown(&self) {
+        if let Some(supervisor) = self.supervisor.lock().await.take() {
+            supervisor.stop().await;
+        }
+        self.set_active(None);
+    }
+}
 
 /// Build the dial target from a saved profile: agent auth is always tried
 /// first, then the profile's key file with the keychain passphrase if one
@@ -146,7 +169,7 @@ pub async fn start_ssh_tunnels(
         return_to_launcher_if_lost(&sink_app, &status);
     });
 
-    let mut guard = state.0.lock().await;
+    let mut guard = state.supervisor.lock().await;
     if let Some(previous) = guard.take() {
         previous.stop().await;
     }
@@ -155,14 +178,13 @@ pub async fn start_ssh_tunnels(
         connector,
         sink,
     ));
+    state.set_active(Some(profile));
     Ok(())
 }
 
 #[tauri::command]
 pub async fn stop_ssh_tunnels(state: tauri::State<'_, TunnelState>) -> Result<(), SshError> {
-    if let Some(supervisor) = state.0.lock().await.take() {
-        supervisor.stop().await;
-    }
+    state.shutdown().await;
     Ok(())
 }
 
@@ -170,7 +192,32 @@ pub async fn stop_ssh_tunnels(state: tauri::State<'_, TunnelState>) -> Result<()
 pub async fn get_tunnel_status(
     state: tauri::State<'_, TunnelState>,
 ) -> Result<Option<TunnelStatus>, SshError> {
-    Ok(state.0.lock().await.as_ref().map(|s| s.status()))
+    Ok(state.supervisor.lock().await.as_ref().map(|s| s.status()))
+}
+
+/// Close-button interception: while an SSH connection is active and the
+/// window shows the remote stack, turn the close into the launcher's quit
+/// dialog (stop the remote stack vs just disconnect) instead of exiting.
+pub(crate) fn on_close_requested(window: &tauri::Window, api: &tauri::CloseRequestApi) {
+    if window.label() != "main" {
+        return;
+    }
+    let app = window.app_handle();
+    let active = app.state::<TunnelState>().active_profile().is_some();
+    if !active || !showing_remote_stack(app) {
+        return; // plain close: the process exit tears the tunnels down
+    }
+    api.prevent_close();
+    let Some(mut url) = launcher_url(app) else {
+        return;
+    };
+    url.set_query(Some("quit=1"));
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.navigate(url);
+        }
+    });
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/ssh/exec.rs
+++ b/desktop/src-tauri/src/ssh/exec.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Remote command execution over an [`SshSession`].
+//!
+//! Two shapes, both running one command in one exec channel:
+//!
+//! - [`SshSession::exec_capture`] — short one-shot probes (`test -f`,
+//!   `python3 --version`, `run.py --status --json`), buffered and bounded by
+//!   a timeout;
+//! - [`SshSession::exec_stream`] — long-running commands (`run.py
+//!   --json-events`, `run.py --stop`) whose stdout is delivered line by line
+//!   as it arrives. Unbounded: the caller decides when to give up by closing
+//!   the session, which ends the stream.
+
+use std::time::Duration;
+
+use russh::ChannelMsg;
+
+use super::session::SshSession;
+use super::SshError;
+
+/// One-shot probes must answer quickly; `run.py --status --json` is the
+/// slowest (it health-checks every service) so the bound is generous.
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Everything a finished one-shot command produced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecOutput {
+    /// The remote command's exit code; `None` when the channel closed
+    /// without reporting one (e.g. the session died mid-command).
+    pub exit_code: Option<u32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl ExecOutput {
+    pub fn success(&self) -> bool {
+        self.exit_code == Some(0)
+    }
+}
+
+impl SshSession {
+    /// Run `command` and buffer everything until it exits.
+    pub async fn exec_capture(&self, command: &str) -> Result<ExecOutput, SshError> {
+        tokio::time::timeout(CAPTURE_TIMEOUT, self.exec_capture_inner(command))
+            .await
+            .map_err(|_| SshError::Timeout {
+                message: format!("remote command timed out: {command}"),
+            })?
+    }
+
+    async fn exec_capture_inner(&self, command: &str) -> Result<ExecOutput, SshError> {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut channel = self.open_session_channel().await?;
+        channel.exec(true, command).await?;
+        let mut exit_code = None;
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::Data { ref data } => stdout.extend_from_slice(data),
+                ChannelMsg::ExtendedData { ref data, ext: 1 } => stderr.extend_from_slice(data),
+                ChannelMsg::ExitStatus { exit_status } => exit_code = Some(exit_status),
+                _ => {}
+            }
+        }
+        Ok(ExecOutput {
+            exit_code,
+            stdout: String::from_utf8_lossy(&stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        })
+    }
+
+    /// Run `command`, delivering each complete stdout line to
+    /// `on_stdout_line` as it arrives and raw stderr chunks to `on_stderr`.
+    /// Returns the exit code once the channel closes. No timeout — cancel by
+    /// closing the session, which terminates the stream.
+    pub async fn exec_stream(
+        &self,
+        command: &str,
+        mut on_stdout_line: impl FnMut(&str) + Send,
+        mut on_stderr: impl FnMut(&[u8]) + Send,
+    ) -> Result<Option<u32>, SshError> {
+        let mut channel = self.open_session_channel().await?;
+        channel.exec(true, command).await?;
+        let mut lines = LineBuffer::default();
+        let mut exit_code = None;
+        while let Some(msg) = channel.wait().await {
+            match msg {
+                ChannelMsg::Data { ref data } => lines.push(data, &mut on_stdout_line),
+                ChannelMsg::ExtendedData { ref data, ext: 1 } => on_stderr(data),
+                ChannelMsg::ExitStatus { exit_status } => exit_code = Some(exit_status),
+                _ => {}
+            }
+        }
+        lines.finish(&mut on_stdout_line);
+        Ok(exit_code)
+    }
+}
+
+/// Reassembles complete lines from arbitrarily chunked byte data (an SSH
+/// channel splits on packet boundaries, not newlines).
+#[derive(Default)]
+struct LineBuffer {
+    buf: Vec<u8>,
+}
+
+impl LineBuffer {
+    fn push(&mut self, data: &[u8], mut emit: impl FnMut(&str)) {
+        self.buf.extend_from_slice(data);
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.buf.drain(..=pos).collect();
+            let line = &line[..line.len() - 1];
+            let line = line.strip_suffix(b"\r").unwrap_or(line);
+            emit(&String::from_utf8_lossy(line));
+        }
+    }
+
+    /// Flush a trailing unterminated line (a crashed remote command may not
+    /// end its last write with a newline).
+    fn finish(self, mut emit: impl FnMut(&str)) {
+        if !self.buf.is_empty() {
+            emit(&String::from_utf8_lossy(&self.buf));
+        }
+    }
+}
+
+/// POSIX single-quote `s` so it survives the remote shell verbatim.
+pub fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// Quote a remote path while keeping a leading `~` meaningful: profiles
+/// store paths the way users type them (`~/tt-studio`), and quoting the
+/// tilde would make the remote shell take it literally.
+pub fn quote_path(path: &str) -> String {
+    if path == "~" {
+        return "\"$HOME\"".to_string();
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        return format!("\"$HOME\"/{}", shell_quote(rest));
+    }
+    shell_quote(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collect_lines(chunks: &[&[u8]]) -> Vec<String> {
+        let mut buf = LineBuffer::default();
+        let mut lines = Vec::new();
+        for chunk in chunks {
+            buf.push(chunk, |l| lines.push(l.to_string()));
+        }
+        buf.finish(|l| lines.push(l.to_string()));
+        lines
+    }
+
+    #[test]
+    fn lines_reassemble_across_chunk_boundaries() {
+        let lines = collect_lines(&[b"{\"a\":", b"1}\n{\"b\"", b":2}\n"]);
+        assert_eq!(lines, vec![r#"{"a":1}"#, r#"{"b":2}"#]);
+    }
+
+    #[test]
+    fn trailing_unterminated_line_is_flushed() {
+        let lines = collect_lines(&[b"complete\npartial"]);
+        assert_eq!(lines, vec!["complete", "partial"]);
+    }
+
+    #[test]
+    fn carriage_returns_are_stripped() {
+        let lines = collect_lines(&[b"one\r\ntwo\n"]);
+        assert_eq!(lines, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn empty_lines_are_preserved_but_empty_tail_is_not() {
+        let lines = collect_lines(&[b"a\n\nb\n"]);
+        assert_eq!(lines, vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn shell_quote_wraps_and_escapes() {
+        assert_eq!(shell_quote("plain"), "'plain'");
+        assert_eq!(shell_quote("has space"), "'has space'");
+        assert_eq!(shell_quote("it's"), r"'it'\''s'");
+    }
+
+    #[test]
+    fn quote_path_keeps_tilde_expandable() {
+        assert_eq!(quote_path("~/tt-studio"), "\"$HOME\"/'tt-studio'");
+        assert_eq!(quote_path("~"), "\"$HOME\"");
+        assert_eq!(quote_path("/opt/tt studio"), "'/opt/tt studio'");
+        // A tilde not at the start is a literal character, not an expansion.
+        assert_eq!(quote_path("/data/~cache"), "'/data/~cache'");
+    }
+}

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -11,6 +11,7 @@
 //! swapped for ssh2 or system-ssh without touching the tunnel supervisor.
 
 pub(crate) mod commands;
+pub mod exec;
 pub mod known_hosts;
 pub mod session;
 pub mod tunnel;

--- a/desktop/src-tauri/src/ssh/session.rs
+++ b/desktop/src-tauri/src/ssh/session.rs
@@ -102,6 +102,14 @@ impl SshSession {
         authenticate(&mut handle, target).await?;
         Ok(Self { handle })
     }
+
+    /// Open a bare session channel — the building block for remote command
+    /// execution (see `exec.rs`).
+    pub(crate) async fn open_session_channel(
+        &self,
+    ) -> Result<russh::Channel<client::Msg>, SshError> {
+        Ok(self.handle.channel_open_session().await?)
+    }
 }
 
 /// Resolve and TCP-connect, classifying each failure mode separately.

--- a/desktop/src-tauri/tests/common/mod.rs
+++ b/desktop/src-tauri/tests/common/mod.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Shared containerized-sshd fixture for the SSH integration tests
+//! (`ssh_tunnel.rs`, `ssh_remote_bringup.rs`).
+//!
+//! The image (tests/fixtures/sshd) bundles a locked-down pubkey-only sshd, a
+//! busybox httpd marker service, and a fake tt-studio checkout at
+//! `/home/tunnel/tt-studio` whose `run.py` speaks the real `--json-events` /
+//! `--status --json` / `--stop` protocol. Each fixture maps a random free
+//! host port to the container's sshd; local listeners in tests always bind
+//! port 0 — the live TT-Studio stack's ports are never touched.
+
+#![allow(dead_code)] // each test binary uses a subset of the helpers
+
+use std::net::TcpListener as StdTcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Once};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::mpsc;
+
+use tt_studio_desktop_lib::ssh::known_hosts::{trust, KnownHostsVerifier};
+use tt_studio_desktop_lib::ssh::session::{AuthMethod, SshSession, SshTarget};
+use tt_studio_desktop_lib::ssh::tunnel::{StatusSink, TunnelStatus};
+use tt_studio_desktop_lib::ssh::SshError;
+
+pub const IMAGE: &str = "tt-studio-desktop-sshd-fixture";
+
+pub fn docker_has_linux_containers() -> bool {
+    Command::new("docker")
+        .args(["info", "--format", "{{.OSType}}"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "linux")
+        .unwrap_or(false)
+}
+
+/// Build the fixture image once per test binary.
+pub fn ensure_image() {
+    static BUILD: Once = Once::new();
+    BUILD.call_once(|| {
+        let context = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sshd");
+        let out = Command::new("docker")
+            .args(["build", "-t", IMAGE])
+            .arg(&context)
+            .output()
+            .expect("docker build failed to spawn");
+        assert!(
+            out.status.success(),
+            "docker build failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    });
+}
+
+pub fn free_port() -> u16 {
+    // Bind-then-drop; the OS hands out a free high port. Tiny race window,
+    // acceptable for tests.
+    StdTcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+pub struct SshdFixture {
+    pub name: String,
+    pub port: u16,
+    /// Holds authorized_keys + the client key pair for this container.
+    keys_dir: tempfile::TempDir,
+}
+
+impl SshdFixture {
+    pub fn start() -> Self {
+        ensure_image();
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let name = format!(
+            "tt-studio-sshd-test-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        );
+        let keys_dir = tempfile::tempdir().unwrap();
+
+        // Fresh client key pair per container, mounted as authorized_keys.
+        let key_path = keys_dir.path().join("id_ed25519");
+        keygen(&key_path);
+        std::fs::copy(
+            key_path.with_extension("pub"),
+            keys_dir.path().join("authorized_keys"),
+        )
+        .unwrap();
+
+        let port = free_port();
+        let out = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "--name",
+                &name,
+                "-p",
+                &format!("127.0.0.1:{port}:22"),
+                "-v",
+                &format!("{}:/keys:ro", keys_dir.path().display()),
+                IMAGE,
+            ])
+            .output()
+            .expect("docker run failed to spawn");
+        assert!(
+            out.status.success(),
+            "docker run failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let fixture = Self {
+            name,
+            port,
+            keys_dir,
+        };
+        fixture.wait_for_sshd();
+        fixture
+    }
+
+    pub fn key_path(&self) -> PathBuf {
+        self.keys_dir.path().join("id_ed25519")
+    }
+
+    pub fn restart(&self) {
+        let out = Command::new("docker")
+            .args(["restart", "-t", "0", &self.name])
+            .output()
+            .expect("docker restart failed to spawn");
+        assert!(out.status.success());
+        self.wait_for_sshd();
+    }
+
+    /// Poll until sshd answers with its banner (docker start is async).
+    fn wait_for_sshd(&self) {
+        for _ in 0..120 {
+            if let Ok(stream) = std::net::TcpStream::connect(("127.0.0.1", self.port)) {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .unwrap();
+                let mut buf = [0u8; 4];
+                use std::io::Read;
+                let mut stream = stream;
+                if stream.read_exact(&mut buf).is_ok() && &buf == b"SSH-" {
+                    return;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        panic!(
+            "sshd fixture {} never came up on port {}",
+            self.name, self.port
+        );
+    }
+
+    pub fn target(&self) -> SshTarget {
+        SshTarget {
+            host: "127.0.0.1".into(),
+            port: self.port,
+            // Key file only: keeps the test independent of whatever
+            // identities the developer's ssh-agent happens to hold.
+            user: "tunnel".into(),
+            auth: vec![AuthMethod::KeyFile {
+                path: self.key_path(),
+                passphrase: None,
+            }],
+        }
+    }
+}
+
+impl Drop for SshdFixture {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .output();
+    }
+}
+
+pub fn keygen(path: &Path) {
+    let out = Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-q", "-f"])
+        .arg(path)
+        .output()
+        .expect("ssh-keygen failed to spawn");
+    assert!(
+        out.status.success(),
+        "ssh-keygen failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---- helpers shared by the tests ----
+
+pub fn channel_sink() -> (StatusSink, mpsc::UnboundedReceiver<TunnelStatus>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let sink: StatusSink = Arc::new(move |s| {
+        let _ = tx.send(s);
+    });
+    (sink, rx)
+}
+
+pub async fn wait_for(
+    rx: &mut mpsc::UnboundedReceiver<TunnelStatus>,
+    what: &str,
+    pred: impl Fn(&TunnelStatus) -> bool,
+) -> TunnelStatus {
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let status = rx.recv().await.expect("status stream ended");
+            if pred(&status) {
+                return status;
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+}
+
+/// TOFU-accept the fixture's host key into `known_hosts` by connecting once,
+/// harvesting the UnknownHostKey error, and persisting the offered key.
+pub async fn trust_fixture_key(fixture: &SshdFixture, known_hosts: &Path) {
+    let err = SshSession::connect(
+        &fixture.target(),
+        KnownHostsVerifier::new(known_hosts.to_path_buf()),
+    )
+    .await
+    .err()
+    .expect("first contact must fail with an unknown host key");
+    match err {
+        SshError::UnknownHostKey {
+            host,
+            port,
+            fingerprint,
+            public_key,
+            ..
+        } => {
+            assert!(fingerprint.starts_with("SHA256:"));
+            trust(known_hosts, &host, port, &public_key).unwrap();
+        }
+        other => panic!("expected UnknownHostKey, got {other:?}"),
+    }
+}
+
+pub async fn http_get_through(port: u16) -> String {
+    let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("connect to forwarded port");
+    sock.write_all(b"GET / HTTP/1.0\r\nHost: fixture\r\n\r\n")
+        .await
+        .unwrap();
+    let mut body = Vec::new();
+    let _ = sock.read_to_end(&mut body).await;
+    String::from_utf8_lossy(&body).to_string()
+}

--- a/desktop/src-tauri/tests/fixtures/sshd/Dockerfile
+++ b/desktop/src-tauri/tests/fixtures/sshd/Dockerfile
@@ -1,11 +1,13 @@
 FROM alpine:3.20
 
-# Minimal sshd fixture for the tunnel integration tests: a locked-down
+# Minimal sshd fixture for the SSH integration tests: a locked-down
 # pubkey-only sshd plus a busybox httpd on 127.0.0.1:8088 that serves a
 # marker file — the "remote service" the tunnel forwards to. Host keys are
 # generated at image build time so they stay stable across container
-# restarts (the reconnect test depends on that).
-RUN apk add --no-cache openssh busybox-extras \
+# restarts (the reconnect test depends on that). python3 (3.12 on alpine
+# 3.20) plus the fake checkout under /home/tunnel/tt-studio back the remote
+# bring-up e2e test (ssh_remote_bringup.rs).
+RUN apk add --no-cache openssh busybox-extras python3 \
     && ssh-keygen -A \
     && adduser -D -s /bin/sh tunnel \
     && sed -i 's/^tunnel:!/tunnel:*/' /etc/shadow \
@@ -13,6 +15,7 @@ RUN apk add --no-cache openssh busybox-extras \
     && echo "tt-studio-tunnel-fixture" > /srv/index.html
 
 COPY sshd_config /etc/ssh/sshd_config
+COPY remote-repo/ /home/tunnel/tt-studio/
 
 EXPOSE 22
 CMD ["/bin/sh", "-c", "httpd -p 127.0.0.1:8088 -h /srv && exec /usr/sbin/sshd -D -e"]

--- a/desktop/src-tauri/tests/fixtures/sshd/remote-repo/fake_stack.py
+++ b/desktop/src-tauri/tests/fixtures/sshd/remote-repo/fake_stack.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Stub TT-Studio stack for the desktop e2e tests.
+
+Answers 200 with a marker body on every path of the stack's ports (frontend
+3000, backend 8000, inference 8001, docker control 8002) inside the fixture
+container — these are container-local ports; tests reach them only through
+the SSH tunnel's random local listeners. Started detached by the fake
+run.py's bring-up; killed via /tmp/fake-stack.pid by its --stop.
+"""
+
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORTS = [3000, 8000, 8001, 8002]
+MARKER = b"fake-tt-studio-stack ok\n"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 (http.server API)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(MARKER)))
+        self.end_headers()
+        self.wfile.write(MARKER)
+
+    def log_message(self, *args):  # keep the container logs quiet
+        pass
+
+
+def main():
+    with open("/tmp/fake-stack.pid", "w") as f:
+        f.write(str(os.getpid()))
+    servers = [ThreadingHTTPServer(("127.0.0.1", port), Handler) for port in PORTS]
+    threads = [threading.Thread(target=s.serve_forever, daemon=True) for s in servers]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop/src-tauri/tests/fixtures/sshd/remote-repo/run.py
+++ b/desktop/src-tauri/tests/fixtures/sshd/remote-repo/run.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Fake TT-Studio launcher for the desktop e2e tests.
+
+Speaks the real machine-readable protocol (dev-docs/json-events.md on the
+json-events branch) without any Docker: `--status --json` dumps a status
+event, `--json-events` emits a canned bring-up (starting fake_stack.py, the
+stub HTTP stand-in for the frontend/backend) ending in `ready`, and `--stop`
+kills the stub stack. Baked into the sshd fixture image at
+/home/tunnel/tt-studio.
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PID_FILE = "/tmp/fake-stack.pid"
+STACK_PORTS = [3000, 8000, 8001, 8002]
+SERVICES = ["frontend", "backend", "inference server", "docker control"]
+
+
+def emit(event, phase=None, detail=None):
+    line = {"v": 1, "ts": time.time(), "event": event, "phase": phase, "detail": detail or {}}
+    print(json.dumps(line), flush=True)
+
+
+def stack_running():
+    if not os.path.exists(PID_FILE):
+        return False
+    try:
+        with open(PID_FILE) as f:
+            os.kill(int(f.read().strip()), 0)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def port_open(port):
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def cmd_status():
+    healthy = stack_running()
+    emit(
+        "status",
+        detail={
+            "services": [
+                {"name": name, "port": port, "url": f"http://localhost:{port}", "healthy": healthy}
+                for name, port in zip(SERVICES, STACK_PORTS)
+            ],
+            "head": "deadbee",
+            "hardware": "fixture",
+        },
+    )
+
+
+def cmd_bring_up():
+    emit("phase_begin", "Checks", {"index": 1, "total": 2})
+    emit("progress", "Checks", {"activity": "fixture preflight"})
+    emit("phase_end", "Checks", {"index": 1, "status": "ok", "duration_s": 0.1})
+
+    emit("phase_begin", "Launch", {"index": 2, "total": 2})
+    if not stack_running():
+        # Detached (new session, no inherited stdio) so it survives this
+        # process — and the SSH exec channel — going away.
+        subprocess.Popen(
+            [sys.executable, os.path.join(HERE, "fake_stack.py")],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if all(port_open(p) for p in STACK_PORTS):
+            break
+        time.sleep(0.2)
+    else:
+        emit(
+            "error",
+            "Launch",
+            {"message": "fake stack never opened its ports", "remediation": "n/a (test fixture)"},
+        )
+        emit("phase_end", "Launch", {"index": 2, "status": "failed"})
+        sys.exit(1)
+    emit("phase_end", "Launch", {"index": 2, "status": "ok", "duration_s": 0.5})
+    emit(
+        "ready",
+        detail={"urls": {"app": "http://localhost:3000"}, "hardware": "fixture"},
+    )
+
+
+def cmd_stop():
+    if stack_running():
+        with open(PID_FILE) as f:
+            os.kill(int(f.read().strip()), signal.SIGTERM)
+        os.unlink(PID_FILE)
+        print("Stopped the TT-Studio stack.")
+    else:
+        print("Nothing to stop.")
+
+
+def main():
+    args = sys.argv[1:]
+    if "--status" in args and "--json" in args:
+        cmd_status()
+    elif "--json-events" in args:
+        cmd_bring_up()
+    elif "--stop" in args:
+        cmd_stop()
+    else:
+        print("fake run.py: unsupported arguments", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop/src-tauri/tests/ssh_remote_bringup.rs
+++ b/desktop/src-tauri/tests/ssh_remote_bringup.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! End-to-end SSH mode against the containerized sshd fixture: the exec
+//! probes classify the (down) fake stack, the bring-up command streams NDJSON
+//! to `ready`, the stub "frontend" then answers through the tunnel's
+//! forwarded port, and `run.py --stop` tears it back down — the whole
+//! one-click connect flow minus the UI. Marked `#[ignore]` like the tunnel
+//! tests; CI runs it on Linux with `--ignored`, and it skips gracefully when
+//! Docker is missing. All local listeners bind port 0 (high random ports) —
+//! the live TT-Studio stack's ports are never touched.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use common::{
+    channel_sink, docker_has_linux_containers, http_get_through, trust_fixture_key, wait_for,
+    SshdFixture,
+};
+
+use tt_studio_desktop_lib::remote::{self, PythonProbe, StackClassification};
+use tt_studio_desktop_lib::ssh::known_hosts::KnownHostsVerifier;
+use tt_studio_desktop_lib::ssh::session::SshSession;
+use tt_studio_desktop_lib::ssh::tunnel::{
+    Connector, ForwardSpec, Supervisor, SupervisorConfig, TunnelPhase,
+};
+use tt_studio_desktop_lib::ssh::SshTransport;
+
+/// The fake checkout baked into the fixture image (HOME is /home/tunnel).
+const REPO: &str = "~/tt-studio";
+/// Served by fake_stack.py on the stack ports inside the container.
+const STACK_MARKER: &str = "fake-tt-studio-stack ok";
+/// The stub stack's ports inside the container (fake_stack.py).
+const STACK_PORTS: [u16; 4] = [3000, 8000, 8001, 8002];
+
+macro_rules! require_docker {
+    () => {
+        if !docker_has_linux_containers() {
+            eprintln!("skipping: docker with Linux containers is not available");
+            return;
+        }
+    };
+}
+
+async fn connect(fixture: &SshdFixture, known_hosts: &std::path::Path) -> SshSession {
+    SshSession::connect(
+        &fixture.target(),
+        KnownHostsVerifier::new(known_hosts.to_path_buf()),
+    )
+    .await
+    .expect("ssh connect")
+}
+
+fn stack_connector(fixture: &SshdFixture, known_hosts: PathBuf) -> Connector {
+    let target = fixture.target();
+    Arc::new(move || {
+        let target = target.clone();
+        let verifier = KnownHostsVerifier::new(known_hosts.clone());
+        Box::pin(async move {
+            SshSession::connect(&target, verifier)
+                .await
+                .map(|s| Arc::new(s) as Arc<dyn SshTransport>)
+        })
+    })
+}
+
+/// Forward every stub stack port to a random local port.
+fn stack_forwards() -> SupervisorConfig {
+    SupervisorConfig {
+        forwards: STACK_PORTS
+            .iter()
+            .map(|&port| ForwardSpec {
+                local_port: 0,
+                remote_host: "127.0.0.1".into(),
+                remote_port: port,
+            })
+            .collect(),
+        initial_backoff: Duration::from_millis(500),
+        max_backoff: Duration::from_secs(2),
+        max_attempts: 30,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs docker; run with --ignored (desktop-ci does on Linux)"]
+async fn exec_captures_output_and_exit_codes() {
+    require_docker!();
+    let fixture = SshdFixture::start();
+    let tmp = tempfile::tempdir().unwrap();
+    let known_hosts = tmp.path().join("known_hosts");
+    trust_fixture_key(&fixture, &known_hosts).await;
+    let session = connect(&fixture, &known_hosts).await;
+
+    let out = session
+        .exec_capture("echo to-stdout; echo to-stderr 1>&2; exit 3")
+        .await
+        .unwrap();
+    assert_eq!(out.exit_code, Some(3));
+    assert_eq!(out.stdout, "to-stdout\n");
+    assert_eq!(out.stderr, "to-stderr\n");
+
+    // Streaming delivers whole lines in order despite SSH packet chunking.
+    let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = lines.clone();
+    let exit = session
+        .exec_stream(
+            "for i in 1 2 3; do echo line-$i; done",
+            |line| sink.lock().unwrap().push(line.to_string()),
+            |_| {},
+        )
+        .await
+        .unwrap();
+    assert_eq!(exit, Some(0));
+    assert_eq!(*lines.lock().unwrap(), vec!["line-1", "line-2", "line-3"]);
+    session.close().await;
+}
+
+#[tokio::test]
+#[ignore = "needs docker; run with --ignored (desktop-ci does on Linux)"]
+async fn one_click_flow_probes_brings_up_and_stops_the_remote_stack() {
+    require_docker!();
+    let fixture = SshdFixture::start();
+    let tmp = tempfile::tempdir().unwrap();
+    let known_hosts = tmp.path().join("known_hosts");
+    trust_fixture_key(&fixture, &known_hosts).await;
+    let session = connect(&fixture, &known_hosts).await;
+
+    // ---- attach detection: probe python, checkout, and stack status ----
+
+    let python = remote::parse_python_probe(
+        &session
+            .exec_capture(remote::python_version_command())
+            .await
+            .unwrap(),
+    );
+    assert!(python.meets_minimum(), "fixture python too old: {python:?}");
+    assert!(matches!(python, PythonProbe::Found { major: 3, .. }));
+
+    let run_py_exists = session
+        .exec_capture(&remote::probe_run_py_command(REPO))
+        .await
+        .unwrap()
+        .success();
+    assert!(run_py_exists, "fake checkout missing from the image");
+
+    // A wrong repo path classifies as no-checkout (the clone-instructions card).
+    let missing = session
+        .exec_capture(&remote::probe_run_py_command("~/nowhere"))
+        .await
+        .unwrap();
+    assert!(!missing.success());
+    assert_eq!(
+        remote::classify(false, false, &python, None, "~/nowhere"),
+        StackClassification::NoCheckout {
+            path: "~/nowhere".into()
+        }
+    );
+
+    let status = session
+        .exec_capture(&remote::status_command(REPO))
+        .await
+        .unwrap();
+    assert!(status.success(), "status failed: {}", status.stderr);
+    let services = remote::parse_status_services(&status.stdout).expect("status event");
+    assert_eq!(services.len(), 4);
+    assert!(services.iter().all(|(_, up)| !up));
+    assert_eq!(
+        remote::classify(false, true, &python, Some(&services), REPO),
+        StackClassification::Down,
+        "a fresh fixture must classify as down (bring-up needed)"
+    );
+
+    // ---- tunnels up (random local ports → the stub stack's ports) ----
+
+    let (sink, mut rx) = channel_sink();
+    let sup = Supervisor::spawn(
+        stack_forwards(),
+        stack_connector(&fixture, known_hosts.clone()),
+        sink,
+    );
+    let connected = wait_for(&mut rx, "tunnel connected", |s| {
+        matches!(s.phase, TunnelPhase::Connected)
+    })
+    .await;
+    let frontend_port = connected
+        .forwards
+        .iter()
+        .find(|f| f.remote_port == 3000)
+        .expect("frontend forward")
+        .local_port;
+    assert_ne!(frontend_port, 0);
+
+    // ---- bring-up: stream NDJSON over ssh exec until ready ----
+
+    let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let line_sink = lines.clone();
+    let exit = session
+        .exec_stream(
+            &remote::bring_up_command(REPO),
+            |line| line_sink.lock().unwrap().push(line.to_string()),
+            |_| {},
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        exit,
+        Some(0),
+        "bring-up failed: {:?}",
+        lines.lock().unwrap()
+    );
+
+    let events: Vec<serde_json::Value> = lines
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    assert!(
+        events.iter().any(|e| e["event"] == "phase_begin"),
+        "no phases in {events:?}"
+    );
+    let ready = events
+        .iter()
+        .find(|e| e["event"] == "ready")
+        .expect("bring-up must end with a ready event");
+    assert_eq!(ready["detail"]["urls"]["app"], "http://localhost:3000");
+
+    // ---- the forwarded "frontend" answers through the tunnel ----
+
+    let response = http_get_through(frontend_port).await;
+    assert!(
+        response.contains(STACK_MARKER),
+        "expected stub stack marker through the tunnel, got:\n{response}"
+    );
+
+    // Re-probing now reports every service healthy → the flow would attach.
+    let status = session
+        .exec_capture(&remote::status_command(REPO))
+        .await
+        .unwrap();
+    let services = remote::parse_status_services(&status.stdout).expect("status event");
+    assert!(services.iter().all(|(_, up)| *up));
+    assert_eq!(
+        remote::classify(true, true, &python, Some(&services), REPO),
+        StackClassification::Healthy
+    );
+
+    // ---- stop on quit: run.py --stop tears the stack down ----
+
+    let stop = session
+        .exec_capture(&remote::stop_command(REPO))
+        .await
+        .unwrap();
+    assert!(stop.success(), "--stop failed: {}", stop.stdout);
+    assert!(stop.stdout.contains("Stopped the TT-Studio stack."));
+
+    let after = session
+        .exec_capture(&remote::status_command(REPO))
+        .await
+        .unwrap();
+    let services = remote::parse_status_services(&after.stdout).expect("status event");
+    assert!(
+        services.iter().all(|(_, up)| !up),
+        "stack still up after --stop: {services:?}"
+    );
+
+    session.close().await;
+    sup.stop().await;
+}

--- a/desktop/src-tauri/tests/ssh_tunnel.rs
+++ b/desktop/src-tauri/tests/ssh_tunnel.rs
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 //! Integration tests for the SSH tunnel engine against a real containerized
-//! sshd (tests/fixtures/sshd). Marked `#[ignore]` so plain `cargo test`
-//! stays hermetic; CI runs them on Linux with
+//! sshd (tests/fixtures/sshd, shared via tests/common). Marked `#[ignore]`
+//! so plain `cargo test` stays hermetic; CI runs them on Linux with
 //! `cargo test --test ssh_tunnel -- --ignored`, and they also skip
 //! gracefully at runtime when Docker (with Linux containers) is missing.
 //!
@@ -12,220 +12,27 @@
 //! every local listener binds port 0 — the tests never touch the live
 //! TT-Studio stack's ports (3000/8000-8002/4000/8080/8111).
 
-use std::net::TcpListener as StdTcpListener;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Once};
+mod common;
+
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::mpsc;
+use common::{
+    channel_sink, docker_has_linux_containers, http_get_through, keygen, trust_fixture_key,
+    wait_for, SshdFixture,
+};
 
 use tt_studio_desktop_lib::ssh::known_hosts::{trust, KnownHostsVerifier};
-use tt_studio_desktop_lib::ssh::session::{AuthMethod, SshSession, SshTarget};
+use tt_studio_desktop_lib::ssh::session::SshSession;
 use tt_studio_desktop_lib::ssh::tunnel::{
-    Connector, ForwardSpec, StatusSink, Supervisor, SupervisorConfig, TunnelPhase, TunnelStatus,
+    Connector, ForwardSpec, Supervisor, SupervisorConfig, TunnelPhase,
 };
 use tt_studio_desktop_lib::ssh::{SshError, SshTransport};
 
-const IMAGE: &str = "tt-studio-desktop-sshd-fixture";
 /// Marker served by the httpd inside the fixture container on 127.0.0.1:8088.
 const REMOTE_HTTP_PORT: u16 = 8088;
 const MARKER: &str = "tt-studio-tunnel-fixture";
-
-// ---- fixture management ----
-
-fn docker_has_linux_containers() -> bool {
-    Command::new("docker")
-        .args(["info", "--format", "{{.OSType}}"])
-        .output()
-        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "linux")
-        .unwrap_or(false)
-}
-
-/// Build the fixture image once per test binary.
-fn ensure_image() {
-    static BUILD: Once = Once::new();
-    BUILD.call_once(|| {
-        let context = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sshd");
-        let out = Command::new("docker")
-            .args(["build", "-t", IMAGE])
-            .arg(&context)
-            .output()
-            .expect("docker build failed to spawn");
-        assert!(
-            out.status.success(),
-            "docker build failed:\n{}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    });
-}
-
-fn free_port() -> u16 {
-    // Bind-then-drop; the OS hands out a free high port. Tiny race window,
-    // acceptable for tests.
-    StdTcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
-struct SshdFixture {
-    name: String,
-    port: u16,
-    /// Holds authorized_keys + the client key pair for this container.
-    keys_dir: tempfile::TempDir,
-}
-
-impl SshdFixture {
-    fn start() -> Self {
-        ensure_image();
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
-        let name = format!(
-            "tt-studio-sshd-test-{}-{}",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::SeqCst)
-        );
-        let keys_dir = tempfile::tempdir().unwrap();
-
-        // Fresh client key pair per container, mounted as authorized_keys.
-        let key_path = keys_dir.path().join("id_ed25519");
-        keygen(&key_path);
-        std::fs::copy(
-            key_path.with_extension("pub"),
-            keys_dir.path().join("authorized_keys"),
-        )
-        .unwrap();
-
-        let port = free_port();
-        let out = Command::new("docker")
-            .args([
-                "run",
-                "-d",
-                "--name",
-                &name,
-                "-p",
-                &format!("127.0.0.1:{port}:22"),
-                "-v",
-                &format!("{}:/keys:ro", keys_dir.path().display()),
-                IMAGE,
-            ])
-            .output()
-            .expect("docker run failed to spawn");
-        assert!(
-            out.status.success(),
-            "docker run failed:\n{}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-
-        let fixture = Self {
-            name,
-            port,
-            keys_dir,
-        };
-        fixture.wait_for_sshd();
-        fixture
-    }
-
-    fn key_path(&self) -> PathBuf {
-        self.keys_dir.path().join("id_ed25519")
-    }
-
-    fn restart(&self) {
-        let out = Command::new("docker")
-            .args(["restart", "-t", "0", &self.name])
-            .output()
-            .expect("docker restart failed to spawn");
-        assert!(out.status.success());
-        self.wait_for_sshd();
-    }
-
-    /// Poll until sshd answers with its banner (docker start is async).
-    fn wait_for_sshd(&self) {
-        for _ in 0..120 {
-            if let Ok(stream) = std::net::TcpStream::connect(("127.0.0.1", self.port)) {
-                stream
-                    .set_read_timeout(Some(Duration::from_secs(2)))
-                    .unwrap();
-                let mut buf = [0u8; 4];
-                use std::io::Read;
-                let mut stream = stream;
-                if stream.read_exact(&mut buf).is_ok() && &buf == b"SSH-" {
-                    return;
-                }
-            }
-            std::thread::sleep(Duration::from_millis(500));
-        }
-        panic!(
-            "sshd fixture {} never came up on port {}",
-            self.name, self.port
-        );
-    }
-
-    fn target(&self) -> SshTarget {
-        SshTarget {
-            host: "127.0.0.1".into(),
-            port: self.port,
-            // Key file only: keeps the test independent of whatever
-            // identities the developer's ssh-agent happens to hold.
-            user: "tunnel".into(),
-            auth: vec![AuthMethod::KeyFile {
-                path: self.key_path(),
-                passphrase: None,
-            }],
-        }
-    }
-}
-
-impl Drop for SshdFixture {
-    fn drop(&mut self) {
-        let _ = Command::new("docker")
-            .args(["rm", "-f", &self.name])
-            .output();
-    }
-}
-
-fn keygen(path: &Path) {
-    let out = Command::new("ssh-keygen")
-        .args(["-t", "ed25519", "-N", "", "-q", "-f"])
-        .arg(path)
-        .output()
-        .expect("ssh-keygen failed to spawn");
-    assert!(
-        out.status.success(),
-        "ssh-keygen failed:\n{}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-}
-
-// ---- helpers shared by the tests ----
-
-fn channel_sink() -> (StatusSink, mpsc::UnboundedReceiver<TunnelStatus>) {
-    let (tx, rx) = mpsc::unbounded_channel();
-    let sink: StatusSink = Arc::new(move |s| {
-        let _ = tx.send(s);
-    });
-    (sink, rx)
-}
-
-async fn wait_for(
-    rx: &mut mpsc::UnboundedReceiver<TunnelStatus>,
-    what: &str,
-    pred: impl Fn(&TunnelStatus) -> bool,
-) -> TunnelStatus {
-    tokio::time::timeout(Duration::from_secs(60), async {
-        loop {
-            let status = rx.recv().await.expect("status stream ended");
-            if pred(&status) {
-                return status;
-            }
-        }
-    })
-    .await
-    .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
-}
 
 fn connector_for(fixture: &SshdFixture, known_hosts: PathBuf) -> Connector {
     let target = fixture.target();
@@ -253,43 +60,6 @@ fn supervisor_config() -> SupervisorConfig {
         max_attempts: 30,
         ..Default::default()
     }
-}
-
-/// TOFU-accept the fixture's host key into `known_hosts` by connecting once,
-/// harvesting the UnknownHostKey error, and persisting the offered key.
-async fn trust_fixture_key(fixture: &SshdFixture, known_hosts: &Path) {
-    let err = SshSession::connect(
-        &fixture.target(),
-        KnownHostsVerifier::new(known_hosts.to_path_buf()),
-    )
-    .await
-    .err()
-    .expect("first contact must fail with an unknown host key");
-    match err {
-        SshError::UnknownHostKey {
-            host,
-            port,
-            fingerprint,
-            public_key,
-            ..
-        } => {
-            assert!(fingerprint.starts_with("SHA256:"));
-            trust(known_hosts, &host, port, &public_key).unwrap();
-        }
-        other => panic!("expected UnknownHostKey, got {other:?}"),
-    }
-}
-
-async fn http_get_through(port: u16) -> String {
-    let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
-        .await
-        .expect("connect to forwarded port");
-    sock.write_all(b"GET / HTTP/1.0\r\nHost: fixture\r\n\r\n")
-        .await
-        .unwrap();
-    let mut body = Vec::new();
-    let _ = sock.read_to_end(&mut body).await;
-    String::from_utf8_lossy(&body).to_string()
 }
 
 macro_rules! require_docker {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -7,6 +7,7 @@ import BringUpProgress from "./views/BringUpProgress";
 import ConnectErrorCard from "./views/ConnectErrorCard";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
+import QuitDialog from "./views/QuitDialog";
 import {
   describeSshError,
   TrustHostKeyDialog,
@@ -33,13 +34,16 @@ import {
   classifyRemoteStack,
   deleteProfile,
   detectHardware,
+  getActiveRemote,
   listProfiles,
   markProfileUsed,
   onBringUpExit,
   onBringUpLine,
+  onRemoteStopLine,
   onStackHealth,
   onTunnelStatus,
   openStack,
+  quitApp,
   saveProfile,
   setSshKeyPassphrase,
   startHealthPoll,
@@ -63,7 +67,8 @@ type Screen =
   | { name: "loading" }
   | { name: "picker" }
   | { name: "editor"; profile?: Profile }
-  | { name: "connecting"; target: Profile | null };
+  | { name: "connecting"; target: Profile | null }
+  | { name: "quit" };
 
 /**
  * Where an SSH connect currently is. Local connects skip this entirely
@@ -141,7 +146,14 @@ function HealthGate({
 }
 
 function App() {
-  const [screen, setScreen] = useState<Screen>({ name: "loading" });
+  // The Rust side intercepts the window close while an SSH connection is
+  // active and navigates here with ?quit=1 — the launcher then owns the
+  // stop-vs-disconnect decision (the stack page itself has no Tauri IPC).
+  const [screen, setScreen] = useState<Screen>(() =>
+    new URLSearchParams(window.location.search).has("quit")
+      ? { name: "quit" }
+      : { name: "loading" },
+  );
   const [hardware, setHardware] = useState<HardwareProbe | null>(null);
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [health, setHealth] = useState<StackHealth | null>(null);
@@ -153,6 +165,7 @@ function App() {
   const opening = useRef(false);
 
   useEffect(() => {
+    if (screen.name === "quit") return;
     Promise.all([detectHardware(), listProfiles()])
       .then(([hw, saved]) => {
         setHardware(hw);
@@ -347,6 +360,49 @@ function App() {
     setScreen({ name: "connecting", target });
   }, []);
 
+  // ---- quit dialog state (screen "quit" only) ----
+  const [quitTarget, setQuitTarget] = useState<Profile | null>(null);
+  const [quitStopping, setQuitStopping] = useState(false);
+  const [quitStopLines, setQuitStopLines] = useState<string[]>([]);
+  const [quitError, setQuitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (screen.name !== "quit") return;
+    getActiveRemote()
+      .then(setQuitTarget)
+      .catch(() => setQuitTarget(null));
+    let unlisten: (() => void) | undefined;
+    onRemoteStopLine((line) =>
+      setQuitStopLines((prev) => [...prev, line]),
+    ).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [screen.name]);
+
+  const handleStopAndQuit = useCallback(() => {
+    setQuitStopping(true);
+    setQuitError(null);
+    setQuitStopLines([]);
+    // On success the app exits before this promise settles visibly; only
+    // the failure path matters here.
+    quitApp(true).catch((e) => {
+      setQuitStopping(false);
+      const ssh = asSshError(e);
+      setQuitError(ssh ? describeSshError(ssh) : String(e));
+    });
+  }, []);
+
+  const handleDisconnectQuit = useCallback(() => {
+    quitApp(false).catch((e) => setQuitError(String(e)));
+  }, []);
+
+  const handleQuitCancel = useCallback(() => {
+    openStack(STACK_URL).catch((e) => setQuitError(String(e)));
+  }, []);
+
   /** Tear down whatever the connect flow has started and go back. */
   const cancelConnect = useCallback(() => {
     cancelRemoteBringUp().catch(() => {});
@@ -412,6 +468,20 @@ function App() {
       setError(String(e));
     }
   }, []);
+
+  if (screen.name === "quit") {
+    return (
+      <QuitDialog
+        machine={quitTarget?.name ?? null}
+        stopping={quitStopping}
+        lines={quitStopLines}
+        error={quitError}
+        onStopAndQuit={handleStopAndQuit}
+        onDisconnectQuit={handleDisconnectQuit}
+        onCancel={handleQuitCancel}
+      />
+    );
+  }
 
   if (screen.name === "loading") {
     return (

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { listen } from "@tauri-apps/api/event";
 import BringUpProgress from "./views/BringUpProgress";
+import ConnectErrorCard from "./views/ConnectErrorCard";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import {
@@ -13,6 +13,14 @@ import {
   TunnelBanner,
 } from "./views/TunnelBanner";
 import {
+  blockedPorts,
+  classificationCard,
+  describeStep,
+  portConflictCard,
+  type ConnectErrorInfo,
+  type ConnectStep,
+} from "./lib/connect";
+import {
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -20,16 +28,22 @@ import {
 } from "./lib/events";
 import {
   asSecretError,
+  asSshError,
+  cancelRemoteBringUp,
+  classifyRemoteStack,
   deleteProfile,
   detectHardware,
   listProfiles,
   markProfileUsed,
+  onBringUpExit,
+  onBringUpLine,
   onStackHealth,
   onTunnelStatus,
   openStack,
   saveProfile,
   setSshKeyPassphrase,
   startHealthPoll,
+  startRemoteBringUp,
   startSshTunnels,
   stopHealthPoll,
   stopSshTunnels,
@@ -51,6 +65,15 @@ type Screen =
   | { name: "editor"; profile?: Profile }
   | { name: "connecting"; target: Profile | null };
 
+/**
+ * Where an SSH connect currently is. Local connects skip this entirely
+ * ("attach" from the start); SSH connects walk tunnel → classify →
+ * bringup-or-attach, or park on an error card.
+ */
+type RemoteStage =
+  | { step: ConnectStep }
+  | { step: "error"; card: ConnectErrorInfo };
+
 const STATUS_STYLE: Record<string, string> = {
   up: "bg-emerald-500",
   down: "bg-red-500",
@@ -62,10 +85,14 @@ function HealthGate({
   health,
   target,
   tunnel,
+  activity,
+  onCancel,
 }: {
   health: StackHealth | null;
   target: Profile | null;
   tunnel: TunnelStatus | null;
+  activity?: string;
+  onCancel?: () => void;
 }) {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
@@ -73,10 +100,10 @@ function HealthGate({
         <h1 className="text-2xl font-semibold tracking-tight">
           {target ? `Connecting to ${target.name}` : "Starting TT-Studio"}
         </h1>
-        <p className="mt-1 text-sm text-zinc-400">
+        <p className="mt-1 text-sm text-zinc-400" data-testid="connect-activity">
           {health?.ready
             ? "All services are up — opening TT-Studio…"
-            : "Waiting for all services to come up"}
+            : (activity ?? "Waiting for all services to come up")}
         </p>
       </header>
       {target && <TunnelBanner status={tunnel} />}
@@ -99,6 +126,16 @@ function HealthGate({
           <li className="text-center text-sm text-zinc-500">Checking…</li>
         )}
       </ul>
+      {onCancel && (
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="connect-cancel"
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
+        >
+          Cancel
+        </button>
+      )}
     </main>
   );
 }
@@ -110,6 +147,7 @@ function App() {
   const [health, setHealth] = useState<StackHealth | null>(null);
   const [bringUp, setBringUp] = useState<BringUpState | null>(null);
   const [tunnel, setTunnel] = useState<TunnelStatus | null>(null);
+  const [stage, setStage] = useState<RemoteStage>({ step: "tunnel" });
   const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const opening = useRef(false);
@@ -128,8 +166,11 @@ function App() {
   }, []);
 
   // While connecting: poll stack health, and navigate once everything is up.
+  // For SSH targets the poll waits for the attach stage — before the tunnel
+  // is verified, localhost:3000 could be some other local server.
   useEffect(() => {
     if (screen.name !== "connecting") return;
+    if (screen.target && stage.step !== "attach") return;
     let unlisten: (() => void) | undefined;
     onStackHealth(setHealth).then((fn) => {
       unlisten = fn;
@@ -139,7 +180,54 @@ function App() {
       unlisten?.();
       stopHealthPoll().catch(() => {});
     };
-  }, [screen.name]);
+  }, [screen, stage.step]);
+
+  // Tunnel established for an SSH target: first make sure every essential
+  // local port actually bound (a taken port 3000 must become an error card,
+  // never a silent remap), then ask the remote side whether to attach to a
+  // running stack or bring one up.
+  useEffect(() => {
+    if (
+      screen.name !== "connecting" ||
+      !screen.target ||
+      stage.step !== "tunnel" ||
+      tunnel?.phase.state !== "connected"
+    )
+      return;
+    const target = screen.target;
+    const blocked = blockedPorts(tunnel);
+    if (blocked.length > 0) {
+      stopSshTunnels().catch(() => {});
+      setStage({ step: "error", card: portConflictCard(blocked) });
+      return;
+    }
+    setStage({ step: "classify" });
+    classifyRemoteStack(target)
+      .then((classification) => {
+        if (classification.kind === "healthy") {
+          setStage({ step: "attach" });
+          return;
+        }
+        const card = classificationCard(classification, target);
+        if (card) {
+          setStage({ step: "error", card });
+          return;
+        }
+        return startRemoteBringUp(target).then(() =>
+          setStage({ step: "bringup" }),
+        );
+      })
+      .catch((e) => {
+        const ssh = asSshError(e);
+        setStage({
+          step: "error",
+          card: {
+            title: `Couldn't inspect the stack on ${target.name}`,
+            body: ssh ? describeSshError(ssh) : String(e),
+          },
+        });
+      });
+  }, [screen, stage.step, tunnel]);
 
   // For SSH targets: follow tunnel status. The listener is scoped to the
   // connecting screen, but the tunnel itself keeps running after we navigate
@@ -167,13 +255,14 @@ function App() {
     setScreen({ name: "picker" });
   }, [screen.name, tunnel]);
 
-  // When a bring-up is running (`python run.py --json-events` piped in by the
-  // shell), render its NDJSON stream natively instead of the bare checklist.
+  // When a bring-up is running (`python run.py --json-events`, native or
+  // over ssh exec), render its NDJSON stream natively instead of the bare
+  // checklist.
   useEffect(() => {
     if (screen.name !== "connecting") return;
     let unlisten: (() => void) | undefined;
-    listen<string>("bringup-line", ({ payload }) => {
-      const event = parseEventLine(payload);
+    onBringUpLine((line) => {
+      const event = parseEventLine(line);
       if (!event) return;
       setBringUp((prev) => reduceEvent(prev ?? initialBringUpState(), event));
     }).then((fn) => {
@@ -182,6 +271,39 @@ function App() {
     return () => {
       unlisten?.();
       setBringUp(null);
+    };
+  }, [screen.name]);
+
+  // A remote bring-up that dies without reaching `ready` (network drop,
+  // remote crash before the launcher could emit its own error event) still
+  // needs an error card — synthesize one from the exit notification.
+  useEffect(() => {
+    if (screen.name !== "connecting") return;
+    let unlisten: (() => void) | undefined;
+    onBringUpExit((exit) => {
+      if (exit.exit_code === 0 && !exit.error) return;
+      setBringUp((prev) => {
+        const state = prev ?? initialBringUpState();
+        if (state.ready || state.errors.length > 0) return state;
+        return reduceEvent(state, {
+          v: 1,
+          ts: 0,
+          event: "error",
+          phase: null,
+          detail: {
+            message:
+              exit.error ??
+              `Bring-up exited with code ${exit.exit_code ?? "unknown"}`,
+            remediation:
+              "Check remote-bringup.log in the app's log folder, then try connecting again.",
+          },
+        });
+      });
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
     };
   }, [screen.name]);
 
@@ -213,12 +335,25 @@ function App() {
   const connect = useCallback((target: Profile | null) => {
     setHealth(null);
     setTunnel(null);
+    setError(null);
+    // Local connects go straight to the health gate; SSH connects walk the
+    // tunnel → classify → attach-or-bringup stages first.
+    setStage({ step: target ? "tunnel" : "attach" });
     opening.current = false;
     if (target) {
       markProfileUsed(target.id).catch(() => {});
       startSshTunnels(target).catch((e) => setError(String(e)));
     }
     setScreen({ name: "connecting", target });
+  }, []);
+
+  /** Tear down whatever the connect flow has started and go back. */
+  const cancelConnect = useCallback(() => {
+    cancelRemoteBringUp().catch(() => {});
+    stopSshTunnels().catch(() => {});
+    setTunnel(null);
+    setHealth(null);
+    setScreen({ name: "picker" });
   }, []);
 
   const handleTrustHostKey = useCallback(
@@ -312,10 +447,41 @@ function App() {
         />
       );
     }
-    if (bringUp && bringUp.phases.length > 0) {
-      return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
+    if (target && stage.step === "error") {
+      return (
+        <ConnectErrorCard
+          card={stage.card}
+          onBack={cancelConnect}
+          onEdit={() => {
+            stopSshTunnels().catch(() => {});
+            setTunnel(null);
+            setScreen({ name: "editor", profile: target });
+          }}
+        />
+      );
     }
-    return <HealthGate health={health} target={target} tunnel={tunnel} />;
+    if (bringUp && (bringUp.phases.length > 0 || bringUp.errors.length > 0)) {
+      return (
+        <BringUpProgress
+          state={bringUp}
+          onReady={handleBringUpReady}
+          onCancel={cancelConnect}
+        />
+      );
+    }
+    return (
+      <HealthGate
+        health={health}
+        target={target}
+        tunnel={tunnel}
+        activity={
+          target && stage.step !== "error"
+            ? describeStep(stage.step, target.name)
+            : undefined
+        }
+        onCancel={cancelConnect}
+      />
+    );
   }
 
   return (

--- a/desktop/src/lib/connect.test.ts
+++ b/desktop/src/lib/connect.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from "vitest";
+import {
+  blockedPorts,
+  classificationCard,
+  describeStep,
+  portConflictCard,
+} from "./connect";
+import type { Profile, TunnelStatus } from "./ipc";
+
+const profile: Profile = {
+  id: "p1",
+  name: "QuietBox",
+  kind: "ssh",
+  host: "qb2.lan",
+  user: "jashan",
+  auth: { method: "agent" },
+};
+
+function connected(
+  forwards: Array<{ port: number; active: boolean }>,
+): TunnelStatus {
+  return {
+    phase: { state: "connected" },
+    forwards: forwards.map(({ port, active }) => ({
+      local_port: port,
+      remote_port: port,
+      active,
+    })),
+  };
+}
+
+describe("blockedPorts", () => {
+  it("reports essential ports whose local listener failed to bind", () => {
+    const status = connected([
+      { port: 3000, active: false },
+      { port: 8000, active: true },
+      { port: 8001, active: false },
+    ]);
+    expect(blockedPorts(status)).toEqual([3000, 8001]);
+  });
+
+  it("ignores the model container port range", () => {
+    const status = connected([
+      { port: 3000, active: true },
+      { port: 7005, active: false },
+    ]);
+    expect(blockedPorts(status)).toEqual([]);
+  });
+
+  it("is empty while not connected", () => {
+    expect(blockedPorts(null)).toEqual([]);
+    expect(
+      blockedPorts({ phase: { state: "connecting" }, forwards: [] }),
+    ).toEqual([]);
+  });
+});
+
+describe("portConflictCard", () => {
+  it("gives 3000 the dev-server guidance", () => {
+    const card = portConflictCard([3000, 8000]);
+    expect(card.title).toBe("Port 3000 is already in use");
+    expect(card.body).toContain("Another TT-Studio or dev server");
+    expect(card.hint).toContain("run.py --stop");
+  });
+
+  it("names the taken ports when 3000 is fine", () => {
+    const card = portConflictCard([8001, 8002]);
+    expect(card.title).toContain("8001, 8002");
+  });
+});
+
+describe("classificationCard", () => {
+  it("turns no_checkout into clone instructions with the profile's path", () => {
+    const card = classificationCard(
+      { kind: "no_checkout", path: "~/tt-studio" },
+      profile,
+    );
+    expect(card?.title).toContain("QuietBox");
+    expect(card?.command).toContain("git clone");
+    expect(card?.command).toContain("jashan@qb2.lan");
+    expect(card?.command).toContain("~/tt-studio");
+    expect(card?.showEdit).toBe(true);
+  });
+
+  it("explains an old python with found and required versions", () => {
+    const card = classificationCard(
+      { kind: "python_too_old", found: "Python 3.10.4", required: "3.12" },
+      profile,
+    );
+    expect(card?.body).toContain("Python 3.10.4");
+    expect(card?.body).toContain("3.12");
+  });
+
+  it("explains a missing python", () => {
+    const card = classificationCard(
+      { kind: "python_missing", message: "sh: python3: not found" },
+      profile,
+    );
+    expect(card?.body).toContain("python3: not found");
+  });
+
+  it("returns null for states the flow proceeds from", () => {
+    expect(classificationCard({ kind: "healthy" }, profile)).toBeNull();
+    expect(classificationCard({ kind: "down" }, profile)).toBeNull();
+    expect(
+      classificationCard(
+        { kind: "partial", healthy: ["frontend"], unhealthy: ["backend"] },
+        profile,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("describeStep", () => {
+  it("names the machine in every stage", () => {
+    for (const step of ["tunnel", "classify", "bringup", "attach"] as const) {
+      expect(describeStep(step, "QuietBox")).toContain("QuietBox");
+    }
+  });
+});

--- a/desktop/src/lib/connect.ts
+++ b/desktop/src/lib/connect.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Pure decisions for the one-click SSH connect flow: which tunnel forwards
+// are allowed to fail, how to describe each stage, and how each
+// classification / failure becomes an error card. No IPC here.
+
+import type { Profile, StackClassification, TunnelStatus } from "./ipc";
+
+/**
+ * Ports the stack cannot work without. The web app derives service URLs
+ * from window.location + these fixed numbers, so the local listeners must
+ * bind the REAL ports — remapping is not an option. The 7000-7010 model
+ * container range is deliberately absent: a taken model port only affects
+ * one model, not the connect flow.
+ */
+export const ESSENTIAL_PORTS = [3000, 8000, 8001, 8002, 4000, 8080];
+
+/**
+ * Essential local ports the tunnel failed to bind (already taken by another
+ * program). Empty while not connected.
+ */
+export function blockedPorts(status: TunnelStatus | null): number[] {
+  if (status?.phase.state !== "connected") return [];
+  return status.forwards
+    .filter((f) => !f.active && ESSENTIAL_PORTS.includes(f.remote_port))
+    .map((f) => f.remote_port);
+}
+
+/** One failure card shown in place of the connect progress. */
+export interface ConnectErrorInfo {
+  title: string;
+  body: string;
+  /** A copyable command that fixes it, when one exists. */
+  command?: string;
+  hint?: string;
+  /** Offer "Edit machine" (the profile itself needs fixing). */
+  showEdit?: boolean;
+}
+
+export function portConflictCard(ports: number[]): ConnectErrorInfo {
+  if (ports.includes(3000)) {
+    return {
+      title: "Port 3000 is already in use",
+      body:
+        "Another TT-Studio or dev server is using port 3000 on this computer. " +
+        "The remote stack has to be served on its real ports, so it can't be remapped around.",
+      hint: "Stop the other server (for a local TT-Studio: python run.py --stop), then connect again.",
+    };
+  }
+  const list = ports.join(", ");
+  return {
+    title: `Port${ports.length > 1 ? "s" : ""} ${list} already in use`,
+    body:
+      `Another program on this computer is using port${ports.length > 1 ? "s" : ""} ${list}, ` +
+      "which the TT-Studio stack needs.",
+    hint: "Free the port and connect again.",
+  };
+}
+
+/**
+ * The error card for a classification the connect flow can't proceed from,
+ * or null when it can (healthy / partial / down).
+ */
+export function classificationCard(
+  classification: StackClassification,
+  profile: Profile,
+): ConnectErrorInfo | null {
+  const host = profile.host ?? profile.name;
+  switch (classification.kind) {
+    case "no_checkout":
+      return {
+        title: `TT-Studio isn't set up on ${profile.name}`,
+        body: `There is no run.py at ${classification.path} on ${host}. Clone the repo there, or point this machine's repo path at an existing checkout.`,
+        command: `ssh ${profile.user ? `${profile.user}@` : ""}${host} git clone https://github.com/tenstorrent/tt-studio.git ${classification.path}`,
+        showEdit: true,
+      };
+    case "python_missing":
+      return {
+        title: `Python 3.12+ is required on ${profile.name}`,
+        body: `TT-Studio's launcher needs python3 on ${host}, but probing it failed: ${classification.message}`,
+        showEdit: false,
+      };
+    case "python_too_old":
+      return {
+        title: `Python on ${profile.name} is too old`,
+        body: `${host} has ${classification.found}, but TT-Studio's launcher needs Python ${classification.required} or newer.`,
+        showEdit: false,
+      };
+    default:
+      return null;
+  }
+}
+
+/** The connect flow's stages, in the order they happen. */
+export type ConnectStep = "tunnel" | "classify" | "bringup" | "attach";
+
+/** One-line progress description for the current stage. */
+export function describeStep(step: ConnectStep, machine: string): string {
+  switch (step) {
+    case "tunnel":
+      return `Opening SSH tunnel to ${machine}…`;
+    case "classify":
+      return `Checking what's running on ${machine}…`;
+    case "bringup":
+      return `Starting the TT-Studio stack on ${machine}…`;
+    case "attach":
+      return `Stack found on ${machine} — waiting for services…`;
+  }
+}

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -190,6 +190,26 @@ export const onBringUpExit = (
 ): Promise<UnlistenFn> =>
   listen<BringUpExit>("bringup-exit", (event) => handler(event.payload));
 
+// ---- quitting (optionally stopping the remote stack first) ----
+
+/** The profile the current SSH connection belongs to, if any. */
+export const getActiveRemote = () =>
+  invoke<Profile | null>("get_active_remote");
+
+/**
+ * Exit the app. With stopStack, `run.py --stop` runs on the active remote
+ * first (rejecting instead of quitting when it fails, so the caller can
+ * offer "quit anyway").
+ */
+export const quitApp = (stopStack: boolean) =>
+  invoke<void>("quit_app", { stopStack });
+
+/** Output lines from the remote `run.py --stop` during a stopping quit. */
+export const onRemoteStopLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("remote-stop-line", (event) => handler(event.payload));
+
 /** Narrow an unknown invoke() rejection into an SshErrorPayload if possible. */
 export function asSshError(e: unknown): SshErrorPayload | null {
   if (typeof e === "object" && e !== null && "code" in e) {

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -155,6 +155,41 @@ export const onTunnelStatus = (
 ): Promise<UnlistenFn> =>
   listen<TunnelStatus>("tunnel-status", (event) => handler(event.payload));
 
+// ---- remote stack detection & bring-up (remote.rs) ----
+
+export type StackClassification =
+  | { kind: "healthy" }
+  | { kind: "partial"; healthy: string[]; unhealthy: string[] }
+  | { kind: "down" }
+  | { kind: "no_checkout"; path: string }
+  | { kind: "python_missing"; message: string }
+  | { kind: "python_too_old"; found: string; required: string };
+
+export interface BringUpExit {
+  exit_code: number | null;
+  error?: string;
+}
+
+export const classifyRemoteStack = (profile: Profile) =>
+  invoke<StackClassification>("classify_remote_stack", { profile });
+
+export const startRemoteBringUp = (profile: Profile) =>
+  invoke<void>("start_remote_bring_up", { profile });
+
+export const cancelRemoteBringUp = () =>
+  invoke<void>("cancel_remote_bring_up");
+
+/** Raw NDJSON lines from a remote bring-up (parse with lib/events.ts). */
+export const onBringUpLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("bringup-line", (event) => handler(event.payload));
+
+export const onBringUpExit = (
+  handler: (exit: BringUpExit) => void,
+): Promise<UnlistenFn> =>
+  listen<BringUpExit>("bringup-exit", (event) => handler(event.payload));
+
 /** Narrow an unknown invoke() rejection into an SshErrorPayload if possible. */
 export function asSshError(e: unknown): SshErrorPayload | null {
   if (typeof e === "object" && e !== null && "code" in e) {

--- a/desktop/src/views/BringUpProgress.tsx
+++ b/desktop/src/views/BringUpProgress.tsx
@@ -47,9 +47,11 @@ interface Props {
   state: BringUpState;
   /** Called once the launcher reports ready and the app URL is known. */
   onReady: (appUrl: string) => void;
+  /** When set, renders a cancel button that aborts the bring-up. */
+  onCancel?: () => void;
 }
 
-function BringUpProgress({ state, onReady }: Props) {
+function BringUpProgress({ state, onReady, onCancel }: Props) {
   const appUrl = state.ready?.urls.app;
   useEffect(() => {
     if (appUrl) onReady(appUrl);
@@ -139,6 +141,17 @@ function BringUpProgress({ state, onReady }: Props) {
             </p>
           )}
         </section>
+      )}
+
+      {onCancel && !state.ready && (
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="bringup-cancel"
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
+        >
+          {state.errors.length > 0 ? "Back" : "Cancel"}
+        </button>
       )}
     </main>
   );

--- a/desktop/src/views/ConnectErrorCard.test.tsx
+++ b/desktop/src/views/ConnectErrorCard.test.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ConnectErrorCard from "./ConnectErrorCard";
+
+afterEach(cleanup);
+
+describe("ConnectErrorCard", () => {
+  it("renders title, body, command and hint", () => {
+    render(
+      <ConnectErrorCard
+        card={{
+          title: "TT-Studio isn't set up on QuietBox",
+          body: "There is no run.py at ~/tt-studio.",
+          command: "git clone https://github.com/tenstorrent/tt-studio.git",
+          hint: "Then connect again.",
+          showEdit: true,
+        }}
+        onBack={() => {}}
+        onEdit={() => {}}
+      />,
+    );
+    expect(screen.getByText("TT-Studio isn't set up on QuietBox")).toBeTruthy();
+    expect(screen.getByText(/no run\.py/)).toBeTruthy();
+    expect(screen.getByText(/git clone/)).toBeTruthy();
+    expect(screen.getByText("Then connect again.")).toBeTruthy();
+  });
+
+  it("wires back, and edit only when the card asks for it", () => {
+    const onBack = vi.fn();
+    const onEdit = vi.fn();
+    const { rerender } = render(
+      <ConnectErrorCard
+        card={{ title: "t", body: "b", showEdit: true }}
+        onBack={onBack}
+        onEdit={onEdit}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("connect-error-edit"));
+    expect(onEdit).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTestId("connect-error-back"));
+    expect(onBack).toHaveBeenCalledOnce();
+
+    rerender(
+      <ConnectErrorCard
+        card={{ title: "t", body: "b" }}
+        onBack={onBack}
+        onEdit={onEdit}
+      />,
+    );
+    expect(screen.queryByTestId("connect-error-edit")).toBeNull();
+  });
+});

--- a/desktop/src/views/ConnectErrorCard.tsx
+++ b/desktop/src/views/ConnectErrorCard.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Full-screen failure card for the SSH connect flow (port conflicts, missing
+// checkout, old python, probe errors). Pure view — all IPC stays in App.
+
+import type { ConnectErrorInfo } from "../lib/connect";
+
+interface Props {
+  card: ConnectErrorInfo;
+  onBack: () => void;
+  /** Wired when the card says the profile itself needs fixing. */
+  onEdit?: () => void;
+}
+
+function ConnectErrorCard({ card, onBack, onEdit }: Props) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
+      <section
+        data-testid="connect-error"
+        className="w-full max-w-md rounded-lg border border-red-900 bg-red-950/40 p-5"
+      >
+        <h1 className="text-lg font-semibold text-red-300">{card.title}</h1>
+        <p className="mt-2 text-sm text-red-200/80">{card.body}</p>
+        {card.command && (
+          <pre className="mt-3 overflow-x-auto rounded bg-zinc-900 px-3 py-2 text-xs text-zinc-200">
+            <code>{card.command}</code>
+          </pre>
+        )}
+        {card.hint && (
+          <p className="mt-3 text-xs text-red-200/60">{card.hint}</p>
+        )}
+      </section>
+      <div className="flex gap-3">
+        {card.showEdit && onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            data-testid="connect-error-edit"
+            className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
+          >
+            Edit machine
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onBack}
+          data-testid="connect-error-back"
+          className="rounded-md bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-700"
+        >
+          Back
+        </button>
+      </div>
+    </main>
+  );
+}
+
+export default ConnectErrorCard;

--- a/desktop/src/views/QuitDialog.test.tsx
+++ b/desktop/src/views/QuitDialog.test.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import QuitDialog from "./QuitDialog";
+
+afterEach(cleanup);
+
+const base = {
+  machine: "QuietBox",
+  stopping: false,
+  lines: [],
+  error: null,
+  onStopAndQuit: () => {},
+  onDisconnectQuit: () => {},
+  onCancel: () => {},
+};
+
+describe("QuitDialog", () => {
+  it("offers stop, disconnect and cancel for an active remote", () => {
+    const onStop = vi.fn();
+    const onDisconnect = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <QuitDialog
+        {...base}
+        onStopAndQuit={onStop}
+        onDisconnectQuit={onDisconnect}
+        onCancel={onCancel}
+      />,
+    );
+    expect(screen.getByText("Disconnect from QuietBox?")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("quit-stop"));
+    expect(onStop).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTestId("quit-disconnect"));
+    expect(onDisconnect).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTestId("quit-cancel"));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("streams stop output and disables the buttons while stopping", () => {
+    render(
+      <QuitDialog {...base} stopping lines={["Stopping containers…"]} />,
+    );
+    expect(screen.getByTestId("quit-stop-output").textContent).toContain(
+      "Stopping containers…",
+    );
+    expect(
+      (screen.getByTestId("quit-stop") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByTestId("quit-disconnect") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("turns a failed stop into quit-anyway", () => {
+    render(<QuitDialog {...base} error="connection lost" />);
+    expect(screen.getByTestId("quit-error").textContent).toContain(
+      "connection lost",
+    );
+    expect(screen.queryByTestId("quit-stop")).toBeNull();
+    expect(screen.getByTestId("quit-disconnect").textContent).toContain(
+      "Quit anyway",
+    );
+  });
+
+  it("degrades to a plain quit with no active remote", () => {
+    render(<QuitDialog {...base} machine={null} />);
+    expect(screen.getByText("Quit TT-Studio?")).toBeTruthy();
+    expect(screen.queryByTestId("quit-stop")).toBeNull();
+  });
+});

--- a/desktop/src/views/QuitDialog.tsx
+++ b/desktop/src/views/QuitDialog.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Quit dialog shown when the window is closed while an SSH connection is
+// active: stop the remote stack first, or just disconnect and leave it
+// running. Pure view — all IPC stays in App.
+
+interface Props {
+  /** Machine name for the wording; null when no remote is active. */
+  machine: string | null;
+  /** A stop is running; its streamed output is in `lines`. */
+  stopping: boolean;
+  lines: string[];
+  /** The stop failed; offer quit-anyway. */
+  error: string | null;
+  onStopAndQuit: () => void;
+  onDisconnectQuit: () => void;
+  onCancel: () => void;
+}
+
+function QuitDialog({
+  machine,
+  stopping,
+  lines,
+  error,
+  onStopAndQuit,
+  onDisconnectQuit,
+  onCancel,
+}: Props) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
+      <header className="max-w-md text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {machine ? `Disconnect from ${machine}?` : "Quit TT-Studio?"}
+        </h1>
+        <p className="mt-2 text-sm text-zinc-400">
+          {machine
+            ? `The TT-Studio stack on ${machine} keeps running (and holding the hardware) unless you stop it.`
+            : "No remote connection is active."}
+        </p>
+      </header>
+
+      {(stopping || lines.length > 0) && (
+        <pre
+          data-testid="quit-stop-output"
+          className="max-h-48 w-full max-w-md overflow-y-auto rounded-md border border-zinc-800 bg-zinc-900 p-3 text-xs text-zinc-300"
+        >
+          {lines.length > 0 ? lines.join("\n") : `Stopping the stack on ${machine}…`}
+        </pre>
+      )}
+
+      {error && (
+        <p
+          data-testid="quit-error"
+          className="w-full max-w-md rounded-md border border-red-900 bg-red-950/40 px-3 py-2 text-xs text-red-300"
+        >
+          Couldn't stop the stack: {error}
+        </p>
+      )}
+
+      <div className="flex flex-col items-center gap-3">
+        {machine && !error && (
+          <button
+            type="button"
+            onClick={onStopAndQuit}
+            disabled={stopping}
+            data-testid="quit-stop"
+            className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+          >
+            {stopping ? "Stopping…" : `Stop the stack on ${machine} and quit`}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDisconnectQuit}
+          disabled={stopping}
+          data-testid="quit-disconnect"
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900 disabled:opacity-50"
+        >
+          {error ? "Quit anyway (leave it running)" : "Just disconnect and quit"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={stopping}
+          data-testid="quit-cancel"
+          className="rounded-md px-4 py-2 text-xs text-zinc-500 hover:text-zinc-300 disabled:opacity-50"
+        >
+          Cancel — back to TT-Studio
+        </button>
+      </div>
+    </main>
+  );
+}
+
+export default QuitDialog;


### PR DESCRIPTION
Completes SSH-client mode for the desktop shell (D5, stacked on #1254 — review only the last 6 commits until that merges).

One click on a saved machine now does the whole thing: SSH connect → tunnels up → figure out what's on the other side → attach or bring the stack up → the window navigates to the running app. Closing the window while connected asks whether to stop the remote stack or just disconnect.

How the flow decides: once the tunnels report every essential local port bound, the launcher runs three probes over `ssh exec` (`test -f <repo>/run.py`, `python3 --version`, `run.py --status --json`) plus a health poll through the forwarded ports. Healthy → attach; down/partial → stream `run.py --no-browser --json-events` over the exec channel, rendered by the same NDJSON reducer the native path uses (stderr goes to `remote-bringup.log`). A validated repo path is written back to the profile.

Failure cards instead of dead spinners:
- local port 3000 (or another essential port) already taken → explicit card, no silent remapping
- no `run.py` at the repo path → clone instructions + "Edit machine" (auto-clone is out of scope)
- python3 missing or older than 3.12 → clear version card
- probe/tunnel errors reuse the typed SSH error descriptions; cancel tears everything down cleanly

- [x] `ssh exec` helpers: one-shot capture (bounded) + line-streamed exec on the existing russh session, with shell/tilde-safe path quoting
- [x] attach detection: probes + tunnel health folded into a pure, unit-tested classifier
- [x] remote bring-up streamed as `bringup-line` events; cancel closes the session; exit-without-ready synthesizes an error card
- [x] one-click connect flow + progress states + cancel in the launcher
- [x] quit dialog: "Stop the stack on <host>" (streams `run.py --stop` output; failure offers quit-anyway) vs disconnect-only
- [x] e2e: sshd fixture extended with python3 + a fake `run.py`/stub stack; test drives probe → classify(down) → bring-up → ready → HTTP through the forwarded port → stop. Passes locally against Docker (`cargo test --test ssh_tunnel --test ssh_remote_bringup -- --ignored`, 5/5)
- [x] cargo fmt/clippy/test and vitest/tsc green; all test listeners bind high random ports only