### PR TITLE
fix(ui): drop the artifact card from the welcome wizard and add a settings icon

### DIFF
--- a/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeIntroStep.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { motion } from "framer-motion";
+import { Settings } from "lucide-react";
 import { Button } from "../ui/button";
 
 interface Props {
@@ -37,7 +38,11 @@ export default function WelcomeIntroStep({ onNext }: Props) {
         <li className="flex items-start gap-2">
           <span className="text-TT-purple">•</span>
           <span>
-            You can add or change it any time from Settings.
+            You can add or change it any time from{" "}
+            <span className="inline-flex items-center gap-1 font-medium">
+              <Settings className="w-3.5 h-3.5" /> Settings
+            </span>
+            .
           </span>
         </li>
       </ul>

--- a/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Check, ExternalLink, Eye, EyeOff, Lock } from "lucide-react";
+import { Check, ExternalLink, Eye, EyeOff } from "lucide-react";
 
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -89,7 +89,6 @@ export default function WelcomeSecretsStep({
   isSaving,
 }: Props) {
   const loading = !current;
-  const artifact = current?.artifact;
 
   return (
     <motion.div
@@ -132,30 +131,6 @@ export default function WelcomeSecretsStep({
           >
             Generate a token <ExternalLink className="w-3 h-3" />
           </a>
-        </p>
-      </div>
-
-      <div className="rounded-md border border-stone-200 dark:border-stone-800 p-3 space-y-2">
-        <div className="flex items-center gap-1 text-sm font-medium">
-          <Lock className="w-3.5 h-3.5" /> tt-inference artifact (read-only)
-        </div>
-        <div className="grid grid-cols-2 gap-2 text-xs">
-          <div>
-            <div className="text-stone-500">Branch</div>
-            <div className="font-mono truncate">
-              {artifact?.branch || "—"}
-            </div>
-          </div>
-          <div>
-            <div className="text-stone-500">Version</div>
-            <div className="font-mono truncate">
-              {artifact?.version || "—"}
-            </div>
-          </div>
-        </div>
-        <p className="text-xs text-stone-500">
-          {artifact?.description ||
-            "Pins which tt-inference-server release TT Studio is built against."}
         </p>
       </div>
 


### PR DESCRIPTION
The tt-inference artifact card on the token step of the welcome wizard is read-only noise during first-run setup, and the intro step referred to Settings with plain text.

- [x] Remove the tt-inference artifact (read-only) card from the Hugging Face token step
- [x] Show a gear icon in front of "Settings" on the intro step
- [x] Verified by walking both wizard steps in the running dev stack (lint clean; type-check failures are pre-existing in TrainingJobDetailPage)