### PR TITLE
fix: remove Z-Image-Turbo from the model catalog

### DIFF
--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.20.0",
     "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 60,
+  "total_models": 59,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -1433,23 +1433,6 @@
       "inference_artifact_ref": {
         "P300x2": "tt-studio/qwen3.8-27b-p300x2"
       }
-    },
-    {
-      "model_name": "Z-Image-Turbo",
-      "model_type": "IMAGE_GENERATION",
-      "display_model_type": "IMAGE",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "Tongyi-MAI/Z-Image-Turbo",
-      "inference_engine": "media",
-      "status": "FUNCTIONAL",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
-      "service_route": "/v1/images/generations",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
     }
   ]
 }

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -55,6 +55,14 @@ HAND_OWNED_KEYS = ("requires_dev_catalog", "inference_artifact_ref", "hand_owned
 # first name match, so keeping both would make them pick arbitrarily.
 HAND_OWNED_MARKER = "hand_owned"
 
+# Models the source artifact advertises but that TT-Studio must not offer.
+# Filtered after merge_hand_owned() so a resync can't reintroduce them.
+# Z-Image-Turbo: wedges Blackhole P300 devices during warmup (eth-core init
+# timeout or a hard device hang mid kernel-compile) hard enough that the host
+# needs a board reset; pull it from the catalog until the media image ships a
+# tt-metal/firmware combo validated on fw 19.7.0.
+EXCLUDED_MODEL_NAMES = {"Z-Image-Turbo"}
+
 
 def _impl_selector(value):
     """Reduce tt-inference-server's impl object to the string its endpoints match on.
@@ -474,6 +482,11 @@ def main():
     for _m in models:
         if "impl" in _m:
             _m["impl"] = _impl_selector(_m.get("impl"))
+
+    excluded = [m["model_name"] for m in models if m["model_name"] in EXCLUDED_MODEL_NAMES]
+    if excluded:
+        models = [m for m in models if m["model_name"] not in EXCLUDED_MODEL_NAMES]
+        print(f"Excluded {len(excluded)} model(s): {', '.join(excluded)}")
 
     if preserved:
         print(f"Preserved {len(preserved)} hand-set field(s): {', '.join(preserved)}")


### PR DESCRIPTION
Z-Image-Turbo deploys wedge Blackhole P300 devices during warmup — one attempt died at device init (eth-core 24-25 timeout), the next hard-hung the board mid kernel-compile badly enough that `tt-smi` timed out on the host and the chips needed a board reset. Until the media image ships a tt-metal/firmware combo validated on fw 19.7.0, the model shouldn't be offered.

- [x] Drop the Z-Image-Turbo entry from `models_from_inference_server.json`
- [x] Add `EXCLUDED_MODEL_NAMES` to the sync script so a resync can't reintroduce it (verified: resync against the 0.20 artifact prints "Excluded 1 model(s): Z-Image-Turbo" and the entry stays gone)
- [x] `test_sync_models.py` — 30 passed