### PR TITLE
feat(desktop): auto-update — shell updater and stack refresh on launch

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -47,6 +47,52 @@ npm run tauri build      # release build + bundles
 Start the TT-Studio stack separately (`python run.py` at the repo root) so
 `http://localhost:3000` is live before clicking "Open TT-Studio".
 
+## Updates
+
+Two layers, both keyed to tagged GitHub releases of tenstorrent/tt-studio.
+Release tags (`v*`) are the source of truth for both: they're the only refs
+`.github/workflows/publish-images.yml` publishes GHCR images for, so
+following raw `main`/`dev` would force local image builds.
+
+### Shell updates (the app itself)
+
+The tauri updater plugin checks the `latest.json` asset on the latest GitHub
+release (endpoint in `src-tauri/tauri.conf.json`). The launcher checks once
+on launch — silently, so being offline never gets in the way of connecting —
+and offers a manual "Check for updates" button whose failures are shown
+(`src/views/UpdateBanner.tsx`). Installing downloads, applies, and relaunches
+via the process plugin.
+
+**Signing key**: the `pubkey` in `tauri.conf.json` is a development
+placeholder. Release CI must generate the real keypair (`tauri signer
+generate`), keep the private key in CI secrets (`TAURI_SIGNING_PRIVATE_KEY`),
+replace the placeholder pubkey, and attach signed updater artifacts +
+`latest.json` to each release. Until then the updater will reject downloaded
+artifacts (signature mismatch) — by design, it fails closed.
+
+### Stack updates (the checkout `run.py` runs in)
+
+Before every bring-up — local spawn or SSH — the app compares the target
+checkout's release tag against the latest `v*` tag
+(`src-tauri/src/update/stack.rs`) and, when behind, runs the stack's own
+guarded `python run.py --switch <tag>` there. Policy is a user setting
+(auto / ask first / never, default ask) stored with the app settings.
+
+Behavior at the edges:
+
+- **Dirty checkout** (tracked changes): `--switch` refuses dirty trees, and
+  the app never forces or resets — it shows "developer checkout detected,
+  skipping stack update" and proceeds with the current version.
+- **Not on a release tag** (branch or detached sha): also treated as a
+  developer checkout and left alone.
+- **Offline / can't learn the latest tag**: skip the update, proceed to
+  bring-up. Updates are best-effort; connecting is the job.
+- **Attach** (stack already healthy): never updated — the checkout isn't
+  switched under a running stack.
+- **Images**: no explicit pull step. The bring-up after a switch pins
+  `TT_STUDIO_IMAGE_TAG` to the exact tag (`tt_setup/env_config/_version.py`)
+  and pulls the matching GHCR images itself (`tt_setup/cli/_run.py`).
+
 ## OS matrix
 
 | OS | Webview | Stack mode |

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1985,6 +1987,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -770,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2592,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3406,6 +3435,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3825,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-store",
+ "tempfile",
  "tokio",
 ]
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +807,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1141,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1723,6 +1753,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2108,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2361,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2595,6 +2676,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,10 +2757,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "p256"
@@ -3270,15 +3383,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3474,6 +3592,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3866,6 +4066,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4122,7 +4338,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4156,6 +4372,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,7 +4405,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4333,6 +4560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +4586,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.20",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,7 +4628,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4381,7 +4651,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4589,6 +4859,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4841,7 +5121,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-process",
  "tauri-plugin-store",
+ "tauri-plugin-updater",
  "tempfile",
  "tokio",
 ]
@@ -5168,6 +5450,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5747,7 +6038,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5792,6 +6083,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5909,6 +6210,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2068,6 +2068,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2577,6 +2578,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3319,6 +3344,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +3891,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-store",
  "tempfile",
  "tokio",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,3 +31,4 @@ tokio = { version = "1", features = ["macros", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-store = "2"
+tauri-plugin-dialog = "2"
 # sync-secret-service links libdbus on Linux (libdbus-1-dev in CI); no
 # secret-service daemon at runtime degrades to a typed error, not a crash.
 keyring = { version = "3", features = [

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -35,5 +35,6 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 
 [dev-dependencies]
+tauri = { version = "2", features = ["test"] }
 tempfile = "3.27.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,8 @@ reqwest = { version = "0.12", default-features = false }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 russh = { version = "0.54", default-features = false, features = ["ring", "flate2"] }
 async-trait = "0.1.92"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "IPC permissions for the bundled launcher UI only. The remote TT-Studio origin (http://localhost:3000) is deliberately NOT granted any capability: no `remote` block appears here, so Tauri denies it all IPC.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "updater:default", "process:allow-restart"]
 }

--- a/desktop/src-tauri/src/hardware.rs
+++ b/desktop/src-tauri/src/hardware.rs
@@ -7,7 +7,9 @@
 //! The first-run picker uses this to choose its default: a machine with a
 //! Tenstorrent accelerator pre-selects "run locally", anything else defaults
 //! to connecting over SSH. Full deployment needs `/dev/tenstorrent`, which
-//! only exists on Linux hosts with the driver loaded.
+//! only exists on Linux hosts with the driver loaded. The platform rides
+//! along so the picker can explain *why* local mode is unavailable (wrong
+//! OS vs. missing device/driver).
 
 use serde::Serialize;
 use std::path::Path;
@@ -23,16 +25,41 @@ pub enum DefaultMode {
 }
 
 #[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Platform {
+    Linux,
+    Macos,
+    Windows,
+    Other,
+}
+
+impl Platform {
+    pub fn current() -> Self {
+        if cfg!(target_os = "linux") {
+            Platform::Linux
+        } else if cfg!(target_os = "macos") {
+            Platform::Macos
+        } else if cfg!(target_os = "windows") {
+            Platform::Windows
+        } else {
+            Platform::Other
+        }
+    }
+}
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HardwareProbe {
+    pub platform: Platform,
     pub accelerator_present: bool,
     pub default_mode: DefaultMode,
 }
 
 /// Pure gating logic: local mode only makes sense on Linux with the device
 /// node present; everything else should steer the picker to SSH.
-pub fn probe_at(is_linux: bool, dev_path: &Path) -> HardwareProbe {
-    let accelerator_present = is_linux && dev_path.exists();
+pub fn probe(platform: Platform, dev_path: &Path) -> HardwareProbe {
+    let accelerator_present = platform == Platform::Linux && dev_path.exists();
     HardwareProbe {
+        platform,
         accelerator_present,
         default_mode: if accelerator_present {
             DefaultMode::Local
@@ -44,7 +71,7 @@ pub fn probe_at(is_linux: bool, dev_path: &Path) -> HardwareProbe {
 
 #[tauri::command]
 pub fn detect_hardware() -> HardwareProbe {
-    probe_at(cfg!(target_os = "linux"), Path::new(TENSTORRENT_DEV))
+    probe(Platform::current(), Path::new(TENSTORRENT_DEV))
 }
 
 #[cfg(test)]
@@ -54,14 +81,17 @@ mod tests {
     #[test]
     fn linux_with_device_defaults_to_local() {
         let dir = std::env::temp_dir();
-        let probe = probe_at(true, &dir); // any existing path stands in for /dev/tenstorrent
+        let probe = probe(Platform::Linux, &dir); // any existing path stands in for /dev/tenstorrent
         assert!(probe.accelerator_present);
         assert_eq!(probe.default_mode, DefaultMode::Local);
     }
 
     #[test]
     fn linux_without_device_defaults_to_ssh() {
-        let probe = probe_at(true, Path::new("/nonexistent/tenstorrent-test-path"));
+        let probe = probe(
+            Platform::Linux,
+            Path::new("/nonexistent/tenstorrent-test-path"),
+        );
         assert!(!probe.accelerator_present);
         assert_eq!(probe.default_mode, DefaultMode::Ssh);
     }
@@ -69,14 +99,17 @@ mod tests {
     #[test]
     fn non_linux_defaults_to_ssh_even_if_path_exists() {
         let dir = std::env::temp_dir();
-        let probe = probe_at(false, &dir);
-        assert!(!probe.accelerator_present);
-        assert_eq!(probe.default_mode, DefaultMode::Ssh);
+        for platform in [Platform::Macos, Platform::Windows, Platform::Other] {
+            let probe = probe(platform, &dir);
+            assert!(!probe.accelerator_present);
+            assert_eq!(probe.default_mode, DefaultMode::Ssh);
+        }
     }
 
     #[test]
     fn probe_serializes_for_the_ui() {
-        let json = serde_json::to_value(probe_at(true, Path::new("/nope"))).unwrap();
+        let json = serde_json::to_value(probe(Platform::Macos, Path::new("/nope"))).unwrap();
+        assert_eq!(json["platform"], "macos");
         assert_eq!(json["accelerator_present"], false);
         assert_eq!(json["default_mode"], "ssh");
     }

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -259,6 +259,95 @@ pub async fn restart_stack(
     spawn_bring_up(&app, &state, &path)
 }
 
+// ---- quit flow ----
+
+/// Ask whether quitting should also stop the stack. The host services
+/// detach and ignore SIGHUP on purpose, so "keep running in the background"
+/// is the truthful default; "stop the stack" runs `run.py --stop` first.
+///
+/// Called from the CloseRequested handler with the close already prevented;
+/// every branch ends in `app.exit(0)`.
+pub fn confirm_quit(app: &tauri::AppHandle<Wry>) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+    let app = app.clone();
+    app.clone()
+        .dialog()
+        .message(
+            "TT-Studio's services keep running in the background — you can \
+             reopen the app (or the browser) and pick up where you left off.\n\n\
+             Stop the stack before quitting?",
+        )
+        .title("Quit TT-Studio")
+        // "Stop the stack" is the affirmative (Ok) button so that dismissing
+        // the dialog (Esc / close) maps to the safe default: keep running.
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Stop the stack".to_string(),
+            "Keep running".to_string(),
+        ))
+        .show(move |stop_stack| {
+            if stop_stack {
+                stop_stack_then_exit(&app);
+            } else {
+                app.exit(0);
+            }
+        });
+}
+
+/// Kill any in-flight bring-up, run `run.py --stop` in the known checkout
+/// (progress streamed as `stop-line` events for whoever is still listening),
+/// then exit. Exits immediately if there is no checkout to stop.
+fn stop_stack_then_exit(app: &tauri::AppHandle<Wry>) {
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let state: tauri::State<LauncherState> = app.state();
+
+        // Free the child slot: signal a running bring-up and give its
+        // reader thread a moment to reap it.
+        kill_child(&state.child);
+        for _ in 0..50 {
+            if state.child.lock().map(|g| g.is_none()).unwrap_or(true) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        let checkout = state
+            .checkout
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+            .or_else(|| default_existing_checkout(&app));
+        let (Some(checkout), Ok(logs)) = (checkout, log_dir(&app)) else {
+            app.exit(0);
+            return;
+        };
+
+        let line_app = app.clone();
+        let exit_app = app.clone();
+        let spawned = spawn_streaming(
+            &stop_spec(&checkout, logs.join("stop.log")),
+            state.child.clone(),
+            move |line| {
+                let _ = line_app.emit(STOP_LINE_EVENT, &line);
+            },
+            move |_code| {
+                exit_app.exit(0);
+            },
+        );
+        if spawned.is_err() {
+            app.exit(0);
+        }
+    });
+}
+
+/// Attached-but-never-spawned sessions still deserve a working "stop the
+/// stack": fall back to the configured/managed checkout (never cloning).
+fn default_existing_checkout(app: &tauri::AppHandle<Wry>) -> Option<PathBuf> {
+    let configured = stack_checkout::configured_path(app).ok().flatten();
+    let home = app.path().home_dir().ok()?;
+    stack_checkout::existing(configured.as_deref(), &stack_checkout::managed_dir(&home))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -43,11 +43,14 @@ pub struct SpawnSpec {
 }
 
 /// Full bring-up. `--no-browser` because the desktop window is the browser;
-/// `--json-events` for the machine-readable stream (implies non-interactive).
+/// `--json-events` for the machine-readable stream (implies non-interactive);
+/// `--no-sudo` because a GUI child can never answer a sudo password prompt —
+/// anything that genuinely needs root becomes a `prompt_blocked`/`error`
+/// event pointing the user at a one-time terminal run instead of a hang.
 pub fn bring_up_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
     SpawnSpec {
         program: PYTHON.to_string(),
-        args: ["run.py", "--no-browser", "--json-events"]
+        args: ["run.py", "--no-browser", "--json-events", "--no-sudo"]
             .map(String::from)
             .to_vec(),
         cwd: checkout.to_path_buf(),
@@ -264,7 +267,10 @@ mod tests {
     fn bring_up_spec_runs_run_py_with_json_events_from_the_checkout() {
         let spec = bring_up_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
         assert_eq!(spec.program, "python3");
-        assert_eq!(spec.args, ["run.py", "--no-browser", "--json-events"]);
+        assert_eq!(
+            spec.args,
+            ["run.py", "--no-browser", "--json-events", "--no-sudo"]
+        );
         // run.py derives TT_STUDIO_ROOT from cwd — this is the contract.
         assert_eq!(spec.cwd, Path::new("/tmp/stack"));
     }

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -211,6 +211,51 @@ pub fn bring_up_running(state: tauri::State<'_, LauncherState>) -> bool {
     state.child.lock().map(|g| g.is_some()).unwrap_or(false)
 }
 
+/// The UI attached to an already-healthy local stack (no bring-up spawned).
+/// Recorded so quitting can still offer to stop that stack.
+#[tauri::command]
+pub fn mark_local_attach(state: tauri::State<'_, LauncherState>) {
+    state.local_stack.store(true, Ordering::SeqCst);
+}
+
+/// Explicit restart: `run.py --stop` (streamed as `stop-line` events), then
+/// a fresh bring-up. Never triggered automatically — only by the launcher
+/// UI's "Restart stack" action.
+#[tauri::command]
+pub async fn restart_stack(
+    app: tauri::AppHandle<Wry>,
+    state: tauri::State<'_, LauncherState>,
+    checkout: String,
+) -> Result<u32, String> {
+    let path = checked_checkout(&checkout)?;
+    let logs = log_dir(&app)?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let line_app = app.clone();
+    spawn_streaming(
+        &stop_spec(&path, logs.join("stop.log")),
+        state.child.clone(),
+        move |line| {
+            let _ = line_app.emit(STOP_LINE_EVENT, &line);
+        },
+        move |code| {
+            let _ = tx.send(code);
+        },
+    )?;
+    let code = tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|_| "run.py --stop ended without reporting an exit code".to_string())?;
+    if code != Some(0) {
+        return Err(format!(
+            "run.py --stop failed (exit {}) — not starting a new bring-up",
+            code.map_or("signal".to_string(), |c| c.to_string())
+        ));
+    }
+
+    spawn_bring_up(&app, &state, &path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -149,7 +149,7 @@ pub fn kill_child(slot: &ChildSlot) -> bool {
 
 // ---- Tauri commands ----
 
-fn log_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+pub(crate) fn log_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
     Ok(app
         .path()
         .app_data_dir()

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Native white-box launcher: spawn `python run.py` inside a checkout and
+//! stream its NDJSON events to the UI.
+//!
+//! `run.py --json-events` keeps stdout machine-readable (one JSON object per
+//! line) and moves all human output to stderr. So: stdout is read
+//! line-buffered and each line is forwarded verbatim as a `bringup-line`
+//! Tauri event (the frontend owns parsing — see src/lib/events.ts), while
+//! stderr goes to a rotating log file in the app data dir for bug reports.
+//!
+//! Two contract details worth keeping in mind:
+//! - `run.py` derives TT_STUDIO_ROOT from its cwd, so the child's cwd must
+//!   be the checkout root.
+//! - The bootstrap re-execs (execve) into `.tt_studio_run_venv`; PID and the
+//!   stdout pipe survive that, so it's still one child from our side.
+
+use crate::state::{ChildSlot, LauncherState};
+use crate::{stack_checkout, state};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::Ordering;
+use tauri::{Emitter, Manager, Wry};
+
+pub const BRINGUP_LINE_EVENT: &str = "bringup-line";
+pub const BRINGUP_EXIT_EVENT: &str = "bringup-exit";
+pub const STOP_LINE_EVENT: &str = "stop-line";
+
+const PYTHON: &str = "python3";
+
+/// Everything needed to spawn one launcher child.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpawnSpec {
+    pub program: String,
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+    pub stderr_log: PathBuf,
+    pub envs: Vec<(String, String)>,
+}
+
+/// Full bring-up. `--no-browser` because the desktop window is the browser;
+/// `--json-events` for the machine-readable stream (implies non-interactive).
+pub fn bring_up_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
+    SpawnSpec {
+        program: PYTHON.to_string(),
+        args: ["run.py", "--no-browser", "--json-events"]
+            .map(String::from)
+            .to_vec(),
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// `run.py --stop`: stop containers, keep the persistent volume.
+pub fn stop_spec(checkout: &Path, stderr_log: PathBuf) -> SpawnSpec {
+    SpawnSpec {
+        program: PYTHON.to_string(),
+        args: ["run.py", "--stop"].map(String::from).to_vec(),
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// One-deep rotation: keep the previous run's stderr as `<name>.1`.
+pub fn rotate_log(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if path.exists() {
+        let mut rotated = path.as_os_str().to_owned();
+        rotated.push(".1");
+        std::fs::rename(path, PathBuf::from(rotated))?;
+    }
+    Ok(())
+}
+
+/// Spawn the child described by `spec`, park it in `slot`, and stream its
+/// stdout line by line to `on_line` from a reader thread. When stdout hits
+/// EOF the same thread reaps the child and calls `on_exit` with its exit
+/// code (None if killed by signal). Errors if `slot` is already occupied.
+pub fn spawn_streaming(
+    spec: &SpawnSpec,
+    slot: ChildSlot,
+    on_line: impl Fn(String) + Send + 'static,
+    on_exit: impl FnOnce(Option<i32>) + Send + 'static,
+) -> Result<u32, String> {
+    let mut guard = slot.lock().map_err(|e| e.to_string())?;
+    if guard.is_some() {
+        return Err("a launcher process is already running".to_string());
+    }
+
+    rotate_log(&spec.stderr_log).map_err(|e| format!("couldn't prepare stderr log: {e}"))?;
+    let log = File::create(&spec.stderr_log).map_err(|e| e.to_string())?;
+
+    let mut child = Command::new(&spec.program)
+        .args(&spec.args)
+        .current_dir(&spec.cwd)
+        .envs(spec.envs.iter().map(|(k, v)| (k, v)))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(log))
+        .spawn()
+        .map_err(|e| format!("failed to spawn {}: {e}", spec.program))?;
+
+    let pid = child.id();
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "child has no stdout pipe".to_string())?;
+    *guard = Some(child);
+    drop(guard);
+
+    let reaper_slot = slot.clone();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(line) => on_line(line),
+                Err(_) => break,
+            }
+        }
+        // EOF: take the child back out of the slot and reap it.
+        let child = reaper_slot.lock().ok().and_then(|mut s| s.take());
+        let code = child.and_then(|mut c| c.wait().ok()).and_then(|s| s.code());
+        on_exit(code);
+    });
+
+    Ok(pid)
+}
+
+/// Signal the running child, if any. The reader thread reaps it on EOF.
+pub fn kill_child(slot: &ChildSlot) -> bool {
+    match slot.lock() {
+        Ok(mut guard) => match guard.as_mut() {
+            Some(child) => child.kill().is_ok(),
+            None => false,
+        },
+        Err(_) => false,
+    }
+}
+
+// ---- Tauri commands ----
+
+fn log_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("logs"))
+}
+
+fn checked_checkout(checkout: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(checkout);
+    if !stack_checkout::is_valid_checkout(&path) {
+        return Err(format!(
+            "{checkout} is not a tt-studio checkout (no run.py)"
+        ));
+    }
+    Ok(path)
+}
+
+fn spawn_bring_up(
+    app: &tauri::AppHandle<Wry>,
+    state: &state::LauncherState,
+    checkout: &Path,
+) -> Result<u32, String> {
+    let spec = bring_up_spec(checkout, log_dir(app)?.join("bringup.log"));
+    *state.checkout.lock().map_err(|e| e.to_string())? = Some(checkout.to_path_buf());
+    state.local_stack.store(true, Ordering::SeqCst);
+    let line_app = app.clone();
+    let exit_app = app.clone();
+    spawn_streaming(
+        &spec,
+        state.child.clone(),
+        move |line| {
+            let _ = line_app.emit(BRINGUP_LINE_EVENT, &line);
+        },
+        move |code| {
+            let _ = exit_app.emit(BRINGUP_EXIT_EVENT, code);
+        },
+    )
+}
+
+/// Start `run.py --no-browser --json-events` in the given checkout and
+/// stream its stdout as `bringup-line` events; `bringup-exit` carries the
+/// exit code when it ends.
+#[tauri::command]
+pub fn start_bring_up(
+    app: tauri::AppHandle<Wry>,
+    state: tauri::State<'_, LauncherState>,
+    checkout: String,
+) -> Result<u32, String> {
+    let path = checked_checkout(&checkout)?;
+    spawn_bring_up(&app, &state, &path)
+}
+
+/// Kill the running launcher child (if any). Returns whether a signal was
+/// actually sent.
+#[tauri::command]
+pub fn stop_bring_up(state: tauri::State<'_, LauncherState>) -> bool {
+    kill_child(&state.child)
+}
+
+#[tauri::command]
+pub fn bring_up_running(state: tauri::State<'_, LauncherState>) -> bool {
+    state.child.lock().map(|g| g.is_some()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bring_up_spec_runs_run_py_with_json_events_from_the_checkout() {
+        let spec = bring_up_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
+        assert_eq!(spec.program, "python3");
+        assert_eq!(spec.args, ["run.py", "--no-browser", "--json-events"]);
+        // run.py derives TT_STUDIO_ROOT from cwd — this is the contract.
+        assert_eq!(spec.cwd, Path::new("/tmp/stack"));
+    }
+
+    #[test]
+    fn stop_spec_runs_run_py_stop() {
+        let spec = stop_spec(Path::new("/tmp/stack"), PathBuf::from("/tmp/log"));
+        assert_eq!(spec.args, ["run.py", "--stop"]);
+        assert_eq!(spec.cwd, Path::new("/tmp/stack"));
+    }
+
+    #[test]
+    fn rotate_keeps_one_previous_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("logs").join("bringup.log");
+
+        rotate_log(&log).unwrap(); // nothing to rotate, just mkdir
+        std::fs::write(&log, "first run").unwrap();
+        rotate_log(&log).unwrap();
+        assert!(!log.exists());
+        let rotated = dir.path().join("logs").join("bringup.log.1");
+        assert_eq!(std::fs::read_to_string(&rotated).unwrap(), "first run");
+
+        std::fs::write(&log, "second run").unwrap();
+        rotate_log(&log).unwrap();
+        assert_eq!(std::fs::read_to_string(&rotated).unwrap(), "second run");
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,15 +5,18 @@
 mod commands;
 mod hardware;
 mod health;
+pub mod launcher;
 mod profiles;
 mod secrets;
-mod stack_checkout;
+pub mod stack_checkout;
+pub mod state;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(health::PollerState::default())
+        .manage(state::LauncherState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_stack,
             profiles::list_profiles,
@@ -29,6 +32,9 @@ pub fn run() {
             health::stop_health_poll,
             stack_checkout::resolve_stack_checkout,
             stack_checkout::set_stack_checkout_path,
+            launcher::start_bring_up,
+            launcher::stop_bring_up,
+            launcher::bring_up_running,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,8 +13,29 @@ pub mod state;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    use std::sync::atomic::Ordering;
+    use tauri::Manager;
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(tauri_plugin_dialog::init())
+        // Quit dialog: only when this session started or attached to a local
+        // stack is there anything to ask about — the host services detach
+        // and survive the app on purpose, so the default is to leave them.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let app = window.app_handle();
+                let launcher_state: tauri::State<state::LauncherState> = app.state();
+                if !launcher_state.local_stack.load(Ordering::SeqCst) {
+                    return; // nothing local: close normally
+                }
+                api.prevent_close();
+                if launcher_state.quitting.swap(true, Ordering::SeqCst) {
+                    return; // quit flow already in flight
+                }
+                launcher::confirm_quit(app);
+            }
+        })
         .manage(health::PollerState::default())
         .manage(state::LauncherState::default())
         .invoke_handler(tauri::generate_handler![

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub fn run() {
             launcher::start_bring_up,
             launcher::stop_bring_up,
             launcher::bring_up_running,
+            launcher::mark_local_attach,
+            launcher::restart_stack,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod hardware;
 mod health;
 mod profiles;
 mod secrets;
+mod stack_checkout;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -26,6 +27,8 @@ pub fn run() {
             health::check_stack_health,
             health::start_health_poll,
             health::stop_health_poll,
+            stack_checkout::resolve_stack_checkout,
+            stack_checkout::set_stack_checkout_path,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod secrets;
 pub mod ssh;
 pub mod stack_checkout;
 pub mod state;
+pub mod update;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -80,6 +81,9 @@ pub fn run() {
             launcher::bring_up_running,
             launcher::mark_local_attach,
             launcher::restart_stack,
+            update::stack::check_stack_freshness,
+            update::stack::get_stack_update_policy,
+            update::stack::set_stack_update_policy,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             launcher::mark_local_attach,
             launcher::restart_stack,
             update::stack::check_stack_freshness,
+            update::stack::run_stack_switch,
             update::stack::get_stack_update_policy,
             update::stack::set_stack_update_policy,
         ])

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,12 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
+        // Shell self-update from tagged GitHub releases. The updater pubkey
+        // in tauri.conf.json is a PLACEHOLDER generated for development —
+        // release CI must replace it with the real signing key before
+        // shipping updater artifacts (see desktop/README.md).
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(health::PollerState::default())
         .manage(ssh::commands::TunnelState::default())
         .manage(remote::RemoteState::default())

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -229,7 +229,7 @@ pub fn classify(
 
 // ---- the Tauri command tying it together ----
 
-async fn connect_session(
+pub(crate) async fn connect_session(
     app: &tauri::AppHandle,
     profile: &Profile,
 ) -> Result<SshSession, SshError> {

--- a/desktop/src-tauri/src/stack_checkout.rs
+++ b/desktop/src-tauri/src/stack_checkout.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Locating (or creating) the tt-studio checkout that native mode runs.
+//!
+//! Native white-box mode drives `python run.py` inside a real tt-studio
+//! checkout. Resolution order:
+//!
+//! 1. A user-configured path (settings store) — must already be a checkout.
+//! 2. The managed checkout at `~/.local/share/tt-studio/stack`.
+//! 3. If neither exists, shallow-clone the latest `v*` release tag of
+//!    tenstorrent/tt-studio into the managed location.
+//!
+//! A directory counts as a checkout when `run.py` sits at its root — that is
+//! the entrypoint the launcher spawns, and `run.py` derives TT_STUDIO_ROOT
+//! from its cwd.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tauri::{Manager, Wry};
+use tauri_plugin_store::StoreExt;
+
+pub const REPO_URL: &str = "https://github.com/tenstorrent/tt-studio";
+const SETTINGS_STORE: &str = "settings.json";
+const STACK_PATH_KEY: &str = "stack_checkout_path";
+
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckoutSource {
+    /// The user pointed the app at an existing checkout.
+    Configured,
+    /// The managed checkout already existed.
+    Managed,
+    /// Freshly cloned into the managed location.
+    Cloned,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StackCheckout {
+    pub path: PathBuf,
+    pub source: CheckoutSource,
+}
+
+/// A directory is a usable checkout iff `run.py` sits at its root.
+pub fn is_valid_checkout(path: &Path) -> bool {
+    path.join("run.py").is_file()
+}
+
+/// Managed checkout location under the user's home directory.
+pub fn managed_dir(home: &Path) -> PathBuf {
+    home.join(".local")
+        .join("share")
+        .join("tt-studio")
+        .join("stack")
+}
+
+/// Numeric components of a plain release tag (`v2.10.0` → `[2, 10, 0]`).
+/// Pre-releases and anything non-numeric are rejected — the managed clone
+/// should only ever track a real release.
+fn release_tag_key(tag: &str) -> Option<Vec<u64>> {
+    let rest = tag.strip_prefix('v')?;
+    rest.split('.')
+        .map(|part| part.parse::<u64>().ok())
+        .collect()
+}
+
+/// Pick the highest release tag out of `git ls-remote --tags` output.
+pub fn latest_v_tag(ls_remote: &str) -> Option<String> {
+    ls_remote
+        .lines()
+        .filter_map(|line| line.split('\t').nth(1))
+        .filter_map(|r| r.strip_prefix("refs/tags/"))
+        .filter(|tag| !tag.ends_with("^{}"))
+        .filter_map(|tag| release_tag_key(tag).map(|key| (key, tag.to_string())))
+        .max()
+        .map(|(_, tag)| tag)
+}
+
+fn git(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.first().unwrap_or(&""),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Find an existing checkout without touching the network. Used where a
+/// clone would be inappropriate (e.g. deciding what `--stop` should run in).
+pub fn existing(configured: Option<&Path>, managed: &Path) -> Option<PathBuf> {
+    if let Some(path) = configured {
+        if is_valid_checkout(path) {
+            return Some(path.to_path_buf());
+        }
+    }
+    is_valid_checkout(managed).then(|| managed.to_path_buf())
+}
+
+/// Resolve the checkout to run, cloning the latest release into `managed`
+/// when nothing exists yet. Runs git synchronously — call off the main
+/// thread.
+pub fn resolve(
+    configured: Option<&Path>,
+    managed: &Path,
+    repo_url: &str,
+) -> Result<StackCheckout, String> {
+    if let Some(path) = configured {
+        // An explicit setting that doesn't point at a checkout is a user
+        // error to surface, not something to silently fall through.
+        if !is_valid_checkout(path) {
+            return Err(format!(
+                "configured stack path {} has no run.py — point the setting at a tt-studio checkout or clear it",
+                path.display()
+            ));
+        }
+        return Ok(StackCheckout {
+            path: path.to_path_buf(),
+            source: CheckoutSource::Configured,
+        });
+    }
+
+    if is_valid_checkout(managed) {
+        return Ok(StackCheckout {
+            path: managed.to_path_buf(),
+            source: CheckoutSource::Managed,
+        });
+    }
+
+    let occupied = managed.is_dir()
+        && managed
+            .read_dir()
+            .map(|mut entries| entries.next().is_some())
+            .unwrap_or(true);
+    if occupied || managed.is_file() {
+        return Err(format!(
+            "{} exists but is not a tt-studio checkout (no run.py) — remove it or configure a checkout path",
+            managed.display()
+        ));
+    }
+
+    let tags = git(&["ls-remote", "--tags", repo_url])?;
+    let tag =
+        latest_v_tag(&tags).ok_or_else(|| format!("no release tags (v*) found at {repo_url}"))?;
+
+    if let Some(parent) = managed.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let managed_str = managed
+        .to_str()
+        .ok_or_else(|| "managed checkout path is not valid UTF-8".to_string())?;
+    git(&[
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        &tag,
+        repo_url,
+        managed_str,
+    ])?;
+
+    if !is_valid_checkout(managed) {
+        return Err(format!(
+            "cloned {tag} into {} but run.py is missing — clone looks broken",
+            managed.display()
+        ));
+    }
+    Ok(StackCheckout {
+        path: managed.to_path_buf(),
+        source: CheckoutSource::Cloned,
+    })
+}
+
+// ---- Tauri commands ----
+
+pub fn configured_path(app: &tauri::AppHandle<Wry>) -> Result<Option<PathBuf>, String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(STACK_PATH_KEY)
+        .and_then(|v| v.as_str().map(PathBuf::from)))
+}
+
+fn default_managed_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+    let home = app.path().home_dir().map_err(|e| e.to_string())?;
+    Ok(managed_dir(&home))
+}
+
+/// Resolve (and if needed clone) the checkout native mode should use.
+#[tauri::command]
+pub async fn resolve_stack_checkout(app: tauri::AppHandle<Wry>) -> Result<StackCheckout, String> {
+    let configured = configured_path(&app)?;
+    let managed = default_managed_dir(&app)?;
+    tauri::async_runtime::spawn_blocking(move || resolve(configured.as_deref(), &managed, REPO_URL))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+/// Set (or with `None`, clear) the user-configured checkout path.
+#[tauri::command]
+pub fn set_stack_checkout_path(
+    app: tauri::AppHandle<Wry>,
+    path: Option<String>,
+) -> Result<(), String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    match path {
+        Some(p) => {
+            if !is_valid_checkout(Path::new(&p)) {
+                return Err(format!("{p} is not a tt-studio checkout (no run.py)"));
+            }
+            store.set(STACK_PATH_KEY, serde_json::Value::String(p));
+        }
+        None => {
+            store.delete(STACK_PATH_KEY);
+        }
+    }
+    store.save().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn run(dir: &Path, cmd: &[&str]) {
+        let output = Command::new(cmd[0])
+            .args(&cmd[1..])
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("spawn {cmd:?}: {e}"));
+        assert!(
+            output.status.success(),
+            "{cmd:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Local bare repo with run.py, tagged v0.1.0 and (one commit later)
+    /// v0.10.0, plus tags resolve() must ignore. Returns a clone URL.
+    fn fixture_repo(base: &Path) -> String {
+        let bare = base.join("origin.git");
+        let work = base.join("work");
+        fs::create_dir_all(&bare).unwrap();
+        run(
+            base,
+            &["git", "init", "-q", "--bare", bare.to_str().unwrap()],
+        );
+        run(
+            base,
+            &[
+                "git",
+                "clone",
+                "-q",
+                bare.to_str().unwrap(),
+                work.to_str().unwrap(),
+            ],
+        );
+        run(&work, &["git", "config", "user.email", "ci@example.com"]);
+        run(&work, &["git", "config", "user.name", "CI"]);
+        fs::write(work.join("run.py"), "# release v0.1.0\n").unwrap();
+        run(&work, &["git", "add", "run.py"]);
+        run(&work, &["git", "commit", "-q", "-m", "v0.1.0"]);
+        run(&work, &["git", "tag", "v0.1.0"]);
+        run(&work, &["git", "tag", "v1.0.0-rc1"]); // pre-release: ignored
+        run(&work, &["git", "tag", "not-a-version"]);
+        fs::write(work.join("run.py"), "# release v0.10.0\n").unwrap();
+        run(&work, &["git", "commit", "-q", "-am", "v0.10.0"]);
+        run(&work, &["git", "tag", "v0.10.0"]);
+        run(
+            &work,
+            &["git", "push", "-q", "--tags", "origin", "HEAD:main"],
+        );
+        bare.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn checkout_validity_hinges_on_run_py() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_valid_checkout(dir.path()));
+        fs::write(dir.path().join("run.py"), "").unwrap();
+        assert!(is_valid_checkout(dir.path()));
+    }
+
+    #[test]
+    fn latest_tag_picks_highest_release_numerically() {
+        let output = "\
+aaa\trefs/tags/not-a-version
+bbb\trefs/tags/v2.9.1
+ccc\trefs/tags/v2.10.0
+ccc\trefs/tags/v2.10.0^{}
+ddd\trefs/tags/v2.10.0-rc1
+eee\trefs/tags/v2.2.0
+";
+        assert_eq!(latest_v_tag(output).as_deref(), Some("v2.10.0"));
+        assert_eq!(latest_v_tag(""), None);
+        assert_eq!(latest_v_tag("aaa\trefs/tags/v3-rc"), None);
+    }
+
+    #[test]
+    fn configured_checkout_wins_but_must_be_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let configured = dir.path().join("mine");
+        fs::create_dir_all(&configured).unwrap();
+        let managed = dir.path().join("managed");
+
+        // Configured but missing run.py: hard error, no fallthrough.
+        let err = resolve(Some(&configured), &managed, "unused").unwrap_err();
+        assert!(err.contains("no run.py"), "{err}");
+
+        fs::write(configured.join("run.py"), "").unwrap();
+        let checkout = resolve(Some(&configured), &managed, "unused").unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Configured);
+        assert_eq!(checkout.path, configured);
+    }
+
+    #[test]
+    fn existing_managed_checkout_is_reused_without_git() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        fs::create_dir_all(&managed).unwrap();
+        fs::write(managed.join("run.py"), "").unwrap();
+        // repo_url is bogus on purpose — no network/git should be needed.
+        let checkout = resolve(None, &managed, "file:///nonexistent").unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Managed);
+        assert_eq!(existing(None, &managed), Some(managed));
+    }
+
+    #[test]
+    fn occupied_non_checkout_managed_dir_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("managed");
+        fs::create_dir_all(&managed).unwrap();
+        fs::write(managed.join("junk.txt"), "").unwrap();
+        let err = resolve(None, &managed, "unused").unwrap_err();
+        assert!(err.contains("not a tt-studio checkout"), "{err}");
+    }
+
+    #[test]
+    fn missing_managed_dir_clones_the_latest_release_tag() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = fixture_repo(dir.path());
+        let managed = dir.path().join("data").join("stack");
+
+        let checkout = resolve(None, &managed, &url).unwrap();
+        assert_eq!(checkout.source, CheckoutSource::Cloned);
+        // v0.10.0 outranks v0.1.0 numerically (not lexically) and the
+        // pre-release/junk tags were skipped.
+        let contents = fs::read_to_string(managed.join("run.py")).unwrap();
+        assert!(contents.contains("v0.10.0"), "{contents}");
+
+        // A second resolve reuses the clone.
+        let again = resolve(None, &managed, &url).unwrap();
+        assert_eq!(again.source, CheckoutSource::Managed);
+    }
+
+    #[test]
+    fn existing_prefers_configured_over_managed() {
+        let dir = tempfile::tempdir().unwrap();
+        let configured = dir.path().join("mine");
+        let managed = dir.path().join("managed");
+        for p in [&configured, &managed] {
+            fs::create_dir_all(p).unwrap();
+            fs::write(p.join("run.py"), "").unwrap();
+        }
+        assert_eq!(existing(Some(&configured), &managed), Some(configured));
+        assert_eq!(
+            existing(Some(Path::new("/nope")), &managed),
+            Some(managed.clone())
+        );
+        assert_eq!(existing(None, Path::new("/nope")), None);
+    }
+}

--- a/desktop/src-tauri/src/stack_checkout.rs
+++ b/desktop/src-tauri/src/stack_checkout.rs
@@ -59,7 +59,7 @@ pub fn managed_dir(home: &Path) -> PathBuf {
 /// Numeric components of a plain release tag (`v2.10.0` → `[2, 10, 0]`).
 /// Pre-releases and anything non-numeric are rejected — the managed clone
 /// should only ever track a real release.
-fn release_tag_key(tag: &str) -> Option<Vec<u64>> {
+pub fn release_tag_key(tag: &str) -> Option<Vec<u64>> {
     let rest = tag.strip_prefix('v')?;
     rest.split('.')
         .map(|part| part.parse::<u64>().ok())
@@ -187,7 +187,7 @@ pub fn configured_path(app: &tauri::AppHandle<Wry>) -> Result<Option<PathBuf>, S
         .and_then(|v| v.as_str().map(PathBuf::from)))
 }
 
-fn default_managed_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
+pub fn default_managed_dir(app: &tauri::AppHandle<Wry>) -> Result<PathBuf, String> {
     let home = app.path().home_dir().map_err(|e| e.to_string())?;
     Ok(managed_dir(&home))
 }

--- a/desktop/src-tauri/src/state.rs
+++ b/desktop/src-tauri/src/state.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Shared state for the native launcher's child process.
+//!
+//! At most one `run.py` child (bring-up or `--stop`) runs at a time. The
+//! child lives in a shared slot: the spawner puts it there, the stdout
+//! reader thread takes it back out to reap it on EOF, and `kill` signals it
+//! in place. `run.py` bootstrap re-execs (execve) into its own venv, so PID
+//! and stdout survive — the slot always holds "the" launcher process.
+
+use std::path::PathBuf;
+use std::process::Child;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+/// Slot holding the currently running launcher child, shared between the
+/// spawner, the reader/reaper thread, and kill/quit paths.
+pub type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+#[derive(Default)]
+pub struct LauncherState {
+    pub child: ChildSlot,
+    /// Checkout the last child was spawned in; quit-time `--stop` reuses it.
+    pub checkout: Mutex<Option<PathBuf>>,
+    /// True once this session started a bring-up or attached to the local
+    /// stack — gates the "stop the stack?" quit dialog.
+    pub local_stack: AtomicBool,
+    /// True while the quit flow (dialog or `--stop`) is in flight, so a
+    /// second close request doesn't start it again.
+    pub quitting: AtomicBool,
+}

--- a/desktop/src-tauri/src/update/mod.rs
+++ b/desktop/src-tauri/src/update/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! The app's two update layers.
+//!
+//! - The **shell** (this Tauri app) self-updates via the tauri updater
+//!   plugin, configured in tauri.conf.json against tagged GitHub releases.
+//! - The **stack** (the tt-studio checkout a connect runs `run.py` in) is
+//!   refreshed to the latest `v*` release tag before bring-up — see
+//!   [`stack`].
+
+pub mod stack;

--- a/desktop/src-tauri/src/update/stack.rs
+++ b/desktop/src-tauri/src/update/stack.rs
@@ -279,6 +279,12 @@ pub fn switch_command(path: &str, tag: &str) -> String {
 /// a non-zero exit is an error (the caller proceeds to bring-up on the old
 /// version and says so). `--switch` re-checks the dirty-tree guard itself —
 /// this never forces anything.
+///
+/// No explicit image pull follows the switch: the bring-up that runs next
+/// pins TT_STUDIO_IMAGE_TAG to the checkout's exact tag
+/// (tt_setup/env_config/_version.py) and runs `docker compose pull` for a
+/// clean, published checkout (tt_setup/cli/_run.py, "Pull" phase), so the
+/// tag's GHCR images arrive as part of normal startup.
 #[tauri::command]
 pub async fn run_stack_switch(
     app: tauri::AppHandle<Wry>,

--- a/desktop/src-tauri/src/update/stack.rs
+++ b/desktop/src-tauri/src/update/stack.rs
@@ -258,7 +258,11 @@ pub fn switch_spec(
 ) -> crate::launcher::SpawnSpec {
     crate::launcher::SpawnSpec {
         program: "python3".to_string(),
-        args: vec!["run.py".to_string(), "--switch".to_string(), tag.to_string()],
+        args: vec![
+            "run.py".to_string(),
+            "--switch".to_string(),
+            tag.to_string(),
+        ],
         cwd: checkout.to_path_buf(),
         stderr_log,
         envs: Vec::new(),
@@ -306,7 +310,11 @@ pub async fn run_stack_switch(
             let managed = stack_checkout::default_managed_dir(&app)?;
             let dir = stack_checkout::existing(configured.as_deref(), &managed)
                 .ok_or_else(|| "no local stack checkout to update".to_string())?;
-            let spec = switch_spec(&dir, &tag, crate::launcher::log_dir(&app)?.join("switch.log"));
+            let spec = switch_spec(
+                &dir,
+                &tag,
+                crate::launcher::log_dir(&app)?.join("switch.log"),
+            );
 
             let (tx, rx) = std::sync::mpsc::channel();
             let line_app = app.clone();
@@ -437,4 +445,210 @@ pub async fn check_stack_freshness(
         latest_tag: latest,
         decision,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean(tag: Option<&str>) -> CheckoutRef {
+        CheckoutRef {
+            tag: tag.map(String::from),
+            dirty: false,
+            label: tag.unwrap_or("jashan/some-branch").to_string(),
+        }
+    }
+
+    fn dirty(tag: Option<&str>) -> CheckoutRef {
+        CheckoutRef {
+            dirty: true,
+            ..clean(tag)
+        }
+    }
+
+    fn skip(reason: SkipReason) -> StackUpdateAction {
+        StackUpdateAction::Skip { reason }
+    }
+
+    #[test]
+    fn decide_covers_the_matrix() {
+        use UpdatePolicy::*;
+        let cases: Vec<(
+            Option<CheckoutRef>,
+            Option<&str>,
+            UpdatePolicy,
+            StackUpdateAction,
+        )> = vec![
+            // No checkout yet: first run clones the latest release anyway.
+            (None, Some("v2.10.0"), Prompt, skip(SkipReason::NoCheckout)),
+            // Dirty tree wins over everything — --switch would refuse.
+            (
+                Some(dirty(Some("v2.9.0"))),
+                Some("v2.10.0"),
+                Auto,
+                skip(SkipReason::DirtyCheckout),
+            ),
+            (
+                Some(dirty(None)),
+                None,
+                Auto,
+                skip(SkipReason::DirtyCheckout),
+            ),
+            // Clean but not on a release tag: developer checkout, hands off.
+            (
+                Some(clean(None)),
+                Some("v2.10.0"),
+                Auto,
+                skip(SkipReason::NotOnRelease),
+            ),
+            // Couldn't learn the latest tag: proceed without updating.
+            (
+                Some(clean(Some("v2.9.0"))),
+                None,
+                Auto,
+                skip(SkipReason::Offline),
+            ),
+            // Same or newer than latest: nothing to do.
+            (
+                Some(clean(Some("v2.10.0"))),
+                Some("v2.10.0"),
+                Auto,
+                skip(SkipReason::UpToDate),
+            ),
+            (
+                Some(clean(Some("v2.11.0"))),
+                Some("v2.10.0"),
+                Prompt,
+                skip(SkipReason::UpToDate),
+            ),
+            // Behind: the policy picks between update, ask, and never.
+            (
+                Some(clean(Some("v2.9.0"))),
+                Some("v2.10.0"),
+                Never,
+                skip(SkipReason::PolicyNever),
+            ),
+            (
+                Some(clean(Some("v2.9.0"))),
+                Some("v2.10.0"),
+                Auto,
+                StackUpdateAction::Update {
+                    from: "v2.9.0".into(),
+                    to: "v2.10.0".into(),
+                },
+            ),
+            (
+                Some(clean(Some("v2.9.0"))),
+                Some("v2.10.0"),
+                Prompt,
+                StackUpdateAction::Ask {
+                    from: "v2.9.0".into(),
+                    to: "v2.10.0".into(),
+                },
+            ),
+            // Numeric compare, not string compare: v2.10 > v2.9.
+            (
+                Some(clean(Some("v2.9.9"))),
+                Some("v2.10.0"),
+                Auto,
+                StackUpdateAction::Update {
+                    from: "v2.9.9".into(),
+                    to: "v2.10.0".into(),
+                },
+            ),
+        ];
+        for (current, latest, policy, expected) in cases {
+            assert_eq!(
+                decide(current.as_ref(), latest, policy),
+                expected,
+                "current={current:?} latest={latest:?} policy={policy:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn checkout_ref_folds_git_output() {
+        // On a release tag, clean.
+        let on_tag = checkout_ref(Some("v2.10.0\n"), "", "v2.10.0");
+        assert_eq!(on_tag.tag.as_deref(), Some("v2.10.0"));
+        assert!(!on_tag.dirty);
+        assert_eq!(on_tag.label, "v2.10.0");
+
+        // Exact match on a non-release tag is NOT a release checkout.
+        let odd_tag = checkout_ref(Some("nightly-1\n"), "", "nightly-1");
+        assert_eq!(odd_tag.tag, None);
+        assert_eq!(odd_tag.label, "nightly-1");
+
+        // Not on a tag: label falls back to describe/sha output.
+        let on_branch = checkout_ref(None, " M run.py\n", "v2.9.0-12-gabc1234");
+        assert_eq!(on_branch.tag, None);
+        assert!(on_branch.dirty);
+        assert_eq!(on_branch.label, "v2.9.0-12-gabc1234");
+
+        // Nothing usable at all.
+        let unknown = checkout_ref(None, "", "");
+        assert_eq!(unknown.label, "(unknown)");
+    }
+
+    #[test]
+    fn switch_commands_quote_the_repo_path() {
+        assert_eq!(
+            switch_command("~/tt studio", "v2.10.0"),
+            "cd \"$HOME\"/'tt studio' && python3 run.py --switch v2.10.0 2>&1"
+        );
+        let spec = switch_spec(Path::new("/opt/stack"), "v2.10.0", "/tmp/switch.log".into());
+        assert_eq!(spec.args, vec!["run.py", "--switch", "v2.10.0"]);
+        assert_eq!(spec.cwd, Path::new("/opt/stack"));
+    }
+
+    // ---- ref detection against a real (temp) git repo ----
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git runs");
+        assert!(status.status.success(), "git {args:?} failed");
+    }
+
+    #[test]
+    fn local_checkout_ref_reads_a_real_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        run_git(path, &["init", "-q"]);
+        std::fs::write(path.join("run.py"), "print('hi')\n").unwrap();
+        run_git(path, &["add", "run.py"]);
+        run_git(path, &["commit", "-q", "-m", "init"]);
+
+        // Untagged commit: no release tag, not dirty.
+        let plain = local_checkout_ref(path).unwrap();
+        assert_eq!(plain.tag, None);
+        assert!(!plain.dirty);
+
+        // Tag it like a release: exact tag detected.
+        run_git(path, &["tag", "v2.10.0"]);
+        let tagged = local_checkout_ref(path).unwrap();
+        assert_eq!(tagged.tag.as_deref(), Some("v2.10.0"));
+        assert_eq!(tagged.label, "v2.10.0");
+        assert!(!tagged.dirty);
+
+        // Tracked modification: dirty (same test --switch refuses on)…
+        std::fs::write(path.join("run.py"), "print('changed')\n").unwrap();
+        assert!(local_checkout_ref(path).unwrap().dirty);
+        run_git(path, &["checkout", "-q", "--", "run.py"]);
+
+        // …but untracked files alone don't count.
+        std::fs::write(path.join("scratch.txt"), "notes\n").unwrap();
+        assert!(!local_checkout_ref(path).unwrap().dirty);
+
+        // Not a git repo at all: an error, not a bogus answer.
+        let empty = tempfile::tempdir().unwrap();
+        assert!(local_checkout_ref(empty.path()).is_err());
+    }
 }

--- a/desktop/src-tauri/src/update/stack.rs
+++ b/desktop/src-tauri/src/update/stack.rs
@@ -244,6 +244,116 @@ async fn remote_checkout_ref(
     ))
 }
 
+// ---- running the switch itself ----
+
+/// Raw output lines from `run.py --switch`, streamed to the launcher UI
+/// (rich renders plain when stdout is a pipe, so lines arrive clean).
+pub const SWITCH_LINE_EVENT: &str = "switch-line";
+
+/// Local spawn spec for `run.py --switch <tag>` inside the checkout.
+pub fn switch_spec(
+    checkout: &Path,
+    tag: &str,
+    stderr_log: std::path::PathBuf,
+) -> crate::launcher::SpawnSpec {
+    crate::launcher::SpawnSpec {
+        program: "python3".to_string(),
+        args: vec!["run.py".to_string(), "--switch".to_string(), tag.to_string()],
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// The same switch over ssh exec. `2>&1` so progress and failure panels
+/// both arrive on the streamed channel.
+pub fn switch_command(path: &str, tag: &str) -> String {
+    format!(
+        "cd {} && python3 run.py --switch {tag} 2>&1",
+        quote_path(path)
+    )
+}
+
+/// Run the guarded `run.py --switch <tag>` on the connect target and stream
+/// its output as `switch-line` events. Resolves once the switch finishes;
+/// a non-zero exit is an error (the caller proceeds to bring-up on the old
+/// version and says so). `--switch` re-checks the dirty-tree guard itself —
+/// this never forces anything.
+#[tauri::command]
+pub async fn run_stack_switch(
+    app: tauri::AppHandle<Wry>,
+    launcher_state: tauri::State<'_, crate::state::LauncherState>,
+    profile: Option<Profile>,
+    tag: String,
+) -> Result<(), String> {
+    use tauri::Emitter;
+
+    // The tag goes into a shell command on the ssh path and an argv here —
+    // only accept what we'd have decided on: a plain numeric v* tag.
+    if release_tag_key(&tag).is_none() {
+        return Err(format!("{tag} is not a release tag (v*)"));
+    }
+
+    match profile {
+        None => {
+            let configured = stack_checkout::configured_path(&app)?;
+            let managed = stack_checkout::default_managed_dir(&app)?;
+            let dir = stack_checkout::existing(configured.as_deref(), &managed)
+                .ok_or_else(|| "no local stack checkout to update".to_string())?;
+            let spec = switch_spec(&dir, &tag, crate::launcher::log_dir(&app)?.join("switch.log"));
+
+            let (tx, rx) = std::sync::mpsc::channel();
+            let line_app = app.clone();
+            crate::launcher::spawn_streaming(
+                &spec,
+                launcher_state.child.clone(),
+                move |line| {
+                    let _ = line_app.emit(SWITCH_LINE_EVENT, &line);
+                },
+                move |code| {
+                    let _ = tx.send(code);
+                },
+            )?;
+            let code = tauri::async_runtime::spawn_blocking(move || rx.recv())
+                .await
+                .map_err(|e| e.to_string())?
+                .map_err(|_| "run.py --switch ended without an exit code".to_string())?;
+            if code != Some(0) {
+                return Err(format!(
+                    "run.py --switch {tag} failed (exit {})",
+                    code.map_or("signal".to_string(), |c| c.to_string())
+                ));
+            }
+            Ok(())
+        }
+        Some(profile) => {
+            let session = crate::remote::connect_session(&app, &profile)
+                .await
+                .map_err(|e| e.to_string())?;
+            let command = switch_command(&crate::remote::repo_path(&profile), &tag);
+            let line_app = app.clone();
+            let result = session
+                .exec_stream(
+                    &command,
+                    |line| {
+                        let _ = line_app.emit(SWITCH_LINE_EVENT, line);
+                    },
+                    |_stderr| {},
+                )
+                .await;
+            session.close().await;
+            let code = result.map_err(|e| e.to_string())?;
+            if code != Some(0) {
+                return Err(format!(
+                    "run.py --switch {tag} failed on the remote machine (exit {})",
+                    code.map_or("unknown".to_string(), |c| c.to_string())
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
 // ---- Tauri commands ----
 
 pub fn stored_policy(app: &tauri::AppHandle<Wry>) -> Result<UpdatePolicy, String> {

--- a/desktop/src-tauri/src/update/stack.rs
+++ b/desktop/src-tauri/src/update/stack.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Stack freshness: is the target checkout on the latest `v*` release?
+//!
+//! Before a bring-up, the app compares the checkout's release tag (local:
+//! git in the managed checkout; remote: `git -C <path> …` over ssh exec)
+//! against the latest `v*` tag on origin, and decides whether to run the
+//! guarded `run.py --switch <tag>` first. Releases — not raw main — are the
+//! update target because .github/workflows/publish-images.yml only publishes
+//! GHCR images on `v*` tags; following main would force local image builds.
+//!
+//! Two hard rules, mirrored from `tt_setup/switch.py`:
+//! - `--switch` REFUSES dirty trees. The app never forces or resets — a
+//!   dirty (or non-release) checkout is a developer checkout: skip the
+//!   update and say so.
+//! - Any failure to learn the latest tag (offline, rate limit) skips the
+//!   update and proceeds to bring-up. Updates are best-effort; connecting
+//!   is the job.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Command;
+use tauri::Wry;
+use tauri_plugin_store::StoreExt;
+
+use crate::profiles::Profile;
+use crate::ssh::exec::quote_path;
+use crate::ssh::SshTransport;
+use crate::stack_checkout::{self, release_tag_key};
+
+/// Settings-store key for the user's update policy.
+const POLICY_KEY: &str = "stack_update_policy";
+const SETTINGS_STORE: &str = "settings.json";
+
+/// What the user wants done when the stack is behind a release.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdatePolicy {
+    /// Switch without asking.
+    Auto,
+    /// Ask before switching (default).
+    #[default]
+    Prompt,
+    /// Never switch; always go straight to bring-up.
+    Never,
+}
+
+/// What could be learned about the target checkout's git state.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct CheckoutRef {
+    /// The exact `v*` release tag HEAD sits on, when it does.
+    pub tag: Option<String>,
+    /// Tracked files modified (same test `run.py --switch` refuses on).
+    pub dirty: bool,
+    /// Human label for display: tag, `describe` output, or short sha.
+    pub label: String,
+}
+
+/// Why an update was skipped (feeds the UI's info card).
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipReason {
+    UpToDate,
+    /// Local changes — `run.py --switch` would refuse; never force.
+    DirtyCheckout,
+    /// Clean but not on a `v*` tag (branch / detached sha): a developer
+    /// checkout the app must not move.
+    NotOnRelease,
+    /// Couldn't learn the latest release tag — proceed without updating.
+    Offline,
+    PolicyNever,
+    /// Nothing checked out yet; first use clones the latest release anyway.
+    NoCheckout,
+}
+
+/// The decision for this connect, serialized for the launcher UI.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum StackUpdateAction {
+    /// Run `run.py --switch <to>` now, then bring up.
+    Update { from: String, to: String },
+    /// Offer the switch and let the user decide (policy = prompt).
+    Ask { from: String, to: String },
+    /// Go straight to bring-up.
+    Skip { reason: SkipReason },
+}
+
+/// Everything the UI needs to render the freshness outcome.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct StackFreshness {
+    pub current: Option<CheckoutRef>,
+    pub latest_tag: Option<String>,
+    #[serde(flatten)]
+    pub decision: StackUpdateAction,
+}
+
+// ---- pure logic ----
+
+/// Fold raw git output into a [`CheckoutRef`]. `describe_exact` is the
+/// stdout of `git describe --tags --exact-match` when it succeeded;
+/// `porcelain` is `git status --porcelain --untracked-files=no` output.
+pub fn checkout_ref(describe_exact: Option<&str>, porcelain: &str, label: &str) -> CheckoutRef {
+    let exact = describe_exact.map(str::trim).filter(|t| !t.is_empty());
+    // Only numeric v* tags count as releases — an exact match on some other
+    // tag is still a developer checkout.
+    let tag = exact
+        .filter(|t| release_tag_key(t).is_some())
+        .map(String::from);
+    let label = exact
+        .or_else(|| Some(label.trim()).filter(|l| !l.is_empty()))
+        .unwrap_or("(unknown)")
+        .to_string();
+    CheckoutRef {
+        tag,
+        dirty: !porcelain.trim().is_empty(),
+        label,
+    }
+}
+
+/// The decision function: current ref × latest tag × policy → action.
+/// Pure so the whole matrix is unit-testable.
+pub fn decide(
+    current: Option<&CheckoutRef>,
+    latest: Option<&str>,
+    policy: UpdatePolicy,
+) -> StackUpdateAction {
+    let Some(current) = current else {
+        return StackUpdateAction::Skip {
+            reason: SkipReason::NoCheckout,
+        };
+    };
+    if current.dirty {
+        return StackUpdateAction::Skip {
+            reason: SkipReason::DirtyCheckout,
+        };
+    }
+    let Some(tag) = &current.tag else {
+        return StackUpdateAction::Skip {
+            reason: SkipReason::NotOnRelease,
+        };
+    };
+    let Some(latest) = latest else {
+        return StackUpdateAction::Skip {
+            reason: SkipReason::Offline,
+        };
+    };
+    if release_tag_key(tag) >= release_tag_key(latest) {
+        return StackUpdateAction::Skip {
+            reason: SkipReason::UpToDate,
+        };
+    }
+    match policy {
+        UpdatePolicy::Never => StackUpdateAction::Skip {
+            reason: SkipReason::PolicyNever,
+        },
+        UpdatePolicy::Auto => StackUpdateAction::Update {
+            from: tag.clone(),
+            to: latest.to_string(),
+        },
+        UpdatePolicy::Prompt => StackUpdateAction::Ask {
+            from: tag.clone(),
+            to: latest.to_string(),
+        },
+    }
+}
+
+// ---- the exact git commands, shared by the local and ssh paths ----
+
+pub fn describe_exact_command(path: &str) -> String {
+    format!("git -C {} describe --tags --exact-match", quote_path(path))
+}
+
+pub fn dirty_command(path: &str) -> String {
+    format!(
+        "git -C {} status --porcelain --untracked-files=no",
+        quote_path(path)
+    )
+}
+
+pub fn label_command(path: &str) -> String {
+    format!("git -C {} describe --tags --always", quote_path(path))
+}
+
+// ---- gathering: local checkout ----
+
+fn git_in(dir: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Read the git state of a local checkout. Errors only when even
+/// `git status` fails (not a repo, git missing).
+pub fn local_checkout_ref(dir: &Path) -> Result<CheckoutRef, String> {
+    let porcelain = git_in(dir, &["status", "--porcelain", "--untracked-files=no"])
+        .map_err(|e| format!("couldn't inspect {}: {e}", dir.display()))?;
+    let exact = git_in(dir, &["describe", "--tags", "--exact-match"]).ok();
+    let label = git_in(dir, &["describe", "--tags", "--always"]).unwrap_or_default();
+    Ok(checkout_ref(exact.as_deref(), &porcelain, &label))
+}
+
+/// Latest `v*` release tag on the repo, straight from `git ls-remote`
+/// (system git handles auth/proxy/TLS the same way the clone did). `None`
+/// means "couldn't learn it" — offline, no tags — and skips the update.
+pub fn latest_release_tag(repo_url: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--tags", repo_url])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    stack_checkout::latest_v_tag(&String::from_utf8_lossy(&output.stdout))
+}
+
+// ---- gathering: remote checkout over ssh exec ----
+
+async fn remote_checkout_ref(
+    session: &crate::ssh::session::SshSession,
+    path: &str,
+) -> Result<CheckoutRef, crate::ssh::SshError> {
+    let porcelain = session.exec_capture(&dirty_command(path)).await?;
+    let exact = session.exec_capture(&describe_exact_command(path)).await?;
+    let label = session.exec_capture(&label_command(path)).await?;
+    Ok(checkout_ref(
+        exact.success().then_some(exact.stdout.as_str()),
+        // A failed status probe reads as clean here; the real guard is
+        // run.py --switch itself, which re-checks and refuses dirty trees.
+        if porcelain.success() {
+            porcelain.stdout.as_str()
+        } else {
+            ""
+        },
+        label.stdout.trim(),
+    ))
+}
+
+// ---- Tauri commands ----
+
+pub fn stored_policy(app: &tauri::AppHandle<Wry>) -> Result<UpdatePolicy, String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(POLICY_KEY)
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn get_stack_update_policy(app: tauri::AppHandle<Wry>) -> Result<UpdatePolicy, String> {
+    stored_policy(&app)
+}
+
+#[tauri::command]
+pub fn set_stack_update_policy(
+    app: tauri::AppHandle<Wry>,
+    policy: UpdatePolicy,
+) -> Result<(), String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    store.set(
+        POLICY_KEY,
+        serde_json::to_value(policy).map_err(|e| e.to_string())?,
+    );
+    store.save().map_err(|e| e.to_string())
+}
+
+/// Check whether the connect target's stack is behind the latest release.
+/// `profile` = None means the local (native-mode) checkout; a profile means
+/// its remote checkout, probed over ssh exec. Never blocks a connect: every
+/// unknowable falls out as a Skip decision or an error the caller treats
+/// the same way.
+#[tauri::command]
+pub async fn check_stack_freshness(
+    app: tauri::AppHandle<Wry>,
+    profile: Option<Profile>,
+) -> Result<StackFreshness, String> {
+    let policy = stored_policy(&app)?;
+
+    let current = match &profile {
+        None => {
+            let configured = stack_checkout::configured_path(&app)?;
+            let managed = stack_checkout::default_managed_dir(&app)?;
+            match stack_checkout::existing(configured.as_deref(), &managed) {
+                Some(dir) => Some(
+                    tauri::async_runtime::spawn_blocking(move || local_checkout_ref(&dir))
+                        .await
+                        .map_err(|e| e.to_string())??,
+                ),
+                None => None,
+            }
+        }
+        Some(profile) => {
+            let session = crate::remote::connect_session(&app, profile)
+                .await
+                .map_err(|e| e.to_string())?;
+            let path = crate::remote::repo_path(profile);
+            let result = remote_checkout_ref(&session, &path).await;
+            session.close().await;
+            Some(result.map_err(|e| e.to_string())?)
+        }
+    };
+
+    // The latest tag always comes from origin as seen from the app's host —
+    // it's about what has been released, not what the target machine knows.
+    let latest =
+        tauri::async_runtime::spawn_blocking(|| latest_release_tag(stack_checkout::REPO_URL))
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let decision = decide(current.as_ref(), latest.as_deref(), policy);
+    Ok(StackFreshness {
+        current,
+        latest_tag: latest,
+        decision,
+    })
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -23,9 +23,18 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/tenstorrent/tt-studio/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEEzNjMwNTM2RTA4M0E1N0QKUldSOXBZUGdOZ1ZqbzJKb1F1c29GT3VySmpYUXlSUGoyWFg4V0g4UmFmUmhicGtVcHRMUi9ORmoK"
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/desktop/src-tauri/tests/fixtures/fake_run.py
+++ b/desktop/src-tauri/tests/fixtures/fake_run.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+"""Fake run.py for the desktop launcher's integration tests.
+
+Emits canned `--json-events` NDJSON streams on stdout (schema per
+dev-docs/json-events.md) selected by the FAKE_RUN_SCENARIO env var:
+success (default), failure, prompt_blocked, slow. `--stop` in argv takes a
+plain-text teardown path and exits 0. Human chatter goes to stderr, like the
+real launcher.
+
+Mirrors run.py's TT_STUDIO_ROOT-from-cwd contract: refuses to run (exit 3)
+when the current directory doesn't contain run.py, so a spawner with the
+wrong cwd fails loudly in tests.
+"""
+
+import json
+import os
+import sys
+import time
+
+
+def emit(event, phase=None, detail=None, ts=1000.0):
+    line = {"v": 1, "ts": ts, "event": event, "phase": phase, "detail": detail or {}}
+    print(json.dumps(line), flush=True)
+
+
+def main():
+    if not os.path.isfile(os.path.join(os.getcwd(), "run.py")):
+        print("fake_run: cwd is not a checkout (no run.py)", file=sys.stderr)
+        return 3
+
+    print("human-facing chatter belongs on stderr", file=sys.stderr)
+
+    if "--stop" in sys.argv:
+        print("stopping containers (fake)", flush=True)
+        return 0
+
+    scenario = os.environ.get("FAKE_RUN_SCENARIO", "success")
+
+    if scenario == "success":
+        emit("phase_begin", "Checks", {"index": 1, "total": 2})
+        emit("progress", "Checks", {"activity": "tt-smi"})
+        emit("phase_end", "Checks", {"index": 1, "status": "ok", "duration_s": 0.1})
+        emit("phase_begin", "Launch", {"index": 2, "total": 2})
+        emit("phase_end", "Launch", {"index": 2, "status": "ok", "duration_s": 0.2})
+        emit(
+            "ready",
+            None,
+            {
+                "urls": {"app": "http://localhost:3000"},
+                "hardware": "Fake QuietBox · 2 device(s)",
+            },
+        )
+        return 0
+
+    if scenario == "failure":
+        emit("phase_begin", "Launch", {"index": 1, "total": 1})
+        emit(
+            "error",
+            "Launch",
+            {
+                "message": "Inference server didn't start — port 8001 is still taken",
+                "remediation": "lsof -i :8001; python run.py --stop, then re-run",
+                "service": "Inference server",
+                "log": "fastapi.log",
+            },
+        )
+        emit("phase_end", "Launch", {"index": 1, "status": "failed"})
+        return 1
+
+    if scenario == "prompt_blocked":
+        emit("phase_begin", "Configure", {"index": 1, "total": 2})
+        emit(
+            "prompt_blocked",
+            "Configure",
+            {
+                "prompt": "A Hugging Face token is required for gated models",
+                "remediation": "set HF_TOKEN in .env, or run: python run.py",
+            },
+        )
+        return 2
+
+    if scenario == "slow":
+        # Drip progress long enough for a test to observe and kill us.
+        emit("phase_begin", "Checks", {"index": 1, "total": 5})
+        for i in range(240):
+            emit("progress", "Checks", {"activity": "step %d" % i})
+            time.sleep(0.25)
+        return 0
+
+    print("fake_run: unknown scenario %r" % scenario, file=sys.stderr)
+    return 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/src-tauri/tests/launcher_spawn.rs
+++ b/desktop/src-tauri/tests/launcher_spawn.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Integration tests for launcher::spawn_streaming, driven against
+//! tests/fixtures/fake_run.py — a stand-in run.py that emits the canned
+//! `--json-events` NDJSON streams (success incl. ready, failure with
+//! remediation, prompt_blocked, slow progress). No real bring-up anywhere.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
+use tt_studio_desktop_lib::launcher::{
+    bring_up_spec, kill_child, spawn_streaming, stop_spec, SpawnSpec,
+};
+use tt_studio_desktop_lib::state::ChildSlot;
+
+const STREAM_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The spec builders hardcode `python3` (the Linux target); CI runners may
+/// only have `python` on PATH, so tests pick whichever answers.
+fn python() -> String {
+    if let Ok(p) = std::env::var("PYTHON") {
+        return p;
+    }
+    for candidate in ["python3", "python"] {
+        let works = std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if works {
+            return candidate.to_string();
+        }
+    }
+    panic!("no python interpreter on PATH (set PYTHON to override)");
+}
+
+/// A temp "checkout": fake_run.py copied in as run.py, so the fixture's
+/// cwd assertion doubles as a test of the spawner's cwd contract.
+fn fake_checkout(dir: &Path) -> PathBuf {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake_run.py");
+    std::fs::copy(&fixture, dir.join("run.py")).unwrap();
+    dir.to_path_buf()
+}
+
+enum Msg {
+    Line(String),
+    Exit(Option<i32>),
+}
+
+fn spawn(spec: &SpawnSpec, slot: &ChildSlot) -> mpsc::Receiver<Msg> {
+    let (tx, rx) = mpsc::channel();
+    let line_tx = tx.clone();
+    spawn_streaming(
+        spec,
+        slot.clone(),
+        move |line| {
+            let _ = line_tx.send(Msg::Line(line));
+        },
+        move |code| {
+            let _ = tx.send(Msg::Exit(code));
+        },
+    )
+    .expect("spawn failed");
+    rx
+}
+
+/// Drain the stream until the exit notification, collecting stdout lines.
+fn wait_exit(rx: &mpsc::Receiver<Msg>, lines: &mut Vec<String>) -> Option<i32> {
+    loop {
+        match rx.recv_timeout(STREAM_TIMEOUT).expect("launcher timed out") {
+            Msg::Line(line) => lines.push(line),
+            Msg::Exit(code) => return code,
+        }
+    }
+}
+
+fn scenario_spec(dir: &Path, scenario: &str) -> SpawnSpec {
+    let checkout = fake_checkout(dir);
+    let mut spec = bring_up_spec(&checkout, dir.join("logs").join("bringup.log"));
+    spec.program = python();
+    spec.envs
+        .push(("FAKE_RUN_SCENARIO".to_string(), scenario.to_string()));
+    spec
+}
+
+fn event_type(line: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(line).ok()?;
+    Some(value.get("event")?.as_str()?.to_string())
+}
+
+#[test]
+fn success_stream_ends_in_ready_and_a_clean_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "success");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(0));
+
+    // Every stdout line is valid NDJSON (stderr noise went to the log file).
+    let events: Vec<String> = lines.iter().filter_map(|l| event_type(l)).collect();
+    assert_eq!(events.len(), lines.len(), "non-JSON on stdout: {lines:?}");
+    assert_eq!(events.first().map(String::as_str), Some("phase_begin"));
+    assert_eq!(events.last().map(String::as_str), Some("ready"));
+
+    // The child is reaped: slot free again.
+    assert!(slot.lock().unwrap().is_none());
+
+    // stderr was captured to the log file, not mixed into the stream.
+    let log = std::fs::read_to_string(spec.stderr_log.clone()).unwrap();
+    assert!(log.contains("stderr"), "{log}");
+}
+
+#[test]
+fn failure_stream_carries_remediation_and_nonzero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "failure");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(1));
+
+    let error_line = lines
+        .iter()
+        .find(|l| event_type(l).as_deref() == Some("error"))
+        .expect("no error event in failure stream");
+    assert!(error_line.contains("remediation"), "{error_line}");
+    assert!(error_line.contains("port 8001"), "{error_line}");
+}
+
+#[test]
+fn blocked_prompt_exits_2_instead_of_hanging() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "prompt_blocked");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    // stdin is null and the fixture never reads it — if the spawner ever
+    // left a prompt attached, this would hit the 60s stream timeout.
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(2));
+    assert!(lines
+        .iter()
+        .any(|l| event_type(l).as_deref() == Some("prompt_blocked")));
+}
+
+#[test]
+fn kill_terminates_a_slow_bring_up_and_frees_the_slot() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "slow");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    // Wait until the child demonstrably streams, then kill it mid-phase.
+    match rx.recv_timeout(STREAM_TIMEOUT).expect("no first line") {
+        Msg::Line(_) => {}
+        Msg::Exit(code) => panic!("slow child exited early: {code:?}"),
+    }
+    assert!(kill_child(&slot), "kill reported no child to signal");
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_ne!(code, Some(0), "killed child reported success");
+    assert!(
+        slot.lock().unwrap().is_none(),
+        "child not reaped after kill"
+    );
+
+    // The slot is genuinely reusable: run the (fake) --stop path in it.
+    let mut stop = stop_spec(dir.path(), dir.path().join("logs").join("stop.log"));
+    stop.program = python();
+    let stop_rx = spawn(&stop, &slot);
+    let mut stop_lines = Vec::new();
+    assert_eq!(wait_exit(&stop_rx, &mut stop_lines), Some(0));
+    assert!(stop_lines.iter().any(|l| l.contains("stopping")));
+}
+
+#[test]
+fn second_spawn_while_running_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "slow");
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+    match rx.recv_timeout(STREAM_TIMEOUT).expect("no first line") {
+        Msg::Line(_) => {}
+        Msg::Exit(code) => panic!("slow child exited early: {code:?}"),
+    }
+
+    let err = spawn_streaming(&spec, slot.clone(), |_| {}, |_| {}).unwrap_err();
+    assert!(err.contains("already running"), "{err}");
+
+    kill_child(&slot);
+    let mut lines = Vec::new();
+    wait_exit(&rx, &mut lines);
+}
+
+#[test]
+fn stderr_log_rotates_between_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec = scenario_spec(dir.path(), "success");
+    let slot = ChildSlot::default();
+
+    let rx = spawn(&spec, &slot);
+    wait_exit(&rx, &mut Vec::new());
+    let rx = spawn(&spec, &slot);
+    wait_exit(&rx, &mut Vec::new());
+
+    assert!(spec.stderr_log.exists());
+    let rotated = spec.stderr_log.with_extension("log.1");
+    assert!(rotated.exists(), "previous run's log was not kept");
+}

--- a/desktop/src-tauri/tests/updater_dryrun.rs
+++ b/desktop/src-tauri/tests/updater_dryrun.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Updater dry-run: a real `updater.check()` against a locally served
+//! `latest.json` fixture — the same plugin code path the launch check and
+//! the "Check for updates" button hit, minus the download/install step
+//! (which needs a signed artifact from release CI).
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use tauri_plugin_updater::UpdaterExt;
+
+/// One-shot HTTP server: serves `body` as JSON for a single request.
+fn serve_once(body: String) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    port
+}
+
+fn fixture(version: &str, port: u16) -> String {
+    format!(
+        r#"{{
+  "version": "{version}",
+  "notes": "dry-run fixture",
+  "pub_date": "2026-08-20T00:00:00Z",
+  "platforms": {{
+    "linux-x86_64": {{
+      "signature": "Zml4dHVyZS1zaWduYXR1cmU=",
+      "url": "http://127.0.0.1:{port}/tt-studio.AppImage.tar.gz"
+    }},
+    "darwin-x86_64": {{
+      "signature": "Zml4dHVyZS1zaWduYXR1cmU=",
+      "url": "http://127.0.0.1:{port}/tt-studio.app.tar.gz"
+    }},
+    "darwin-aarch64": {{
+      "signature": "Zml4dHVyZS1zaWduYXR1cmU=",
+      "url": "http://127.0.0.1:{port}/tt-studio.app.tar.gz"
+    }},
+    "windows-x86_64": {{
+      "signature": "Zml4dHVyZS1zaWduYXR1cmU=",
+      "url": "http://127.0.0.1:{port}/tt-studio.msi"
+    }}
+  }}
+}}"#
+    )
+}
+
+/// A mock app with the updater plugin configured like tauri.conf.json, but
+/// pointed at the local fixture endpoint (http allowed for the test only).
+fn mock_app(port: u16) -> tauri::App<tauri::test::MockRuntime> {
+    let mut context = tauri::test::mock_context(tauri::test::noop_assets());
+    context.config_mut().plugins.0.insert(
+        "updater".to_string(),
+        serde_json::json!({
+            // Any well-formed minisign pubkey works here: check() only
+            // verifies signatures at download time, which this test stops
+            // short of.
+            "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEEzNjMwNTM2RTA4M0E1N0QKUldSOXBZUGdOZ1ZqbzJKb1F1c29GT3VySmpYUXlSUGoyWFg4V0g4UmFmUmhicGtVcHRMUi9ORmoK",
+            "endpoints": [format!("http://127.0.0.1:{port}/latest.json")],
+            "dangerousInsecureTransportProtocol": true
+        }),
+    );
+    tauri::test::mock_builder()
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .build(context)
+        .unwrap()
+}
+
+#[test]
+fn check_finds_a_newer_release_on_the_feed() {
+    let port = serve_once(fixture("99.0.0", port_placeholder()));
+    let app = mock_app(port);
+    let updater = app.handle().updater().unwrap();
+    let update = tauri::async_runtime::block_on(updater.check()).unwrap();
+    let update = update.expect("99.0.0 > 0.1.0 must be an available update");
+    assert_eq!(update.version, "99.0.0");
+}
+
+#[test]
+fn check_reports_up_to_date_for_an_older_release() {
+    let port = serve_once(fixture("0.0.1", port_placeholder()));
+    let app = mock_app(port);
+    let updater = app.handle().updater().unwrap();
+    let update = tauri::async_runtime::block_on(updater.check()).unwrap();
+    assert!(update.is_none(), "0.0.1 < 0.1.0 must not offer an update");
+}
+
+#[test]
+fn check_errors_when_the_feed_is_unreachable() {
+    // Bind-and-drop: nothing listens on this port anymore.
+    let port = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let app = mock_app(port);
+    let updater = app.handle().updater().unwrap();
+    let result = tauri::async_runtime::block_on(updater.check());
+    assert!(
+        result.is_err(),
+        "offline check must reject, not hang or lie"
+    );
+}
+
+/// The artifact URL's port doesn't matter for check(); keep it obvious.
+fn port_placeholder() -> u16 {
+    9
+}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,7 +8,13 @@ import ConnectErrorCard from "./views/ConnectErrorCard";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import QuitDialog from "./views/QuitDialog";
+import {
+  StackSwitchProgress,
+  StackUpdatePrompt,
+} from "./views/StackUpdateCard";
+import StackUpdateSetting from "./views/StackUpdateSetting";
 import UpdateBanner from "./views/UpdateBanner";
+import { stackSkipNotice } from "./lib/updates";
 import {
   describeSshError,
   TrustHostKeyDialog,
@@ -33,6 +39,7 @@ import {
   asSecretError,
   asSshError,
   cancelRemoteBringUp,
+  checkStackFreshness,
   checkStackHealth,
   classifyRemoteStack,
   deleteProfile,
@@ -45,11 +52,13 @@ import {
   onBringUpLine,
   onRemoteStopLine,
   onStackHealth,
+  onSwitchLine,
   onTunnelStatus,
   openStack,
   quitApp,
   resolveStackCheckout,
   restartStack,
+  runStackSwitch,
   saveProfile,
   setSshKeyPassphrase,
   startBringUp,
@@ -176,7 +185,85 @@ function App() {
   const [prep, setPrep] = useState<string | null>(null);
   /** Whether a local stack already answers its health checks (picker info). */
   const [stackUp, setStackUp] = useState(false);
+  /** Why the stack update was skipped this connect (info line, not an error). */
+  const [stackNotice, setStackNotice] = useState<string | null>(null);
+  /** Freshness said "behind" and policy is prompt — waiting on the user. */
+  const [pendingUpdate, setPendingUpdate] = useState<{
+    target: Profile | null;
+    from: string;
+    to: string;
+  } | null>(null);
+  /** A `run.py --switch` is running; lines stream into the progress card. */
+  const [switching, setSwitching] = useState<{
+    to: string;
+    lines: string[];
+  } | null>(null);
   const opening = useRef(false);
+
+  /** Kick off the actual bring-up on the target (after any update handling). */
+  const continueBringUp = useCallback(async (target: Profile | null) => {
+    if (target) {
+      await startRemoteBringUp(target);
+      setStage({ step: "bringup" });
+      return;
+    }
+    setPrep("Preparing the TT-Studio checkout (first run clones it)…");
+    try {
+      const checkout = await resolveStackCheckout();
+      await startBringUp(checkout.path);
+    } finally {
+      setPrep(null);
+    }
+  }, []);
+
+  /**
+   * Run `run.py --switch` with a streamed progress card. A failed switch
+   * (including the dirty-tree refusal) becomes an info line — bring-up
+   * continues on the current version.
+   */
+  const runSwitch = useCallback(async (target: Profile | null, to: string) => {
+    setSwitching({ to, lines: [] });
+    const unlisten = await onSwitchLine((line) =>
+      setSwitching(
+        (prev) => prev && { ...prev, lines: [...prev.lines.slice(-199), line] },
+      ),
+    );
+    try {
+      await runStackSwitch(target, to);
+    } catch (e) {
+      setStackNotice(
+        `Stack update to ${to} failed — continuing on the current version. ${e}`,
+      );
+    } finally {
+      unlisten();
+      setSwitching(null);
+    }
+  }, []);
+
+  // The freshness gate before every bring-up: maybe switch the checkout to
+  // the latest release first. Never blocks connecting — every failure or
+  // skip falls through to bring-up, at most with an info line.
+  const maybeUpdateThenBringUp = useCallback(
+    async (target: Profile | null) => {
+      let fresh = null;
+      try {
+        fresh = await checkStackFreshness(target);
+      } catch (e) {
+        setStackNotice(`Couldn't check for stack updates — continuing. ${e}`);
+      }
+      if (fresh?.action === "ask") {
+        setPendingUpdate({ target, from: fresh.from, to: fresh.to });
+        return;
+      }
+      if (fresh?.action === "update") {
+        await runSwitch(target, fresh.to);
+      } else if (fresh?.action === "skip") {
+        setStackNotice(stackSkipNotice(fresh.reason));
+      }
+      await continueBringUp(target);
+    },
+    [continueBringUp, runSwitch],
+  );
 
   useEffect(() => {
     if (screen.name === "quit") return;
@@ -249,9 +336,7 @@ function App() {
           setStage({ step: "error", card });
           return;
         }
-        return startRemoteBringUp(target).then(() =>
-          setStage({ step: "bringup" }),
-        );
+        return maybeUpdateThenBringUp(target);
       })
       .catch((e) => {
         const ssh = asSshError(e);
@@ -263,7 +348,7 @@ function App() {
           },
         });
       });
-  }, [screen, stage.step, tunnel]);
+  }, [screen, stage.step, tunnel, maybeUpdateThenBringUp]);
 
   // For SSH targets: follow tunnel status. The listener is scoped to the
   // connecting screen, but the tunnel itself keeps running after we navigate
@@ -369,6 +454,7 @@ function App() {
     setHealth(null);
     setTunnel(null);
     setError(null);
+    setStackNotice(null);
     // Local connects go straight to the health gate; SSH connects walk the
     // tunnel → classify → attach-or-bringup stages first.
     setStage({ step: target ? "tunnel" : "attach" });
@@ -380,30 +466,51 @@ function App() {
     setScreen({ name: "connecting", target });
   }, []);
 
+  const handleUpdateNow = useCallback(() => {
+    if (!pendingUpdate) return;
+    const { target, to } = pendingUpdate;
+    setPendingUpdate(null);
+    runSwitch(target, to)
+      .then(() => continueBringUp(target))
+      .catch((e) => {
+        setError(String(e));
+        setScreen({ name: "picker" });
+      });
+  }, [pendingUpdate, runSwitch, continueBringUp]);
+
+  const handleUpdateSkip = useCallback(() => {
+    if (!pendingUpdate) return;
+    const target = pendingUpdate.target;
+    setPendingUpdate(null);
+    continueBringUp(target).catch((e) => {
+      setError(String(e));
+      setScreen({ name: "picker" });
+    });
+  }, [pendingUpdate, continueBringUp]);
+
   // Native mode: attach if the stack is already healthy, otherwise resolve
-  // the checkout (cloning on first use) and spawn the bring-up.
+  // the checkout (cloning on first use), maybe refresh it, and spawn the
+  // bring-up.
   const connectLocal = useCallback(async () => {
     setHealth(null);
     setStage({ step: "attach" });
+    setStackNotice(null);
     opening.current = false;
     setScreen({ name: "connecting", target: null });
     try {
       const current = await checkStackHealth();
       if (current.ready) {
-        // Already running: no bring-up — the health poller opens the stack.
+        // Already running: no bring-up (and no update — never switch the
+        // checkout under a live stack); the health poller opens the stack.
         await markLocalAttach();
         return;
       }
-      setPrep("Preparing the TT-Studio checkout (first run clones it)…");
-      const checkout = await resolveStackCheckout();
-      await startBringUp(checkout.path);
+      await maybeUpdateThenBringUp(null);
     } catch (e) {
       setError(String(e));
       setScreen({ name: "picker" });
-    } finally {
-      setPrep(null);
     }
-  }, []);
+  }, [maybeUpdateThenBringUp]);
 
   // Explicit "Restart stack": run.py --stop, then a fresh bring-up. Health
   // polling is suppressed (bringUpOnly) so the old, still-draining services
@@ -475,6 +582,9 @@ function App() {
     stopSshTunnels().catch(() => {});
     setTunnel(null);
     setHealth(null);
+    setPendingUpdate(null);
+    setSwitching(null);
+    setStackNotice(null);
     setScreen({ name: "picker" });
   }, []);
 
@@ -596,6 +706,28 @@ function App() {
         />
       );
     }
+    if (pendingUpdate) {
+      return (
+        <StackUpdatePrompt
+          from={pendingUpdate.from}
+          to={pendingUpdate.to}
+          machine={target?.name ?? null}
+          onUpdate={handleUpdateNow}
+          onSkip={handleUpdateSkip}
+        />
+      );
+    }
+    if (switching) {
+      return <StackSwitchProgress to={switching.to} lines={switching.lines} />;
+    }
+    const notice = stackNotice && (
+      <p
+        data-testid="stack-notice"
+        className="fixed inset-x-0 bottom-4 mx-auto max-w-md rounded-md bg-zinc-900 px-4 py-2 text-center text-xs text-zinc-400"
+      >
+        {stackNotice}
+      </p>
+    );
     if (
       bringUp &&
       (bringUp.phases.length > 0 ||
@@ -603,11 +735,14 @@ function App() {
         bringUp.promptBlocked)
     ) {
       return (
-        <BringUpProgress
-          state={bringUp}
-          onReady={handleBringUpReady}
-          onCancel={cancelConnect}
-        />
+        <>
+          <BringUpProgress
+            state={bringUp}
+            onReady={handleBringUpReady}
+            onCancel={cancelConnect}
+          />
+          {notice}
+        </>
       );
     }
     if (prep) {
@@ -621,17 +756,20 @@ function App() {
       );
     }
     return (
-      <HealthGate
-        health={health}
-        target={target}
-        tunnel={tunnel}
-        activity={
-          target && stage.step !== "error"
-            ? describeStep(stage.step, target.name)
-            : undefined
-        }
-        onCancel={cancelConnect}
-      />
+      <>
+        <HealthGate
+          health={health}
+          target={target}
+          tunnel={tunnel}
+          activity={
+            target && stage.step !== "error"
+              ? describeStep(stage.step, target.name)
+              : undefined
+          }
+          onCancel={cancelConnect}
+        />
+        {notice}
+      </>
     );
   }
 
@@ -648,8 +786,9 @@ function App() {
         onEditProfile={(profile) => setScreen({ name: "editor", profile })}
         onDeleteProfile={handleDelete}
       />
-      <div className="fixed bottom-4 left-4">
+      <div className="fixed bottom-4 left-4 flex items-center gap-4">
         <UpdateBanner />
+        <StackUpdateSetting />
       </div>
       {(error || keychainWarning) && (
         <p className="fixed inset-x-0 bottom-4 mx-auto max-w-md rounded-md bg-zinc-900 px-4 py-2 text-center text-xs text-amber-400">

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import BringUpProgress from "./views/BringUpProgress";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import {
+  applyExit,
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -151,16 +152,25 @@ function App() {
   // shell), render its NDJSON stream natively instead of the bare checklist.
   useEffect(() => {
     if (screen.name !== "connecting") return;
-    let unlisten: (() => void) | undefined;
+    let unlistenLine: (() => void) | undefined;
+    let unlistenExit: (() => void) | undefined;
     listen<string>("bringup-line", ({ payload }) => {
       const event = parseEventLine(payload);
       if (!event) return;
       setBringUp((prev) => reduceEvent(prev ?? initialBringUpState(), event));
     }).then((fn) => {
-      unlisten = fn;
+      unlistenLine = fn;
+    });
+    // If the child dies without a terminal event (crash, kill, blocked
+    // prompt before the stream existed), surface that instead of spinning.
+    listen<number | null>("bringup-exit", ({ payload }) => {
+      setBringUp((prev) => applyExit(prev ?? initialBringUpState(), payload));
+    }).then((fn) => {
+      unlistenExit = fn;
     });
     return () => {
-      unlisten?.();
+      unlistenLine?.();
+      unlistenExit?.();
       setBringUp(null);
     };
   }, [screen.name]);
@@ -299,7 +309,12 @@ function App() {
   }
 
   if (screen.name === "connecting") {
-    if (bringUp && bringUp.phases.length > 0) {
+    if (
+      bringUp &&
+      (bringUp.phases.length > 0 ||
+        bringUp.errors.length > 0 ||
+        bringUp.promptBlocked)
+    ) {
       return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
     }
     if (prep) {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -15,14 +15,19 @@ import {
 } from "./lib/events";
 import {
   asSecretError,
+  checkStackHealth,
   deleteProfile,
   detectHardware,
   listProfiles,
+  markLocalAttach,
   markProfileUsed,
   onStackHealth,
   openStack,
+  resolveStackCheckout,
+  restartStack,
   saveProfile,
   setSshKeyPassphrase,
+  startBringUp,
   startHealthPoll,
   stopHealthPoll,
   type HardwareProbe,
@@ -39,7 +44,9 @@ type Screen =
   | { name: "loading" }
   | { name: "picker" }
   | { name: "editor"; profile?: Profile }
-  | { name: "connecting"; target: Profile | null };
+  // bringUpOnly: a restart is in flight — services may briefly still look
+  // healthy, so only the bring-up's own ready event may open the stack.
+  | { name: "connecting"; target: Profile | null; bringUpOnly?: boolean };
 
 const STATUS_STYLE: Record<string, string> = {
   up: "bg-emerald-500",
@@ -98,6 +105,10 @@ function App() {
   const [bringUp, setBringUp] = useState<BringUpState | null>(null);
   const [keychainWarning, setKeychainWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /** One-line status while native mode prepares (checkout clone, --stop). */
+  const [prep, setPrep] = useState<string | null>(null);
+  /** Whether a local stack already answers its health checks (picker info). */
+  const [stackUp, setStackUp] = useState(false);
   const opening = useRef(false);
 
   useEffect(() => {
@@ -113,9 +124,18 @@ function App() {
       });
   }, []);
 
+  // On the picker, take one health snapshot so it can say whether a local
+  // stack is already running (read-only GETs).
+  useEffect(() => {
+    if (screen.name !== "picker") return;
+    checkStackHealth()
+      .then((h) => setStackUp(h.ready))
+      .catch(() => setStackUp(false));
+  }, [screen.name]);
+
   // While connecting: poll stack health, and navigate once everything is up.
   useEffect(() => {
-    if (screen.name !== "connecting") return;
+    if (screen.name !== "connecting" || screen.bringUpOnly) return;
     let unlisten: (() => void) | undefined;
     onStackHealth(setHealth).then((fn) => {
       unlisten = fn;
@@ -158,7 +178,12 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (screen.name !== "connecting" || !health?.ready || opening.current)
+    if (
+      screen.name !== "connecting" ||
+      screen.bringUpOnly ||
+      !health?.ready ||
+      opening.current
+    )
       return;
     opening.current = true;
     stopHealthPoll()
@@ -175,6 +200,49 @@ function App() {
     opening.current = false;
     if (target) markProfileUsed(target.id).catch(() => {});
     setScreen({ name: "connecting", target });
+  }, []);
+
+  // Native mode: attach if the stack is already healthy, otherwise resolve
+  // the checkout (cloning on first use) and spawn the bring-up.
+  const connectLocal = useCallback(async () => {
+    setHealth(null);
+    opening.current = false;
+    setScreen({ name: "connecting", target: null });
+    try {
+      const current = await checkStackHealth();
+      if (current.ready) {
+        // Already running: no bring-up — the health poller opens the stack.
+        await markLocalAttach();
+        return;
+      }
+      setPrep("Preparing the TT-Studio checkout (first run clones it)…");
+      const checkout = await resolveStackCheckout();
+      await startBringUp(checkout.path);
+    } catch (e) {
+      setError(String(e));
+      setScreen({ name: "picker" });
+    } finally {
+      setPrep(null);
+    }
+  }, []);
+
+  // Explicit "Restart stack": run.py --stop, then a fresh bring-up. Health
+  // polling is suppressed (bringUpOnly) so the old, still-draining services
+  // can't re-open the stack mid-restart.
+  const handleRestart = useCallback(async () => {
+    setHealth(null);
+    opening.current = false;
+    setScreen({ name: "connecting", target: null, bringUpOnly: true });
+    setPrep("Stopping the current stack…");
+    try {
+      const checkout = await resolveStackCheckout();
+      await restartStack(checkout.path);
+    } catch (e) {
+      setError(String(e));
+      setScreen({ name: "picker" });
+    } finally {
+      setPrep(null);
+    }
   }, []);
 
   const handleSave = useCallback(
@@ -234,6 +302,16 @@ function App() {
     if (bringUp && bringUp.phases.length > 0) {
       return <BringUpProgress state={bringUp} onReady={handleBringUpReady} />;
     }
+    if (prep) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 px-6 text-zinc-100">
+          <span className="inline-block h-5 w-5 animate-spin rounded-full border border-zinc-500 border-t-transparent" />
+          <p data-testid="native-prep" className="text-sm text-zinc-400">
+            {prep}
+          </p>
+        </main>
+      );
+    }
     return <HealthGate health={health} target={screen.target} />;
   }
 
@@ -242,7 +320,9 @@ function App() {
       <ConnectionPicker
         hardware={hardware}
         profiles={profiles}
-        onConnectLocal={() => connect(null)}
+        stackUp={stackUp}
+        onConnectLocal={connectLocal}
+        onRestartStack={handleRestart}
         onConnectSsh={connect}
         onAddMachine={() => setScreen({ name: "editor" })}
         onEditProfile={(profile) => setScreen({ name: "editor", profile })}

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import ConnectErrorCard from "./views/ConnectErrorCard";
 import ConnectionPicker from "./views/ConnectionPicker";
 import ProfileEditor from "./views/ProfileEditor";
 import QuitDialog from "./views/QuitDialog";
+import UpdateBanner from "./views/UpdateBanner";
 import {
   describeSshError,
   TrustHostKeyDialog,
@@ -647,6 +648,9 @@ function App() {
         onEditProfile={(profile) => setScreen({ name: "editor", profile })}
         onDeleteProfile={handleDelete}
       />
+      <div className="fixed bottom-4 left-4">
+        <UpdateBanner />
+      </div>
       {(error || keychainWarning) && (
         <p className="fixed inset-x-0 bottom-4 mx-auto max-w-md rounded-md bg-zinc-900 px-4 py-2 text-center text-xs text-amber-400">
           {error ?? keychainWarning}

--- a/desktop/src/lib/events.test.ts
+++ b/desktop/src/lib/events.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  applyExit,
   initialBringUpState,
   parseEventLine,
   reduceEvent,
@@ -132,5 +133,30 @@ describe("reduceEvent / reduceStream", () => {
       `pre-bootstrap chatter\n${FAILURE_STREAM}\nmore chatter`,
     );
     expect(state.errors).toHaveLength(1);
+  });
+});
+
+describe("applyExit (child died — was the stream self-explanatory?)", () => {
+  it("leaves a ready or already-explained stream alone", () => {
+    const ready = reduceStream(SUCCESS_STREAM);
+    expect(applyExit(ready, 0)).toBe(ready);
+    const failed = reduceStream(FAILURE_STREAM);
+    expect(applyExit(failed, 1)).toBe(failed);
+    const blocked = reduceStream(PROMPT_BLOCKED_STREAM);
+    expect(applyExit(blocked, 2)).toBe(blocked);
+  });
+
+  it("turns a bare exit 2 into a prompt-blocked card", () => {
+    const state = applyExit(initialBringUpState(), 2);
+    expect(state.promptBlocked?.remediation).toBe("python run.py");
+  });
+
+  it("turns an unexplained crash or kill into an error card", () => {
+    const crashed = applyExit(initialBringUpState(), 1);
+    expect(crashed.errors[0].message).toContain("exited with code 1");
+    expect(crashed.errors[0].remediation).toBe("python run.py");
+
+    const killed = applyExit(initialBringUpState(), null);
+    expect(killed.errors[0].message).toContain("interrupted");
   });
 });

--- a/desktop/src/lib/events.ts
+++ b/desktop/src/lib/events.ts
@@ -210,6 +210,49 @@ export function reduceEvent(
   }
 }
 
+/** What the prompt-blocked card tells the user to run in a terminal. */
+export const ONE_TIME_SETUP_COMMAND = "python run.py";
+
+/**
+ * Fold the child's exit code into the state. A healthy stream carries its
+ * own terminal event (ready / error / prompt_blocked); this fills the gap
+ * when the process dies without one — a crash, a kill, or exit code 2 from
+ * a prompt hit before the event stream existed — so the UI never waits on a
+ * dead child. No-op when the stream already explained itself.
+ */
+export function applyExit(
+  state: BringUpState,
+  code: number | null,
+): BringUpState {
+  if (state.ready || code === 0) return state;
+  // Exit code 2 is the --json-events contract for "needed interactive input".
+  if (code === 2) {
+    return state.promptBlocked
+      ? state
+      : {
+          ...state,
+          promptBlocked: {
+            prompt: "The launcher needed interactive input before it could report why.",
+            remediation: ONE_TIME_SETUP_COMMAND,
+          },
+        };
+  }
+  if (state.errors.length > 0) return state;
+  return {
+    ...state,
+    errors: [
+      ...state.errors,
+      {
+        message:
+          code === null
+            ? "Bring-up was interrupted before it finished"
+            : `Bring-up exited with code ${code}`,
+        remediation: ONE_TIME_SETUP_COMMAND,
+      },
+    ],
+  };
+}
+
 /** Convenience for tests and replay: fold a whole NDJSON document. */
 export function reduceStream(ndjson: string): BringUpState {
   return ndjson

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -96,6 +96,39 @@ export const onStackHealth = (
 ): Promise<UnlistenFn> =>
   listen<StackHealth>("stack-health", (event) => handler(event.payload));
 
+// ---- native launcher (stack checkout + run.py child) ----
+
+export interface StackCheckout {
+  path: string;
+  source: "configured" | "managed" | "cloned";
+}
+
+/** May shallow-clone the latest release on first use — can take a while. */
+export const resolveStackCheckout = () =>
+  invoke<StackCheckout>("resolve_stack_checkout");
+
+export const setStackCheckoutPath = (path: string | null) =>
+  invoke<void>("set_stack_checkout_path", { path });
+
+export const startBringUp = (checkout: string) =>
+  invoke<number>("start_bring_up", { checkout });
+
+export const stopBringUp = () => invoke<boolean>("stop_bring_up");
+
+export const bringUpRunning = () => invoke<boolean>("bring_up_running");
+
+/** Raw NDJSON lines from `run.py --json-events` (parse with events.ts). */
+export const onBringUpLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("bringup-line", (event) => handler(event.payload));
+
+/** Exit code of the bring-up child; null when killed by a signal. */
+export const onBringUpExit = (
+  handler: (code: number | null) => void,
+): Promise<UnlistenFn> =>
+  listen<number | null>("bringup-exit", (event) => handler(event.payload));
+
 // ---- navigation ----
 
 export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -251,6 +251,57 @@ export function asSshError(e: unknown): SshErrorPayload | null {
   return null;
 }
 
+// ---- stack updates (update/stack.rs) ----
+
+export type StackUpdatePolicy = "auto" | "prompt" | "never";
+
+export type StackSkipReason =
+  | "up_to_date"
+  | "dirty_checkout"
+  | "not_on_release"
+  | "offline"
+  | "policy_never"
+  | "no_checkout";
+
+export interface StackCheckoutRef {
+  tag: string | null;
+  dirty: boolean;
+  label: string;
+}
+
+export type StackFreshness = {
+  current: StackCheckoutRef | null;
+  latest_tag: string | null;
+} & (
+  | { action: "update"; from: string; to: string }
+  | { action: "ask"; from: string; to: string }
+  | { action: "skip"; reason: StackSkipReason }
+);
+
+/** Is the target's checkout behind the latest v* release? null profile = local. */
+export const checkStackFreshness = (profile: Profile | null) =>
+  invoke<StackFreshness>("check_stack_freshness", { profile });
+
+/**
+ * Run the guarded `run.py --switch <tag>` on the target (local spawn or ssh
+ * exec). Resolves when done; rejects on failure — including a dirty tree,
+ * which --switch itself refuses. Never forces anything.
+ */
+export const runStackSwitch = (profile: Profile | null, tag: string) =>
+  invoke<void>("run_stack_switch", { profile, tag });
+
+export const getStackUpdatePolicy = () =>
+  invoke<StackUpdatePolicy>("get_stack_update_policy");
+
+export const setStackUpdatePolicy = (policy: StackUpdatePolicy) =>
+  invoke<void>("set_stack_update_policy", { policy });
+
+/** Raw output lines from a running `run.py --switch`. */
+export const onSwitchLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("switch-line", (event) => handler(event.payload));
+
 // ---- navigation ----
 
 export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -117,6 +117,13 @@ export const stopBringUp = () => invoke<boolean>("stop_bring_up");
 
 export const bringUpRunning = () => invoke<boolean>("bring_up_running");
 
+/** Record that the UI attached to an already-running local stack. */
+export const markLocalAttach = () => invoke<void>("mark_local_attach");
+
+/** `run.py --stop`, then a fresh bring-up. Explicit user action only. */
+export const restartStack = (checkout: string) =>
+  invoke<number>("restart_stack", { checkout });
+
 /** Raw NDJSON lines from `run.py --json-events` (parse with events.ts). */
 export const onBringUpLine = (
   handler: (line: string) => void,

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -25,7 +25,10 @@ export interface Profile {
   last_used?: number;
 }
 
+export type Platform = "linux" | "macos" | "windows" | "other";
+
 export interface HardwareProbe {
+  platform: Platform;
   accelerator_present: boolean;
   default_mode: ProfileKind;
 }

--- a/desktop/src/lib/updates.ts
+++ b/desktop/src/lib/updates.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Shell self-update via the Tauri updater plugin. The update feed is the
+// `latest.json` asset attached to tagged GitHub releases of
+// tenstorrent/tt-studio (see tauri.conf.json), so the shell only ever moves
+// between released versions — never raw main.
+
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check } from "@tauri-apps/plugin-updater";
+
+export interface ShellUpdate {
+  version: string;
+  body?: string;
+  /** Download the new shell, install it, and relaunch the app. */
+  install: () => Promise<void>;
+}
+
+/**
+ * Ask the release feed whether a newer shell exists. Resolves null when
+ * already current; rejects when the feed is unreachable (offline) — callers
+ * decide whether that's silent (launch check) or surfaced (manual check).
+ */
+export async function checkShellUpdate(): Promise<ShellUpdate | null> {
+  const update = await check();
+  if (!update) return null;
+  return {
+    version: update.version,
+    body: update.body ?? undefined,
+    install: async () => {
+      await update.downloadAndInstall();
+      await relaunch();
+    },
+  };
+}

--- a/desktop/src/lib/updates.ts
+++ b/desktop/src/lib/updates.ts
@@ -9,6 +9,7 @@
 
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
+import type { StackSkipReason } from "./ipc";
 
 export interface ShellUpdate {
   version: string;
@@ -22,6 +23,24 @@ export interface ShellUpdate {
  * already current; rejects when the feed is unreachable (offline) — callers
  * decide whether that's silent (launch check) or surfaced (manual check).
  */
+/**
+ * What (if anything) to tell the user when a stack update was skipped.
+ * null = say nothing: up-to-date and policy "never" are the expected quiet
+ * paths, and a missing checkout gets cloned at the latest release anyway.
+ */
+export function stackSkipNotice(reason: StackSkipReason): string | null {
+  switch (reason) {
+    case "dirty_checkout":
+      return "Developer checkout detected (local changes) — skipping the stack update.";
+    case "not_on_release":
+      return "Developer checkout detected (not on a release tag) — skipping the stack update.";
+    case "offline":
+      return "Couldn't check for stack updates — continuing with the current version.";
+    default:
+      return null;
+  }
+}
+
 export async function checkShellUpdate(): Promise<ShellUpdate | null> {
   const update = await check();
   if (!update) return null;

--- a/desktop/src/views/BringUpProgress.test.tsx
+++ b/desktop/src/views/BringUpProgress.test.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import BringUpProgress from "./BringUpProgress";
 import { reduceStream } from "../lib/events";
@@ -66,5 +66,27 @@ describe("BringUpProgress", () => {
     const card = screen.getByTestId("bringup-prompt-blocked");
     expect(card.textContent).toContain("Hugging Face");
     expect(card.textContent).toContain("HF_TOKEN");
+    expect(card.textContent).toContain("one-time setup");
+  });
+
+  it("copies the remediation command to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    try {
+      render(
+        <BringUpProgress
+          state={reduceStream(PROMPT_BLOCKED_STREAM)}
+          onReady={() => {}}
+        />,
+      );
+      const button = screen.getByTestId("copy-remediation");
+      fireEvent.click(button);
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining("HF_TOKEN"),
+      );
+      await waitFor(() => expect(button.textContent).toBe("Copied"));
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/desktop/src/views/BringUpProgress.tsx
+++ b/desktop/src/views/BringUpProgress.tsx
@@ -6,8 +6,39 @@
 // phase stepper, notes/warnings, error cards with remediation, and the
 // ready → open-the-stack transition. Pure view over BringUpState.
 
-import { useEffect } from "react";
-import type { BringUpState, PhaseState } from "../lib/events";
+import { useEffect, useState } from "react";
+import {
+  ONE_TIME_SETUP_COMMAND,
+  type BringUpState,
+  type PhaseState,
+} from "../lib/events";
+
+/** A remediation command with a copy-to-clipboard affordance. */
+function Remediation({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard
+      ?.writeText(command)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  };
+  return (
+    <span className="inline-flex items-center gap-2">
+      <code className="rounded bg-zinc-900 px-1 py-0.5">{command}</code>
+      <button
+        type="button"
+        onClick={copy}
+        data-testid="copy-remediation"
+        className="rounded border border-zinc-700 px-1.5 py-0.5 text-[10px] text-zinc-300 transition-colors hover:border-zinc-500 hover:text-zinc-100"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </span>
+  );
+}
 
 function PhaseRow({ phase, total }: { phase: PhaseState; total: number | null }) {
   const icon =
@@ -107,10 +138,7 @@ function BringUpProgress({ state, onReady }: Props) {
           </p>
           {err.remediation && (
             <p className="mt-2 text-xs text-red-200/80">
-              Try:{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5">
-                {err.remediation}
-              </code>
+              Try: <Remediation command={err.remediation} />
             </p>
           )}
           {err.log && (
@@ -130,14 +158,12 @@ function BringUpProgress({ state, onReady }: Props) {
           <p className="mt-1 text-xs text-amber-200/80">
             {state.promptBlocked.prompt}
           </p>
-          {state.promptBlocked.remediation && (
-            <p className="mt-2 text-xs text-amber-200/80">
-              Try:{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5">
-                {state.promptBlocked.remediation}
-              </code>
-            </p>
-          )}
+          <p className="mt-2 text-xs text-amber-200/80">
+            Run the one-time setup in a terminal, then relaunch:{" "}
+            <Remediation
+              command={state.promptBlocked.remediation ?? ONE_TIME_SETUP_COMMAND}
+            />
+          </p>
         </section>
       )}
     </main>

--- a/desktop/src/views/ConnectionPicker.test.tsx
+++ b/desktop/src/views/ConnectionPicker.test.tsx
@@ -4,14 +4,24 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import ConnectionPicker, { defaultSelection } from "./ConnectionPicker";
+import ConnectionPicker, {
+  defaultSelection,
+  noLocalReason,
+} from "./ConnectionPicker";
 import type { HardwareProbe, Profile } from "../lib/ipc";
 
 const withHardware: HardwareProbe = {
+  platform: "linux",
   accelerator_present: true,
   default_mode: "local",
 };
 const noHardware: HardwareProbe = {
+  platform: "linux",
+  accelerator_present: false,
+  default_mode: "ssh",
+};
+const onMac: HardwareProbe = {
+  platform: "macos",
   accelerator_present: false,
   default_mode: "ssh",
 };
@@ -132,6 +142,33 @@ describe("ConnectionPicker", () => {
     expect(screen.getByText("Old box")).toBeTruthy();
     expect(screen.getByText(/old\.lan/)).toBeTruthy();
     expect(screen.getByText(/key ~\/\.ssh\/id_ed25519/)).toBeTruthy();
+  });
+
+  it("explains why local mode is unavailable, per platform", () => {
+    // Linux without the device node: point at the driver setup.
+    expect(noLocalReason(noHardware)).toContain("/dev/tenstorrent");
+    expect(noLocalReason(noHardware)).toContain("python run.py");
+    // Non-Linux: native mode is out entirely, steer to SSH.
+    expect(noLocalReason(onMac)).toContain("macOS");
+    expect(noLocalReason(onMac)).toContain("SSH");
+    // Hardware present (or still probing): no card.
+    expect(noLocalReason(withHardware)).toBeNull();
+    expect(noLocalReason(null)).toBeNull();
+
+    const first = render(
+      <ConnectionPicker hardware={onMac} profiles={[qb2]} {...noop} />,
+    );
+    expect(screen.getByTestId("no-local-card").textContent).toContain(
+      "macOS",
+    );
+    // Saved SSH profiles are still front and center.
+    expect(screen.getByTestId("connect-qb2")).toBeTruthy();
+    first.unmount();
+
+    render(
+      <ConnectionPicker hardware={withHardware} profiles={[]} {...noop} />,
+    );
+    expect(screen.queryByTestId("no-local-card")).toBeNull();
   });
 
   it("always offers adding a machine", () => {

--- a/desktop/src/views/ConnectionPicker.test.tsx
+++ b/desktop/src/views/ConnectionPicker.test.tsx
@@ -36,7 +36,9 @@ const older: Profile = {
 };
 
 const noop = {
+  stackUp: false,
   onConnectLocal: () => {},
+  onRestartStack: () => {},
   onConnectSsh: () => {},
   onAddMachine: () => {},
   onEditProfile: () => {},
@@ -72,6 +74,41 @@ describe("ConnectionPicker", () => {
     render(<ConnectionPicker hardware={noHardware} profiles={[]} {...noop} />);
     expect(screen.queryByTestId("connect-local")).toBeNull();
     expect(screen.getByTestId("picker-empty")).toBeTruthy();
+  });
+
+  it("offers restart only when a local stack is already up", () => {
+    const onRestartStack = vi.fn();
+    const { unmount } = render(
+      <ConnectionPicker
+        hardware={withHardware}
+        profiles={[]}
+        {...noop}
+        stackUp
+        onRestartStack={onRestartStack}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("restart-stack"));
+    expect(onRestartStack).toHaveBeenCalled();
+    expect(screen.getByText(/already running/)).toBeTruthy();
+    unmount();
+
+    // Stack down → no restart affordance.
+    const second = render(
+      <ConnectionPicker hardware={withHardware} profiles={[]} {...noop} />,
+    );
+    expect(screen.queryByTestId("restart-stack")).toBeNull();
+    second.unmount();
+
+    // No hardware → no restart even if something answers on the ports.
+    render(
+      <ConnectionPicker
+        hardware={noHardware}
+        profiles={[]}
+        {...noop}
+        stackUp
+      />,
+    );
+    expect(screen.queryByTestId("restart-stack")).toBeNull();
   });
 
   it("connects a saved ssh machine with one click", () => {

--- a/desktop/src/views/ConnectionPicker.tsx
+++ b/desktop/src/views/ConnectionPicker.tsx
@@ -27,6 +27,26 @@ export function defaultSelection(
   return mostRecent.id;
 }
 
+/**
+ * Why local mode is unavailable, phrased for the picker — distinguishing
+ * "wrong OS" (native mode is Linux-only) from "Linux but no device node"
+ * (card missing or driver not set up). Null when local mode is offered.
+ * Exported for unit tests.
+ */
+export function noLocalReason(hardware: HardwareProbe | null): string | null {
+  if (!hardware || hardware.accelerator_present) return null;
+  if (hardware.platform === "linux") {
+    return "No Tenstorrent accelerator was found on this machine (/dev/tenstorrent is missing). If a card is installed, finish the one-time driver setup in a terminal with python run.py; otherwise connect to a machine that has one over SSH.";
+  }
+  const os =
+    hardware.platform === "macos"
+      ? "macOS"
+      : hardware.platform === "windows"
+        ? "Windows"
+        : "this OS";
+  return `Running models locally needs a Linux machine with a Tenstorrent accelerator — TT-Studio can't run natively on ${os}. Connect to a Linux machine over SSH instead.`;
+}
+
 export function describeAuth(profile: Profile): string {
   if (!profile.auth || profile.auth.method === "agent") return "ssh-agent";
   return `key ${profile.auth.path}`;
@@ -70,6 +90,15 @@ function ConnectionPicker({
       </header>
 
       <section className="flex w-full max-w-md flex-col gap-3">
+        {noLocalReason(hardware) && (
+          <p
+            data-testid="no-local-card"
+            className="rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3 text-xs leading-relaxed text-zinc-400"
+          >
+            {noLocalReason(hardware)}
+          </p>
+        )}
+
         {hardware?.accelerator_present && (
           <button
             type="button"
@@ -162,8 +191,8 @@ function ConnectionPicker({
             data-testid="picker-empty"
             className="rounded-lg border border-dashed border-zinc-800 px-4 py-6 text-center text-sm text-zinc-400"
           >
-            No Tenstorrent hardware found on this machine. Add a machine that
-            has one to connect over SSH.
+            No machines yet — add one that has a Tenstorrent accelerator to
+            connect over SSH.
           </p>
         )}
 

--- a/desktop/src/views/ConnectionPicker.tsx
+++ b/desktop/src/views/ConnectionPicker.tsx
@@ -35,7 +35,11 @@ export function describeAuth(profile: Profile): string {
 interface Props {
   hardware: HardwareProbe | null;
   profiles: Profile[];
+  /** A local stack already answers its health checks. */
+  stackUp: boolean;
   onConnectLocal: () => void;
+  /** Explicit stop-then-bring-up; never triggered automatically. */
+  onRestartStack: () => void;
   onConnectSsh: (profile: Profile) => void;
   onAddMachine: () => void;
   onEditProfile: (profile: Profile) => void;
@@ -45,7 +49,9 @@ interface Props {
 function ConnectionPicker({
   hardware,
   profiles,
+  stackUp,
   onConnectLocal,
+  onRestartStack,
   onConnectSsh,
   onAddMachine,
   onEditProfile,
@@ -80,13 +86,28 @@ function ConnectionPicker({
                 Run on this machine
               </span>
               <span className="block text-xs text-zinc-400">
-                Tenstorrent accelerator detected
+                {stackUp
+                  ? "Stack already running — connect attaches to it"
+                  : "Tenstorrent accelerator detected"}
               </span>
             </span>
             <span className="text-xs font-medium text-purple-400">
               Recommended
             </span>
           </button>
+        )}
+
+        {hardware?.accelerator_present && stackUp && (
+          <div className="flex items-center justify-end px-1">
+            <button
+              type="button"
+              onClick={onRestartStack}
+              data-testid="restart-stack"
+              className="rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+            >
+              Restart stack
+            </button>
+          </div>
         )}
 
         {sshProfiles.map((profile) => (

--- a/desktop/src/views/StackUpdateCard.test.tsx
+++ b/desktop/src/views/StackUpdateCard.test.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stackSkipNotice } from "../lib/updates";
+import { StackSwitchProgress, StackUpdatePrompt } from "./StackUpdateCard";
+
+afterEach(cleanup);
+
+describe("StackUpdatePrompt", () => {
+  it("names both versions and routes the two choices", () => {
+    const onUpdate = vi.fn();
+    const onSkip = vi.fn();
+    render(
+      <StackUpdatePrompt
+        from="v2.9.0"
+        to="v2.10.0"
+        machine="QuietBox"
+        onUpdate={onUpdate}
+        onSkip={onSkip}
+      />,
+    );
+    expect(
+      screen.getByTestId("stack-update-versions").textContent,
+    ).toContain("QuietBox is on v2.9.0");
+    fireEvent.click(screen.getByTestId("stack-update-now"));
+    expect(onUpdate).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTestId("stack-update-skip"));
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it("says 'your stack' for the local target", () => {
+    render(
+      <StackUpdatePrompt
+        from="v2.9.0"
+        to="v2.10.0"
+        machine={null}
+        onUpdate={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("stack-update-versions").textContent,
+    ).toContain("Your stack is on v2.9.0");
+  });
+});
+
+describe("StackSwitchProgress", () => {
+  it("streams switch output lines", () => {
+    render(
+      <StackSwitchProgress to="v2.10.0" lines={["Fetching origin", "done"]} />,
+    );
+    expect(screen.getByTestId("stack-switch-lines").textContent).toBe(
+      "Fetching origin\ndone",
+    );
+  });
+});
+
+describe("stackSkipNotice", () => {
+  it("explains developer and offline skips, stays quiet otherwise", () => {
+    expect(stackSkipNotice("dirty_checkout")).toMatch(/Developer checkout/);
+    expect(stackSkipNotice("not_on_release")).toMatch(/Developer checkout/);
+    expect(stackSkipNotice("offline")).toMatch(/current version/);
+    expect(stackSkipNotice("up_to_date")).toBeNull();
+    expect(stackSkipNotice("policy_never")).toBeNull();
+    expect(stackSkipNotice("no_checkout")).toBeNull();
+  });
+});

--- a/desktop/src/views/StackUpdateCard.tsx
+++ b/desktop/src/views/StackUpdateCard.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * Ask before running `run.py --switch` (the default "prompt" policy).
+ * Skipping is always safe — bring-up proceeds on the current version.
+ */
+export function StackUpdatePrompt({
+  from,
+  to,
+  machine,
+  onUpdate,
+  onSkip,
+}: {
+  from: string;
+  to: string;
+  machine: string | null;
+  onUpdate: () => void;
+  onSkip: () => void;
+}) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-zinc-950 px-6 text-zinc-100">
+      <header className="max-w-md text-center">
+        <h1 className="text-xl font-semibold tracking-tight">
+          Stack update available
+        </h1>
+        <p className="mt-2 text-sm text-zinc-400" data-testid="stack-update-versions">
+          {machine ? `${machine} is` : "Your stack is"} on {from}; the latest
+          release is {to}. Updating switches the checkout and pulls the
+          matching images before starting.
+        </p>
+      </header>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          data-testid="stack-update-now"
+          onClick={onUpdate}
+          className="rounded-md bg-sky-700 px-4 py-2 text-sm font-medium text-white hover:bg-sky-600"
+        >
+          Update to {to}
+        </button>
+        <button
+          type="button"
+          data-testid="stack-update-skip"
+          onClick={onSkip}
+          className="rounded-md border border-zinc-700 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
+        >
+          Not now
+        </button>
+      </div>
+    </main>
+  );
+}
+
+/** Streamed `run.py --switch` output while the stack updates. */
+export function StackSwitchProgress({
+  to,
+  lines,
+}: {
+  to: string;
+  lines: string[];
+}) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-zinc-950 px-6 text-zinc-100">
+      <header className="text-center">
+        <h1 className="text-xl font-semibold tracking-tight">
+          Updating the stack to {to}
+        </h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          Running run.py --switch — bring-up starts when it finishes.
+        </p>
+      </header>
+      <pre
+        data-testid="stack-switch-lines"
+        className="max-h-64 w-full max-w-xl overflow-y-auto rounded-md border border-zinc-800 bg-zinc-900 p-3 text-xs text-zinc-400"
+      >
+        {lines.length > 0 ? lines.join("\n") : "Starting…"}
+      </pre>
+    </main>
+  );
+}

--- a/desktop/src/views/StackUpdateSetting.tsx
+++ b/desktop/src/views/StackUpdateSetting.tsx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useEffect, useState } from "react";
+import {
+  getStackUpdatePolicy,
+  setStackUpdatePolicy,
+  type StackUpdatePolicy,
+} from "../lib/ipc";
+
+const LABELS: Record<StackUpdatePolicy, string> = {
+  auto: "update automatically",
+  prompt: "ask first",
+  never: "never update",
+};
+
+/**
+ * The stack-refresh policy control: what to do when a connect target's
+ * checkout is behind the latest release. Stored with the app settings.
+ */
+function StackUpdateSetting() {
+  const [policy, setPolicy] = useState<StackUpdatePolicy | null>(null);
+
+  useEffect(() => {
+    getStackUpdatePolicy()
+      .then(setPolicy)
+      .catch(() => setPolicy("prompt"));
+  }, []);
+
+  if (!policy) return null;
+  return (
+    <label className="flex items-center gap-2 text-xs text-zinc-500">
+      Stack updates:
+      <select
+        data-testid="stack-update-policy"
+        value={policy}
+        onChange={(e) => {
+          const next = e.target.value as StackUpdatePolicy;
+          setPolicy(next);
+          setStackUpdatePolicy(next).catch(() => {});
+        }}
+        className="rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300"
+      >
+        {(Object.keys(LABELS) as StackUpdatePolicy[]).map((value) => (
+          <option key={value} value={value}>
+            {LABELS[value]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export default StackUpdateSetting;

--- a/desktop/src/views/UpdateBanner.test.tsx
+++ b/desktop/src/views/UpdateBanner.test.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ShellUpdate } from "../lib/updates";
+import UpdateBanner from "./UpdateBanner";
+
+afterEach(cleanup);
+
+const update = (install = vi.fn(() => new Promise<void>(() => {}))) =>
+  ({ version: "2.11.0", install }) as ShellUpdate;
+
+describe("UpdateBanner", () => {
+  it("offers install when the launch check finds an update", async () => {
+    render(<UpdateBanner checkUpdate={async () => update()} />);
+    await waitFor(() => screen.getByTestId("update-banner"));
+    expect(screen.getByText(/2\.11\.0 is available/)).toBeTruthy();
+  });
+
+  it("shows up-to-date after a check with no update", async () => {
+    render(<UpdateBanner checkUpdate={async () => null} />);
+    await waitFor(() => screen.getByTestId("update-current"));
+  });
+
+  it("stays quiet when the launch check fails (offline)", async () => {
+    render(<UpdateBanner checkUpdate={async () => Promise.reject("net down")} />);
+    await waitFor(() => screen.getByTestId("update-check"));
+    expect(screen.queryByTestId("update-error")).toBeNull();
+  });
+
+  it("surfaces a manual check failure", async () => {
+    let calls = 0;
+    render(
+      <UpdateBanner
+        checkUpdate={() => {
+          calls += 1;
+          return Promise.reject("net down");
+        }}
+      />,
+    );
+    await waitFor(() => screen.getByTestId("update-check"));
+    fireEvent.click(screen.getByTestId("update-check"));
+    await waitFor(() => screen.getByTestId("update-error"));
+    expect(calls).toBe(2);
+  });
+
+  it("disables the install button while installing", async () => {
+    const install = vi.fn(() => new Promise<void>(() => {}));
+    render(<UpdateBanner checkUpdate={async () => update(install)} />);
+    await waitFor(() => screen.getByTestId("update-install"));
+    fireEvent.click(screen.getByTestId("update-install"));
+    expect(install).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("update-install") as HTMLButtonElement).disabled,
+      ).toBe(true),
+    );
+  });
+});

--- a/desktop/src/views/UpdateBanner.tsx
+++ b/desktop/src/views/UpdateBanner.tsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback, useEffect, useState } from "react";
+import { checkShellUpdate, type ShellUpdate } from "../lib/updates";
+
+type Phase =
+  | { name: "idle" }
+  | { name: "checking" }
+  | { name: "current" }
+  | { name: "available"; update: ShellUpdate }
+  | { name: "installing"; update: ShellUpdate }
+  | { name: "error"; message: string };
+
+/**
+ * Shell self-update strip for the connection picker: checks the release feed
+ * once on launch (silently — offline must not get in the way of connecting)
+ * and offers a manual "Check for updates" whose failures are shown.
+ */
+function UpdateBanner({
+  checkUpdate = checkShellUpdate,
+}: {
+  checkUpdate?: () => Promise<ShellUpdate | null>;
+}) {
+  const [phase, setPhase] = useState<Phase>({ name: "idle" });
+
+  const runCheck = useCallback(
+    (manual: boolean) => {
+      setPhase({ name: "checking" });
+      checkUpdate()
+        .then((update) =>
+          setPhase(update ? { name: "available", update } : { name: "current" }),
+        )
+        .catch((e) =>
+          setPhase(
+            manual
+              ? { name: "error", message: String(e) }
+              : { name: "idle" },
+          ),
+        );
+    },
+    [checkUpdate],
+  );
+
+  useEffect(() => {
+    runCheck(false);
+  }, [runCheck]);
+
+  const install = useCallback(() => {
+    if (phase.name !== "available") return;
+    const update = phase.update;
+    setPhase({ name: "installing", update });
+    // On success the app relaunches; only the failure path renders.
+    update.install().catch((e) => {
+      setPhase({ name: "error", message: String(e) });
+    });
+  }, [phase]);
+
+  if (phase.name === "available" || phase.name === "installing") {
+    const installing = phase.name === "installing";
+    return (
+      <div
+        data-testid="update-banner"
+        className="flex items-center justify-between gap-3 rounded-md border border-sky-900 bg-sky-950/40 px-3 py-2 text-sm"
+      >
+        <span className="text-sky-200">
+          TT-Studio {phase.update.version} is available.
+        </span>
+        <button
+          type="button"
+          data-testid="update-install"
+          onClick={install}
+          disabled={installing}
+          className="rounded-md bg-sky-700 px-3 py-1 text-xs font-medium text-white hover:bg-sky-600 disabled:opacity-60"
+        >
+          {installing ? "Installing…" : "Install and restart"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3 text-xs text-zinc-500">
+      <button
+        type="button"
+        data-testid="update-check"
+        onClick={() => runCheck(true)}
+        disabled={phase.name === "checking"}
+        className="rounded-md border border-zinc-800 px-2 py-1 hover:bg-zinc-900 disabled:opacity-60"
+      >
+        {phase.name === "checking" ? "Checking…" : "Check for updates"}
+      </button>
+      {phase.name === "current" && (
+        <span data-testid="update-current">You're on the latest version.</span>
+      )}
+      {phase.name === "error" && (
+        <span data-testid="update-error" className="text-amber-400">
+          Couldn't check for updates: {phase.message}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default UpdateBanner;


### PR DESCRIPTION
Two update layers for the desktop app, both keyed to tagged GitHub releases (the only refs publish-images.yml ships GHCR images for — following raw main would force local image builds).

**Shell updates**: tauri-plugin-updater + tauri-plugin-process, endpoint at the GitHub releases `latest.json`. Silent check on launch (offline never blocks connecting) plus a manual "Check for updates" button with an install-and-relaunch flow. The pubkey in tauri.conf.json is a development placeholder — release CI must generate the real signing key and replace it before shipping updater artifacts; until then the updater fails closed on signature mismatch (documented in desktop/README.md).

**Stack updates**: before every bring-up (native spawn or SSH), `src-tauri/src/update/stack.rs` reads the target checkout's release tag (git locally, `git -C` over ssh exec remotely), compares it to the latest `v*` tag, and when behind runs the stack's own guarded `python run.py --switch <tag>` with streamed output. Policy is a stored setting: auto / ask first (default) / never. It never forces anything: dirty trees and non-release checkouts show "developer checkout detected, skipping stack update" and proceed; offline skips quietly; an already-healthy stack is attached without touching the checkout. No explicit image pull is added — bring-up after a switch pins TT_STUDIO_IMAGE_TAG to the exact tag (tt_setup/env_config/_version.py) and runs `docker compose pull` itself (tt_setup/cli/_run.py "Pull" phase), so the tag's GHCR images arrive as part of normal startup.

Stacking: based on #1256 (jashan/desktop-ssh-bringup, SSH track) with #1255 (jashan/desktop-native-mode, native track) merged in so both spawn paths exist — the first commit is that merge (unified `bringup-exit` payload and combined close-request handling). Review this PR for the seven commits on top.

- [x] tauri updater + process plugins, updater capability, check-on-launch UI
- [x] stack freshness check (pure decision fn + local/ssh gathering)
- [x] `run.py --switch` executor with streamed progress, prompt/auto/never policy
- [x] image-pull coverage verified in tt_setup, documented instead of duplicated
- [x] cargo test (79 lib + 3 updater dry-run + launcher/ssh suites), clippy -D warnings, fmt clean
- [x] vitest 72 passing, tsc + vite build clean
- [x] updater dry-run: real `updater.check()` against a locally served latest.json fixture (newer / older / unreachable feed)
- [x] no real switch or pull was run against a live checkout; tests use temp git repos and fixtures