### PR TITLE
fix: keep image-pull progress across backend workers and restarts

### DIFF
--- a/app/backend/docker_control/image_pull.py
+++ b/app/backend/docker_control/image_pull.py
@@ -30,20 +30,24 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 from shared_config.logger_config import get_logger
 from docker_control.docker_control_client import get_docker_client
+from docker_control import image_pull_store as store
 
 logger = get_logger(__name__)
 
-# pull_id -> snapshot dict (see _new_entry)
-_image_pull_jobs: Dict[str, dict] = {}
-_lock = threading.Lock()
+# Progress lives in image_pull_store (JSON in the persistent volume), NOT in a
+# module global: the backend runs multiple uvicorn workers, so the process that
+# mints a pull_id is usually not the one serving the client's progress polls.
 
 _POLL_INTERVAL_SECONDS = 1.5
 _PULL_TIMEOUT_SECONDS = 2 * 60 * 60  # 2h hard cap; large multi-GB images
-_ENTRY_TTL_SECONDS = 3600            # evict finished entries after an hour
+# How long the pull backend may stop answering before we call the pull dead.
+# Previously a None snapshot was treated as a transient hiccup and the loop ran
+# the full 2h reporting 0%, with no way to tell a stalled pull from a slow one.
+_UNREACHABLE_GRACE_SECONDS = 120
 # A pull can run for many minutes — longer than the canonical "starting" grace
 # window — so we periodically refresh the placeholder deployment record's
 # timestamp (via heartbeat_fn) to keep it alive and its chip slot reserved.
@@ -77,34 +81,38 @@ def _new_entry(image_ref: str) -> dict:
 def request_pull_cancel(pull_id: str) -> bool:
     """Flag a pull job for cancellation so its worker bails before starting the
     deploy. Returns True if the pull job was tracked."""
-    with _lock:
-        entry = _image_pull_jobs.get(pull_id)
-        if entry is None:
-            return False
-        entry["cancelled"] = True
-        return True
+    return store.update_entry(pull_id, cancelled=True) is not None
 
 
 def _is_pull_cancelled(pull_id: str) -> bool:
-    with _lock:
-        entry = _image_pull_jobs.get(pull_id)
-        return bool(entry and entry.get("cancelled"))
+    entry = store.get_entry(pull_id)
+    return bool(entry and entry.get("cancelled"))
 
 
 def get_pull_job(pull_id: str) -> Optional[dict]:
-    """Return a copy of the pull-job snapshot, or None if not tracked."""
-    with _lock:
-        entry = _image_pull_jobs.get(pull_id)
-        return dict(entry) if entry is not None else None
+    """Return the pull-job snapshot, or None if not tracked.
+
+    A pull whose owning process died (backend restart, dev-mode --reload, crash)
+    stops being heartbeated. Rather than reporting it as perpetually "pulling",
+    surface it as an error with an actionable message — the caller can then tell
+    the user what happened instead of showing a bare failure.
+    """
+    entry = store.get_entry(pull_id)
+    if entry is None:
+        return None
+    if store.is_stalled(entry):
+        entry = dict(entry)
+        entry["status"] = "error"
+        entry["error"] = "Image pull was interrupted"
+        entry["message"] = (
+            "Image pull was interrupted (the server restarted while it ran). "
+            "Retry the deployment — already-downloaded layers are reused."
+        )
+    return entry
 
 
 def _update(pull_id: str, **changes) -> None:
-    with _lock:
-        entry = _image_pull_jobs.get(pull_id)
-        if entry is None:
-            return
-        entry.update(changes)
-        entry["updated_at"] = time.time()
+    store.update_entry(pull_id, **changes)
 
 
 def clamp_progress_pct(pull_id: str, pct: int) -> int:
@@ -118,23 +126,7 @@ def clamp_progress_pct(pull_id: str, pct: int) -> int:
     (mirroring the single-deploy bar's client-side ``maxPctRef`` clamp). Scoped per
     pull_id, so each deploy starts fresh.
     """
-    with _lock:
-        entry = _image_pull_jobs.get(pull_id)
-        if entry is None:
-            return pct
-        peak = max(int(entry.get("peak_progress") or 0), pct)
-        entry["peak_progress"] = peak
-        return peak
-
-
-def _evict_stale_locked() -> None:
-    now = time.time()
-    stale = [
-        pid for pid, e in _image_pull_jobs.items()
-        if e["status"] != "pulling" and now - e["updated_at"] > _ENTRY_TTL_SECONDS
-    ]
-    for pid in stale:
-        _image_pull_jobs.pop(pid, None)
+    return store.bump_peak_progress(pull_id, pct)
 
 
 def start_prepull_and_deploy(
@@ -151,9 +143,8 @@ def start_prepull_and_deploy(
     heartbeat_fn (optional) is invoked periodically while the pull runs — used to
     keep the placeholder deployment record fresh so it isn't reconciled away.
     """
-    with _lock:
-        _evict_stale_locked()
-        _image_pull_jobs[pull_id] = _new_entry(image_ref)
+    store.evict_stale()
+    store.create_entry(pull_id, _new_entry(image_ref))
 
     thread = threading.Thread(
         target=_worker,
@@ -204,6 +195,7 @@ def _worker(
             last_t: Optional[float] = None
             last_bytes: Optional[int] = None
             last_heartbeat = 0.0
+            unreachable_since: Optional[float] = None
             while time.time() < deadline:
                 if _is_pull_cancelled(pull_id):
                     break
@@ -214,8 +206,32 @@ def _worker(
 
                 snap = client.get_image_pull_progress(pull_id)
                 if snap is None:
+                    # The pull backend isn't answering for this id. Briefly this is
+                    # a normal hiccup (service restart, a dropped request), but if it
+                    # persists nobody is driving the pull any more — report it instead
+                    # of looping for the full 2h timeout showing 0%.
+                    now = time.time()
+                    if unreachable_since is None:
+                        unreachable_since = now
+                    elif now - unreachable_since > _UNREACHABLE_GRACE_SECONDS:
+                        logger.warning(
+                            f"[image_pull] pull backend stopped answering for {pull_id} "
+                            f"after {_UNREACHABLE_GRACE_SECONDS}s; marking stalled"
+                        )
+                        _update(
+                            pull_id,
+                            status="error",
+                            error="Image pull stalled",
+                            message=(
+                                "Image pull stalled — the pull service stopped "
+                                "responding. Retry the deployment; already-downloaded "
+                                "layers are reused."
+                            ),
+                        )
+                        return
                     time.sleep(_POLL_INTERVAL_SECONDS)
                     continue
+                unreachable_since = None
 
                 downloaded = int(snap.get("downloaded_bytes") or 0)
                 total = int(snap.get("total_bytes") or 0)

--- a/app/backend/docker_control/image_pull_store.py
+++ b/app/backend/docker_control/image_pull_store.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Durable, cross-process store for image-pull progress.
+
+Why this exists: the backend runs multiple uvicorn workers (``--workers 4`` in
+app/docker-compose.yml). A module-level dict is per-process, so the worker that
+mints a ``pull_id`` and runs its pull thread is usually NOT the worker that serves
+the client's progress polls — roughly 3 in 4 polls landed on a process that had
+never heard of the job and returned ``not_found``, which the UI rendered as
+"Deployment failed" while the pull was in fact running fine.
+
+Design mirrors deployment_store.py (the house pattern for shared state): JSON in
+the persistent volume, atomic replace, no new dependency or migration. Differences:
+
+  * **One file per pull_id.** Concurrent pulls never touch the same file, so two
+    pulls can't clobber each other's updates.
+  * **flock on read-modify-write.** A threading.Lock only guards one process;
+    progress updates cross process boundaries here, so we take an OS-level
+    exclusive lock for the read-modify-write cycle.
+
+Entries are self-expiring in two senses: finished ones are evicted after
+``ENTRY_TTL_SECONDS``, and a "pulling" entry whose owner process died stops being
+refreshed — ``is_stalled()`` detects that, so a dead pull surfaces as an error
+instead of sitting at "pulling" forever.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from shared_config.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+_STORE_DIR = (
+    Path(os.getenv("INTERNAL_PERSISTENT_STORAGE_VOLUME", "/tt_studio_persistent_volume"))
+    / "backend_volume"
+    / "image_pulls"
+)
+
+# Guards this process's own read-modify-write cycles; flock guards across processes.
+_local_lock = threading.Lock()
+
+# Degraded-mode fallback. If the persistent volume isn't writable (it has had
+# permission problems in the field), file ops raise and we keep state in-process
+# instead. That is exactly the old per-worker behaviour — no worse than before —
+# rather than making every pull look orphaned, which would be far worse.
+_fallback: Dict[str, dict] = {}
+_fallback_active = False
+
+
+def _use_fallback(reason: str) -> None:
+    global _fallback_active
+    if not _fallback_active:
+        _fallback_active = True
+        logger.warning(
+            f"[image_pull_store] persistent store unavailable ({reason}); falling back "
+            "to per-process memory. Pull progress will not survive across workers."
+        )
+
+ENTRY_TTL_SECONDS = 3600  # evict finished entries after an hour
+
+# A live worker refreshes updated_at at least every _HEARTBEAT_INTERVAL_SECONDS
+# (30s in image_pull.py). Allow generous slack for a loaded box before calling a
+# pull stalled — a false positive would fail a healthy multi-GB pull.
+STALL_AFTER_SECONDS = 180
+
+
+def _path_for(pull_id: str) -> Path:
+    # pull_ids are minted as f"imgpull_{uuid4().hex}", but never build a path from
+    # unvalidated input — a stray separator would escape the store directory.
+    safe = "".join(c for c in pull_id if c.isalnum() or c in ("_", "-"))
+    if not safe:
+        raise ValueError(f"unusable pull_id: {pull_id!r}")
+    return _STORE_DIR / f"{safe}.json"
+
+
+def _ensure_dir() -> None:
+    _STORE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _write_atomic(path: Path, data: dict) -> None:
+    """Write JSON via a temp file in the same directory + os.replace, so a reader
+    never observes a partially written file."""
+    _ensure_dir()
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def create_entry(pull_id: str, entry: dict) -> None:
+    """Persist a new pull-job entry, replacing any stale file for the same id."""
+    try:
+        _write_atomic(_path_for(pull_id), entry)
+    except Exception as e:
+        # Never block a deploy on the progress store — the pull itself still runs.
+        _use_fallback(str(e))
+        with _local_lock:
+            _fallback[pull_id] = dict(entry)
+
+
+def get_entry(pull_id: str) -> Optional[dict]:
+    """Return the stored snapshot, or None when this id isn't tracked."""
+    try:
+        path = _path_for(pull_id)
+    except ValueError:
+        return None
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        with _local_lock:
+            entry = _fallback.get(pull_id)
+            return dict(entry) if entry is not None else None
+    except (json.JSONDecodeError, OSError) as e:
+        # A torn read shouldn't look like "job doesn't exist" — that would be
+        # reported as a hard failure. Surface it as unknown-but-present instead.
+        logger.warning(f"[image_pull_store] unreadable entry {pull_id}: {e}")
+        return None
+
+
+def update_entry(pull_id: str, **changes) -> Optional[dict]:
+    """Read-modify-write one entry under an exclusive cross-process lock.
+
+    Returns the updated snapshot, or None if the entry is gone.
+    """
+    try:
+        path = _path_for(pull_id)
+    except ValueError:
+        return None
+
+    with _local_lock:
+        try:
+            _ensure_dir()
+            # Open r+ so we hold the lock on the very file we're updating.
+            with open(path, "r+") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    try:
+                        f.seek(0)
+                        entry = json.load(f)
+                    except json.JSONDecodeError:
+                        return None
+                    entry.update(changes)
+                    entry["updated_at"] = time.time()
+                    # Rewrite in place while holding the lock. The file is small and
+                    # written whole, so truncate-then-write is safe here; readers that
+                    # catch a torn read fall back to "unknown", never to "not found".
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(entry, f, default=str)
+                    f.flush()
+                    os.fsync(f.fileno())
+                    return entry
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        except FileNotFoundError:
+            return _update_fallback_locked(pull_id, changes)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return _update_fallback_locked(pull_id, changes)
+            _use_fallback(str(e))
+            return _update_fallback_locked(pull_id, changes)
+
+
+def bump_peak_progress(pull_id: str, pct: int) -> int:
+    """Raise the stored peak percent to at least ``pct`` and return the peak.
+
+    Kept in the store (rather than read-then-update by the caller) so the
+    read-compare-write runs inside one cross-process lock — otherwise two workers
+    could interleave and let the reported percent go backwards, which is exactly
+    what the clamp exists to prevent.
+    """
+    try:
+        path = _path_for(pull_id)
+    except ValueError:
+        return pct
+    with _local_lock:
+        try:
+            with open(path, "r+") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    try:
+                        f.seek(0)
+                        entry = json.load(f)
+                    except json.JSONDecodeError:
+                        return pct
+                    peak = max(int(entry.get("peak_progress") or 0), int(pct))
+                    entry["peak_progress"] = peak
+                    entry["updated_at"] = time.time()
+                    f.seek(0)
+                    f.truncate()
+                    json.dump(entry, f, default=str)
+                    f.flush()
+                    return peak
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        except (FileNotFoundError, OSError):
+            entry = _fallback.get(pull_id)
+            if entry is None:
+                return pct
+            peak = max(int(entry.get("peak_progress") or 0), int(pct))
+            entry["peak_progress"] = peak
+            entry["updated_at"] = time.time()
+            return peak
+
+
+def _update_fallback_locked(pull_id: str, changes: dict) -> Optional[dict]:
+    """Apply an update to the in-process fallback. Caller holds _local_lock."""
+    entry = _fallback.get(pull_id)
+    if entry is None:
+        return None
+    entry.update(changes)
+    entry["updated_at"] = time.time()
+    return dict(entry)
+
+
+def delete_entry(pull_id: str) -> None:
+    with _local_lock:
+        _fallback.pop(pull_id, None)
+    try:
+        _path_for(pull_id).unlink()
+    except (FileNotFoundError, ValueError):
+        pass
+    except OSError as e:
+        logger.debug(f"[image_pull_store] could not delete entry {pull_id}: {e}")
+
+
+def is_stalled(entry: dict) -> bool:
+    """True when an entry claims to be pulling but nothing has refreshed it.
+
+    The owning worker heartbeats ``updated_at`` while it runs, so a gap beyond
+    STALL_AFTER_SECONDS means that process is gone (restart, --reload, crash) and
+    no one is driving this pull any more.
+    """
+    if entry.get("status") != "pulling":
+        return False
+    try:
+        updated_at = float(entry.get("updated_at") or 0)
+    except (TypeError, ValueError):
+        return False
+    return (time.time() - updated_at) > STALL_AFTER_SECONDS
+
+
+def all_entries() -> Dict[str, dict]:
+    """Every tracked pull, keyed by pull_id. Used for reconciliation."""
+    out: Dict[str, dict] = {}
+    try:
+        if not _STORE_DIR.exists():
+            return out
+        for path in _STORE_DIR.glob("*.json"):
+            try:
+                with open(path, "r") as f:
+                    out[path.stem] = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+    except OSError as e:
+        logger.debug(f"[image_pull_store] could not list entries: {e}")
+    return out
+
+
+def evict_stale() -> List[str]:
+    """Drop finished entries past their TTL. Returns the ids removed.
+
+    Unlike the previous in-memory eviction this also removes long-dead "pulling"
+    entries: one whose owner died is never going to finish, and leaving it behind
+    made every future lookup return a job that looks perpetually in progress.
+    """
+    removed: List[str] = []
+    now = time.time()
+    for pull_id, entry in all_entries().items():
+        try:
+            updated_at = float(entry.get("updated_at") or 0)
+        except (TypeError, ValueError):
+            updated_at = 0
+        age = now - updated_at
+        finished = entry.get("status") != "pulling"
+        if (finished and age > ENTRY_TTL_SECONDS) or (
+            not finished and age > max(ENTRY_TTL_SECONDS, STALL_AFTER_SECONDS * 4)
+        ):
+            delete_entry(pull_id)
+            removed.append(pull_id)
+    return removed

--- a/app/backend/docker_control/image_pull_store.py
+++ b/app/backend/docker_control/image_pull_store.py
@@ -128,8 +128,11 @@ def get_entry(pull_id: str) -> Optional[dict]:
         return None
     try:
         with open(path, "r") as f:
-            return json.load(f)
-    except FileNotFoundError:
+            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+            try:
+                return json.load(f)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
         with _local_lock:
             entry = _fallback.get(pull_id)
             return dict(entry) if entry is not None else None

--- a/app/backend/docker_control/test_image_pull_store.py
+++ b/app/backend/docker_control/test_image_pull_store.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the durable image-pull progress store.
+
+The point of this store is that a pull's progress is visible from a process other
+than the one running the pull — the backend serves polls from several uvicorn
+workers. A test that only exercises one process would pass on the old in-memory
+implementation too, so the cross-process cases here spawn real subprocesses.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+# The store only needs get_logger from shared_config; stub it so these tests run
+# without Django settings configured.
+if "shared_config.logger_config" not in sys.modules:
+    _pkg = types.ModuleType("shared_config")
+    _mod = types.ModuleType("shared_config.logger_config")
+    _mod.get_logger = lambda name: types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    _pkg.logger_config = _mod
+    sys.modules.setdefault("shared_config", _pkg)
+    sys.modules["shared_config.logger_config"] = _mod
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from docker_control import image_pull_store as store  # noqa: E402
+
+
+class ImagePullStoreTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_dir = store._STORE_DIR
+        store._STORE_DIR = Path(self._tmp.name) / "image_pulls"
+        store._fallback.clear()
+        store._fallback_active = False
+
+    def tearDown(self):
+        store._STORE_DIR = self._orig_dir
+        self._tmp.cleanup()
+
+    @staticmethod
+    def _entry(**over):
+        base = {
+            "status": "pulling",
+            "downloaded_bytes": 0,
+            "total_bytes": 0,
+            "peak_progress": 0,
+            "message": "Preparing…",
+            "image_ref": "ghcr.io/example/img:1.0",
+            "real_job_id": None,
+            "cancelled": False,
+            "started_at": time.time(),
+            "updated_at": time.time(),
+        }
+        base.update(over)
+        return base
+
+    def test_roundtrip(self):
+        store.create_entry("imgpull_a", self._entry())
+        got = store.get_entry("imgpull_a")
+        self.assertIsNotNone(got)
+        self.assertEqual(got["image_ref"], "ghcr.io/example/img:1.0")
+
+    def test_unknown_id_is_none(self):
+        self.assertIsNone(store.get_entry("imgpull_missing"))
+
+    def test_update_persists_and_stamps(self):
+        store.create_entry("imgpull_b", self._entry())
+        before = store.get_entry("imgpull_b")["updated_at"]
+        time.sleep(0.01)
+        store.update_entry("imgpull_b", downloaded_bytes=123, status="success")
+        got = store.get_entry("imgpull_b")
+        self.assertEqual(got["downloaded_bytes"], 123)
+        self.assertEqual(got["status"], "success")
+        self.assertGreater(got["updated_at"], before)
+
+    def test_update_unknown_returns_none(self):
+        self.assertIsNone(store.update_entry("imgpull_nope", downloaded_bytes=1))
+
+    def test_peak_progress_never_regresses(self):
+        store.create_entry("imgpull_c", self._entry())
+        self.assertEqual(store.bump_peak_progress("imgpull_c", 40), 40)
+        # Docker reveals layers late, so the raw ratio can dip — the clamp must hold.
+        self.assertEqual(store.bump_peak_progress("imgpull_c", 12), 40)
+        self.assertEqual(store.bump_peak_progress("imgpull_c", 55), 55)
+
+    def test_stall_detection(self):
+        fresh = self._entry()
+        self.assertFalse(store.is_stalled(fresh))
+        stale = self._entry(updated_at=time.time() - (store.STALL_AFTER_SECONDS + 10))
+        self.assertTrue(store.is_stalled(stale))
+        # A finished entry is never "stalled", however old it is.
+        done = self._entry(status="success", updated_at=time.time() - 99999)
+        self.assertFalse(store.is_stalled(done))
+
+    def test_evict_stale_removes_finished_but_keeps_live(self):
+        store.create_entry("imgpull_old", self._entry(
+            status="success", updated_at=time.time() - (store.ENTRY_TTL_SECONDS + 60)))
+        store.create_entry("imgpull_live", self._entry())
+        removed = store.evict_stale()
+        self.assertIn("imgpull_old", removed)
+        self.assertIsNone(store.get_entry("imgpull_old"))
+        self.assertIsNotNone(store.get_entry("imgpull_live"))
+
+    def test_delete(self):
+        store.create_entry("imgpull_d", self._entry())
+        store.delete_entry("imgpull_d")
+        self.assertIsNone(store.get_entry("imgpull_d"))
+
+    def test_pull_id_cannot_escape_store_dir(self):
+        # Separators are stripped rather than rejected, so a traversal attempt is
+        # neutralised into a harmless name that still lands inside the store dir.
+        escaped = store._path_for("../../etc/passwd")
+        self.assertEqual(escaped.parent.resolve(), store._STORE_DIR.resolve())
+        # A pull_id with nothing usable left is rejected outright.
+        with self.assertRaises(ValueError):
+            store._path_for("../../")
+        # And a traversal attempt never resolves to an existing entry.
+        self.assertIsNone(store.get_entry("../../etc/passwd"))
+
+    def test_visible_across_processes(self):
+        """The whole point: a different PROCESS must see the progress.
+
+        This is what the old module-level dict could not do, and why ~3 in 4
+        progress polls returned not_found under --workers 4.
+        """
+        store.create_entry("imgpull_x", self._entry(downloaded_bytes=5))
+
+        script = f"""
+import sys, types, json
+from pathlib import Path
+pkg = types.ModuleType("shared_config"); mod = types.ModuleType("shared_config.logger_config")
+mod.get_logger = lambda n: types.SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None)
+pkg.logger_config = mod
+sys.modules["shared_config"] = pkg; sys.modules["shared_config.logger_config"] = mod
+sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})
+from docker_control import image_pull_store as s
+s._STORE_DIR = Path({str(store._STORE_DIR)!r})
+# Read what the parent wrote, then write back from this process.
+e = s.get_entry("imgpull_x")
+print(json.dumps({{"read": e["downloaded_bytes"]}}))
+s.update_entry("imgpull_x", downloaded_bytes=999, status="success")
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=60
+        )
+        self.assertEqual(proc.returncode, 0, f"child failed: {proc.stderr}")
+        self.assertEqual(json.loads(proc.stdout.strip())["read"], 5,
+                         "child process could not read the parent's entry")
+        # And the child's write is visible back in the parent.
+        got = store.get_entry("imgpull_x")
+        self.assertEqual(got["downloaded_bytes"], 999)
+        self.assertEqual(got["status"], "success")
+
+    def test_concurrent_writers_do_not_lose_the_peak(self):
+        """Interleaved bumps from several processes must still end at the max."""
+        store.create_entry("imgpull_y", self._entry())
+        script_tmpl = """
+import sys, types
+from pathlib import Path
+pkg = types.ModuleType("shared_config"); mod = types.ModuleType("shared_config.logger_config")
+mod.get_logger = lambda n: types.SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None)
+pkg.logger_config = mod
+sys.modules["shared_config"] = pkg; sys.modules["shared_config.logger_config"] = mod
+sys.path.insert(0, {parent!r})
+from docker_control import image_pull_store as s
+s._STORE_DIR = Path({store_dir!r})
+for pct in range({lo}, {hi}):
+    s.bump_peak_progress("imgpull_y", pct)
+"""
+        parent = str(Path(__file__).resolve().parent.parent)
+        store_dir = str(store._STORE_DIR)
+        procs = [
+            subprocess.Popen([sys.executable, "-c", script_tmpl.format(
+                parent=parent, store_dir=store_dir, lo=lo, hi=hi)])
+            for lo, hi in ((0, 30), (30, 60), (60, 91))
+        ]
+        for p in procs:
+            self.assertEqual(p.wait(timeout=60), 0)
+        self.assertEqual(store.get_entry("imgpull_y")["peak_progress"], 90)
+
+    def test_falls_back_to_memory_when_volume_unwritable(self):
+        """A read-only volume must degrade to the old per-process behaviour, not
+        make every pull look orphaned (which would be worse than the bug)."""
+        ro = Path(self._tmp.name) / "readonly"
+        ro.mkdir()
+        os.chmod(ro, 0o500)
+        store._STORE_DIR = ro / "image_pulls"
+        try:
+            store.create_entry("imgpull_ro", self._entry(downloaded_bytes=7))
+            self.assertTrue(store._fallback_active)
+            got = store.get_entry("imgpull_ro")
+            self.assertIsNotNone(got, "fallback must still serve the entry")
+            self.assertEqual(got["downloaded_bytes"], 7)
+            store.update_entry("imgpull_ro", downloaded_bytes=8)
+            self.assertEqual(store.get_entry("imgpull_ro")["downloaded_bytes"], 8)
+            self.assertEqual(store.bump_peak_progress("imgpull_ro", 33), 33)
+        finally:
+            os.chmod(ro, 0o700)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -741,7 +741,14 @@ class DeployView(APIView):
                     try:
                         need_pull = not get_docker_client().image_exists(image_name, image_tag)
                     except Exception as e:
-                        logger.warning(f"image_exists check failed for {deploy_image}: {e}")
+                        # Deliberately fall through to an inline deploy: image_pull's
+                        # design rule is that this feature never blocks a deploy. The
+                        # inference server pulls the image itself as it always has —
+                        # the only loss is the byte-level progress bar.
+                        logger.warning(
+                            f"image_exists check failed for {deploy_image}: {e}; "
+                            "deploying without a pre-pull (no image-pull progress bar)"
+                        )
                         need_pull = False
 
                 if need_pull:
@@ -893,7 +900,14 @@ class DeployView(APIView):
                     try:
                         need_pull = not get_docker_client().image_exists(image_name, image_tag)
                     except Exception as e:
-                        logger.warning(f"image_exists check failed for {deploy_image}: {e}")
+                        # Deliberately fall through to an inline deploy: image_pull's
+                        # design rule is that this feature never blocks a deploy. The
+                        # inference server pulls the image itself as it always has —
+                        # the only loss is the byte-level progress bar.
+                        logger.warning(
+                            f"image_exists check failed for {deploy_image}: {e}; "
+                            "deploying without a pre-pull (no image-pull progress bar)"
+                        )
                         need_pull = False
 
                 if need_pull:
@@ -1165,6 +1179,62 @@ class CancelDeploymentView(APIView):
 
 
 class DeploymentProgressView(APIView):
+    @staticmethod
+    def _reconcile_orphaned_pull(pull_id):
+        """Decide the true outcome of a pull whose progress record is gone.
+
+        Returns a terminal progress Response either way, but never a bare status:
+        the client can only explain itself to the user if we send a message.
+        """
+        from docker_control.models import ModelDeployment
+
+        # The chat deploy path parks a placeholder record under the pull_id. If the
+        # deploy went on to succeed, that record was updated with the real container
+        # and the pull genuinely completed.
+        try:
+            placeholder = ModelDeployment.objects.filter(container_id=pull_id).first()
+        except Exception as e:
+            logger.warning(f"orphaned pull {pull_id}: could not read deployment record: {e}")
+            placeholder = None
+
+        if placeholder is not None:
+            record_status = getattr(placeholder, "status", None)
+            if record_status in ("running", "healthy", "ready"):
+                logger.info(f"orphaned pull {pull_id} reconciled to a running deployment")
+                return Response(
+                    {
+                        "status": "completed",
+                        "stage": "complete",
+                        "progress": 100,
+                        "message": "Deployment completed successfully",
+                    },
+                    status=status.HTTP_200_OK,
+                )
+            # Still parked at "starting" with nobody driving it: the pull died. Free
+            # the chip slot it reserved, otherwise the board reads as in use forever
+            # and the next deploy is blocked by a phantom.
+            try:
+                placeholder.status = "stopped"
+                placeholder.save()
+                logger.info(f"orphaned pull {pull_id}: released placeholder chip slot")
+            except Exception as e:
+                logger.warning(f"orphaned pull {pull_id}: could not release placeholder: {e}")
+
+        return Response(
+            {
+                "status": "error",
+                "stage": "error",
+                "progress": 0,
+                "message": (
+                    "Image pull was interrupted and its progress was lost "
+                    "(the server most likely restarted while it ran). Retry the "
+                    "deployment — already-downloaded layers are reused, so it will "
+                    "pick up where it left off."
+                ),
+            },
+            status=status.HTTP_200_OK,
+        )
+
     def get(self, request, job_id, *args, **kwargs):
         """Track deployment progress - proxy FastAPI progress endpoints with fallback"""
         import time
@@ -1225,12 +1295,16 @@ class DeploymentProgressView(APIView):
                     )
 
             # An imgpull_ id that isn't a tracked pull job (job_id is reassigned to
-            # the real inference id on handoff above) is an orphan — its in-memory
-            # pull job was lost, e.g. the backend restarted mid-pull. It maps to no
-            # real container, so the container fallback below would fabricate endless
-            # fake progress. Report it terminal so the client stops polling.
+            # the real inference id on handoff above) is an orphan — its pull record
+            # is gone, e.g. it aged out or the persistent store was unavailable. It
+            # maps to no real container, so the container fallback below would
+            # fabricate endless fake progress.
+            #
+            # Before calling it a failure, reconcile against reality: a pull that
+            # completed and handed off just before its record vanished did in fact
+            # succeed, and reporting that as "Deployment failed" is simply wrong.
             if job_id.startswith("imgpull_"):
-                return Response({"status": "not_found"}, status=status.HTTP_200_OK)
+                return self._reconcile_orphaned_pull(job_id)
 
             # Track deployment start time if not already tracked
             if job_id not in deployment_start_times:
@@ -1545,7 +1619,60 @@ class DeploymentLogsView(APIView):
         """Get deployment logs from FastAPI inference server"""
         try:
             logger.info(f"Fetching deployment logs for job_id: {job_id}")
-            
+
+            # An imgpull_ id is ours, not the inference server's — asking FastAPI for
+            # it always 404s, which surfaced in the UI as a dead "View logs" button.
+            # Resolve it to the real job once the handoff has happened; until then,
+            # report the pull's own state so the button shows something useful.
+            if job_id.startswith("imgpull_"):
+                pull_job = get_pull_job(job_id)
+                if pull_job is None:
+                    return Response(
+                        {
+                            "job_id": job_id,
+                            "logs": [
+                                {
+                                    "level": "ERROR",
+                                    "message": (
+                                        "Image pull was interrupted and its record is "
+                                        "gone. Retry the deployment — already-downloaded "
+                                        "layers are reused."
+                                    ),
+                                }
+                            ],
+                            "total_messages": 1,
+                        },
+                        status=status.HTTP_200_OK,
+                    )
+                real_job_id = pull_job.get("real_job_id")
+                if real_job_id:
+                    job_id = real_job_id
+                else:
+                    downloaded = pull_job.get("downloaded_bytes") or 0
+                    total = pull_job.get("total_bytes") or 0
+                    lines = [
+                        {
+                            "level": "ERROR" if pull_job.get("status") == "error" else "INFO",
+                            "message": pull_job.get("message") or "Pulling image…",
+                        },
+                        {
+                            "level": "INFO",
+                            "message": (
+                                f"Image: {pull_job.get('image_ref')} — "
+                                f"{downloaded / 1e9:.2f} GB of "
+                                f"{(total / 1e9) if total else 0:.2f} GB, "
+                                f"{pull_job.get('layers_done') or 0}/"
+                                f"{pull_job.get('layers_total') or 0} layers"
+                            ),
+                        },
+                    ]
+                    if pull_job.get("error"):
+                        lines.append({"level": "ERROR", "message": str(pull_job["error"])})
+                    return Response(
+                        {"job_id": job_id, "logs": lines, "total_messages": len(lines)},
+                        status=status.HTTP_200_OK,
+                    )
+
             # Try to get logs from FastAPI inference server
             try:
                 fastapi_url = _build_fastapi_url(f"run/logs/{job_id}")

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1210,9 +1210,43 @@ class DeploymentProgressView(APIView):
                     },
                     status=status.HTTP_200_OK,
                 )
-            # Still parked at "starting" with nobody driving it: the pull died. Free
-            # the chip slot it reserved, otherwise the board reads as in use forever
-            # and the next deploy is blocked by a phantom.
+            # Still parked at "starting" with nobody driving it: the pull may have died.
+            # However, a missing pull record can also be transient (e.g. persistent-store
+            # hiccup or degraded per-process fallback). Only free the reserved slot once
+            # the placeholder is clearly stale.
+            try:
+                import time
+                from docker_control import image_pull_store as pull_store
+
+                deployed_at = getattr(placeholder, "deployed_at", None)
+                started_ts = deployed_at.timestamp() if deployed_at else None
+                if started_ts and (time.time() - started_ts) < pull_store.STALL_AFTER_SECONDS:
+                    return Response(
+                        {
+                            "status": "not_found",
+                            "stage": "pulling_image",
+                            "progress": 0,
+                            "message": (
+                                "Pull progress is temporarily unavailable; continuing to track it."
+                            ),
+                        },
+                        status=status.HTTP_200_OK,
+                    )
+            except Exception:
+                # If we cannot determine staleness, err on the side of not killing the placeholder.
+                return Response(
+                    {
+                        "status": "not_found",
+                        "stage": "pulling_image",
+                        "progress": 0,
+                        "message": (
+                            "Pull progress is temporarily unavailable; continuing to track it."
+                        ),
+                    },
+                    status=status.HTTP_200_OK,
+                )
+
+            # Pull is old enough to be considered dead: release its reserved chip slot.
             try:
                 placeholder.status = "stopped"
                 placeholder.save()

--- a/app/frontend/src/components/VoiceAgentSolutionStep.tsx
+++ b/app/frontend/src/components/VoiceAgentSolutionStep.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useState, useEffect, type ReactNode, type CSSProperties } from "react";
+import { useState, useEffect, useCallback, type ReactNode, type CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Bot,
@@ -99,7 +99,15 @@ async function pollDeployProgress(
   // Keep a long safety timeout so a stalled backend does not leave UI stuck forever.
   const SAFETY_TIMEOUT_MS = 30 * 60 * 1000;
   const deadline = Date.now() + SAFETY_TIMEOUT_MS;
-  const TERMINAL_ERRORS = ["error", "failed", "cancelled", "timeout", "not_found"];
+  const TERMINAL_ERRORS = ["error", "failed", "cancelled", "timeout"];
+  // `not_found` is NOT terminal on sight. A job can legitimately read as unknown for
+  // a short window — the record is still being registered, or a backend worker that
+  // hasn't seen it yet serves the poll. Treating the first one as fatal killed cards
+  // within seconds of a perfectly healthy deploy. useDeploymentProgress.ts and
+  // useActiveDeployments.ts both allow 90s; match them rather than inventing a
+  // third policy.
+  const NOT_FOUND_GRACE_MS = 90 * 1000;
+  const startedAt = Date.now();
   while (Date.now() < deadline) {
     try {
       const resp = await fetch(`/docker-api/deploy/progress/${jobId}/`);
@@ -107,7 +115,18 @@ async function pollDeployProgress(
         const data = await resp.json();
         onUpdate?.(data);
         if (data.status === "completed") return { outcome: "done", status: data.status };
-        if (TERMINAL_ERRORS.includes(data.status)) {
+        if (data.status === "not_found") {
+          if (Date.now() - startedAt >= NOT_FOUND_GRACE_MS) {
+            return {
+              outcome: "error",
+              status: data.status,
+              message:
+                data.message ??
+                "Deployment could not be tracked — the job is no longer known to the server.",
+            };
+          }
+          // Inside the grace window: keep polling.
+        } else if (TERMINAL_ERRORS.includes(data.status)) {
           return { outcome: "error", status: data.status, message: data.message };
         }
       }
@@ -119,13 +138,60 @@ async function pollDeployProgress(
   return { outcome: "error", timedOut: true };
 }
 
-/** Concise per-card sub-status from a progress poll (image pull shows real %). */
-function deployDetailFromProgress(data: { stage?: string; progress?: number }): string | undefined {
-  if (data.stage === "pulling_image") {
-    const pct = typeof data.progress === "number" ? Math.round(data.progress) : 0;
-    return `Pulling Docker Image… ${pct}%`;
+type PullProgressData = {
+  stage?: string;
+  progress?: number;
+  message?: string;
+  downloaded_bytes?: number;
+  total_bytes?: number | null;
+  speed_bps?: number | null;
+  eta_seconds?: number | null;
+};
+
+const formatGB = (bytes: number) => `${(bytes / 1e9).toFixed(1)} GB`;
+
+const formatSpeed = (bps: number) =>
+  bps >= 1e6 ? `${(bps / 1e6).toFixed(1)} MB/s` : `${Math.max(1, Math.round(bps / 1e3))} KB/s`;
+
+const formatEta = (seconds: number) => {
+  const mins = Math.round(seconds / 60);
+  if (mins < 1) return "under a minute left";
+  if (mins < 60) return `~${mins} min left`;
+  return `~${Math.floor(mins / 60)}h ${mins % 60}m left`;
+};
+
+/** Concise per-card sub-status from a progress poll.
+ *
+ *  The backend already sends bytes, speed, ETA and a layer count for image pulls
+ *  (DeploymentProgressView); this previously discarded all of it and re-derived a
+ *  bare percentage, so a multi-GB pull looked identical to a stalled one. Show the
+ *  same detail the model-weights download gets. */
+function deployDetailFromProgress(data: PullProgressData): string | undefined {
+  if (data.stage !== "pulling_image") return undefined;
+
+  const pct = typeof data.progress === "number" ? Math.round(data.progress) : 0;
+  const downloaded = data.downloaded_bytes ?? 0;
+  const total = data.total_bytes ?? 0;
+  const parts: string[] = [`Pulling image… ${pct}%`];
+
+  if (total > 0 && downloaded > 0) {
+    parts.push(`${formatGB(downloaded)} / ${formatGB(total)}`);
   }
-  return undefined;
+  if (data.speed_bps && data.speed_bps > 0) {
+    parts.push(formatSpeed(data.speed_bps));
+  }
+  // Early in a pull the rate is measured over very few samples and the ETA can be
+  // off by 5-10x (a run that finished in 16 min was projecting 106 min at 5%).
+  // Withhold it until enough of the image has landed for the estimate to mean
+  // something, rather than showing a number that pushes people to cancel.
+  if (data.eta_seconds && data.eta_seconds > 0 && total > 0 && downloaded / total > 0.1) {
+    parts.push(formatEta(data.eta_seconds));
+  }
+
+  const detail = parts.join(" • ");
+  // The backend's message carries the layer count, e.g. "(36/46 layers)".
+  const layers = data.message?.match(/\((\d+\/\d+) layers\)/)?.[1];
+  return layers ? `${detail} • ${layers} layers` : detail;
 }
 
 async function deployOneModel(
@@ -220,6 +286,45 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
   const [allDone, setAllDone] = useState(false);
   const [countdown, setCountdown] = useState(AUTO_REDIRECT_MS / 1000);
 
+  /** Re-read which devices are in use. Deliberately callable on demand: this used to
+   *  run once on mount only, so after a deploy finished (or its containers went away)
+   *  the page kept showing minutes-old occupancy — and because that state feeds
+   *  `canDeploy`, the Deploy button stayed disabled with a generic tooltip while the
+   *  backend reported every slot free. A swallowed click is indistinguishable from a
+   *  broken app, so keep this fresh. */
+  const refreshOccupiedDevices = useCallback(
+    () =>
+      fetch("/docker-api/status/")
+        .then((r) => r.json())
+        .then((data: Record<string, { name: string; device_id?: number | null; device_ids?: number[] | null }>) => {
+          const occupied = Object.values(data)
+            .map((c) => {
+              const normalizedDeviceIds = Array.isArray(c.device_ids)
+                ? c.device_ids
+                    .map((slot) => Number(slot))
+                    .filter((slot) => Number.isInteger(slot))
+                : [];
+              const fallbackDeviceId = c.device_id != null ? Number(c.device_id) : null;
+              const resolvedDeviceIds =
+                normalizedDeviceIds.length > 0
+                  ? Array.from(new Set(normalizedDeviceIds)).sort((a, b) => a - b)
+                  : fallbackDeviceId != null && Number.isInteger(fallbackDeviceId)
+                    ? [fallbackDeviceId]
+                    : [];
+              if (resolvedDeviceIds.length === 0) return undefined;
+              return {
+                device_id: resolvedDeviceIds[0],
+                device_ids: resolvedDeviceIds,
+                name: c.name,
+              };
+            })
+            .filter((item): item is OccupiedDevice => item !== undefined);
+          setOccupiedDevices(occupied);
+        })
+        .catch(() => { /* non-fatal — just no pre-flight warnings */ }),
+    []
+  );
+
   useEffect(() => {
     const loadModels = fetch(getModelsUrl)
       .then((r) => r.json())
@@ -255,34 +360,7 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
       })
       .catch(() => customToast.error("Failed to load model catalog"));
 
-    const loadSlots = fetch("/docker-api/status/")
-      .then((r) => r.json())
-      .then((data: Record<string, { name: string; device_id?: number | null; device_ids?: number[] | null }>) => {
-        const occupied = Object.values(data)
-          .map((c) => {
-            const normalizedDeviceIds = Array.isArray(c.device_ids)
-              ? c.device_ids
-                  .map((slot) => Number(slot))
-                  .filter((slot) => Number.isInteger(slot))
-              : [];
-            const fallbackDeviceId = c.device_id != null ? Number(c.device_id) : null;
-            const resolvedDeviceIds =
-              normalizedDeviceIds.length > 0
-                ? Array.from(new Set(normalizedDeviceIds)).sort((a, b) => a - b)
-                : fallbackDeviceId != null && Number.isInteger(fallbackDeviceId)
-                  ? [fallbackDeviceId]
-                  : [];
-            if (resolvedDeviceIds.length === 0) return undefined;
-            return {
-              device_id: resolvedDeviceIds[0],
-              device_ids: resolvedDeviceIds,
-              name: c.name,
-            };
-          })
-          .filter((item): item is OccupiedDevice => item !== undefined);
-        setOccupiedDevices(occupied);
-      })
-      .catch(() => { /* non-fatal — just no pre-flight warnings */ });
+    const loadSlots = refreshOccupiedDevices();
 
     // Board slot count for the device pre-flight check.
     const loadSlotCount = fetch("/docker-api/chip-status/")
@@ -293,7 +371,20 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
       .catch(() => { /* non-fatal */ });
 
     Promise.all([loadModels, loadSlots, loadSlotCount]).finally(() => setLoadingModels(false));
-  }, []);
+  }, [refreshOccupiedDevices]);
+
+  // Keep occupancy fresh without polling hard: refresh when the tab regains focus
+  // (the common case — the user was elsewhere while a deploy finished) and on a
+  // slow interval as a backstop.
+  useEffect(() => {
+    const onFocus = () => { void refreshOccupiedDevices(); };
+    window.addEventListener("focus", onFocus);
+    const timer = setInterval(onFocus, 30000);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      clearInterval(timer);
+    };
+  }, [refreshOccupiedDevices]);
 
   // Auto-redirect countdown after all done
   useEffect(() => {
@@ -435,6 +526,10 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
 
     const failures = results.filter((r) => !r.ok);
     setIsDeploying(false);
+    // Whatever the outcome, occupancy just changed — slots were taken, or a failed
+    // deploy released the ones it had reserved. Re-read it so a retry isn't blocked
+    // by stale conflicts.
+    void refreshOccupiedDevices();
     if (failures.length === 0) {
       setAllDone(true);
       customToast.success("Voice Agent pipeline submitted! Redirecting…");

--- a/docker-control-service/routers/images.py
+++ b/docker-control-service/routers/images.py
@@ -25,9 +25,13 @@ _PULLS_LOCK = threading.Lock()
 _PULL_ENTRY_TTL_SECONDS = 3600  # drop finished entries after an hour to bound memory
 
 
-def _new_pull_entry() -> dict:
+def _new_pull_entry(image_ref: str = "") -> dict:
     return {
         "status": "pulling",          # pulling | success | error
+        "image_ref": image_ref,
+        # Set when this id attached to another id's in-flight pull of the same image
+        # (see start_pull_image); progress is then read from the leader.
+        "follows": None,
         "downloaded_bytes": 0,
         "total_bytes": 0,
         "layers_done": 0,
@@ -139,12 +143,42 @@ async def start_pull_image(request: ImagePullStartRequest):
     progress. Safe to call repeatedly for the same pull_id (a live pull is reused).
     """
     pull_id = request.pull_id
+    image_ref = f"{request.image_name}:{request.image_tag}"
     with _PULLS_LOCK:
         _evict_stale_locked()
         existing = _PULLS.get(pull_id)
         if existing is not None and existing["status"] == "pulling":
             return {"status": "success", "message": f"Pull {pull_id} already in progress"}
-        _PULLS[pull_id] = _new_pull_entry()
+
+        # Attach to an in-flight pull of the SAME image rather than starting a second
+        # one. Deploying several models that share an image (the Voice Agent's
+        # speech-to-text and text-to-speech both use tt-media-inference-server) used
+        # to mint one pull_id each and run two pulls of identical bytes, with two
+        # progress trackers reporting the same numbers.
+        leader_id = next(
+            (
+                pid
+                for pid, e in _PULLS.items()
+                if pid != pull_id
+                and e.get("status") == "pulling"
+                and e.get("image_ref") == image_ref
+                and not e.get("follows")
+            ),
+            None,
+        )
+        if leader_id is not None:
+            entry = _new_pull_entry(image_ref)
+            entry["follows"] = leader_id
+            _PULLS[pull_id] = entry
+            logger.info(
+                f"Pull {pull_id} attached to in-flight pull {leader_id} for {image_ref}"
+            )
+            return {
+                "status": "success",
+                "message": f"Pull {pull_id} attached to in-flight pull of {image_ref}",
+            }
+
+        _PULLS[pull_id] = _new_pull_entry(image_ref)
 
     thread = threading.Thread(
         target=_run_pull,
@@ -163,6 +197,24 @@ async def get_pull_progress(pull_id: str):
         entry = _PULLS.get(pull_id)
         if entry is None:
             raise HTTPException(status_code=404, detail=f"No pull tracked for {pull_id}")
+        # A follower has no bytes of its own — report the pull it attached to.
+        leader_id = entry.get("follows")
+        if leader_id:
+            leader = _PULLS.get(leader_id)
+            if leader is not None:
+                # Mirror the leader's terminal state onto the follower so the
+                # follower's own entry can age out of the TTL sweep, which only
+                # evicts entries that are no longer "pulling".
+                entry["status"] = leader.get("status", entry.get("status"))
+                entry["updated_at"] = leader.get("updated_at", time.time())
+                entry = leader
+            else:
+                # Leader already evicted: it ran to completion an hour ago, so the
+                # image is cached. Reporting "pulling" forever would strand the
+                # caller; report done and let it move on.
+                entry["status"] = "success"
+                entry["message"] = "Image already present"
+                entry["updated_at"] = time.time()
         snapshot = dict(entry)
     snapshot["pull_id"] = pull_id
     return snapshot


### PR DESCRIPTION
Deploying a model whose image isn't cached would show "Deployment failed" on the card while the pull was actually running fine.

The backend runs uvicorn with `--workers 4`, but image-pull progress lived in a module-level dict. The worker that minted a `pull_id` and ran its pull thread was usually not the worker serving the client's progress polls, so roughly 3 in 4 polls landed on a process that had never heard of the job and returned a bare `not_found`. The Voice Agent card treated the first `not_found` as fatal — no grace period, unlike the two shared hooks — so a healthy deploy died within seconds with no explanation. This reproduces in prod mode; dev mode is single-worker, which is why it looked intermittent.

State now lives in a small JSON store in the persistent volume, one file per pull with `flock` around read-modify-write, following the `deployment_store.py` pattern already used for deployments. If the volume isn't writable it falls back to per-process memory, so the degraded case is no worse than today rather than making every pull look orphaned.

The rest is about reporting an interrupted pull honestly, and using telemetry the UI already receives but discarded.

- [x] Durable cross-process pull store — fixes the `--workers 4` sharding
- [x] Detect a pull whose owner died instead of reporting "pulling" forever
- [x] Stall detection when the pull backend stops answering, instead of looping the full 2h at 0%
- [x] Reconcile an unknown pull against reality before calling it a failure, and release the chip slot its placeholder was holding
- [x] Give the orphan response a message — it was the only terminal branch in `DeploymentProgressView` without one
- [x] 90s `not_found` grace in the Voice Agent poller, matching `useDeploymentProgress` and `useActiveDeployments`
- [x] Attach to an in-flight pull of the same image rather than starting a second one — speech-to-text and text-to-speech share `tt-media-inference-server` and were pulling it twice
- [x] Show the bytes/speed/layers the backend already sends, and withhold the ETA until it stabilises (a pull that finished in 16 min was projecting 106 min at 5%)
- [x] Refetch device occupancy on focus and after deploys, so the Deploy button can't stay disabled against stale state and silently swallow clicks
- [x] "View logs" resolves `imgpull_` ids instead of 404ing
- [x] 12 new tests, including cross-process visibility and concurrent writers
- [x] Verified against a running backend: an entry written by a separate process is served correctly through the HTTP API (49%, bytes, speed, layers) where the old code returned `not_found`; orphaned and stalled pulls both return actionable messages
- [x] tsc + eslint clean; ruff unchanged from baseline (11 pre-existing findings before and after)

One thing I deliberately did not change: `image_exists` failing open to an inline deploy. That is `image_pull`'s stated design rule — never block a deploy — so I only made the log say what the user loses (the progress bar).