### PR TITLE
ci: grant write permissions to community labeling workflow

### DIFF
--- a/.github/workflows/community-issue-tagging.yml
+++ b/.github/workflows/community-issue-tagging.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   call-central-workflow:
     uses: tenstorrent/tt-github-actions/.github/workflows/on-community-issue.yml@main


### PR DESCRIPTION
Every run of the community issue/PR labeling workflow has ended in startup_failure since it was added (e.g. run 32663894063). The reusable workflow it calls (tt-github-actions/on-community-issue.yml) requests `issues: write` / `pull-requests: write` on its job, and since our caller grants nothing beyond the repo's read-only default token, GitHub rejects the run at plan time before any job starts.

Other repos calling the same central workflow (e.g. tt-forge) grant these permissions in the caller and their runs succeed — this brings our caller in line with theirs and the org workflow template.

- [x] Add `permissions: issues: write, pull-requests: write` to the caller workflow
- [x] Verified the file now matches tt-forge's working caller; YAML parses

Targets `main` (not `dev`) because `issues`-triggered workflows only run from the default branch and this file exists only on `main` (added there directly in #1203).