### PR TITLE
fix: remove gemma-1.1-2b-it from the model catalog

### DIFF
--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.20.0",
     "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 61,
+  "total_models": 60,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -892,37 +892,6 @@
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "gemma-1.1-2b-it",
-      "hand_owned": true,
-      "model_type": "TRAINING",
-      "display_model_type": "TRAINING",
-      "device_configurations": [
-        "P150"
-      ],
-      "hf_model_id": "google/gemma-1.1-2b-it",
-      "inference_engine": "forge",
-      "impl": "training-lora",
-      "supported_modalities": [
-        "text"
-      ],
-      "status": "EXPERIMENTAL",
-      "version": "0.0.1",
-      "docker_image": "tt-media-server-forge:local",
-      "service_route": "/v1/jobs",
-      "health_route": "/health",
-      "shm_size": "32G",
-      "setup_type": "TT_INFERENCE_SERVER",
-      "env_vars": {
-        "MODEL_RUNNER": "training-lora",
-        "TRAINING_MODEL": "gemma-1.1-2b-it",
-        "ENABLE_JOB_PERSISTENCE": true,
-        "JOB_CLEANUP_INTERVAL_SECONDS": 10000,
-        "JOB_MAX_STUCK_TIME_SECONDS": 100000,
-        "REQUEST_PROCESSING_TIMEOUT_SECONDS": 100000
-      },
       "param_count": null
     },
     {


### PR DESCRIPTION
The hand-added gemma-1.1-2b-it training entry can't actually deploy: the pinned tt-inference-server artifact (v0.20.0) rejects it at argument parsing (invalid --model choice), so every deploy attempt dies instantly and the UI shows a progress bar frozen at 0%. Remove it from the catalog until an artifact version that supports it is pinned.

- [x] Removed the hand_owned gemma-1.1-2b-it entry and decremented total_models (61 → 60)
- [x] shared_config/test_sync_models.py: 30 passed
- [x] Verified on the running dev stack: /docker-api/catalog/ no longer lists the model