### PR TITLE
feat(inference-api): let public models deploy and download without an HF token

### DIFF
--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -290,6 +290,119 @@ def _patched_check_model_weights_dir(self, host_weights_dir):
 
 _setup_host_module.HostSetupManager.check_model_weights_dir = _patched_check_model_weights_dir
 
+# Patch the artifact's HF_TOKEN hard-gates so public (non-gated) models deploy
+# without a token.
+#
+# tt-inference-server requires a non-empty HF_TOKEN in three places, all of which
+# either block on an interactive getpass() prompt (which hangs forever inside this
+# headless process, leaving the deploy frozen at 0%) or assert:
+#   1. run.handle_secrets()                       — prompt/assert before anything runs
+#   2. HostSetupManager.get_hf_env_vars()         — assert check_hf_access(token)
+#   3. HostSetupManager.setup_weights_huggingface — `assert self.hf_token` before download
+#
+# Public models need none of that: huggingface_hub treats an empty HF_TOKEN env var
+# as no token and downloads anonymously (utils._auth._clean_token("") -> None). So
+# when no token is configured we pass a truthy-but-empty token through the asserts,
+# and replace the token validation with an anonymous repo check that fails fast —
+# with an actionable message — only for genuinely gated repos.
+import run as _run_module  # noqa: E402
+
+
+class _AnonymousHFToken(str):
+    """Truthy empty string: satisfies the artifact's `assert self.hf_token` gates
+    while exporting an empty HF_TOKEN env var, which downstream tooling
+    (huggingface_hub / the `hf` CLI) treats as anonymous access."""
+    __slots__ = ()
+
+    def __new__(cls):
+        return super().__new__(cls, "")
+
+    def __bool__(self):
+        return True
+
+
+# getattr-guarded: the test suite imports api against stub artifact modules that
+# don't define these attributes; the real artifact always does.
+_orig_handle_secrets = getattr(_run_module, "handle_secrets", None)
+
+
+def _patched_handle_secrets(runtime_config):
+    if os.getenv("HF_TOKEN"):
+        return _orig_handle_secrets(runtime_config)
+    # Keep the original's JWT gate as a fail-fast instead of a hidden prompt.
+    jwt_required = (
+        str(runtime_config.workflow).lower() == "server"
+        and runtime_config.docker_server
+        and not runtime_config.interactive
+        and not runtime_config.no_auth
+    )
+    if jwt_required and not os.getenv("JWT_SECRET"):
+        raise RuntimeError(
+            "JWT_SECRET is not set — refusing to start a docker-server deploy."
+        )
+    logging.getLogger(__name__).warning(
+        "HF_TOKEN not set — deploying anonymously. Public models download "
+        "normally; gated models (Llama, Gemma, ...) need a token set in "
+        "TT-Studio Settings or .env."
+    )
+
+
+if _orig_handle_secrets is not None:
+    _run_module.handle_secrets = _patched_handle_secrets
+
+_orig_get_hf_env_vars = getattr(_setup_host_module.HostSetupManager, "get_hf_env_vars", None)
+
+
+def _patched_get_hf_env_vars(self):
+    if not (self.hf_token or os.getenv("HF_TOKEN")):
+        self.hf_token = _AnonymousHFToken()
+    return _orig_get_hf_env_vars(self)
+
+
+if _orig_get_hf_env_vars is not None:
+    _setup_host_module.HostSetupManager.get_hf_env_vars = _patched_get_hf_env_vars
+
+_orig_check_hf_access = getattr(_setup_host_module.HostSetupManager, "check_hf_access", None)
+
+
+def _patched_check_hf_access(self, token):
+    if token and not isinstance(token, _AnonymousHFToken):
+        return _orig_check_hf_access(self, token)
+    # Anonymous path: usable iff the repo is public. The models API serves gated
+    # repos' metadata anonymously, so inspect the `gated` field rather than the
+    # HTTP status.
+    repo = self.model_spec.hf_weights_repo
+    log = logging.getLogger(__name__)
+    url = f"https://huggingface.co/api/models/{repo}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "tt-studio/anon-access-check"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            info = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:
+        log.error(
+            "⛔ Anonymous Hugging Face access check failed for %s: %s. "
+            "Set a HF token in TT-Studio Settings (or HF_TOKEN in .env) and retry.",
+            repo, exc,
+        )
+        return False
+    if info.get("gated"):
+        log.error(
+            "⛔ %s is a gated model — it cannot be downloaded anonymously. "
+            "Set your Hugging Face token in TT-Studio Settings (or HF_TOKEN in .env).",
+            repo,
+        )
+        return False
+    if not info.get("siblings"):
+        log.error("⛔ No files found in repository %s.", repo)
+        return False
+    return True
+
+
+if _orig_check_hf_access is not None:
+    _setup_host_module.HostSetupManager.check_hf_access = _patched_check_hf_access
+
 # Set up logging
 # DO NOT use basicConfig() - it interferes with file handlers
 # Instead, configure logging manually


### PR DESCRIPTION
tt-inference-server hard-requires a non-empty HF_TOKEN in three places (handle_secrets, check_hf_access, an assert before the weights download). Without a token the first one blocks on an interactive getpass() prompt inside the headless inference-api process, so the deploy silently freezes at 0% — even for public models that need no credentials at all.

huggingface_hub treats an empty HF_TOKEN as anonymous access, so public models can download fine without one. This patches the three gates at the artifact-import seam in api.py (same pattern as the existing check_model_weights_dir patch):

- [x] handle_secrets: with no token, skip the prompt and continue anonymously; the JWT_SECRET requirement stays as a fail-fast RuntimeError instead of a hidden prompt
- [x] check_hf_access: with no token, do an anonymous repo lookup — public repos pass, gated repos fail fast with a message pointing at Settings/.env instead of a 401 later
- [x] The pre-download assert is satisfied by a truthy-but-empty token that exports an empty (anonymous) HF_TOKEN env var
- [x] With a token set, all three behave exactly as before (wrappers delegate to the originals)
- [x] getattr-guarded so the test suite's stub artifact modules still import
- [x] Verified against the real v0.20.0 artifact modules: anonymous handle_secrets returns, JWT fail-fast raises, live HF checks pass for a public repo and refuse a gated one; inference-api tests 12/12

Known limitation: the dev-mode subprocess path runs run.py out of process, so it doesn't get these patches — it already fails fast there (stdin is /dev/null) rather than hanging.