### PR TITLE
fix: AnythingLLM container unable to start

### DIFF
--- a/app/backend/docker_control/docker_control_client.py
+++ b/app/backend/docker_control/docker_control_client.py
@@ -199,10 +199,11 @@ class DockerControlClient:
         response = self._request("POST", f"/api/v1/containers/{container_id}/stop", json=payload)
         return response.json()
 
-    def remove_container(self, container_id: str, force: bool = False, v: bool = False) -> Dict:
-        """Remove a container"""
-        payload = {"force": force, "v": v}
-        response = self._request("POST", f"/api/v1/containers/{container_id}/remove", json=payload)
+    def remove_container(self, container_id: str, force: bool = False) -> Dict:
+        """Remove a container."""
+        response = self._request(
+            "POST", f"/api/v1/containers/{container_id}/remove", params={"force": force}
+        )
         return response.json()
 
     def rename_container(self, container_id: str, new_name: str) -> Dict:


### PR DESCRIPTION
## Summary
Users experienced the following error when trying to launch the AnythingLLM container:
`Could not prepare AnythingLLM: 400 Client Error: Bad Request for url: http://host.docker.internal:8002/api/v1/containers/tt_studio_app_anythingllm/remove`

`_launch` clears a leftover container of the same name before starting. The launch view skips that path when the container is running, so the removal only runs for what it believes is a non-running leftover. It fires when that belief is wrong or incomplete:

The container is restarting (AnythingLLM crash-looping, e.g. a volume-permission problem) or paused — not "running", so the view proceeds, but Docker still refuses removal without force. This is the case a user can never escape: every retry gives the same 400.
list_containers() swallows Docker errors and returns [], so a single control-service hiccup makes the view think nothing exists, and the worker then meets a live container.

## Fix
[docker_control_client.py](vscode-webview://1bktm79uf2r8k97avltdqd58t3jvgk9jv3pu3kuiddr092a54crm/app/backend/docker_control/docker_control_client.py) now passes force on the query string.


RUNNING + force=True  -> {'status': 'success'}      (was HTTP 400)
missing container     -> HTTP 404                    (what the launch path tolerates)