### PR TITLE
feat: desktop polish — tray, logs viewer, bug reports, teardown setting, dynamic app ports

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -104,6 +104,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +368,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -485,6 +618,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1064,12 +1206,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1100,6 +1269,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1264,6 +1453,19 @@ name = "futures-io"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1645,6 +1847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2216,25 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "itoa"
@@ -2757,6 +2984,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "open"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +3005,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "osakit"
@@ -2861,6 +3109,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2981,6 +3235,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,6 +3326,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4050,6 +4329,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4557,6 +4846,28 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]
@@ -5113,6 +5424,7 @@ name = "tt-studio-desktop"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "keyring",
  "reqwest 0.12.28",
  "russh",
@@ -5121,6 +5433,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-store",
  "tauri-plugin-updater",
@@ -5139,6 +5452,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6119,6 +6443,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,3 +6623,44 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
+]

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4881,6 +4881,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5435,6 +5451,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tempfile",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 # Reveal-in-file-manager for bug-report bundles (Rust-side only).
 tauri-plugin-opener = "2"
+# Focus the existing window when the app is launched a second time.
+tauri-plugin-single-instance = "2"
 # Decode `base64` output when copying remote bundles back over ssh exec.
 base64 = "0.22"
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -35,6 +35,10 @@ russh = { version = "0.54", default-features = false, features = ["ring", "flate
 async-trait = "0.1.92"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Reveal-in-file-manager for bug-report bundles (Rust-side only).
+tauri-plugin-opener = "2"
+# Decode `base64` output when copying remote bundles back over ssh exec.
+base64 = "0.22"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -14,7 +14,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+# tray-icon: system tray with the stack-status dot (Linux needs the ayatana
+# appindicator at runtime; the .deb declares it).
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
 # sync-secret-service links libdbus on Linux (libdbus-1-dev in CI); no

--- a/desktop/src-tauri/src/bug_report.rs
+++ b/desktop/src-tauri/src/bug_report.rs
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Bug-report bundles from the desktop shell.
+//!
+//! Reuses the launcher's own machinery (`python run.py --report-bug`,
+//! tt_setup/bug_report.py): it collects host-side logs and system info into
+//! `logs/tt-studio-logs-ttbr-<hex>.zip` inside the checkout. `--no-browser`
+//! keeps it from opening a GitHub issue tab — the desktop app reveals the
+//! ZIP in the file manager instead and the user attaches it wherever they
+//! report.
+//!
+//! Local profiles spawn the command in the local checkout; SSH profiles run
+//! it in the remote checkout, then copy the ZIP back over the same session
+//! (`base64` over an exec channel — no sftp subsystem required) into the
+//! app's data dir.
+
+use serde::Serialize;
+use tauri::{Manager, Wry};
+
+use crate::profiles::Profile;
+use crate::ssh::exec::quote_path;
+use crate::ssh::SshTransport;
+
+/// Progress lines (the launcher's human output) while a bundle is collected.
+pub const BUGREPORT_LINE_EVENT: &str = "bugreport-line";
+
+/// Bundle filenames as written by tt_setup/bug_report.py.
+pub const BUNDLE_PREFIX: &str = "tt-studio-logs-ttbr-";
+
+// ---- the exact commands ----
+
+/// Local spawn spec: `run.py --report-bug --no-browser` inside the checkout.
+pub fn report_bug_spec(
+    checkout: &std::path::Path,
+    stderr_log: std::path::PathBuf,
+) -> crate::launcher::SpawnSpec {
+    crate::launcher::SpawnSpec {
+        program: "python3".to_string(),
+        args: ["run.py", "--report-bug", "--no-browser"]
+            .map(String::from)
+            .to_vec(),
+        cwd: checkout.to_path_buf(),
+        stderr_log,
+        envs: Vec::new(),
+    }
+}
+
+/// The same over ssh exec. `2>&1` so the human progress output arrives on
+/// the streamed channel.
+pub fn report_bug_command(path: &str) -> String {
+    format!(
+        "cd {} && python3 run.py --report-bug --no-browser 2>&1",
+        quote_path(path)
+    )
+}
+
+/// Newest bundle in the remote checkout's logs dir (empty stdout when none).
+pub fn newest_bundle_command(path: &str) -> String {
+    format!(
+        "ls -t {}/logs/{BUNDLE_PREFIX}*.zip 2>/dev/null | head -1",
+        quote_path(path)
+    )
+}
+
+/// Stream the bundle back as base64 (ASCII survives the lossy UTF-8 capture).
+pub fn fetch_bundle_command(remote_zip: &str) -> String {
+    format!("base64 < {}", quote_path(remote_zip))
+}
+
+// ---- pure helpers ----
+
+pub fn is_bundle_name(name: &str) -> bool {
+    name.starts_with(BUNDLE_PREFIX) && name.ends_with(".zip")
+}
+
+/// The `ttbr-<hex>` reference inside a bundle filename, for display.
+pub fn bundle_ref(name: &str) -> Option<&str> {
+    if !is_bundle_name(name) {
+        return None;
+    }
+    name.strip_prefix("tt-studio-logs-")?.strip_suffix(".zip")
+}
+
+/// Newest `tt-studio-logs-ttbr-*.zip` under `<checkout>/logs`.
+pub fn newest_bundle_in(checkout: &std::path::Path) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(checkout.join("logs")).ok()?;
+    entries
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .map(is_bundle_name)
+                .unwrap_or(false)
+        })
+        .max_by_key(|e| {
+            e.metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        })
+        .map(|e| e.path())
+}
+
+/// Decode the accumulated stdout of `base64 <file>` (line wraps and blank
+/// trailing lines included).
+pub fn decode_base64_stream(text: &str) -> Result<Vec<u8>, String> {
+    use base64::Engine;
+    let compact: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(compact.as_bytes())
+        .map_err(|e| format!("couldn't decode the fetched bundle: {e}"))
+}
+
+// ---- the Tauri command ----
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct BugReportResult {
+    /// Local path of the bundle (for remote profiles: the fetched copy).
+    pub path: String,
+    /// The `ttbr-<hex>` id to quote in an issue.
+    pub reference: Option<String>,
+}
+
+/// Collect a diagnostics bundle on the given target (None = local checkout)
+/// and reveal it in the file manager. Progress lines stream as
+/// `bugreport-line` events.
+#[tauri::command]
+pub async fn create_bug_report(
+    app: tauri::AppHandle<Wry>,
+    launcher_state: tauri::State<'_, crate::state::LauncherState>,
+    profile: Option<Profile>,
+) -> Result<BugReportResult, String> {
+    let result = match profile {
+        None => local_bug_report(&app, &launcher_state).await?,
+        Some(profile) => remote_bug_report(&app, &profile).await?,
+    };
+    reveal(&app, &result.path);
+    Ok(result)
+}
+
+async fn local_bug_report(
+    app: &tauri::AppHandle<Wry>,
+    state: &crate::state::LauncherState,
+) -> Result<BugReportResult, String> {
+    use tauri::Emitter;
+    let checkout = state
+        .checkout
+        .lock()
+        .ok()
+        .and_then(|g| g.clone())
+        .or_else(|| crate::launcher::default_existing_checkout(app))
+        .ok_or_else(|| "no local TT-Studio checkout to collect logs from".to_string())?;
+
+    let spec = report_bug_spec(
+        &checkout,
+        crate::launcher::log_dir(app)?.join("bugreport.log"),
+    );
+    let (tx, rx) = std::sync::mpsc::channel();
+    let line_app = app.clone();
+    crate::launcher::spawn_streaming(
+        &spec,
+        state.child.clone(),
+        move |line| {
+            let _ = line_app.emit(BUGREPORT_LINE_EVENT, &line);
+        },
+        move |code| {
+            let _ = tx.send(code);
+        },
+    )?;
+    let code = tauri::async_runtime::spawn_blocking(move || rx.recv())
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|_| "run.py --report-bug ended without an exit code".to_string())?;
+    if code != Some(0) {
+        return Err(format!(
+            "run.py --report-bug failed (exit {})",
+            code.map_or("signal".to_string(), |c| c.to_string())
+        ));
+    }
+
+    let zip = newest_bundle_in(&checkout)
+        .ok_or_else(|| "the bundle finished but no ZIP appeared in logs/".to_string())?;
+    Ok(BugReportResult {
+        reference: zip
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(bundle_ref)
+            .map(String::from),
+        path: zip.display().to_string(),
+    })
+}
+
+async fn remote_bug_report(
+    app: &tauri::AppHandle<Wry>,
+    profile: &Profile,
+) -> Result<BugReportResult, String> {
+    use tauri::Emitter;
+    let session = crate::remote::connect_session(app, profile)
+        .await
+        .map_err(|e| e.to_string())?;
+    let path = crate::remote::repo_path(profile);
+
+    let run = async {
+        let line_app = app.clone();
+        let code = session
+            .exec_stream(
+                &report_bug_command(&path),
+                |line| {
+                    let _ = line_app.emit(BUGREPORT_LINE_EVENT, line);
+                },
+                |_| {},
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        if code != Some(0) {
+            return Err(format!(
+                "run.py --report-bug failed on {} (exit {})",
+                profile.name,
+                code.map_or("unknown".to_string(), |c| c.to_string())
+            ));
+        }
+
+        let listing = session
+            .exec_capture(&newest_bundle_command(&path))
+            .await
+            .map_err(|e| e.to_string())?;
+        let remote_zip = listing.stdout.trim().to_string();
+        if !listing.success() || remote_zip.is_empty() {
+            return Err("the bundle finished but no ZIP appeared in the remote logs/".to_string());
+        }
+        let name = remote_zip
+            .rsplit('/')
+            .next()
+            .unwrap_or(BUNDLE_PREFIX)
+            .to_string();
+
+        // Copy it back over the same session; no timeout — bundles can be
+        // sizable and the caller cancels by closing the session.
+        let mut encoded = String::new();
+        let code = session
+            .exec_stream(
+                &fetch_bundle_command(&remote_zip),
+                |line| {
+                    encoded.push_str(line);
+                    encoded.push('\n');
+                },
+                |_| {},
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        if code != Some(0) {
+            return Err("couldn't read the bundle back from the remote machine".to_string());
+        }
+        let bytes = decode_base64_stream(&encoded)?;
+
+        let dir = app
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())?
+            .join("bug-reports");
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        let local = dir.join(&name);
+        std::fs::write(&local, bytes).map_err(|e| e.to_string())?;
+        Ok(BugReportResult {
+            reference: bundle_ref(&name).map(String::from),
+            path: local.display().to_string(),
+        })
+    };
+    let result = run.await;
+    session.close().await;
+    result
+}
+
+/// Best-effort "show it in the file manager"; the returned path is the
+/// deliverable either way.
+fn reveal(app: &tauri::AppHandle<Wry>, path: &str) {
+    use tauri_plugin_opener::OpenerExt;
+    let _ = app.opener().reveal_item_in_dir(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn commands_quote_the_repo_path() {
+        assert_eq!(
+            report_bug_command("~/tt-studio"),
+            "cd \"$HOME\"/'tt-studio' && python3 run.py --report-bug --no-browser 2>&1"
+        );
+        assert_eq!(
+            newest_bundle_command("/opt/tt studio"),
+            "ls -t '/opt/tt studio'/logs/tt-studio-logs-ttbr-*.zip 2>/dev/null | head -1"
+        );
+        assert_eq!(
+            fetch_bundle_command("~/tt-studio/logs/tt-studio-logs-ttbr-ab.zip"),
+            "base64 < \"$HOME\"/'tt-studio/logs/tt-studio-logs-ttbr-ab.zip'"
+        );
+    }
+
+    #[test]
+    fn local_spec_runs_report_bug_in_the_checkout() {
+        let spec = report_bug_spec(Path::new("/tmp/stack"), "/tmp/log".into());
+        assert_eq!(spec.args, ["run.py", "--report-bug", "--no-browser"]);
+        assert_eq!(spec.cwd, Path::new("/tmp/stack"));
+    }
+
+    #[test]
+    fn bundle_names_parse_to_references() {
+        assert!(is_bundle_name("tt-studio-logs-ttbr-abc123.zip"));
+        assert!(!is_bundle_name("tt-studio-logs-ttbr-abc123.tar"));
+        assert!(!is_bundle_name("other.zip"));
+        assert_eq!(
+            bundle_ref("tt-studio-logs-ttbr-abc123.zip"),
+            Some("ttbr-abc123")
+        );
+        assert_eq!(bundle_ref("random.zip"), None);
+    }
+
+    #[test]
+    fn newest_bundle_wins_by_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = dir.path().join("logs");
+        std::fs::create_dir(&logs).unwrap();
+        let old = logs.join("tt-studio-logs-ttbr-old111111111.zip");
+        let new = logs.join("tt-studio-logs-ttbr-new222222222.zip");
+        std::fs::write(&old, "old").unwrap();
+        std::fs::write(&new, "new").unwrap();
+        let earlier = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        let f = std::fs::File::options().write(true).open(&old).unwrap();
+        f.set_modified(earlier).unwrap();
+        std::fs::write(logs.join("startup.log"), "not a bundle").unwrap();
+
+        assert_eq!(newest_bundle_in(dir.path()), Some(new));
+        // No logs dir at all → None, not an error.
+        assert_eq!(newest_bundle_in(&dir.path().join("nope")), None);
+    }
+
+    #[test]
+    fn base64_stream_decodes_with_wrapping_and_whitespace() {
+        let payload = b"PK\x03\x04 fake zip bytes".repeat(10);
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&payload);
+        // Simulate `base64` line-wrapping at 76 columns plus a trailing newline.
+        let wrapped: String = encoded
+            .as_bytes()
+            .chunks(76)
+            .map(|c| String::from_utf8_lossy(c).into_owned())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        assert_eq!(decode_base64_stream(&wrapped).unwrap(), payload);
+        assert!(decode_base64_stream("!!! not base64 !!!").is_err());
+    }
+}

--- a/desktop/src-tauri/src/bug_report.rs
+++ b/desktop/src-tauri/src/bug_report.rs
@@ -88,12 +88,7 @@ pub fn newest_bundle_in(checkout: &std::path::Path) -> Option<std::path::PathBuf
     let entries = std::fs::read_dir(checkout.join("logs")).ok()?;
     entries
         .flatten()
-        .filter(|e| {
-            e.file_name()
-                .to_str()
-                .map(is_bundle_name)
-                .unwrap_or(false)
-        })
+        .filter(|e| e.file_name().to_str().map(is_bundle_name).unwrap_or(false))
         .max_by_key(|e| {
             e.metadata()
                 .and_then(|m| m.modified())

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -309,7 +309,7 @@ pub fn confirm_quit(app: &tauri::AppHandle<Wry>) {
 /// Kill any in-flight bring-up, run `run.py --stop` in the known checkout
 /// (progress streamed as `stop-line` events for whoever is still listening),
 /// then exit. Exits immediately if there is no checkout to stop.
-fn stop_stack_then_exit(app: &tauri::AppHandle<Wry>) {
+pub(crate) fn stop_stack_then_exit(app: &tauri::AppHandle<Wry>) {
     let app = app.clone();
     std::thread::spawn(move || {
         let state: tauri::State<LauncherState> = app.state();

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -355,7 +355,7 @@ fn stop_stack_then_exit(app: &tauri::AppHandle<Wry>) {
 
 /// Attached-but-never-spawned sessions still deserve a working "stop the
 /// stack": fall back to the configured/managed checkout (never cloning).
-fn default_existing_checkout(app: &tauri::AppHandle<Wry>) -> Option<PathBuf> {
+pub(crate) fn default_existing_checkout(app: &tauri::AppHandle<Wry>) -> Option<PathBuf> {
     let configured = stack_checkout::configured_path(app).ok().flatten();
     let home = app.path().home_dir().ok()?;
     stack_checkout::existing(configured.as_deref(), &stack_checkout::managed_dir(&home))

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -172,15 +172,19 @@ fn spawn_bring_up(
     state: &state::LauncherState,
     checkout: &Path,
 ) -> Result<u32, String> {
-    let spec = bring_up_spec(checkout, log_dir(app)?.join("bringup.log"));
+    let logs = log_dir(app)?;
+    let spec = bring_up_spec(checkout, logs.join("bringup.log"));
     *state.checkout.lock().map_err(|e| e.to_string())? = Some(checkout.to_path_buf());
     state.local_stack.store(true, Ordering::SeqCst);
+    // Tee the NDJSON stdout stream to disk for the logs viewer.
+    let ndjson_log = crate::logs::LineLog::create(&logs.join("bringup.ndjson"));
     let line_app = app.clone();
     let exit_app = app.clone();
     spawn_streaming(
         &spec,
         state.child.clone(),
         move |line| {
+            ndjson_log.append(&line);
             let _ = line_app.emit(BRINGUP_LINE_EVENT, &line);
         },
         move |code| {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod commands;
 mod hardware;
 mod health;
 pub mod launcher;
+pub mod logs;
 pub mod profiles;
 pub mod remote;
 mod secrets;
@@ -86,6 +87,9 @@ pub fn run() {
             launcher::bring_up_running,
             launcher::mark_local_attach,
             launcher::restart_stack,
+            logs::list_app_logs,
+            logs::read_app_log,
+            logs::export_app_log,
             update::stack::check_stack_freshness,
             update::stack::run_stack_switch,
             update::stack::get_stack_update_policy,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod secrets;
 pub mod ssh;
 pub mod stack_checkout;
 pub mod state;
+pub mod tray;
 pub mod update;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -32,6 +33,10 @@ pub fn run() {
         .manage(ssh::commands::TunnelState::default())
         .manage(remote::RemoteState::default())
         .manage(state::LauncherState::default())
+        .setup(|app| {
+            tray::setup(app.handle())?;
+            Ok(())
+        })
         // Quit handling picks the path that matches how this session runs the
         // stack: a locally spawned/attached stack gets the stop-or-leave
         // dialog; an SSH session with live tunnels gets the in-app quit

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -14,14 +14,12 @@ mod secrets;
 pub mod ssh;
 pub mod stack_checkout;
 pub mod state;
+pub mod teardown;
 pub mod tray;
 pub mod update;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    use std::sync::atomic::Ordering;
-    use tauri::Manager;
-
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
@@ -42,24 +40,12 @@ pub fn run() {
             tray::setup(app.handle())?;
             Ok(())
         })
-        // Quit handling picks the path that matches how this session runs the
-        // stack: a locally spawned/attached stack gets the stop-or-leave
-        // dialog; an SSH session with live tunnels gets the in-app quit
-        // prompt; anything else closes normally (host services detach and
-        // survive the app on purpose).
+        // Close-button behavior is a setting (teardown.rs): ask via the
+        // stop-or-leave dialog / ssh quit prompt (default), minimize to the
+        // tray, quit leaving the stack running, or stop the stack first.
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                let app = window.app_handle();
-                let launcher_state: tauri::State<state::LauncherState> = app.state();
-                if launcher_state.local_stack.load(Ordering::SeqCst) {
-                    api.prevent_close();
-                    if launcher_state.quitting.swap(true, Ordering::SeqCst) {
-                        return; // quit flow already in flight
-                    }
-                    launcher::confirm_quit(app);
-                    return;
-                }
-                ssh::commands::on_close_requested(window, api);
+                teardown::on_close_requested(window, api);
             }
         })
         .invoke_handler(tauri::generate_handler![
@@ -99,6 +85,8 @@ pub fn run() {
             update::stack::run_stack_switch,
             update::stack::get_stack_update_policy,
             update::stack::set_stack_update_policy,
+            teardown::get_close_behavior,
+            teardown::set_close_behavior,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
+pub mod bug_report;
 mod commands;
 mod hardware;
 mod health;
@@ -30,6 +31,9 @@ pub fn run() {
         // shipping updater artifacts (see desktop/README.md).
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // Rust-side only (reveal the bug-report ZIP); no webview permission
+        // is granted in capabilities/default.json.
+        .plugin(tauri_plugin_opener::init())
         .manage(health::PollerState::default())
         .manage(ssh::commands::TunnelState::default())
         .manage(remote::RemoteState::default())
@@ -90,6 +94,7 @@ pub fn run() {
             logs::list_app_logs,
             logs::read_app_log,
             logs::export_app_log,
+            bug_report::create_bug_report,
             update::stack::check_stack_freshness,
             update::stack::run_stack_switch,
             update::stack::get_stack_update_policy,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,17 @@ pub mod update;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        // Must be the first plugin so a second launch is caught before any
+        // other state exists: it focuses the running window (un-hiding a
+        // minimized-to-tray one) instead of starting a second stack manager.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         // Shell self-update from tagged GitHub releases. The updater pubkey

--- a/desktop/src-tauri/src/logs.rs
+++ b/desktop/src-tauri/src/logs.rs
@@ -69,7 +69,10 @@ pub struct LogFileInfo {
 }
 
 fn is_log_name(name: &str) -> bool {
-    name.ends_with(".log") || name.ends_with(".log.1") || name.ends_with(".ndjson") || name.ends_with(".ndjson.1")
+    name.ends_with(".log")
+        || name.ends_with(".log.1")
+        || name.ends_with(".ndjson")
+        || name.ends_with(".ndjson.1")
 }
 
 /// Scan one directory for launcher log files.
@@ -141,12 +144,10 @@ fn log_dirs(app: &tauri::AppHandle<Wry>) -> Vec<PathBuf> {
 }
 
 fn scan_all(app: &tauri::AppHandle<Wry>) -> Vec<(LogFileInfo, PathBuf)> {
-    let mut all: Vec<(LogFileInfo, PathBuf)> = log_dirs(app)
-        .iter()
-        .flat_map(|d| scan_dir(d))
-        .collect();
+    let mut all: Vec<(LogFileInfo, PathBuf)> =
+        log_dirs(app).iter().flat_map(|d| scan_dir(d)).collect();
     // Newest first; duplicates (same name in both dirs) keep the newest.
-    all.sort_by(|a, b| b.0.modified_secs.cmp(&a.0.modified_secs));
+    all.sort_by_key(|entry| std::cmp::Reverse(entry.0.modified_secs));
     let mut seen = std::collections::HashSet::new();
     all.retain(|(info, _)| seen.insert(info.name.clone()));
     all

--- a/desktop/src-tauri/src/logs.rs
+++ b/desktop/src-tauri/src/logs.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! The launcher's own log files, surfaced to the logs viewer.
+//!
+//! Two directories hold everything the desktop shell writes:
+//! - `app_data_dir/logs` — native `run.py` children: `bringup.log` (stderr),
+//!   `bringup.ndjson` (the machine-readable stdout tee), `stop.log`,
+//!   `switch.log`, and their `.1` rotations;
+//! - `app_log_dir` — `remote-bringup.log` / `remote-bringup.ndjson` from the
+//!   ssh bring-up path.
+//!
+//! The viewer only ever reads files these scans found — names are looked up
+//! against the scan result, never joined into a path from UI input.
+
+use serde::Serialize;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use tauri::{Manager, Wry};
+
+/// Reading more than this per request keeps the UI responsive on huge logs.
+pub const MAX_TAIL_BYTES: u64 = 512 * 1024;
+
+// ---- NDJSON tee: persist the bring-up event stream for the viewer ----
+
+/// Append-only line sink for the NDJSON stdout stream. Failures degrade to
+/// dropping the tee (the UI stream is unaffected) — logging must never block
+/// or break a bring-up.
+pub struct LineLog(Option<Mutex<File>>);
+
+impl LineLog {
+    /// Rotate like the stderr logs (keep one `.1` predecessor) and open fresh.
+    pub fn create(path: &Path) -> Self {
+        let file = crate::launcher::rotate_log(path)
+            .ok()
+            .and_then(|_| File::create(path).ok());
+        Self(file.map(Mutex::new))
+    }
+
+    pub fn append(&self, line: &str) {
+        if let Some(file) = &self.0 {
+            if let Ok(mut f) = file.lock() {
+                let _ = writeln!(f, "{line}");
+            }
+        }
+    }
+}
+
+/// Append one line to a log file without rotation (remote path: the file is
+/// recreated per bring-up by the caller).
+pub fn append_line(file: &mut File, line: &str) {
+    let _ = writeln!(file, "{line}");
+}
+
+// ---- scanning ----
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct LogFileInfo {
+    /// Display name, unique across both directories.
+    pub name: String,
+    pub size_bytes: u64,
+    /// Seconds since the Unix epoch, for sorting newest-first.
+    pub modified_secs: u64,
+    /// The stream is NDJSON events (level filtering applies).
+    pub ndjson: bool,
+}
+
+fn is_log_name(name: &str) -> bool {
+    name.ends_with(".log") || name.ends_with(".log.1") || name.ends_with(".ndjson") || name.ends_with(".ndjson.1")
+}
+
+/// Scan one directory for launcher log files.
+pub fn scan_dir(dir: &Path) -> Vec<(LogFileInfo, PathBuf)> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !path.is_file() || !is_log_name(name) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let modified_secs = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        found.push((
+            LogFileInfo {
+                name: name.to_string(),
+                size_bytes: meta.len(),
+                modified_secs,
+                ndjson: name.contains(".ndjson"),
+            },
+            path,
+        ));
+    }
+    found
+}
+
+/// Read at most `MAX_TAIL_BYTES` from the end of the file, starting at the
+/// first complete line when truncating.
+pub fn read_tail(path: &Path) -> std::io::Result<(String, bool)> {
+    let mut file = OpenOptions::new().read(true).open(path)?;
+    let len = file.metadata()?.len();
+    let truncated = len > MAX_TAIL_BYTES;
+    if truncated {
+        file.seek(SeekFrom::End(-(MAX_TAIL_BYTES as i64)))?;
+    }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let mut content = String::from_utf8_lossy(&buf).into_owned();
+    if truncated {
+        // Drop the partial first line so parsers see whole lines only.
+        if let Some(pos) = content.find('\n') {
+            content = content.split_off(pos + 1);
+        }
+    }
+    Ok((content, truncated))
+}
+
+// ---- Tauri commands ----
+
+fn log_dirs(app: &tauri::AppHandle<Wry>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(dir) = crate::launcher::log_dir(app) {
+        dirs.push(dir);
+    }
+    if let Ok(dir) = app.path().app_log_dir() {
+        dirs.push(dir);
+    }
+    dirs
+}
+
+fn scan_all(app: &tauri::AppHandle<Wry>) -> Vec<(LogFileInfo, PathBuf)> {
+    let mut all: Vec<(LogFileInfo, PathBuf)> = log_dirs(app)
+        .iter()
+        .flat_map(|d| scan_dir(d))
+        .collect();
+    // Newest first; duplicates (same name in both dirs) keep the newest.
+    all.sort_by(|a, b| b.0.modified_secs.cmp(&a.0.modified_secs));
+    let mut seen = std::collections::HashSet::new();
+    all.retain(|(info, _)| seen.insert(info.name.clone()));
+    all
+}
+
+fn resolve(app: &tauri::AppHandle<Wry>, name: &str) -> Result<PathBuf, String> {
+    scan_all(app)
+        .into_iter()
+        .find(|(info, _)| info.name == name)
+        .map(|(_, path)| path)
+        .ok_or_else(|| format!("no launcher log named {name}"))
+}
+
+#[tauri::command]
+pub fn list_app_logs(app: tauri::AppHandle<Wry>) -> Vec<LogFileInfo> {
+    scan_all(&app).into_iter().map(|(info, _)| info).collect()
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct LogTail {
+    pub content: String,
+    /// Only the newest `MAX_TAIL_BYTES` are returned for oversized logs.
+    pub truncated: bool,
+}
+
+#[tauri::command]
+pub fn read_app_log(app: tauri::AppHandle<Wry>, name: String) -> Result<LogTail, String> {
+    let path = resolve(&app, &name)?;
+    let (content, truncated) = read_tail(&path).map_err(|e| e.to_string())?;
+    Ok(LogTail { content, truncated })
+}
+
+/// Export one log via a native save dialog. Resolves to the chosen path, or
+/// null when the user cancelled.
+#[tauri::command]
+pub async fn export_app_log(
+    app: tauri::AppHandle<Wry>,
+    name: String,
+) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+    let source = resolve(&app, &name)?;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .set_file_name(&name)
+        .save_file(move |chosen| {
+            let _ = tx.send(chosen);
+        });
+    let Some(target) = rx.await.map_err(|e| e.to_string())? else {
+        return Ok(None);
+    };
+    let target = target
+        .into_path()
+        .map_err(|e| format!("unsupported save location: {e}"))?;
+    std::fs::copy(&source, &target).map_err(|e| e.to_string())?;
+    Ok(Some(target.display().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_finds_only_log_files() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in [
+            "bringup.log",
+            "bringup.log.1",
+            "bringup.ndjson",
+            "notes.txt",
+            ".env",
+        ] {
+            std::fs::write(dir.path().join(name), "x\n").unwrap();
+        }
+        std::fs::create_dir(dir.path().join("sub.log")).unwrap(); // dir, not file
+
+        let mut names: Vec<String> = scan_dir(dir.path())
+            .into_iter()
+            .map(|(info, _)| info.name)
+            .collect();
+        names.sort();
+        assert_eq!(names, ["bringup.log", "bringup.log.1", "bringup.ndjson"]);
+    }
+
+    #[test]
+    fn scan_marks_ndjson_streams() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bringup.ndjson"), "{}\n").unwrap();
+        std::fs::write(dir.path().join("bringup.log"), "text\n").unwrap();
+        for (info, _) in scan_dir(dir.path()) {
+            assert_eq!(info.ndjson, info.name.contains("ndjson"), "{}", info.name);
+        }
+    }
+
+    #[test]
+    fn tail_returns_whole_small_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a.log");
+        std::fs::write(&path, "one\ntwo\n").unwrap();
+        let (content, truncated) = read_tail(&path).unwrap();
+        assert_eq!(content, "one\ntwo\n");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn tail_truncates_to_complete_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.log");
+        let line = "x".repeat(1000);
+        let mut body = String::new();
+        for i in 0..600 {
+            body.push_str(&format!("{i} {line}\n"));
+        }
+        std::fs::write(&path, &body).unwrap();
+
+        let (content, truncated) = read_tail(&path).unwrap();
+        assert!(truncated);
+        assert!(content.len() as u64 <= MAX_TAIL_BYTES);
+        // Starts at a line boundary, ends with the file's last line.
+        assert!(!content.starts_with('x'));
+        assert!(content.ends_with(&format!("599 {line}\n")));
+        let first = content.lines().next().unwrap();
+        assert!(first.split(' ').next().unwrap().parse::<u32>().is_ok());
+    }
+
+    #[test]
+    fn line_log_appends_and_rotates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logs").join("bringup.ndjson");
+
+        let log = LineLog::create(&path);
+        log.append(r#"{"v":1}"#);
+        log.append(r#"{"v":2}"#);
+        drop(log);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\"v\":1}\n{\"v\":2}\n"
+        );
+
+        // A second create rotates the first run's stream aside.
+        let log = LineLog::create(&path);
+        log.append("fresh");
+        drop(log);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh\n");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("logs").join("bringup.ndjson.1")).unwrap(),
+            "{\"v\":1}\n{\"v\":2}\n"
+        );
+    }
+
+    #[test]
+    fn line_log_swallows_unwritable_paths() {
+        // A path whose parent can't be a directory: create fails, append is a no-op.
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("file");
+        std::fs::write(&blocker, "x").unwrap();
+        let log = LineLog::create(&blocker.join("nested.ndjson"));
+        log.append("dropped");
+    }
+}

--- a/desktop/src-tauri/src/remote.rs
+++ b/desktop/src-tauri/src/remote.rs
@@ -340,6 +340,12 @@ pub async fn start_remote_bring_up(
     let session = std::sync::Arc::new(connect_session(&app, &profile).await?);
     let command = bring_up_command(&repo_path(&profile));
     let mut stderr_log = stderr_log_file(&app);
+    // Tee the NDJSON stream to disk for the logs viewer, next to the stderr log.
+    let ndjson_log = app
+        .path()
+        .app_log_dir()
+        .ok()
+        .map(|dir| crate::logs::LineLog::create(&dir.join("remote-bringup.ndjson")));
 
     let task_session = session.clone();
     let task = tauri::async_runtime::spawn(async move {
@@ -350,6 +356,9 @@ pub async fn start_remote_bring_up(
             .exec_stream(
                 &command,
                 |line| {
+                    if let Some(log) = &ndjson_log {
+                        log.append(line);
+                    }
                     let _ = line_app.emit(BRINGUP_LINE_EVENT, line);
                 },
                 |chunk| {

--- a/desktop/src-tauri/src/ssh/app_ports.rs
+++ b/desktop/src-tauri/src/ssh/app_ports.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Dynamic tunnel forwards for marketplace app ports.
+//!
+//! Marketplace apps (AppsPage.tsx → `/models-api/marketplace/apps/`) run in
+//! containers whose host ports the backend allocates at launch time from its
+//! own range (shared_config/marketplace_config.py) — no static forward list
+//! can cover them. While an SSH tunnel is connected, this poller asks the
+//! backend (a read-only GET through the already-forwarded port 8000) which
+//! apps hold a host port right now, and reconciles the supervisor's dynamic
+//! forwards to exactly that set: launched apps become reachable through the
+//! tunnel within one poll, stopped apps free their local listeners.
+
+use std::time::Duration;
+
+use super::tunnel::{ForwardSpec, TunnelPhase};
+
+/// The backend's marketplace listing, through the tunneled backend port.
+pub const MARKETPLACE_URL: &str = "http://localhost:8000/models/marketplace/apps/";
+
+pub const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// App statuses that hold (or are about to hold) a live host port.
+const ACTIVE_STATUSES: [&str; 3] = ["pulling", "starting", "running"];
+
+/// Extract the host ports to forward from a marketplace listing. Ports in
+/// `exclude` (the static production forwards) are skipped; the result is
+/// sorted and deduplicated so callers can compare sets cheaply.
+pub fn desired_app_ports(payload: &str, exclude: &[u16]) -> Vec<u16> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return Vec::new();
+    };
+    let Some(apps) = value["apps"].as_array() else {
+        return Vec::new();
+    };
+    let mut ports: Vec<u16> = apps
+        .iter()
+        .filter(|app| {
+            app["status"]
+                .as_str()
+                .map(|s| ACTIVE_STATUSES.contains(&s))
+                .unwrap_or(false)
+        })
+        .filter_map(|app| app["host_port"].as_u64())
+        .filter_map(|p| u16::try_from(p).ok())
+        .filter(|p| !exclude.contains(p))
+        .collect();
+    ports.sort_unstable();
+    ports.dedup();
+    ports
+}
+
+pub fn forwards_for(ports: &[u16]) -> Vec<ForwardSpec> {
+    ports
+        .iter()
+        .map(|&port| ForwardSpec {
+            local_port: port,
+            remote_host: "127.0.0.1".into(),
+            remote_port: port,
+        })
+        .collect()
+}
+
+/// Poll loop: runs until aborted (see TunnelState). Only talks to the
+/// backend while the supervisor reports Connected — before that, port 8000
+/// might be some unrelated local server.
+pub(crate) async fn sync_loop(app: tauri::AppHandle) {
+    use tauri::Manager;
+    let client = crate::health::client();
+    let static_ports: Vec<u16> = super::tunnel::production_forwards()
+        .iter()
+        .map(|f| f.local_port)
+        .collect();
+    let mut last: Option<Vec<u16>> = None;
+
+    loop {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        let state = app.state::<super::commands::TunnelState>();
+
+        let connected = {
+            let guard = state.supervisor.lock().await;
+            match guard.as_ref() {
+                Some(sup) => matches!(sup.status().phase, TunnelPhase::Connected),
+                None => return, // tunnels are gone; so is this loop's job
+            }
+        };
+        if !connected {
+            continue;
+        }
+
+        let Ok(response) = client.get(MARKETPLACE_URL).send().await else {
+            continue; // backend not answering yet; try again next tick
+        };
+        let Ok(payload) = response.text().await else {
+            continue;
+        };
+        let ports = desired_app_ports(&payload, &static_ports);
+        if last.as_ref() == Some(&ports) {
+            continue;
+        }
+
+        let guard = state.supervisor.lock().await;
+        if let Some(sup) = guard.as_ref() {
+            sup.set_dynamic_forwards(forwards_for(&ports));
+            last = Some(ports);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn listing(apps: &[(&str, Option<u64>)]) -> String {
+        let apps: Vec<serde_json::Value> = apps
+            .iter()
+            .map(|(status, port)| {
+                let mut app = serde_json::json!({ "id": "x", "status": status });
+                if let Some(port) = port {
+                    app["host_port"] = serde_json::json!(port);
+                }
+                app
+            })
+            .collect();
+        serde_json::json!({ "gateway_configured": true, "apps": apps }).to_string()
+    }
+
+    #[test]
+    fn active_apps_with_ports_are_forwarded() {
+        let payload = listing(&[
+            ("running", Some(3085)),
+            ("starting", Some(3086)),
+            ("pulling", Some(3087)),
+            ("stopped", Some(3088)),      // inactive: no forward
+            ("running", None),            // no port yet
+            ("guide", None),
+            ("error", Some(3089)),        // failed: port is being released
+        ]);
+        assert_eq!(desired_app_ports(&payload, &[]), vec![3085, 3086, 3087]);
+    }
+
+    #[test]
+    fn static_ports_and_duplicates_are_dropped() {
+        let payload = listing(&[
+            ("running", Some(8000)), // already a production forward
+            ("running", Some(3085)),
+            ("starting", Some(3085)), // duplicate
+        ]);
+        assert_eq!(desired_app_ports(&payload, &[8000]), vec![3085]);
+    }
+
+    #[test]
+    fn garbage_payloads_forward_nothing() {
+        assert!(desired_app_ports("not json", &[]).is_empty());
+        assert!(desired_app_ports("{}", &[]).is_empty());
+        assert!(desired_app_ports(r#"{"apps": 3}"#, &[]).is_empty());
+        // Out-of-range port numbers are ignored, not truncated.
+        let payload = listing(&[("running", Some(70000))]);
+        assert!(desired_app_ports(&payload, &[]).is_empty());
+    }
+
+    #[test]
+    fn forwards_map_ports_one_to_one() {
+        let forwards = forwards_for(&[3085, 3086]);
+        assert_eq!(forwards.len(), 2);
+        assert!(forwards
+            .iter()
+            .all(|f| f.local_port == f.remote_port && f.remote_host == "127.0.0.1"));
+    }
+}

--- a/desktop/src-tauri/src/ssh/app_ports.rs
+++ b/desktop/src-tauri/src/ssh/app_ports.rs
@@ -133,10 +133,10 @@ mod tests {
             ("running", Some(3085)),
             ("starting", Some(3086)),
             ("pulling", Some(3087)),
-            ("stopped", Some(3088)),      // inactive: no forward
-            ("running", None),            // no port yet
+            ("stopped", Some(3088)), // inactive: no forward
+            ("running", None),       // no port yet
             ("guide", None),
-            ("error", Some(3089)),        // failed: port is being released
+            ("error", Some(3089)), // failed: port is being released
         ]);
         assert_eq!(desired_app_ports(&payload, &[]), vec![3085, 3086, 3087]);
     }

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -114,7 +114,7 @@ pub(crate) fn launcher_url(app: &AppHandle) -> Option<Url> {
 
 /// True when the main window currently shows the remote stack (a plain
 /// http(s) origin) rather than the bundled launcher.
-fn showing_remote_stack(app: &AppHandle) -> bool {
+pub(crate) fn showing_remote_stack(app: &AppHandle) -> bool {
     let Some(window) = app.get_webview_window("main") else {
         return false;
     };
@@ -195,19 +195,11 @@ pub async fn get_tunnel_status(
     Ok(state.supervisor.lock().await.as_ref().map(|s| s.status()))
 }
 
-/// Close-button interception: while an SSH connection is active and the
-/// window shows the remote stack, turn the close into the launcher's quit
-/// dialog (stop the remote stack vs just disconnect) instead of exiting.
-pub(crate) fn on_close_requested(window: &tauri::Window, api: &tauri::CloseRequestApi) {
-    if window.label() != "main" {
-        return;
-    }
-    let app = window.app_handle();
-    let active = app.state::<TunnelState>().active_profile().is_some();
-    if !active || !showing_remote_stack(app) {
-        return; // plain close: the process exit tears the tunnels down
-    }
-    api.prevent_close();
+/// Show the launcher's quit prompt (stop the remote stack vs just
+/// disconnect) by navigating the window to the bundled launcher with
+/// `?quit=1`. Callers decide when — teardown.rs routes the close button
+/// here while an SSH connection is active and the window shows the stack.
+pub(crate) fn show_quit_prompt(app: &AppHandle) {
     let Some(mut url) = launcher_url(app) else {
         return;
     };
@@ -215,6 +207,7 @@ pub(crate) fn on_close_requested(window: &tauri::Window, api: &tauri::CloseReque
     let app = app.clone();
     let _ = app.clone().run_on_main_thread(move || {
         if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
             let _ = window.navigate(url);
         }
     });

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -28,10 +28,13 @@ const DEFAULT_SSH_PORT: u16 = 22;
 /// At most one tunnel supervisor runs at a time (one remote stack per window).
 #[derive(Default)]
 pub struct TunnelState {
-    supervisor: tokio::sync::Mutex<Option<Supervisor>>,
+    pub(crate) supervisor: tokio::sync::Mutex<Option<Supervisor>>,
     /// The profile the running tunnels belong to. Drives the quit dialog:
     /// while set, closing the window offers stop-vs-disconnect first.
     active: std::sync::Mutex<Option<Profile>>,
+    /// The marketplace app-port poller (ssh/app_ports.rs), aborted with the
+    /// supervisor it feeds.
+    app_ports_task: std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
 }
 
 impl TunnelState {
@@ -43,8 +46,15 @@ impl TunnelState {
         *self.active.lock().expect("active profile lock") = profile;
     }
 
+    fn stop_app_ports_task(&self) {
+        if let Some(task) = self.app_ports_task.lock().expect("app ports lock").take() {
+            task.abort();
+        }
+    }
+
     /// Stop the supervisor (if any) and forget the active profile.
     pub(crate) async fn shutdown(&self) {
+        self.stop_app_ports_task();
         if let Some(supervisor) = self.supervisor.lock().await.take() {
             supervisor.stop().await;
         }
@@ -170,6 +180,7 @@ pub async fn start_ssh_tunnels(
     });
 
     let mut guard = state.supervisor.lock().await;
+    state.stop_app_ports_task();
     if let Some(previous) = guard.take() {
         previous.stop().await;
     }
@@ -178,6 +189,11 @@ pub async fn start_ssh_tunnels(
         connector,
         sink,
     ));
+    drop(guard);
+    // Keep marketplace app ports forwarded while this tunnel set lives.
+    *state.app_ports_task.lock().expect("app ports lock") = Some(
+        tauri::async_runtime::spawn(super::app_ports::sync_loop(app)),
+    );
     state.set_active(Some(profile));
     Ok(())
 }

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -191,9 +191,9 @@ pub async fn start_ssh_tunnels(
     ));
     drop(guard);
     // Keep marketplace app ports forwarded while this tunnel set lives.
-    *state.app_ports_task.lock().expect("app ports lock") = Some(
-        tauri::async_runtime::spawn(super::app_ports::sync_loop(app)),
-    );
+    *state.app_ports_task.lock().expect("app ports lock") = Some(tauri::async_runtime::spawn(
+        super::app_ports::sync_loop(app),
+    ));
     state.set_active(Some(profile));
     Ok(())
 }

--- a/desktop/src-tauri/src/ssh/commands.rs
+++ b/desktop/src-tauri/src/ssh/commands.rs
@@ -101,7 +101,7 @@ fn expand_tilde(path: &str, home: Option<PathBuf>) -> PathBuf {
 
 /// Where "back to the launcher" points: the dev server during development,
 /// the bundled app origin in production builds.
-fn launcher_url(app: &AppHandle) -> Option<Url> {
+pub(crate) fn launcher_url(app: &AppHandle) -> Option<Url> {
     if let Some(dev_url) = &app.config().build.dev_url {
         return Some(dev_url.clone());
     }

--- a/desktop/src-tauri/src/ssh/mod.rs
+++ b/desktop/src-tauri/src/ssh/mod.rs
@@ -10,6 +10,7 @@
 //! [`SshTransport`] trait so the russh implementation in `session.rs` can be
 //! swapped for ssh2 or system-ssh without touching the tunnel supervisor.
 
+pub mod app_ports;
 pub(crate) mod commands;
 pub mod exec;
 pub mod known_hosts;

--- a/desktop/src-tauri/src/ssh/tunnel.rs
+++ b/desktop/src-tauri/src/ssh/tunnel.rs
@@ -33,14 +33,15 @@ pub struct ForwardSpec {
     pub remote_port: u16,
 }
 
-/// The TT-Studio stack's port map: frontend 3000, backend 8000, inference
-/// 8001, docker control 8002, agent 8080, ChromaDB 8111, 4000, and the
-/// 7000-7010 model-container range. Same numbers locally and remotely.
+/// The TT-Studio stack's fixed port map: frontend 3000, backend 8000,
+/// inference 8001, docker control 8002, agent 8080, ChromaDB 8111, 4000.
+/// Same numbers locally and remotely. Marketplace app containers get their
+/// host ports dynamically from the backend (see ssh/app_ports.rs) and are
+/// added as dynamic forwards at runtime — the backend allocates them from
+/// its own range, so no static range here can cover them.
 pub fn production_forwards() -> Vec<ForwardSpec> {
-    let fixed = [3000u16, 8000, 8001, 8002, 8080, 8111, 4000];
-    fixed
+    [3000u16, 8000, 8001, 8002, 8080, 8111, 4000]
         .into_iter()
-        .chain(7000..=7010)
         .map(|port| ForwardSpec {
             local_port: port,
             remote_host: "127.0.0.1".into(),
@@ -119,6 +120,7 @@ const LIVENESS_POLL: Duration = Duration::from_millis(500);
 pub struct Supervisor {
     status: Arc<Mutex<TunnelStatus>>,
     shutdown: watch::Sender<bool>,
+    dynamic: tokio::sync::mpsc::UnboundedSender<Vec<ForwardSpec>>,
     task: JoinHandle<()>,
 }
 
@@ -129,16 +131,33 @@ impl Supervisor {
             forwards: Vec::new(),
         }));
         let (shutdown, shutdown_rx) = watch::channel(false);
-        let task = tokio::spawn(run(config, connector, sink, status.clone(), shutdown_rx));
+        let (dynamic, dynamic_rx) = tokio::sync::mpsc::unbounded_channel();
+        let task = tokio::spawn(run(
+            config,
+            connector,
+            sink,
+            status.clone(),
+            shutdown_rx,
+            dynamic_rx,
+        ));
         Self {
             status,
             shutdown,
+            dynamic,
             task,
         }
     }
 
     pub fn status(&self) -> TunnelStatus {
         self.status.lock().expect("status lock").clone()
+    }
+
+    /// Replace the set of dynamic forwards (marketplace app ports). Applied
+    /// while connected: new ports get listeners on the live session, dropped
+    /// ports lose theirs; the whole set is re-bound after a reconnect. The
+    /// static production forwards are never touched.
+    pub fn set_dynamic_forwards(&self, specs: Vec<ForwardSpec>) {
+        let _ = self.dynamic.send(specs);
     }
 
     /// Clean shutdown: closes the session and stops all listeners without
@@ -162,15 +181,63 @@ fn publish(
     sink(snapshot);
 }
 
+/// Bind one forward on the current transport: a health row plus the accept
+/// task when the bind succeeded.
+async fn bind_forward(
+    bind_addr: IpAddr,
+    spec: &ForwardSpec,
+    transport: &Arc<dyn SshTransport>,
+    status: &Arc<Mutex<TunnelStatus>>,
+    sink: &StatusSink,
+) -> (ForwardHealth, Option<JoinHandle<()>>) {
+    match TcpListener::bind((bind_addr, spec.local_port)).await {
+        Ok(listener) => {
+            let bound = listener
+                .local_addr()
+                .map(|a| a.port())
+                .unwrap_or(spec.local_port);
+            let task = tokio::spawn(accept_loop(
+                listener,
+                spec.clone(),
+                transport.clone(),
+                status.clone(),
+                sink.clone(),
+                bound,
+            ));
+            (
+                ForwardHealth {
+                    local_port: bound,
+                    remote_port: spec.remote_port,
+                    active: true,
+                    last_error: None,
+                },
+                Some(task),
+            )
+        }
+        Err(e) => (
+            ForwardHealth {
+                local_port: spec.local_port,
+                remote_port: spec.remote_port,
+                active: false,
+                last_error: Some(format!("bind 127.0.0.1:{}: {e}", spec.local_port)),
+            },
+            None,
+        ),
+    }
+}
+
 async fn run(
     config: SupervisorConfig,
     connector: Connector,
     sink: StatusSink,
     status: Arc<Mutex<TunnelStatus>>,
     mut shutdown: watch::Receiver<bool>,
+    mut dynamic_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<ForwardSpec>>,
 ) {
     let mut attempt: u32 = 0;
     let mut delay = config.initial_backoff;
+    // The current dynamic forward set; survives reconnects.
+    let mut dynamic: Vec<ForwardSpec> = Vec::new();
 
     loop {
         if *shutdown.borrow() {
@@ -212,43 +279,17 @@ async fn run(
             },
         };
 
-        // Session is up: bind every listener and start accept loops.
+        // Session is up: bind every static listener and start accept loops.
         let mut accept_tasks: Vec<JoinHandle<()>> = Vec::new();
         let mut healths: Vec<ForwardHealth> = Vec::new();
         let mut bind_failure: Option<String> = None;
-        for (idx, spec) in config.forwards.iter().enumerate() {
-            match TcpListener::bind((config.bind_addr, spec.local_port)).await {
-                Ok(listener) => {
-                    let bound = listener
-                        .local_addr()
-                        .map(|a| a.port())
-                        .unwrap_or(spec.local_port);
-                    healths.push(ForwardHealth {
-                        local_port: bound,
-                        remote_port: spec.remote_port,
-                        active: true,
-                        last_error: None,
-                    });
-                    accept_tasks.push(tokio::spawn(accept_loop(
-                        listener,
-                        spec.clone(),
-                        transport.clone(),
-                        status.clone(),
-                        sink.clone(),
-                        idx,
-                    )));
-                }
-                Err(e) => {
-                    let message = format!("bind 127.0.0.1:{}: {e}", spec.local_port);
-                    bind_failure.get_or_insert(message.clone());
-                    healths.push(ForwardHealth {
-                        local_port: spec.local_port,
-                        remote_port: spec.remote_port,
-                        active: false,
-                        last_error: Some(message),
-                    });
-                }
+        for spec in &config.forwards {
+            let (health, task) = bind_forward(config.bind_addr, spec, &transport, &status, &sink).await;
+            if let Some(err) = &health.last_error {
+                bind_failure.get_or_insert(err.clone());
             }
+            accept_tasks.extend(task);
+            healths.push(health);
         }
 
         if healths.iter().all(|h| !h.active) {
@@ -269,16 +310,70 @@ async fn run(
             return;
         }
 
+        // Re-bind the dynamic set from previous epochs on the new session.
+        let mut dyn_tasks: std::collections::HashMap<u16, JoinHandle<()>> =
+            std::collections::HashMap::new();
+        for spec in dynamic.clone() {
+            let (health, task) =
+                bind_forward(config.bind_addr, &spec, &transport, &status, &sink).await;
+            if let Some(task) = task {
+                // Keyed by the actually-bound port (resolves a 0 in the spec).
+                dyn_tasks.insert(health.local_port, task);
+            }
+            healths.push(health);
+        }
+
         delay = config.initial_backoff;
         publish(&status, &sink, |s| {
             s.phase = TunnelPhase::Connected;
             s.forwards = healths;
         });
 
-        // Watch the session until it dies or we're told to stop.
+        // Watch the session until it dies or we're told to stop, applying
+        // dynamic forward updates as they arrive.
         let session_died = loop {
             tokio::select! {
                 _ = shutdown.changed() => break false,
+                specs = dynamic_rx.recv() => {
+                    let Some(specs) = specs else { break false };
+                    // Drop forwards that fell out of the set…
+                    let keep: std::collections::HashSet<u16> =
+                        specs.iter().map(|s| s.local_port).collect();
+                    let dropped: Vec<u16> = dyn_tasks
+                        .keys()
+                        .filter(|p| !keep.contains(p))
+                        .copied()
+                        .collect();
+                    for port in dropped {
+                        if let Some(task) = dyn_tasks.remove(&port) {
+                            task.abort();
+                        }
+                        publish(&status, &sink, |s| {
+                            s.forwards.retain(|h| h.local_port != port);
+                        });
+                    }
+                    // …and bind the new ones on the live session. Port 0
+                    // (OS-assigned, tests only) can't collide, so it skips
+                    // the already-bound checks.
+                    for spec in &specs {
+                        if spec.local_port != 0
+                            && (dyn_tasks.contains_key(&spec.local_port)
+                                || config.forwards.iter().any(|f| f.local_port == spec.local_port))
+                        {
+                            continue;
+                        }
+                        let (health, task) =
+                            bind_forward(config.bind_addr, spec, &transport, &status, &sink).await;
+                        if let Some(task) = task {
+                            dyn_tasks.insert(health.local_port, task);
+                        }
+                        publish(&status, &sink, |s| {
+                            s.forwards.retain(|h| h.local_port != health.local_port);
+                            s.forwards.push(health.clone());
+                        });
+                    }
+                    dynamic = specs;
+                }
                 _ = tokio::time::sleep(LIVENESS_POLL) => {
                     if transport.is_closed() {
                         break true;
@@ -289,6 +384,9 @@ async fn run(
 
         for t in &accept_tasks {
             t.abort();
+        }
+        for task in dyn_tasks.values() {
+            task.abort();
         }
         transport.close().await;
 
@@ -317,7 +415,7 @@ async fn accept_loop(
     transport: Arc<dyn SshTransport>,
     status: Arc<Mutex<TunnelStatus>>,
     sink: StatusSink,
-    idx: usize,
+    bound_port: u16,
 ) {
     loop {
         let mut sock = match listener.accept().await {
@@ -341,8 +439,12 @@ async fn accept_loop(
                     let _ = tokio::io::copy_bidirectional(&mut sock, &mut stream).await;
                 }
                 Err(e) => {
+                    // Forwards come and go dynamically, so rows are keyed by
+                    // their bound local port, never by position.
                     publish(&status, &sink, |s| {
-                        if let Some(h) = s.forwards.get_mut(idx) {
+                        if let Some(h) =
+                            s.forwards.iter_mut().find(|h| h.local_port == bound_port)
+                        {
                             h.last_error = Some(e.to_string());
                         }
                     });
@@ -610,13 +712,111 @@ mod tests {
     fn production_map_covers_the_stack_ports() {
         let forwards = production_forwards();
         let ports: Vec<u16> = forwards.iter().map(|f| f.local_port).collect();
-        for expected in [3000, 8000, 8001, 8002, 8080, 8111, 4000, 7000, 7010] {
+        for expected in [3000, 8000, 8001, 8002, 8080, 8111, 4000] {
             assert!(ports.contains(&expected), "missing port {expected}");
         }
-        assert_eq!(forwards.len(), 7 + 11);
+        // Marketplace app ports are dynamic (ssh/app_ports.rs), not static.
+        assert_eq!(forwards.len(), 7);
         // Local and remote port numbers must match — the web app derives its
         // URLs from window.location.hostname plus these fixed ports.
         assert!(forwards.iter().all(|f| f.local_port == f.remote_port));
+    }
+
+    async fn connect_ok(sock: &mut tokio::net::TcpStream, payload: &[u8]) {
+        sock.write_all(payload).await.unwrap();
+        let mut buf = vec![0u8; payload.len()];
+        sock.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, payload);
+    }
+
+    #[tokio::test]
+    async fn dynamic_forwards_bind_and_unbind_while_connected() {
+        let echo = echo_server().await;
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let flags = Arc::new(Mutex::new(Vec::new()));
+        let sup = Supervisor::spawn(test_config(), connector_to(echo, dials, flags), sink);
+        wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+
+        // Add one dynamic app port (0 = OS-assigned for the test).
+        sup.set_dynamic_forwards(vec![ForwardSpec {
+            local_port: 0,
+            remote_host: "127.0.0.1".into(),
+            remote_port: 3085,
+        }]);
+        let status = wait_for(&mut rx, |s| {
+            s.forwards.iter().any(|f| f.remote_port == 3085 && f.active)
+        })
+        .await;
+        assert_eq!(status.forwards.len(), 2);
+        let port = status
+            .forwards
+            .iter()
+            .find(|f| f.remote_port == 3085)
+            .unwrap()
+            .local_port;
+
+        // Traffic flows through the dynamic forward.
+        let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .unwrap();
+        connect_ok(&mut sock, b"app").await;
+
+        // Empty set removes it; the static forward stays.
+        sup.set_dynamic_forwards(Vec::new());
+        let status = wait_for(&mut rx, |s| s.forwards.len() == 1).await;
+        assert_eq!(status.forwards[0].remote_port, 9999);
+        assert!(
+            tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_err(),
+            "dynamic listener should be gone"
+        );
+
+        sup.stop().await;
+    }
+
+    #[tokio::test]
+    async fn dynamic_forwards_survive_a_reconnect() {
+        let echo = echo_server().await;
+        let (sink, mut rx) = channel_sink();
+        let dials = Arc::new(AtomicU32::new(0));
+        let flags: Arc<Mutex<Vec<Arc<AtomicBool>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sup = Supervisor::spawn(
+            test_config(),
+            connector_to(echo, dials, flags.clone()),
+            sink,
+        );
+        wait_for(&mut rx, |s| matches!(s.phase, TunnelPhase::Connected)).await;
+
+        // Bind a real high port so the re-bind after reconnect is observable.
+        let free_port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        sup.set_dynamic_forwards(vec![ForwardSpec {
+            local_port: free_port,
+            remote_host: "127.0.0.1".into(),
+            remote_port: 3085,
+        }]);
+        wait_for(&mut rx, |s| {
+            s.forwards.iter().any(|f| f.local_port == free_port && f.active)
+        })
+        .await;
+
+        // Kill the session; after the reconnect the dynamic port is back.
+        flags.lock().unwrap()[0].store(true, Ordering::SeqCst);
+        let reconnected = wait_for(&mut rx, |s| {
+            matches!(s.phase, TunnelPhase::Connected)
+                && s.forwards.iter().any(|f| f.local_port == free_port && f.active)
+        })
+        .await;
+        assert_eq!(reconnected.forwards.len(), 2);
+
+        let mut sock = tokio::net::TcpStream::connect(("127.0.0.1", free_port))
+            .await
+            .unwrap();
+        connect_ok(&mut sock, b"back").await;
+
+        sup.stop().await;
     }
 
     #[test]

--- a/desktop/src-tauri/src/ssh/tunnel.rs
+++ b/desktop/src-tauri/src/ssh/tunnel.rs
@@ -284,7 +284,8 @@ async fn run(
         let mut healths: Vec<ForwardHealth> = Vec::new();
         let mut bind_failure: Option<String> = None;
         for spec in &config.forwards {
-            let (health, task) = bind_forward(config.bind_addr, spec, &transport, &status, &sink).await;
+            let (health, task) =
+                bind_forward(config.bind_addr, spec, &transport, &status, &sink).await;
             if let Some(err) = &health.last_error {
                 bind_failure.get_or_insert(err.clone());
             }
@@ -442,8 +443,7 @@ async fn accept_loop(
                     // Forwards come and go dynamically, so rows are keyed by
                     // their bound local port, never by position.
                     publish(&status, &sink, |s| {
-                        if let Some(h) =
-                            s.forwards.iter_mut().find(|h| h.local_port == bound_port)
+                        if let Some(h) = s.forwards.iter_mut().find(|h| h.local_port == bound_port)
                         {
                             h.last_error = Some(e.to_string());
                         }
@@ -767,7 +767,9 @@ mod tests {
         let status = wait_for(&mut rx, |s| s.forwards.len() == 1).await;
         assert_eq!(status.forwards[0].remote_port, 9999);
         assert!(
-            tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_err(),
+            tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_err(),
             "dynamic listener should be gone"
         );
 
@@ -798,7 +800,9 @@ mod tests {
             remote_port: 3085,
         }]);
         wait_for(&mut rx, |s| {
-            s.forwards.iter().any(|f| f.local_port == free_port && f.active)
+            s.forwards
+                .iter()
+                .any(|f| f.local_port == free_port && f.active)
         })
         .await;
 
@@ -806,7 +810,9 @@ mod tests {
         flags.lock().unwrap()[0].store(true, Ordering::SeqCst);
         let reconnected = wait_for(&mut rx, |s| {
             matches!(s.phase, TunnelPhase::Connected)
-                && s.forwards.iter().any(|f| f.local_port == free_port && f.active)
+                && s.forwards
+                    .iter()
+                    .any(|f| f.local_port == free_port && f.active)
         })
         .await;
         assert_eq!(reconnected.forwards.len(), 2);

--- a/desktop/src-tauri/src/teardown.rs
+++ b/desktop/src-tauri/src/teardown.rs
@@ -279,7 +279,8 @@ mod tests {
             serde_json::to_value(CloseBehavior::MinimizeToTray).unwrap(),
             serde_json::json!("minimize_to_tray")
         );
-        let parsed: CloseBehavior = serde_json::from_value(serde_json::json!("stop_stack")).unwrap();
+        let parsed: CloseBehavior =
+            serde_json::from_value(serde_json::json!("stop_stack")).unwrap();
         assert_eq!(parsed, CloseBehavior::StopStack);
         // Unknown store values fall back to the default at the read site.
         assert!(serde_json::from_value::<CloseBehavior>(serde_json::json!("bogus")).is_err());

--- a/desktop/src-tauri/src/teardown.rs
+++ b/desktop/src-tauri/src/teardown.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! Close-button behavior.
+//!
+//! What the window's close button does is a setting: ask (the existing quit
+//! dialogs), minimize to the tray, quit but leave the stack running, or stop
+//! the stack (local child or remote over ssh) on the way out. The decision
+//! itself is a pure function over the setting and the session kind so the
+//! whole matrix is unit-testable; the CloseRequested handler in lib.rs just
+//! executes the returned action.
+//!
+//! Quitting from the tray menu ignores "minimize to tray" (a tray quit must
+//! actually quit) but still honors the ask-vs-stop semantics.
+
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::Ordering;
+use tauri::{Manager, Wry};
+use tauri_plugin_store::StoreExt;
+
+const SETTINGS_STORE: &str = "settings.json";
+const BEHAVIOR_KEY: &str = "close_behavior";
+
+/// The user's close-button preference, persisted with the app settings.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CloseBehavior {
+    /// Ask via the existing quit dialogs (default).
+    #[default]
+    Ask,
+    /// Hide the window; the tray keeps the app reachable.
+    MinimizeToTray,
+    /// Quit the app, leave the stack running (local host services and remote
+    /// stacks both survive on purpose).
+    KeepRunning,
+    /// `run.py --stop` on whatever this session runs, then quit.
+    StopStack,
+}
+
+/// How this session relates to a stack, in precedence order (mirrors the
+/// original CloseRequested handler: a local stack wins over an SSH view).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionKind {
+    /// This session spawned or attached to the local stack.
+    LocalStack,
+    /// An SSH connection is active and the window shows the remote stack.
+    SshActive,
+    /// Neither — closing has nothing to tear down.
+    Detached,
+}
+
+/// What the close handler should do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CloseAction {
+    /// Let the close proceed (process exit tears everything down).
+    CloseNormally,
+    /// Hide the window instead of closing.
+    Hide,
+    /// Show the native stop-or-keep dialog (local stack).
+    AskLocal,
+    /// Navigate to the launcher's ?quit=1 prompt (remote stack).
+    AskRemote,
+    /// `run.py --stop` locally, then exit.
+    StopLocalThenExit,
+    /// `run.py --stop` on the active remote, then exit.
+    StopRemoteThenExit,
+}
+
+/// The whole close-button decision matrix.
+pub fn close_action(behavior: CloseBehavior, session: SessionKind) -> CloseAction {
+    match behavior {
+        CloseBehavior::MinimizeToTray => CloseAction::Hide,
+        CloseBehavior::KeepRunning => CloseAction::CloseNormally,
+        CloseBehavior::StopStack => match session {
+            SessionKind::LocalStack => CloseAction::StopLocalThenExit,
+            SessionKind::SshActive => CloseAction::StopRemoteThenExit,
+            SessionKind::Detached => CloseAction::CloseNormally,
+        },
+        CloseBehavior::Ask => match session {
+            SessionKind::LocalStack => CloseAction::AskLocal,
+            SessionKind::SshActive => CloseAction::AskRemote,
+            SessionKind::Detached => CloseAction::CloseNormally,
+        },
+    }
+}
+
+// ---- persistence ----
+
+pub fn stored_behavior(app: &tauri::AppHandle<Wry>) -> CloseBehavior {
+    app.store(SETTINGS_STORE)
+        .ok()
+        .and_then(|store| store.get(BEHAVIOR_KEY))
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn get_close_behavior(app: tauri::AppHandle<Wry>) -> CloseBehavior {
+    stored_behavior(&app)
+}
+
+#[tauri::command]
+pub fn set_close_behavior(
+    app: tauri::AppHandle<Wry>,
+    behavior: CloseBehavior,
+) -> Result<(), String> {
+    let store = app.store(SETTINGS_STORE).map_err(|e| e.to_string())?;
+    store.set(
+        BEHAVIOR_KEY,
+        serde_json::to_value(behavior).map_err(|e| e.to_string())?,
+    );
+    store.save().map_err(|e| e.to_string())
+}
+
+// ---- executing the decision ----
+
+pub(crate) fn session_kind(app: &tauri::AppHandle<Wry>) -> SessionKind {
+    let launcher_state = app.state::<crate::state::LauncherState>();
+    if launcher_state.local_stack.load(Ordering::SeqCst) {
+        return SessionKind::LocalStack;
+    }
+    let tunnels = app.state::<crate::ssh::commands::TunnelState>();
+    if tunnels.active_profile().is_some() && crate::ssh::commands::showing_remote_stack(app) {
+        return SessionKind::SshActive;
+    }
+    SessionKind::Detached
+}
+
+/// Best-effort remote stop, then exit. Close-button semantics: quitting must
+/// succeed even when the stop can't (the ask flow is the careful path).
+fn stop_remote_then_exit(app: &tauri::AppHandle<Wry>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        use crate::ssh::SshTransport;
+        use tauri::Emitter;
+        let tunnels = app.state::<crate::ssh::commands::TunnelState>();
+        if let Some(profile) = tunnels.active_profile() {
+            if let Ok(session) = crate::remote::connect_session(&app, &profile).await {
+                let command = crate::remote::stop_command(&crate::remote::repo_path(&profile));
+                let line_app = app.clone();
+                let _ = session
+                    .exec_stream(
+                        &command,
+                        |line| {
+                            let _ = line_app.emit(crate::remote::REMOTE_STOP_EVENT, line);
+                        },
+                        |_| {},
+                    )
+                    .await;
+                session.close().await;
+            }
+        }
+        tunnels.shutdown().await;
+        app.exit(0);
+    });
+}
+
+/// Run a close decision. `api` is present when called from CloseRequested
+/// (so the close can be prevented); a tray-menu quit passes None and treats
+/// Hide/CloseNormally as a plain exit.
+pub(crate) fn run_close_action(
+    app: &tauri::AppHandle<Wry>,
+    action: CloseAction,
+    api: Option<&tauri::CloseRequestApi>,
+) {
+    let launcher_state = app.state::<crate::state::LauncherState>();
+    match action {
+        CloseAction::CloseNormally => {
+            if api.is_none() {
+                app.exit(0);
+            }
+        }
+        CloseAction::Hide => {
+            if let Some(api) = api {
+                api.prevent_close();
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.hide();
+                }
+            } else {
+                app.exit(0);
+            }
+        }
+        CloseAction::AskLocal => {
+            if let Some(api) = api {
+                api.prevent_close();
+            }
+            if launcher_state.quitting.swap(true, Ordering::SeqCst) {
+                return; // quit flow already in flight
+            }
+            crate::launcher::confirm_quit(app);
+        }
+        CloseAction::AskRemote => {
+            if let Some(api) = api {
+                api.prevent_close();
+            }
+            crate::ssh::commands::show_quit_prompt(app);
+        }
+        CloseAction::StopLocalThenExit => {
+            if let Some(api) = api {
+                api.prevent_close();
+            }
+            if launcher_state.quitting.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            crate::launcher::stop_stack_then_exit(app);
+        }
+        CloseAction::StopRemoteThenExit => {
+            if let Some(api) = api {
+                api.prevent_close();
+            }
+            if launcher_state.quitting.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            stop_remote_then_exit(app);
+        }
+    }
+}
+
+/// The CloseRequested entry point: setting × session → action.
+pub(crate) fn on_close_requested(window: &tauri::Window<Wry>, api: &tauri::CloseRequestApi) {
+    if window.label() != "main" {
+        return;
+    }
+    let app = window.app_handle();
+    let action = close_action(stored_behavior(app), session_kind(app));
+    run_close_action(app, action, Some(api));
+}
+
+/// A quit from the tray menu: never minimizes, otherwise same semantics.
+pub(crate) fn request_quit(app: &tauri::AppHandle<Wry>) {
+    let behavior = match stored_behavior(app) {
+        CloseBehavior::MinimizeToTray => CloseBehavior::Ask,
+        other => other,
+    };
+    run_close_action(app, close_action(behavior, session_kind(app)), None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_matrix_covers_every_combination() {
+        use CloseAction::*;
+        use CloseBehavior::*;
+        use SessionKind::*;
+        let cases = [
+            // Ask keeps the existing dialog flows.
+            (Ask, LocalStack, AskLocal),
+            (Ask, SshActive, AskRemote),
+            (Ask, Detached, CloseNormally),
+            // Minimize hides regardless of what's running.
+            (MinimizeToTray, LocalStack, Hide),
+            (MinimizeToTray, SshActive, Hide),
+            (MinimizeToTray, Detached, Hide),
+            // Keep running quits without ceremony.
+            (KeepRunning, LocalStack, CloseNormally),
+            (KeepRunning, SshActive, CloseNormally),
+            (KeepRunning, Detached, CloseNormally),
+            // Stop stack tears down whatever this session runs.
+            (StopStack, LocalStack, StopLocalThenExit),
+            (StopStack, SshActive, StopRemoteThenExit),
+            (StopStack, Detached, CloseNormally),
+        ];
+        for (behavior, session, expected) in cases {
+            assert_eq!(
+                close_action(behavior, session),
+                expected,
+                "{behavior:?} × {session:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn behavior_serializes_snake_case_and_defaults_to_ask() {
+        assert_eq!(CloseBehavior::default(), CloseBehavior::Ask);
+        assert_eq!(
+            serde_json::to_value(CloseBehavior::MinimizeToTray).unwrap(),
+            serde_json::json!("minimize_to_tray")
+        );
+        let parsed: CloseBehavior = serde_json::from_value(serde_json::json!("stop_stack")).unwrap();
+        assert_eq!(parsed, CloseBehavior::StopStack);
+        // Unknown store values fall back to the default at the read site.
+        assert!(serde_json::from_value::<CloseBehavior>(serde_json::json!("bogus")).is_err());
+    }
+}

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -36,9 +36,9 @@ pub enum StackDot {
 impl StackDot {
     pub fn rgba(self) -> [u8; 4] {
         match self {
-            StackDot::Ready => [34, 197, 94, 255],   // emerald-500
+            StackDot::Ready => [34, 197, 94, 255],    // emerald-500
             StackDot::Partial => [245, 158, 11, 255], // amber-500
-            StackDot::Off => [113, 113, 122, 255],   // zinc-500
+            StackDot::Off => [113, 113, 122, 255],    // zinc-500
         }
     }
 
@@ -98,7 +98,10 @@ pub fn stamp_dot(rgba: &mut [u8], width: u32, height: u32, color: [u8; 4]) {
     }
 }
 
-fn stamped_icon(app: &tauri::AppHandle<Wry>, dot: StackDot) -> Option<tauri::image::Image<'static>> {
+fn stamped_icon(
+    app: &tauri::AppHandle<Wry>,
+    dot: StackDot,
+) -> Option<tauri::image::Image<'static>> {
     let base = app.default_window_icon()?;
     let (width, height) = (base.width(), base.height());
     let mut rgba = base.rgba().to_vec();
@@ -178,7 +181,13 @@ fn stop_stack(app: &tauri::AppHandle<Wry>) {
 
 /// Build the tray and keep its dot in sync with `stack-health` events.
 pub fn setup(app: &tauri::AppHandle<Wry>) -> tauri::Result<()> {
-    let status = MenuItem::with_id(app, "tray-status", StackDot::Off.label(), false, None::<&str>)?;
+    let status = MenuItem::with_id(
+        app,
+        "tray-status",
+        StackDot::Off.label(),
+        false,
+        None::<&str>,
+    )?;
     let open = MenuItem::with_id(app, "tray-open", "Open TT-Studio", true, None::<&str>)?;
     let switch = MenuItem::with_id(app, "tray-switch", "Switch machine", true, None::<&str>)?;
     let stop = MenuItem::with_id(app, "tray-stop", "Stop stack", true, None::<&str>)?;

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -203,14 +203,9 @@ pub fn setup(app: &tauri::AppHandle<Wry>) -> tauri::Result<()> {
             "tray-open" => show_main_window(app),
             "tray-switch" => back_to_picker(app),
             "tray-stop" => stop_stack(app),
-            // Close the window instead of exiting directly so the normal
-            // quit flow (stop-stack dialog, ssh quit prompt) still runs.
-            "tray-quit" => match app.get_webview_window("main") {
-                Some(window) => {
-                    let _ = window.close();
-                }
-                None => app.exit(0),
-            },
+            // The teardown module owns quit semantics (dialogs, stop-stack);
+            // a tray quit never minimizes, it actually quits.
+            "tray-quit" => crate::teardown::request_quit(app),
             _ => {}
         });
     if let Some(icon) = stamped_icon(app, StackDot::Off) {

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+//! System tray: stack-status dot + quick actions.
+//!
+//! The tray mirrors the health poller: every `stack-health` event restamps
+//! the tray icon with a colored dot (green = every service up, amber = some,
+//! gray = none/unknown) and updates a disabled status row in the menu. The
+//! actions are thin: they reuse the same paths the launcher UI drives —
+//! showing the window, navigating back to the picker, `run.py --stop`
+//! (local child or ssh exec), and the normal close-requested quit flow.
+//!
+//! On Linux this uses tauri's `tray-icon` feature (ayatana appindicator at
+//! runtime); the health poller only runs while the launcher asks it to, so
+//! the dot goes gray whenever nothing is polling.
+
+use serde::Deserialize;
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tauri::tray::TrayIconBuilder;
+use tauri::{Listener, Manager, Wry};
+
+pub const TRAY_ID: &str = "tt-studio-tray";
+
+/// What the dot should say about the stack.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StackDot {
+    /// Every service up.
+    Ready,
+    /// Some services answered, some didn't.
+    Partial,
+    /// Nothing up (or nothing known).
+    Off,
+}
+
+impl StackDot {
+    pub fn rgba(self) -> [u8; 4] {
+        match self {
+            StackDot::Ready => [34, 197, 94, 255],   // emerald-500
+            StackDot::Partial => [245, 158, 11, 255], // amber-500
+            StackDot::Off => [113, 113, 122, 255],   // zinc-500
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            StackDot::Ready => "Stack: running",
+            StackDot::Partial => "Stack: partially up",
+            StackDot::Off => "Stack: not running",
+        }
+    }
+}
+
+/// The slice of a `stack-health` payload the tray cares about.
+#[derive(Deserialize)]
+struct HealthSlice {
+    ready: bool,
+    services: Vec<ServiceSlice>,
+}
+
+#[derive(Deserialize)]
+struct ServiceSlice {
+    status: String,
+}
+
+/// Fold a `stack-health` event payload (JSON) into a dot state. Anything
+/// unparseable reads as Off — the tray must never wedge on a bad payload.
+pub fn dot_from_health(payload: &str) -> StackDot {
+    let Ok(health) = serde_json::from_str::<HealthSlice>(payload) else {
+        return StackDot::Off;
+    };
+    if health.ready {
+        return StackDot::Ready;
+    }
+    if health.services.iter().any(|s| s.status == "up") {
+        return StackDot::Partial;
+    }
+    StackDot::Off
+}
+
+/// Stamp a filled status dot into the bottom-right corner of an RGBA icon.
+/// Pure pixel math so it's unit-testable without a display.
+pub fn stamp_dot(rgba: &mut [u8], width: u32, height: u32, color: [u8; 4]) {
+    let radius = (width.min(height) as i64 / 4).max(2);
+    let cx = width as i64 - radius - 1;
+    let cy = height as i64 - radius - 1;
+    for y in (cy - radius).max(0)..(cy + radius + 1).min(height as i64) {
+        for x in (cx - radius).max(0)..(cx + radius + 1).min(width as i64) {
+            let dx = x - cx;
+            let dy = y - cy;
+            if dx * dx + dy * dy <= radius * radius {
+                let idx = ((y * width as i64 + x) * 4) as usize;
+                if idx + 3 < rgba.len() {
+                    rgba[idx..idx + 4].copy_from_slice(&color);
+                }
+            }
+        }
+    }
+}
+
+fn stamped_icon(app: &tauri::AppHandle<Wry>, dot: StackDot) -> Option<tauri::image::Image<'static>> {
+    let base = app.default_window_icon()?;
+    let (width, height) = (base.width(), base.height());
+    let mut rgba = base.rgba().to_vec();
+    stamp_dot(&mut rgba, width, height, dot.rgba());
+    Some(tauri::image::Image::new_owned(rgba, width, height))
+}
+
+fn show_main_window(app: &tauri::AppHandle<Wry>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+/// "Switch machine": bring the window up and navigate it back to the bundled
+/// launcher (the connection picker), regardless of what it currently shows.
+fn back_to_picker(app: &tauri::AppHandle<Wry>) {
+    show_main_window(app);
+    let Some(url) = crate::ssh::commands::launcher_url(app) else {
+        return;
+    };
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.navigate(url);
+        }
+    });
+}
+
+/// "Stop stack" without quitting: `run.py --stop` on whatever this session
+/// is connected to — the active SSH profile if there is one, otherwise the
+/// local checkout. Fire-and-forget; the health poller shows the result.
+fn stop_stack(app: &tauri::AppHandle<Wry>) {
+    use crate::ssh::SshTransport;
+    let tunnels = app.state::<crate::ssh::commands::TunnelState>();
+    if let Some(profile) = tunnels.active_profile() {
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            use tauri::Emitter;
+            let Ok(session) = crate::remote::connect_session(&app, &profile).await else {
+                return;
+            };
+            let command = crate::remote::stop_command(&crate::remote::repo_path(&profile));
+            let line_app = app.clone();
+            let _ = session
+                .exec_stream(
+                    &command,
+                    |line| {
+                        let _ = line_app.emit(crate::remote::REMOTE_STOP_EVENT, line);
+                    },
+                    |_| {},
+                )
+                .await;
+            session.close().await;
+        });
+        return;
+    }
+
+    let state = app.state::<crate::state::LauncherState>();
+    let checkout = state.checkout.lock().ok().and_then(|g| g.clone());
+    let Some(checkout) = checkout else { return };
+    let Ok(logs) = crate::launcher::log_dir(app) else {
+        return;
+    };
+    let line_app = app.clone();
+    let _ = crate::launcher::spawn_streaming(
+        &crate::launcher::stop_spec(&checkout, logs.join("stop.log")),
+        state.child.clone(),
+        move |line| {
+            use tauri::Emitter;
+            let _ = line_app.emit(crate::launcher::STOP_LINE_EVENT, &line);
+        },
+        |_code| {},
+    );
+}
+
+/// Build the tray and keep its dot in sync with `stack-health` events.
+pub fn setup(app: &tauri::AppHandle<Wry>) -> tauri::Result<()> {
+    let status = MenuItem::with_id(app, "tray-status", StackDot::Off.label(), false, None::<&str>)?;
+    let open = MenuItem::with_id(app, "tray-open", "Open TT-Studio", true, None::<&str>)?;
+    let switch = MenuItem::with_id(app, "tray-switch", "Switch machine", true, None::<&str>)?;
+    let stop = MenuItem::with_id(app, "tray-stop", "Stop stack", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "tray-quit", "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            &status,
+            &PredefinedMenuItem::separator(app)?,
+            &open,
+            &switch,
+            &stop,
+            &PredefinedMenuItem::separator(app)?,
+            &quit,
+        ],
+    )?;
+
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&menu)
+        .tooltip("TT-Studio")
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "tray-open" => show_main_window(app),
+            "tray-switch" => back_to_picker(app),
+            "tray-stop" => stop_stack(app),
+            // Close the window instead of exiting directly so the normal
+            // quit flow (stop-stack dialog, ssh quit prompt) still runs.
+            "tray-quit" => match app.get_webview_window("main") {
+                Some(window) => {
+                    let _ = window.close();
+                }
+                None => app.exit(0),
+            },
+            _ => {}
+        });
+    if let Some(icon) = stamped_icon(app, StackDot::Off) {
+        builder = builder.icon(icon);
+    }
+    builder.build(app)?;
+
+    let handle = app.clone();
+    app.listen_any(crate::health::HEALTH_EVENT, move |event| {
+        let dot = dot_from_health(event.payload());
+        let app = handle.clone();
+        let status = status.clone();
+        let _ = handle.clone().run_on_main_thread(move || {
+            let _ = status.set_text(dot.label());
+            if let Some(tray) = app.tray_by_id(TRAY_ID) {
+                if let Some(icon) = stamped_icon(&app, dot) {
+                    let _ = tray.set_icon(Some(icon));
+                }
+                let _ = tray.set_tooltip(Some(format!("TT-Studio — {}", dot.label())));
+            }
+        });
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn health_payload(ready: bool, statuses: &[&str]) -> String {
+        let services: Vec<serde_json::Value> = statuses
+            .iter()
+            .map(|s| serde_json::json!({ "name": "svc", "url": "u", "status": s }))
+            .collect();
+        serde_json::json!({ "services": services, "ready": ready }).to_string()
+    }
+
+    #[test]
+    fn dot_follows_the_health_snapshot() {
+        assert_eq!(
+            dot_from_health(&health_payload(true, &["up", "up"])),
+            StackDot::Ready
+        );
+        assert_eq!(
+            dot_from_health(&health_payload(false, &["up", "down"])),
+            StackDot::Partial
+        );
+        assert_eq!(
+            dot_from_health(&health_payload(false, &["unreachable", "down"])),
+            StackDot::Off
+        );
+    }
+
+    #[test]
+    fn garbage_payloads_read_as_off() {
+        assert_eq!(dot_from_health("not json"), StackDot::Off);
+        assert_eq!(dot_from_health("{}"), StackDot::Off);
+        assert_eq!(dot_from_health(""), StackDot::Off);
+    }
+
+    #[test]
+    fn stamp_paints_only_the_corner_dot() {
+        let (w, h) = (16u32, 16u32);
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        stamp_dot(&mut rgba, w, h, StackDot::Ready.rgba());
+
+        // The dot center is painted…
+        let radius = (w.min(h) as i64 / 4).max(2);
+        let (cx, cy) = (w as i64 - radius - 1, h as i64 - radius - 1);
+        let center = ((cy * w as i64 + cx) * 4) as usize;
+        assert_eq!(&rgba[center..center + 4], &StackDot::Ready.rgba());
+
+        // …and the opposite corner is untouched.
+        assert_eq!(&rgba[0..4], &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn stamp_survives_tiny_and_empty_icons() {
+        // Must never panic on odd sizes.
+        let mut tiny = vec![0u8; 4];
+        stamp_dot(&mut tiny, 1, 1, [1, 2, 3, 4]);
+        let mut empty: Vec<u8> = Vec::new();
+        stamp_dot(&mut empty, 0, 0, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn labels_and_colors_are_distinct() {
+        let dots = [StackDot::Ready, StackDot::Partial, StackDot::Off];
+        for (i, a) in dots.iter().enumerate() {
+            for b in dots.iter().skip(i + 1) {
+                assert_ne!(a.label(), b.label());
+                assert_ne!(a.rgba(), b.rgba());
+            }
+        }
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -35,6 +35,18 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "category": "DeveloperTool",
+    "shortDescription": "Run AI models on Tenstorrent hardware",
+    "longDescription": "Desktop launcher for TT-Studio: connect to this machine or a remote Tenstorrent box over SSH, bring the stack up, and open the web UI.",
+    "linux": {
+      "deb": {
+        "depends": ["libayatana-appindicator3-1"],
+        "desktopTemplate": "./tt-studio.desktop"
+      },
+      "rpm": {
+        "desktopTemplate": "./tt-studio.desktop"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/desktop/src-tauri/tests/fixtures/fake_run.py
+++ b/desktop/src-tauri/tests/fixtures/fake_run.py
@@ -35,6 +35,17 @@ def main():
         print("stopping containers (fake)", flush=True)
         return 0
 
+    if "--report-bug" in sys.argv:
+        # Mirror tt_setup/bug_report.py: write logs/tt-studio-logs-ttbr-*.zip.
+        import zipfile
+
+        os.makedirs("logs", exist_ok=True)
+        path = os.path.join("logs", "tt-studio-logs-ttbr-abcdef123456.zip")
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("system_info.json", "{}")
+        print("Bundle      →  %s" % path, flush=True)
+        return 0
+
     scenario = os.environ.get("FAKE_RUN_SCENARIO", "success")
 
     if scenario == "success":

--- a/desktop/src-tauri/tests/launcher_spawn.rs
+++ b/desktop/src-tauri/tests/launcher_spawn.rs
@@ -219,3 +219,28 @@ fn stderr_log_rotates_between_runs() {
     let rotated = spec.stderr_log.with_extension("log.1");
     assert!(rotated.exists(), "previous run's log was not kept");
 }
+
+#[test]
+fn report_bug_run_produces_a_findable_bundle() {
+    use tt_studio_desktop_lib::bug_report::{bundle_ref, newest_bundle_in, report_bug_spec};
+
+    let dir = tempfile::tempdir().unwrap();
+    let checkout = fake_checkout(dir.path());
+    let mut spec = report_bug_spec(&checkout, dir.path().join("logs").join("bugreport.log"));
+    spec.program = python();
+    let slot = ChildSlot::default();
+    let rx = spawn(&spec, &slot);
+
+    let mut lines = Vec::new();
+    let code = wait_exit(&rx, &mut lines);
+    assert_eq!(code, Some(0));
+    assert!(
+        lines.iter().any(|l| l.contains("Bundle")),
+        "no bundle progress line: {lines:?}"
+    );
+
+    let zip = newest_bundle_in(&checkout).expect("no bundle in logs/");
+    assert!(zip.exists());
+    let name = zip.file_name().unwrap().to_str().unwrap();
+    assert_eq!(bundle_ref(name), Some("ttbr-abcdef123456"));
+}

--- a/desktop/src-tauri/tt-studio.desktop
+++ b/desktop/src-tauri/tt-studio.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+# Desktop entry template for the .deb/.rpm bundles (handlebars vars are
+# filled by tauri-bundler). Polished so a double-click install on a
+# QuietBox looks first-class: proper categories, keywords, and a
+# StartupWMClass matching the Tauri window so docks group it correctly.
+Categories=Development;Utility;
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} {{exec_arg}}
+Icon={{icon}}
+Name=TT-Studio
+Terminal=false
+Type=Application
+Keywords=Tenstorrent;TT-Studio;AI;LLM;inference;
+StartupWMClass=TT-Studio
+SingleMainWindow=true

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -43,6 +43,7 @@ import {
   checkStackFreshness,
   checkStackHealth,
   classifyRemoteStack,
+  createBugReport,
   deleteProfile,
   detectHardware,
   getActiveRemote,
@@ -639,6 +640,27 @@ function App() {
     [],
   );
 
+  /** Collecting a diagnostics bundle (picker footer action). */
+  const [bugReportBusy, setBugReportBusy] = useState(false);
+
+  // Collect on whatever this session is connected to: the active SSH
+  // profile if there is one, otherwise the local checkout.
+  const handleBugReport = useCallback(async () => {
+    setBugReportBusy(true);
+    setError(null);
+    try {
+      const remote = await getActiveRemote().catch(() => null);
+      const result = await createBugReport(remote);
+      setError(
+        `Diagnostics bundle ready (${result.reference ?? "no id"}) — ${result.path}`,
+      );
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBugReportBusy(false);
+    }
+  }, []);
+
   const handleDelete = useCallback(async (profile: Profile) => {
     try {
       setProfiles(await deleteProfile(profile.id));
@@ -802,6 +824,15 @@ function App() {
           className="text-xs text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
         >
           Logs
+        </button>
+        <button
+          type="button"
+          data-testid="report-bug"
+          onClick={handleBugReport}
+          disabled={bugReportBusy}
+          className="text-xs text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline disabled:opacity-50"
+        >
+          {bugReportBusy ? "Collecting diagnostics…" : "Report a bug"}
         </button>
       </div>
       {(error || keychainWarning) && (

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import BringUpProgress from "./views/BringUpProgress";
 import ConnectErrorCard from "./views/ConnectErrorCard";
+import CloseBehaviorSetting from "./views/CloseBehaviorSetting";
 import ConnectionPicker from "./views/ConnectionPicker";
 import LogsViewer from "./views/LogsViewer";
 import ProfileEditor from "./views/ProfileEditor";
@@ -817,6 +818,7 @@ function App() {
       <div className="fixed bottom-4 left-4 flex items-center gap-4">
         <UpdateBanner />
         <StackUpdateSetting />
+        <CloseBehaviorSetting />
         <button
           type="button"
           data-testid="open-logs"

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import BringUpProgress from "./views/BringUpProgress";
 import ConnectErrorCard from "./views/ConnectErrorCard";
 import ConnectionPicker from "./views/ConnectionPicker";
+import LogsViewer from "./views/LogsViewer";
 import ProfileEditor from "./views/ProfileEditor";
 import QuitDialog from "./views/QuitDialog";
 import {
@@ -87,6 +88,7 @@ type Screen =
   // bringUpOnly: a restart is in flight — services may briefly still look
   // healthy, so only the bring-up's own ready event may open the stack.
   | { name: "connecting"; target: Profile | null; bringUpOnly?: boolean }
+  | { name: "logs" }
   | { name: "quit" };
 
 /**
@@ -667,6 +669,10 @@ function App() {
     );
   }
 
+  if (screen.name === "logs") {
+    return <LogsViewer onBack={() => setScreen({ name: "picker" })} />;
+  }
+
   if (screen.name === "editor") {
     return (
       <ProfileEditor
@@ -789,6 +795,14 @@ function App() {
       <div className="fixed bottom-4 left-4 flex items-center gap-4">
         <UpdateBanner />
         <StackUpdateSetting />
+        <button
+          type="button"
+          data-testid="open-logs"
+          onClick={() => setScreen({ name: "logs" })}
+          className="text-xs text-zinc-500 underline-offset-2 hover:text-zinc-300 hover:underline"
+        >
+          Logs
+        </button>
       </div>
       {(error || keychainWarning) && (
         <p className="fixed inset-x-0 bottom-4 mx-auto max-w-md rounded-md bg-zinc-900 px-4 py-2 text-center text-xs text-amber-400">

--- a/desktop/src/lib/connect.ts
+++ b/desktop/src/lib/connect.ts
@@ -11,9 +11,10 @@ import type { Profile, StackClassification, TunnelStatus } from "./ipc";
 /**
  * Ports the stack cannot work without. The web app derives service URLs
  * from window.location + these fixed numbers, so the local listeners must
- * bind the REAL ports — remapping is not an option. The 7000-7010 model
- * container range is deliberately absent: a taken model port only affects
- * one model, not the connect flow.
+ * bind the REAL ports — remapping is not an option. Marketplace app ports
+ * are deliberately absent: they're forwarded dynamically while connected
+ * (ssh/app_ports.rs), and a taken app port only affects that one app, not
+ * the connect flow.
  */
 export const ESSENTIAL_PORTS = [3000, 8000, 8001, 8002, 4000, 8080];
 

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -302,6 +302,28 @@ export const onSwitchLine = (
 ): Promise<UnlistenFn> =>
   listen<string>("switch-line", (event) => handler(event.payload));
 
+// ---- bug reports (bug_report.rs) ----
+
+export interface BugReportResult {
+  /** Local path of the collected bundle ZIP. */
+  path: string;
+  /** The ttbr-<hex> id to quote in an issue. */
+  reference: string | null;
+}
+
+/**
+ * Run `run.py --report-bug` on the target (null = local checkout; an SSH
+ * profile collects remotely and copies the ZIP back), then reveal the ZIP in
+ * the file manager. Progress lines stream as `bugreport-line` events.
+ */
+export const createBugReport = (profile: Profile | null) =>
+  invoke<BugReportResult>("create_bug_report", { profile });
+
+export const onBugReportLine = (
+  handler: (line: string) => void,
+): Promise<UnlistenFn> =>
+  listen<string>("bugreport-line", (event) => handler(event.payload));
+
 // ---- launcher logs (logs.rs) ----
 
 export interface LogFileInfo {

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -302,6 +302,30 @@ export const onSwitchLine = (
 ): Promise<UnlistenFn> =>
   listen<string>("switch-line", (event) => handler(event.payload));
 
+// ---- launcher logs (logs.rs) ----
+
+export interface LogFileInfo {
+  name: string;
+  size_bytes: number;
+  modified_secs: number;
+  /** NDJSON event stream (level filtering applies). */
+  ndjson: boolean;
+}
+
+export interface LogTail {
+  content: string;
+  truncated: boolean;
+}
+
+export const listAppLogs = () => invoke<LogFileInfo[]>("list_app_logs");
+
+export const readAppLog = (name: string) =>
+  invoke<LogTail>("read_app_log", { name });
+
+/** Native save dialog; resolves to the chosen path or null on cancel. */
+export const exportAppLog = (name: string) =>
+  invoke<string | null>("export_app_log", { name });
+
 // ---- navigation ----
 
 export const openStack = (url: string) => invoke<void>("open_stack", { url });

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -302,6 +302,20 @@ export const onSwitchLine = (
 ): Promise<UnlistenFn> =>
   listen<string>("switch-line", (event) => handler(event.payload));
 
+// ---- close-button behavior (teardown.rs) ----
+
+export type CloseBehavior =
+  | "ask"
+  | "minimize_to_tray"
+  | "keep_running"
+  | "stop_stack";
+
+export const getCloseBehavior = () =>
+  invoke<CloseBehavior>("get_close_behavior");
+
+export const setCloseBehavior = (behavior: CloseBehavior) =>
+  invoke<void>("set_close_behavior", { behavior });
+
 // ---- bug reports (bug_report.rs) ----
 
 export interface BugReportResult {

--- a/desktop/src/lib/logs.test.ts
+++ b/desktop/src/lib/logs.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyLog,
+  classifyNdjsonLine,
+  filterByLevel,
+  formatSize,
+} from "./logs";
+
+const ev = (event: string, detail: object, phase: string | null = null) =>
+  JSON.stringify({ v: 1, ts: 1, event, phase, detail });
+
+describe("classifyNdjsonLine", () => {
+  it("maps event types to levels", () => {
+    expect(classifyNdjsonLine(ev("error", { message: "boom" }))).toMatchObject({
+      level: "error",
+      text: "error: boom",
+    });
+    expect(
+      classifyNdjsonLine(ev("prompt_blocked", { prompt: "sudo" })).level,
+    ).toBe("error");
+    expect(classifyNdjsonLine(ev("warn", { text: "careful" }))).toMatchObject({
+      level: "warn",
+      text: "warn: careful",
+    });
+    expect(classifyNdjsonLine(ev("note", { text: "fyi" }))).toMatchObject({
+      level: "info",
+      text: "fyi",
+    });
+  });
+
+  it("renders phase transitions compactly", () => {
+    expect(classifyNdjsonLine(ev("phase_begin", {}, "Pull")).text).toBe(
+      "▶ Pull",
+    );
+    expect(
+      classifyNdjsonLine(ev("phase_end", { status: "ok" }, "Pull")),
+    ).toMatchObject({ level: "info", text: "✓ Pull" });
+    expect(
+      classifyNdjsonLine(ev("phase_end", { status: "failed" }, "Pull")),
+    ).toMatchObject({ level: "error", text: "✗ Pull" });
+  });
+
+  it("passes unparseable lines through as info", () => {
+    expect(classifyNdjsonLine("bootstrap: creating venv")).toMatchObject({
+      level: "info",
+      text: "bootstrap: creating venv",
+    });
+  });
+});
+
+describe("classifyLog / filterByLevel", () => {
+  it("splits, classifies and filters a document", () => {
+    const doc = [
+      ev("note", { text: "starting" }),
+      ev("warn", { text: "slow disk" }),
+      ev("error", { message: "no docker" }),
+      "",
+    ].join("\n");
+    const lines = classifyLog(doc, true);
+    expect(lines).toHaveLength(3);
+    expect(filterByLevel(lines, "info")).toHaveLength(3);
+    expect(filterByLevel(lines, "warn").map((l) => l.level)).toEqual([
+      "warn",
+      "error",
+    ]);
+    expect(filterByLevel(lines, "error")).toHaveLength(1);
+  });
+
+  it("treats plain stderr logs as all-info", () => {
+    const lines = classifyLog("Traceback (most recent call last):\n  boom\n", false);
+    expect(lines.map((l) => l.level)).toEqual(["info", "info"]);
+    expect(filterByLevel(lines, "error")).toHaveLength(0);
+  });
+});
+
+describe("formatSize", () => {
+  it("humanizes byte counts", () => {
+    expect(formatSize(512)).toBe("512 B");
+    expect(formatSize(2048)).toBe("2.0 KB");
+    expect(formatSize(3 * 1024 * 1024)).toBe("3.0 MB");
+  });
+});

--- a/desktop/src/lib/logs.ts
+++ b/desktop/src/lib/logs.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Level classification and filtering for the logs viewer. NDJSON streams
+// (bringup.ndjson & friends) carry the --json-events envelope, so each line
+// gets a level from its event type; plain stderr logs have no structure and
+// every line reads as "info".
+
+import { parseEventLine } from "./events";
+
+export type LogLevel = "info" | "warn" | "error";
+
+export interface LogLine {
+  raw: string;
+  level: LogLevel;
+  /** Short human rendering for NDJSON events; raw text otherwise. */
+  text: string;
+}
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" ? v : undefined;
+
+/** Classify one NDJSON line. Unparseable lines pass through as info. */
+export function classifyNdjsonLine(raw: string): LogLine {
+  const event = parseEventLine(raw);
+  if (!event) return { raw, level: "info", text: raw };
+  const d = event.detail;
+  switch (event.event) {
+    case "error":
+      return {
+        raw,
+        level: "error",
+        text: `error: ${str(d.message) ?? raw}`,
+      };
+    case "prompt_blocked":
+      return {
+        raw,
+        level: "error",
+        text: `blocked: ${str(d.prompt) ?? raw}`,
+      };
+    case "warn":
+      return { raw, level: "warn", text: `warn: ${str(d.text) ?? raw}` };
+    case "note":
+      return { raw, level: "info", text: str(d.text) ?? raw };
+    case "phase_begin":
+      return { raw, level: "info", text: `▶ ${event.phase ?? "phase"}` };
+    case "phase_end":
+      return {
+        raw,
+        level: d.status === "ok" ? "info" : "error",
+        text: `${d.status === "ok" ? "✓" : "✗"} ${event.phase ?? "phase"}`,
+      };
+    case "ready":
+      return { raw, level: "info", text: "✓ stack ready" };
+    default:
+      return { raw, level: "info", text: raw };
+  }
+}
+
+/** Split a log document into classified lines. */
+export function classifyLog(content: string, ndjson: boolean): LogLine[] {
+  const lines = content.split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines.map((raw) =>
+    ndjson ? classifyNdjsonLine(raw) : { raw, level: "info" as const, text: raw },
+  );
+}
+
+const RANK: Record<LogLevel, number> = { info: 0, warn: 1, error: 2 };
+
+/** Keep lines at or above the selected minimum level. */
+export function filterByLevel(lines: LogLine[], min: LogLevel): LogLine[] {
+  return lines.filter((l) => RANK[l.level] >= RANK[min]);
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/desktop/src/views/CloseBehaviorSetting.test.tsx
+++ b/desktop/src/views/CloseBehaviorSetting.test.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import CloseBehaviorSetting from "./CloseBehaviorSetting";
+
+const getCloseBehavior = vi.fn();
+const setCloseBehavior = vi.fn();
+
+vi.mock("../lib/ipc", () => ({
+  getCloseBehavior: (...args: unknown[]) => getCloseBehavior(...args),
+  setCloseBehavior: (...args: unknown[]) => setCloseBehavior(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("CloseBehaviorSetting", () => {
+  it("loads and shows the stored behavior", async () => {
+    getCloseBehavior.mockResolvedValue("minimize_to_tray");
+    render(<CloseBehaviorSetting />);
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("close-behavior") as HTMLSelectElement).value,
+      ).toBe("minimize_to_tray"),
+    );
+  });
+
+  it("persists a new choice", async () => {
+    getCloseBehavior.mockResolvedValue("ask");
+    setCloseBehavior.mockResolvedValue(undefined);
+    render(<CloseBehaviorSetting />);
+    await waitFor(() => screen.getByTestId("close-behavior"));
+
+    fireEvent.change(screen.getByTestId("close-behavior"), {
+      target: { value: "stop_stack" },
+    });
+    expect(setCloseBehavior).toHaveBeenCalledWith("stop_stack");
+  });
+
+  it("falls back to ask when the store is unreadable", async () => {
+    getCloseBehavior.mockRejectedValue(new Error("no store"));
+    render(<CloseBehaviorSetting />);
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("close-behavior") as HTMLSelectElement).value,
+      ).toBe("ask"),
+    );
+  });
+});

--- a/desktop/src/views/CloseBehaviorSetting.tsx
+++ b/desktop/src/views/CloseBehaviorSetting.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useEffect, useState } from "react";
+import {
+  getCloseBehavior,
+  setCloseBehavior,
+  type CloseBehavior,
+} from "../lib/ipc";
+
+const LABELS: Record<CloseBehavior, string> = {
+  ask: "ask every time",
+  minimize_to_tray: "minimize to tray",
+  keep_running: "keep the stack running",
+  stop_stack: "stop the stack",
+};
+
+/**
+ * What the window close button does: ask via the quit dialogs (default),
+ * minimize to the tray, quit leaving the stack up, or stop the stack (local
+ * or remote) on the way out. Stored with the app settings (teardown.rs).
+ */
+function CloseBehaviorSetting() {
+  const [behavior, setBehavior] = useState<CloseBehavior | null>(null);
+
+  useEffect(() => {
+    getCloseBehavior()
+      .then(setBehavior)
+      .catch(() => setBehavior("ask"));
+  }, []);
+
+  if (!behavior) return null;
+  return (
+    <label className="flex items-center gap-2 text-xs text-zinc-500">
+      On close:
+      <select
+        data-testid="close-behavior"
+        value={behavior}
+        onChange={(e) => {
+          const next = e.target.value as CloseBehavior;
+          setBehavior(next);
+          setCloseBehavior(next).catch(() => {});
+        }}
+        className="rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300"
+      >
+        {(Object.keys(LABELS) as CloseBehavior[]).map((value) => (
+          <option key={value} value={value}>
+            {LABELS[value]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export default CloseBehaviorSetting;

--- a/desktop/src/views/LogsViewer.test.tsx
+++ b/desktop/src/views/LogsViewer.test.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LogsViewer from "./LogsViewer";
+
+const listAppLogs = vi.fn();
+const readAppLog = vi.fn();
+const exportAppLog = vi.fn();
+
+vi.mock("../lib/ipc", () => ({
+  listAppLogs: (...args: unknown[]) => listAppLogs(...args),
+  readAppLog: (...args: unknown[]) => readAppLog(...args),
+  exportAppLog: (...args: unknown[]) => exportAppLog(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const ev = (event: string, detail: object) =>
+  JSON.stringify({ v: 1, ts: 1, event, phase: null, detail });
+
+const NDJSON_FILE = {
+  name: "bringup.ndjson",
+  size_bytes: 100,
+  modified_secs: 2,
+  ndjson: true,
+};
+const STDERR_FILE = {
+  name: "bringup.log",
+  size_bytes: 50,
+  modified_secs: 1,
+  ndjson: false,
+};
+
+describe("LogsViewer", () => {
+  it("lists log files and renders the newest one's tail", async () => {
+    listAppLogs.mockResolvedValue([NDJSON_FILE, STDERR_FILE]);
+    readAppLog.mockResolvedValue({
+      content: [
+        ev("note", { text: "starting" }),
+        ev("error", { message: "no docker" }),
+      ].join("\n"),
+      truncated: false,
+    });
+    render(<LogsViewer onBack={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("logs-body").textContent).toContain(
+        "starting",
+      ),
+    );
+    expect(readAppLog).toHaveBeenCalledWith("bringup.ndjson");
+    expect(screen.getByTestId("logs-body").textContent).toContain(
+      "error: no docker",
+    );
+  });
+
+  it("filters NDJSON lines by level", async () => {
+    listAppLogs.mockResolvedValue([NDJSON_FILE]);
+    readAppLog.mockResolvedValue({
+      content: [
+        ev("note", { text: "quiet" }),
+        ev("error", { message: "loud" }),
+      ].join("\n"),
+      truncated: false,
+    });
+    render(<LogsViewer onBack={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("logs-body").textContent).toContain("quiet"),
+    );
+
+    fireEvent.change(screen.getByTestId("logs-level"), {
+      target: { value: "error" },
+    });
+    const body = screen.getByTestId("logs-body").textContent ?? "";
+    expect(body).toContain("error: loud");
+    expect(body).not.toContain("quiet");
+  });
+
+  it("exports through the ipc save dialog", async () => {
+    listAppLogs.mockResolvedValue([STDERR_FILE]);
+    readAppLog.mockResolvedValue({ content: "boom\n", truncated: false });
+    exportAppLog.mockResolvedValue("/tmp/bringup.log");
+    render(<LogsViewer onBack={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("logs-body").textContent).toContain("boom"),
+    );
+
+    fireEvent.click(screen.getByTestId("logs-export"));
+    await waitFor(() =>
+      expect(screen.getByTestId("logs-notice").textContent).toContain(
+        "/tmp/bringup.log",
+      ),
+    );
+    expect(exportAppLog).toHaveBeenCalledWith("bringup.log");
+  });
+
+  it("says so when there are no logs yet", async () => {
+    listAppLogs.mockResolvedValue([]);
+    render(<LogsViewer onBack={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("logs-body").textContent).toContain(
+        "No launcher logs yet",
+      ),
+    );
+  });
+});

--- a/desktop/src/views/LogsViewer.tsx
+++ b/desktop/src/views/LogsViewer.tsx
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+// Logs viewer: tails the launcher's own log files (bring-up NDJSON streams
+// and stderr logs in the app data dirs) with level filtering, copy and
+// export. Read-only over the IPC surface in logs.rs.
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  exportAppLog,
+  listAppLogs,
+  readAppLog,
+  type LogFileInfo,
+} from "../lib/ipc";
+import {
+  classifyLog,
+  filterByLevel,
+  formatSize,
+  type LogLevel,
+} from "../lib/logs";
+
+const TAIL_INTERVAL_MS = 2000;
+
+const LEVEL_STYLE: Record<LogLevel, string> = {
+  info: "text-zinc-300",
+  warn: "text-amber-300",
+  error: "text-red-300",
+};
+
+function LogsViewer({ onBack }: { onBack: () => void }) {
+  const [files, setFiles] = useState<LogFileInfo[]>([]);
+  const [selected, setSelected] = useState<LogFileInfo | null>(null);
+  const [content, setContent] = useState("");
+  const [truncated, setTruncated] = useState(false);
+  const [level, setLevel] = useState<LogLevel>("info");
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    listAppLogs()
+      .then((found) => {
+        setFiles(found);
+        setSelected((prev) => prev ?? found[0] ?? null);
+      })
+      .catch((e) => setNotice(String(e)));
+  }, []);
+
+  // Tail the selected file while the view is open.
+  useEffect(() => {
+    if (!selected) return;
+    let cancelled = false;
+    const load = () =>
+      readAppLog(selected.name)
+        .then((tail) => {
+          if (cancelled) return;
+          setContent(tail.content);
+          setTruncated(tail.truncated);
+        })
+        .catch((e) => !cancelled && setNotice(String(e)));
+    load();
+    const timer = setInterval(load, TAIL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [selected]);
+
+  const lines = filterByLevel(
+    classifyLog(content, selected?.ndjson ?? false),
+    selected?.ndjson ? level : "info",
+  );
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard
+      .writeText(lines.map((l) => l.raw).join("\n"))
+      .then(() => setNotice("Copied to the clipboard."))
+      .catch((e) => setNotice(String(e)));
+  }, [lines]);
+
+  const handleExport = useCallback(() => {
+    if (!selected) return;
+    exportAppLog(selected.name)
+      .then((path) => setNotice(path ? `Exported to ${path}` : null))
+      .catch((e) => setNotice(String(e)));
+  }, [selected]);
+
+  return (
+    <main className="flex min-h-screen flex-col gap-4 bg-zinc-950 p-6 text-zinc-100">
+      <header className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold tracking-tight">Launcher logs</h1>
+        <button
+          type="button"
+          onClick={onBack}
+          data-testid="logs-back"
+          className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-300 hover:bg-zinc-900"
+        >
+          Back
+        </button>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        <select
+          data-testid="logs-file"
+          value={selected?.name ?? ""}
+          onChange={(e) =>
+            setSelected(files.find((f) => f.name === e.target.value) ?? null)
+          }
+          className="rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1 text-sm text-zinc-300"
+        >
+          {files.map((f) => (
+            <option key={f.name} value={f.name}>
+              {f.name} ({formatSize(f.size_bytes)})
+            </option>
+          ))}
+        </select>
+        {selected?.ndjson && (
+          <label className="flex items-center gap-2 text-xs text-zinc-500">
+            Level:
+            <select
+              data-testid="logs-level"
+              value={level}
+              onChange={(e) => setLevel(e.target.value as LogLevel)}
+              className="rounded-md border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300"
+            >
+              <option value="info">everything</option>
+              <option value="warn">warnings & errors</option>
+              <option value="error">errors only</option>
+            </select>
+          </label>
+        )}
+        <button
+          type="button"
+          onClick={handleCopy}
+          data-testid="logs-copy"
+          className="rounded-md border border-zinc-700 px-3 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          data-testid="logs-export"
+          className="rounded-md border border-zinc-700 px-3 py-1 text-xs text-zinc-300 hover:bg-zinc-900"
+        >
+          Export…
+        </button>
+      </div>
+
+      {truncated && (
+        <p className="text-xs text-zinc-500">
+          Showing the newest 512 KB — export for the full file.
+        </p>
+      )}
+      {notice && (
+        <p data-testid="logs-notice" className="text-xs text-zinc-400">
+          {notice}
+        </p>
+      )}
+
+      <pre
+        data-testid="logs-body"
+        className="min-h-0 flex-1 overflow-auto rounded-md border border-zinc-800 bg-zinc-900 p-3 text-xs leading-5"
+      >
+        {files.length === 0
+          ? "No launcher logs yet — they appear after the first bring-up."
+          : lines.map((l, i) => (
+              <div key={i} className={LEVEL_STYLE[l.level]}>
+                {selected?.ndjson ? l.text : l.raw}
+              </div>
+            ))}
+      </pre>
+    </main>
+  );
+}
+
+export default LogsViewer;


### PR DESCRIPTION
Rounds out the desktop launcher (milestone D8). Stacked on #1259 (`jashan/desktop-release-ci`); the chain below it is #1258 ← #1256 ← #1255/#1254 ← #1253 ← #1252 → dev. Retarget to dev as the stack merges.

- [x] **System tray** — stack-status dot stamped onto the app icon from the health poller (green all-up / amber partial / gray down), menu: Open TT-Studio, Switch machine, Stop stack (`run.py --stop` locally or over ssh), Quit (goes through the normal quit flow). Linux uses tauri's `tray-icon` feature; the .deb now depends on `libayatana-appindicator3-1`.
- [x] **Logs viewer** — the launcher now tees the `--json-events` stdout stream to `bringup.ndjson` / `remote-bringup.ndjson` next to the existing stderr logs; a new view tails any of them with level filtering (NDJSON events map to info/warn/error), copy, and export via a native save dialog. Reads are capped at the newest 512 KB and file names only resolve against the scan result (no path input).
- [x] **Bug report bundle** — reuses `run.py --report-bug --no-browser` (tt_setup/bug_report.py). Local: spawn in the checkout and pick up the newest `logs/tt-studio-logs-ttbr-*.zip`. SSH: run it remotely, find the ZIP, copy it back over the same session (`base64` over exec — no sftp needed), then reveal it in the file manager (tauri-plugin-opener, Rust-side only).
- [x] **Close-button behavior setting** — ask every time (default, the existing dialogs) / minimize to tray / keep the stack running / stop the stack (local or remote), persisted in the settings store. The decision matrix is a pure function with full coverage; tray Quit ignores "minimize" but honors the rest.
- [x] **Single instance + desktop entry** — tauri-plugin-single-instance focuses (and un-hides) the running window on a second launch; custom .desktop template (categories, keywords, StartupWMClass) and bundle descriptions so a QuietBox install looks first-class.
- [x] **Dynamic marketplace app ports** — the static 7000-7010 tunnel range never matched reality: the backend allocates app host ports from `APP_PORT_RANGE = range(3080, 3100)` (shared_config/marketplace_config.py) plus per-app defaults. While the tunnel is connected, a poller GETs `/models/marketplace/apps/` through the forwarded backend port and reconciles dynamic forwards to the apps that actually hold ports (pulling/starting/running); the supervisor now binds/unbinds listeners on the live session and re-binds the set after reconnects. The static range is gone.

Verified: `cargo test` (103 lib + integration incl. a fake-run.py bug-report round trip and new dynamic-forward tunnel tests), `cargo clippy`/`fmt` clean, `vitest` 85 tests, `npm run build`, `tsc --noEmit`. Not verified here: real tray/window interaction (headless box — WebKitGTK renders blank under Xvfb), real bundle installs.

Manual validation checklist:
- [ ] Tray dot follows stack health; Open/Switch/Stop/Quit actions work (Linux + macOS menu bar)
- [ ] Close button honors each of the four behaviors; tray Quit still quits when set to minimize
- [ ] Second launch focuses the existing window instead of starting a new one
- [ ] `.deb` install on a QuietBox: icon/name/keywords in the launcher menu, tray icon present
- [ ] Bug report on a remote profile lands the ZIP locally and reveals it
- [ ] Launch a marketplace app over ssh → its port becomes reachable within ~5 s; stop it → listener released