### PR TITLE
ci: build, sign, and publish desktop releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -195,6 +195,32 @@ jobs:
             echo "::warning::APPLE_ID not set — signing but skipping notarization"
           fi
 
+      # Windows Authenticode via Azure Trusted Signing: when the AZURE_*
+      # secrets exist, wire the bundler's signCommand to trusted-signing-cli
+      # (authenticates with the AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET env
+      # on the build step). Without them the NSIS installer builds unsigned.
+      - name: Enable Windows code signing
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          AZURE_SIGNING_PROFILE: ${{ secrets.AZURE_SIGNING_PROFILE }}
+        run: |
+          set -euo pipefail
+          if [ -z "$AZURE_CLIENT_SECRET" ]; then
+            echo "::warning::AZURE_CLIENT_SECRET not set — building unsigned Windows installer"
+            exit 0
+          fi
+          cargo install trusted-signing-cli --locked
+          OVERLAY="${RUNNER_TEMP//\\//}/tauri-conf-overlay.json"
+          [ -f "$OVERLAY" ] || echo '{}' > "$OVERLAY"
+          jq --arg cmd "trusted-signing-cli -e $AZURE_SIGNING_ENDPOINT -a $AZURE_SIGNING_ACCOUNT -c $AZURE_SIGNING_PROFILE %1" \
+            '.bundle.windows.signCommand = $cmd' "$OVERLAY" > "$OVERLAY.tmp"
+          mv "$OVERLAY.tmp" "$OVERLAY"
+          echo "TAURI_EXTRA_ARGS=--config $OVERLAY" >> "$GITHUB_ENV"
+
       # tauri-action runs the bundler (beforeBuildCommand builds the launcher
       # bundle first) and, when tagName is set, uploads the installers to the
       # GitHub release for that tag — creating the release if the tag push got
@@ -211,6 +237,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Consumed by trusted-signing-cli when the Windows signCommand is
+          # configured above; harmless (unused) when empty.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         with:
           projectPath: desktop
           tagName: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.tag || '' }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -160,6 +160,41 @@ jobs:
             echo "::warning::TAURI_SIGNING_PRIVATE_KEY not set — building without updater artifacts"
           fi
 
+      # The tauri bundler codesigns when APPLE_CERTIFICATE (base64 .p12) +
+      # APPLE_SIGNING_IDENTITY are in the env, and notarizes when APPLE_ID /
+      # APPLE_PASSWORD / APPLE_TEAM_ID are too. It treats the variables as
+      # enabled the moment they exist — even empty — so absent secrets must
+      # not reach the build env: export them only when non-empty, and build
+      # unsigned otherwise instead of failing.
+      - name: Enable macOS code signing and notarization
+        if: runner.os == 'macOS'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_CERTIFICATE" ]; then
+            echo "::warning::APPLE_CERTIFICATE not set — building unsigned, unnotarized macOS bundles"
+            exit 0
+          fi
+          for VAR in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
+                     APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -n "${!VAR}" ]; then
+              {
+                echo "${VAR}<<TT_EOF"
+                echo "${!VAR}"
+                echo "TT_EOF"
+              } >> "$GITHUB_ENV"
+            fi
+          done
+          if [ -z "$APPLE_ID" ]; then
+            echo "::warning::APPLE_ID not set — signing but skipping notarization"
+          fi
+
       # tauri-action runs the bundler (beforeBuildCommand builds the launcher
       # bundle first) and, when tagName is set, uploads the installers to the
       # GitHub release for that tag — creating the release if the tag push got

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,80 @@
+name: Desktop release
+
+# Builds the TT-Studio desktop app (desktop/, Tauri v2) for macOS, Windows,
+# and Linux and attaches the installers + the updater manifest (latest.json)
+# to the GitHub release, so one v* tag drives both the GHCR service images
+# (publish-images.yml) and the desktop artifacts.
+#
+# Publishing is deliberately release-only: a v* tag push or a published GitHub
+# release uploads artifacts to the release for that tag. workflow_dispatch
+# builds everything as a dry run by default; its `publish` input allows an
+# explicit ad-hoc upload (only when dispatched on a v* tag ref). Nothing
+# publishes from dev or feature branches automatically.
+#
+# Caveat (same as publish-images.yml): tags/releases created by another
+# workflow using the default GITHUB_TOKEN do not trigger this workflow
+# (GitHub suppresses recursive triggers). Release tagging today is done from
+# a maintainer's machine (run.py --merge-rc-branch) with their credentials,
+# which does trigger it; if tagging is ever automated, that workflow must
+# call this one via workflow_call or push the tag with a PAT.
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload artifacts + latest.json to the GitHub release (off = dry-run build only)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
+# contents: write is required to upload assets to the release.
+permissions:
+  contents: write
+
+jobs:
+  # Resolves which release tag (if any) this run targets and whether artifacts
+  # should be uploaded, so every build job shares one publish decision.
+  prepare:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      publish: ${{ steps.meta.outputs.publish }}
+    steps:
+      - name: Compute tag and publish decision
+        id: meta
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+          TAG=""
+          case "$GITHUB_REF" in
+            refs/tags/v*) TAG="$GITHUB_REF_NAME" ;;
+          esac
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          fi
+
+          PUBLISH=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PUBLISH="${DISPATCH_PUBLISH:-false}"
+          fi
+          # Without a v* tag there is no release to attach artifacts to.
+          [ -n "$TAG" ] || PUBLISH=false
+
+          {
+            echo "tag=$TAG"
+            echo "version=${TAG#v}"
+            echo "publish=$PUBLISH"
+          } >> "$GITHUB_OUTPUT"
+          echo "tag='$TAG' publish=$PUBLISH"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -140,18 +140,47 @@ jobs:
         working-directory: desktop
         run: npm ci
 
+      # tauri.conf.json sets createUpdaterArtifacts, which makes the bundler
+      # sign the update packages with TAURI_SIGNING_PRIVATE_KEY and fail hard
+      # if it's absent. Forks and dry runs without the secret still need green
+      # builds, so in that case updater artifacts are disabled via a config
+      # overlay (installers still build — they're just not updater-servable).
+      - name: Configure updater artifact signing
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            OVERLAY="${RUNNER_TEMP//\\//}/tauri-conf-overlay.json"
+            [ -f "$OVERLAY" ] || echo '{}' > "$OVERLAY"
+            jq '.bundle.createUpdaterArtifacts = false' "$OVERLAY" > "$OVERLAY.tmp"
+            mv "$OVERLAY.tmp" "$OVERLAY"
+            echo "TAURI_EXTRA_ARGS=--config $OVERLAY" >> "$GITHUB_ENV"
+            echo "::warning::TAURI_SIGNING_PRIVATE_KEY not set — building without updater artifacts"
+          fi
+
       # tauri-action runs the bundler (beforeBuildCommand builds the launcher
       # bundle first) and, when tagName is set, uploads the installers to the
       # GitHub release for that tag — creating the release if the tag push got
       # here before run.py --merge-rc-branch created it. On a dry run tagName
       # is empty and nothing is uploaded.
+      #
+      # includeUpdaterJson makes each matrix job upload/merge latest.json on
+      # the release, so once all three finish it lists every platform. The
+      # tauri updater plugin in the app polls exactly that asset (endpoint in
+      # desktop/src-tauri/tauri.conf.json).
       - name: Build desktop app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: desktop
           tagName: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.tag || '' }}
           releaseName: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.tag || '' }}
           releaseDraft: false
-          args: ${{ matrix.args }}
+          includeUpdaterJson: true
+          updaterJsonPreferNsis: true
+          args: ${{ matrix.args }} ${{ env.TAURI_EXTRA_ARGS }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -78,3 +78,80 @@ jobs:
             echo "publish=$PUBLISH"
           } >> "$GITHUB_OUTPUT"
           echo "tag='$TAG' publish=$PUBLISH"
+
+  build:
+    name: ${{ matrix.name }}
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS ships one universal .dmg (aarch64 + x86_64 in a single
+          # binary) rather than per-arch installers.
+          - name: macos-universal
+            os: macos-latest
+            rust_targets: aarch64-apple-darwin,x86_64-apple-darwin
+            args: --target universal-apple-darwin
+          - name: windows-x64
+            os: windows-latest
+            args: --bundles nsis
+          # ubuntu-22.04 (not -latest) keeps the AppImage/.deb glibc floor low
+          # enough for older distros. Shipping a .deb follows the precedent
+          # set by tt-local-generator's release-deb workflow.
+          - name: linux-x64
+            os: ubuntu-22.04
+            args: --bundles appimage,deb
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux webview dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            libdbus-1-dev \
+            build-essential \
+            curl \
+            wget \
+            file
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_targets || '' }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+
+      - name: Install launcher dependencies
+        working-directory: desktop
+        run: npm ci
+
+      # tauri-action runs the bundler (beforeBuildCommand builds the launcher
+      # bundle first) and, when tagName is set, uploads the installers to the
+      # GitHub release for that tag — creating the release if the tag push got
+      # here before run.py --merge-rc-branch created it. On a dry run tagName
+      # is empty and nothing is uploaded.
+      - name: Build desktop app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: desktop
+          tagName: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.tag || '' }}
+          releaseName: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.tag || '' }}
+          releaseDraft: false
+          args: ${{ matrix.args }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -160,6 +160,16 @@ jobs:
             echo "::warning::TAURI_SIGNING_PRIVATE_KEY not set — building without updater artifacts"
           fi
 
+      # Releases are plain git tags with no version bumps committed to the
+      # tree (same philosophy as tt_setup/env_config/_version.py), so the
+      # checked-in desktop versions are dev placeholders. Sync them to the
+      # tag before bundling; dry runs off a tag keep the placeholder.
+      - name: Stamp version from release tag
+        if: needs.prepare.outputs.version != ''
+        shell: bash
+        working-directory: desktop
+        run: node scripts/stamp-version.mjs "${{ needs.prepare.outputs.version }}"
+
       # The tauri bundler codesigns when APPLE_CERTIFICATE (base64 .p12) +
       # APPLE_SIGNING_IDENTITY are in the env, and notarizes when APPLE_ID /
       # APPLE_PASSWORD / APPLE_TEAM_ID are too. It treats the variables as

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -64,11 +64,14 @@ and offers a manual "Check for updates" button whose failures are shown
 via the process plugin.
 
 **Signing key**: the `pubkey` in `tauri.conf.json` is a development
-placeholder. Release CI must generate the real keypair (`tauri signer
-generate`), keep the private key in CI secrets (`TAURI_SIGNING_PRIVATE_KEY`),
-replace the placeholder pubkey, and attach signed updater artifacts +
-`latest.json` to each release. Until then the updater will reject downloaded
-artifacts (signature mismatch) — by design, it fails closed.
+placeholder — a real keypair must be generated **once, by a maintainer**
+(`npm run tauri signer generate`; never commit the private key). The private
+key + password go into the repo secrets `TAURI_SIGNING_PRIVATE_KEY` /
+`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, and the matching public key replaces
+the placeholder here. Release CI (`.github/workflows/desktop-release.yml`)
+then signs the updater artifacts and attaches them + `latest.json` to each
+release. Until the real key lands, the updater rejects downloaded artifacts
+(signature mismatch) — by design, it fails closed.
 
 ### Stack updates (the checkout `run.py` runs in)
 

--- a/desktop/scripts/stamp-version.mjs
+++ b/desktop/scripts/stamp-version.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Stamp the desktop app version from a release tag.
+//
+// TT-Studio releases are plain git tags (vX.Y.Z) with no version bumps
+// committed to the tree — git is the source of truth for "what build is
+// this", the same philosophy as tt_setup/env_config/_version.py for the web
+// frontend. The versions checked into tauri.conf.json / Cargo.toml /
+// package.json are therefore dev placeholders; release CI runs this script
+// to sync all of them (plus Cargo.lock, so locked builds stay consistent)
+// to the tag before bundling.
+//
+// Usage: node scripts/stamp-version.mjs <tag-or-version>   (e.g. v2.10.0)
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const arg = process.argv[2];
+if (!arg) {
+  console.error("usage: node scripts/stamp-version.mjs <tag-or-version>");
+  process.exit(1);
+}
+const version = arg.replace(/^v/, "");
+// Tauri and Cargo both require semver (prerelease suffixes like -rc1 are ok).
+if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error(`not a semver version: "${arg}"`);
+  process.exit(1);
+}
+
+function stampJson(relPath) {
+  const path = join(desktopDir, relPath);
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  data.version = version;
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+  console.log(`${relPath}: version = ${version}`);
+}
+
+// Replace the version of the tt-studio-desktop package only: in Cargo.toml
+// that's the first `version =` in [package]; in Cargo.lock it's the line
+// following its `name =` entry (dependencies keep their own versions).
+function stampCargo(relPath, pattern) {
+  const path = join(desktopDir, relPath);
+  const text = readFileSync(path, "utf8");
+  const stamped = text.replace(pattern, `$1"${version}"`);
+  if (stamped === text) {
+    console.error(`${relPath}: found no version to stamp`);
+    process.exit(1);
+  }
+  writeFileSync(path, stamped);
+  console.log(`${relPath}: version = ${version}`);
+}
+
+stampJson("src-tauri/tauri.conf.json");
+stampJson("package.json");
+stampCargo("src-tauri/Cargo.toml", /(^version = )"[^"]+"/m);
+stampCargo(
+  "src-tauri/Cargo.lock",
+  /(name = "tt-studio-desktop"\nversion = )"[^"]+"/
+);

--- a/dev-docs/desktop-release.md
+++ b/dev-docs/desktop-release.md
@@ -1,0 +1,103 @@
+# Desktop release runbook
+
+How the Tauri desktop app (`desktop/`) is packaged, signed, and published,
+and what a maintainer has to set up once for signing to work.
+
+## One tag drives everything
+
+TT-Studio releases are plain git tags (`vX.Y.Z`) on `main`, normally created
+by `python run.py --merge-rc-branch` (see the `cut-release` skill). A single
+`v*` tag (and the GitHub release created for it) triggers two workflows:
+
+| Workflow | Produces |
+|---|---|
+| `.github/workflows/publish-images.yml` | GHCR service images (`backend`, `frontend`, `frontend-dev`, `agent`) tagged `vX.Y.Z` / `latest` / `sha-<12>` |
+| `.github/workflows/desktop-release.yml` | Desktop installers + updater manifest, attached as assets on the GitHub release |
+
+Both share the same caveat: tags or releases created by a workflow using the
+default `GITHUB_TOKEN` do **not** trigger them (GitHub suppresses recursive
+triggers). Today the tag is pushed from a maintainer's machine with their own
+credentials, which triggers both. Because the tag push and the subsequent
+`release: published` event both match, the workflow can run twice for one
+release; the concurrency group serializes the runs and the second re-uploads
+the same assets — wasteful but harmless.
+
+## What desktop-release.yml builds
+
+| Platform | Runner | Artifacts |
+|---|---|---|
+| macOS | `macos-latest` | universal (aarch64 + x86_64) `.dmg` + `.app.tar.gz` updater package |
+| Windows | `windows-latest` | NSIS `.exe` installer (doubles as the updater package) |
+| Linux | `ubuntu-22.04` | `.AppImage` (+ updater package) and `.deb` — the `.deb` follows tt-local-generator's release-deb precedent; `ubuntu-22.04` keeps the glibc floor low |
+
+Each job also uploads/merges `latest.json` on the release
+(`includeUpdaterJson`), which is the exact asset the in-app updater polls
+(endpoint in `desktop/src-tauri/tauri.conf.json`). See
+`desktop/README.md` → *Updates* for how the app consumes it.
+
+Versions are stamped from the tag at build time
+(`desktop/scripts/stamp-version.mjs` syncs `tauri.conf.json`, `package.json`,
+`Cargo.toml`, `Cargo.lock`) — git tags are the source of truth, matching
+`tt_setup/env_config/_version.py`; no version-bump commits are needed.
+
+### Dry runs
+
+`workflow_dispatch` builds everything without uploading; set its `publish`
+input to true (and dispatch on a `v*` tag ref) for an explicit ad-hoc upload.
+Every signing step is skip-if-secret-absent, so forks and dry runs without
+secrets still build green — just unsigned, and without updater artifacts.
+
+## Secrets inventory
+
+All plain repository **Actions secrets** (admin: Settings → Secrets and
+variables → Actions). None exist yet at the time of writing.
+
+| Secret | Needed for | Required? |
+|---|---|---|
+| `TAURI_SIGNING_PRIVATE_KEY` | Signing updater packages; without it `latest.json` artifacts are skipped and **in-app updates cannot ship** | Yes, for updates to work |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the key above (set at generation time) | Yes, with the key |
+| `APPLE_CERTIFICATE` | macOS codesigning — base64 of a Developer ID Application `.p12` (`base64 -i cert.p12`) | Optional — unsigned builds still ship, Gatekeeper warns |
+| `APPLE_CERTIFICATE_PASSWORD` | Password of the `.p12` export | With `APPLE_CERTIFICATE` |
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Tenstorrent AI ULC (TEAMID)` | With `APPLE_CERTIFICATE` |
+| `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` | Notarization (app-specific password for the Apple ID) | Optional — signing without notarization still warns on download |
+| `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` | Azure Trusted Signing service principal for Windows Authenticode | Optional — unsigned installer triggers SmartScreen |
+| `AZURE_SIGNING_ENDPOINT` / `AZURE_SIGNING_ACCOUNT` / `AZURE_SIGNING_PROFILE` | Trusted Signing endpoint URL, account name, certificate profile | With the Azure credentials |
+
+## One-time setup: the updater signing key
+
+The `pubkey` currently in `desktop/src-tauri/tauri.conf.json` is a
+development placeholder — the updater deliberately fails closed against it.
+A maintainer must, once:
+
+```bash
+cd desktop
+npm run tauri signer generate    # choose a password; prints both keys
+```
+
+1. Put the **private key** and its password into the
+   `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+   secrets. Never commit the private key; losing it means shipped apps can
+   never verify another update (users must reinstall manually).
+2. Replace the placeholder `pubkey` in `tauri.conf.json` with the printed
+   public key (a normal PR).
+
+Rotating the key has the same reinstall consequence as losing it — treat it
+as permanent.
+
+## Interaction with the existing release flow
+
+Nothing about cutting a release changes: `--make-rc-branch` →
+`--update-rc-branch` → `--merge-rc-branch` as before. The merge step's tag
+push + release creation now additionally produce desktop artifacts. Points of
+contact:
+
+- **Release assets**: desktop installers and `latest.json` appear on the
+  release alongside the auto-generated notes; don't delete `latest.json`,
+  every installed app polls it.
+- **Stack updates**: the desktop app also updates the *stack checkout* it
+  manages via `run.py --switch <tag>` (see `desktop/README.md`), which relies
+  on the same tag having GHCR images from publish-images.yml.
+- **RC tags**: any `v*` tag builds and publishes desktop artifacts to its
+  release. `latest.json` lives on each release, but the updater endpoint
+  resolves `releases/latest/download/latest.json`, so only the release GitHub
+  marks *latest* (non-prerelease) is what installed apps see.


### PR DESCRIPTION
Desktop milestone D7 — stacked on #1258 (D6, updater); base is `jashan/desktop-updates` and should be retargeted to `dev` once that merges.

One `v*` tag now drives desktop artifacts alongside the GHCR images: `.github/workflows/desktop-release.yml` mirrors publish-images.yml's trigger shape (tag push / release published / workflow_dispatch dry-run with an explicit `publish` input, same GITHUB_TOKEN-pushed-tag caveat) and builds a universal macOS .dmg, a Windows NSIS installer, and Linux .AppImage + .deb (following tt-local-generator's release-deb precedent), uploading them plus the updater `latest.json` to the release via tauri-action.

Every signing layer is skip-if-secret-absent so forks and dry runs stay green: updater artifact signing (config overlay disables `createUpdaterArtifacts` when the key is missing), macOS codesign/notarization (APPLE_* exported only when non-empty), and Windows Authenticode via Azure Trusted Signing (`signCommand` overlay + trusted-signing-cli). Versions are stamped from the tag at build time (`desktop/scripts/stamp-version.mjs`) — git tags stay the source of truth, no version-bump commits.

**Admin action needed before the first real release** (full inventory in `dev-docs/desktop-release.md`):
- `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — a maintainer runs `npm run tauri signer generate` once, stores the private key in secrets, and replaces the placeholder pubkey in `tauri.conf.json`. Without these, releases ship but in-app updates can't.
- Optional: `APPLE_*` (Developer ID cert + notarization) and `AZURE_*` (Trusted Signing) — unsigned builds still publish, with Gatekeeper/SmartScreen warnings.

- [x] Workflow passes actionlint and yaml parse
- [x] `npm ci && npm run build`, `cargo build` green locally
- [x] Local release `tauri build` produced working `.deb` and `.AppImage` bundles using the same no-key config overlay the workflow uses
- [x] Version stamp script tested against a fake tag (one-line diff in each of tauri.conf.json / package.json / Cargo.toml / Cargo.lock) and rejects non-semver input
- [x] No tags pushed, no workflow dispatches run