### PR TITLE
fix: hide training models and the /training page for this release

### DIFF
--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -317,6 +317,11 @@ def load_model_implementations_from_json(json_path: Path) -> list:
         catalog = json.load(f)
     impls = []
     for entry in catalog["models"]:
+        # Training models are hidden for this release: the pinned inference-server
+        # artifact can't run the training-lora impl yet, so offering them only
+        # produces deploys that die at dispatch. Remove this once training ships.
+        if entry.get("model_type") == "TRAINING":
+            continue
         docker_image = entry.get("docker_image") or ""
         if ":" in docker_image:
             image_name, image_tag = docker_image.rsplit(":", 1)

--- a/app/frontend/src/routes/route-config.tsx
+++ b/app/frontend/src/routes/route-config.tsx
@@ -173,14 +173,17 @@ export const getRoutes = (): RouteConfig[] => {
       condition: true,
     },
     {
+      // Hidden for this release — training models are filtered out of the
+      // catalog (shared_config/model_config.py) until the pinned inference
+      // server supports them. Flip back to true when training ships.
       path: "/training",
       element: <TrainingPage />,
-      condition: true,
+      condition: false,
     },
     {
       path: "/training/:jobId",
       element: <TrainingJobDetailPage />,
-      condition: true,
+      condition: false,
     },
     {
       path: "/apps",


### PR DESCRIPTION
Training isn't deployable on the pinned inference-server artifact yet (training-lora impls die at dispatch), so hide the whole surface for this release instead of leaving dead ends in the UI.

- [x] Catalog loader skips model_type TRAINING entries, so no training model is offered or synced back in
- [x] /training and /training/:jobId routes disabled via the existing route condition flag (flip back when training ships)
- [x] Verified on the running dev stack: /docker-api/catalog/ has zero training entries; both routes served with condition false
- [x] shared_config tests: 53 passed; the 8 ImplSelectorTests errors are pre-existing on dev (identical with the change stashed)