### PR TITLE
feat(ui): warn when no HF token is set and explain stalled 0% deploys

### DIFF
--- a/app/frontend/src/components/DeployModelStep.tsx
+++ b/app/frontend/src/components/DeployModelStep.tsx
@@ -9,6 +9,7 @@ import { useRefresh } from "../hooks/useRefresh";
 import { useIsResetting } from "../hooks/useIsResetting";
 import { DeploymentProgress } from "./ui/DeploymentProgress";
 import { cancelDeployment } from "../api/modelsDeployedApis";
+import { getSettings } from "../api/settingsApi";
 import { useActiveDeploymentsContext } from "../providers/ActiveDeploymentsContext";
 import type { ActiveDeployment, DeploymentProgressData } from "../hooks/useActiveDeployments";
 import { Cpu, AlertTriangle, ExternalLink, Info, CheckCircle } from "lucide-react";
@@ -66,6 +67,22 @@ export function DeployModelStep({
   // Block deployment while a board/device reset is in progress.
   const isResetting = useIsResetting();
   const [modelName, setModelName] = useState<string | null>(null);
+  // A missing HF token is the most common reason a deploy of a gated model
+  // stalls at 0% — warn up front and sharpen the stall message in the progress
+  // card. On lookup failure stay silent rather than warn spuriously.
+  const [hfTokenMissing, setHfTokenMissing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSettings()
+      .then((s) => {
+        if (!cancelled) setHfTokenMissing(!s.hf_token.set);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const slotInfo = useMemo(() => {
     if (!chipStatus) {
@@ -235,6 +252,7 @@ export function DeployModelStep({
               }
               startTime={activeDeployment.startedAt}
               imagePulled={activeDeployment.hadImagePull}
+              hfTokenMissing={hfTokenMissing}
               onCancel={() => {
                 void cancelDeployment(activeDeployment.jobId);
                 removeDeployment(activeDeployment.jobId);
@@ -276,6 +294,31 @@ export function DeployModelStep({
                   <p className="text-sm text-blue-700 dark:text-blue-300">
                     Deployment is paused while the board resets — about a minute or two.
                     Try again once it finishes.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Missing HF token: gated model deploys will hang at 0% waiting for
+            credentials, so warn before the user starts one. Non-blocking —
+            ungated models still deploy fine without a token. */}
+        {hfTokenMissing && (
+          <div className="w-full max-w-2xl mb-6">
+            <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
+                <div className="flex-1">
+                  <h4 className="text-sm font-semibold text-yellow-800 dark:text-yellow-200 mb-1">
+                    No Hugging Face token configured
+                  </h4>
+                  <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                    Deploys of gated models (Llama, Gemma, …) will stall at 0%
+                    without one. Set it in Settings (gear icon in the navbar),
+                    or add <code className="font-mono">HF_TOKEN</code> to the{" "}
+                    <code className="font-mono">.env</code> file at the repo
+                    root and restart TT-Studio.
                   </p>
                 </div>
               </div>

--- a/app/frontend/src/components/ui/DeploymentProgress.tsx
+++ b/app/frontend/src/components/ui/DeploymentProgress.tsx
@@ -41,7 +41,19 @@ interface DeploymentProgressProps {
   /** True once the image has been pulled in this deploy. When set, the bar reserves
    *  a leading pull segment; otherwise the download owns the front of the bar. */
   imagePulled?: boolean;
+  /** True when the server reports no HuggingFace token configured. Sharpens the
+   *  stall troubleshooting message — a missing token is the most common reason a
+   *  deploy freezes at 0% (the inference server waits for credentials). */
+  hfTokenMissing?: boolean;
 }
+
+/** How long the backend progress record may go without an update, while still in
+ *  the pre-download stages, before we surface troubleshooting steps. Normal runs
+ *  leave these stages within seconds; a run waiting on a missing HF token (or one
+ *  that died before emitting progress) never does. Later stages (setup, weights
+ *  download) legitimately go quiet for minutes and are excluded. */
+const EARLY_STALL_MS = 120_000;
+const EARLY_STALL_STAGES = new Set(['starting', 'initialization', 'unknown']);
 
 /** Friendly, stable sub-text for the container-start stages. The backend message for
  *  these can be noisy (e.g. the raw `docker run` command), so we describe the phase
@@ -107,7 +119,8 @@ export const DeploymentProgress: React.FC<DeploymentProgressProps> = ({
   onCancel,
   onViewLogs,
   startTime,
-  imagePulled = false
+  imagePulled = false,
+  hfTokenMissing = false
 }) => {
   const [elapsedTime, setElapsedTime] = useState(0);
 
@@ -131,6 +144,16 @@ export const DeploymentProgress: React.FC<DeploymentProgressProps> = ({
   const isStalled = status === 'stalled';
   const isCancelled = status === 'cancelled';
   const isRunning = status === 'running' || status === 'starting';
+
+  // Stalled before any real work started: the backend record hasn't moved in
+  // minutes and the deploy never left the pre-download stages. The 1s elapsed
+  // ticker above keeps this re-evaluating while the panel is visible.
+  const lastUpdatedMs = progress.last_updated ? progress.last_updated * 1000 : null;
+  const stalledEarly =
+    isRunning &&
+    EARLY_STALL_STAGES.has(progress.stage) &&
+    lastUpdatedMs !== null &&
+    Date.now() - lastUpdatedMs > EARLY_STALL_MS;
 
   const formatBytes = (bytes?: number | null) => {
     if (bytes === undefined || bytes === null || bytes < 0) return '—';
@@ -323,6 +346,33 @@ export const DeploymentProgress: React.FC<DeploymentProgressProps> = ({
           indicatorClassName={`${getProgressBarColor()} transition-[width] duration-300`}
         />
       </div>
+
+      {/* The deploy froze before doing any real work — walk the user through the
+          usual fix (missing HF token) instead of leaving a silent 0% bar. */}
+      {stalledEarly && (
+        <div className="mb-3 rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 p-3" role="alert">
+          <p className="text-xs font-semibold text-yellow-800 dark:text-yellow-200 mb-1">
+            Deployment isn't reporting progress
+          </p>
+          <p className="text-xs text-yellow-700 dark:text-yellow-300 mb-2">
+            {hfTokenMissing
+              ? 'No Hugging Face token is configured — the server is most likely waiting for credentials it will never receive.'
+              : 'The server has not sent an update in a few minutes. The most common cause is a missing or unreadable Hugging Face token.'}
+          </p>
+          <ol className="list-decimal list-inside space-y-1 text-xs text-yellow-700 dark:text-yellow-300">
+            <li>
+              Set your Hugging Face token in Settings (gear icon in the navbar), or add{' '}
+              <code className="font-mono">HF_TOKEN</code> to the <code className="font-mono">.env</code>{' '}
+              file at the repo root and restart TT-Studio.
+            </li>
+            <li>Cancel this deployment and deploy the model again.</li>
+            <li>
+              Still stuck? Check <code className="font-mono">logs/model_run.log</code> for{' '}
+              "HF_TOKEN not set", and run <code className="font-mono">python run.py --report-bug</code>.
+            </li>
+          </ol>
+        </div>
+      )}
 
       {/* Confirm the pull finished while the container spins up. */}
       {imagePulled && isContainerStarting && (

--- a/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
+++ b/app/frontend/src/components/welcome/WelcomeSecretsStep.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Check, ExternalLink, Eye, EyeOff } from "lucide-react";
+import { AlertTriangle, Check, ExternalLink, Eye, EyeOff } from "lucide-react";
 
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -133,6 +133,23 @@ export default function WelcomeSecretsStep({
           </a>
         </p>
       </div>
+
+      {/* Without a token the inference server waits for credentials when a gated
+          model is deployed, and the deploy sits at 0% with no explanation. Warn
+          here, before the user hits that dead end. */}
+      {!loading && !current?.hf_token.set && values.hf_token.trim() === "" && (
+        <div className="flex items-start gap-3 rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 p-3">
+          <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-yellow-600 dark:text-yellow-400" />
+          <p className="text-xs text-yellow-800 dark:text-yellow-200">
+            <span className="font-semibold">No token configured.</span> Deploys
+            of gated models (Llama, Gemma, …) will stall at 0% while the server
+            waits for Hugging Face credentials. Add a token above, or set{" "}
+            <code className="font-mono">HF_TOKEN</code> in the{" "}
+            <code className="font-mono">.env</code> file at the repo root and
+            restart TT-Studio.
+          </p>
+        </div>
+      )}
 
       <div className="flex justify-between pt-2">
         <Button variant="outline" onClick={onBack} disabled={isSaving}>


### PR DESCRIPTION
Deploying a gated model without a Hugging Face token makes the inference server wait forever for credentials, and the UI just shows a progress bar frozen at 0% "Initializing" with no explanation.

- [x] Welcome wizard: warning on the token step when no token is stored and none was typed — set it in the wizard or as HF_TOKEN in the repo .env
- [x] Deploy step: non-blocking notice before deploying when the server reports no token configured
- [x] Progress card: when the backend record goes stale for 2+ minutes while still in the pre-download stages, show troubleshooting steps (set the token in Settings or .env and restart, cancel + redeploy, check logs/model_run.log / run.py --report-bug)
- [x] Verified against the running dev stack: tsc + eslint clean on the touched files, /up/ and /settings-api/ healthy, and a real frozen job's progress record (stale last_updated, stage initialization) matches the stall condition