### PR TITLE
docs: refresh the tt_setup module map and cross-link the CLI skills

### DIFF
--- a/.claude/skills/cli-design/SKILL.md
+++ b/.claude/skills/cli-design/SKILL.md
@@ -47,7 +47,9 @@ python3 reference/cli_skeleton.py --help   # the command surface  (then: no flag
 | `reference/test_cli_output.py` | copy into `tests/`: pure helpers, stream parsing, PTY + non-TTY render checks |
 
 Reference implementation in the wild: TT-Studio's `tt_setup/` (+ its house-rules doc
-`dev-docs/launcher-terminal-design.md`).
+`dev-docs/launcher-terminal-design.md`). When you're working in this repo, the
+companion **`tt-studio-cli`** skill has the concrete mechanics — package map, flag
+plumbing, hardware detection.
 
 ---
 

--- a/.claude/skills/tt-studio-cli/SKILL.md
+++ b/.claude/skills/tt-studio-cli/SKILL.md
@@ -22,6 +22,10 @@ deprecated.
 > Read this before touching the launcher. For the terminal-output design system
 > specifically, `dev-docs/launcher-terminal-design.md` is the canonical reference —
 > this skill covers the broader "how the launcher is built and how we like CLIs."
+>
+> This skill is TT-Studio-specific — it names real paths, modules and hardware in
+> this repo. The same design language with nothing repo-specific in it, plus runnable
+> reference files, is the **`cli-design`** skill; use that one for any other CLI.
 
 ## Architecture
 
@@ -39,7 +43,7 @@ The package is split into focused **subpackages**, each with an `__init__.py` th
 | Inference-server artifact | `inference_server/` (`_catalog`, `_config`, `_env`, `_git`, `_metadata`, `_privileges`, `_orchestrator`) |
 | Stop / purge teardown | `cleanup/` (`_runtime`, `_orchestrate`, `_resource_ops`) |
 | Docker build/failure diag | `docker_diag/` (`_build_progress`, `_diagnostics`) |
-| Standalone modules | `bootstrap.py`, `shell.py`, `startup_checks.py`, `docker.py`, `constants.py`, `logging.py`, `monitor.py`/`monitor_app.py` (`--status` TUI), `bug_report.py` (`--report-bug`), `shortcut.py` (`--install-shortcut`), `spdx.py`, `settings.py`, `venv_utils.py` |
+| Standalone modules | `bootstrap.py`, `shell.py`, `startup_checks.py`, `docker.py`, `constants.py`, `logging.py`, `monitor.py`/`monitor_app.py` (`--status` TUI), `bug_report.py` (`--report-bug`), `shortcut.py` (`--install-shortcut`), `switch.py` (`--switch`), `image_source.py` (prebuilt-vs-local image choice), `config_store.py`, `spdx.py`, `settings.py`, `venv_utils.py` |
 
 **The re-export rule.** A package's `__init__.py` imports and re-exports the names
 its submodules define, so `from tt_setup.console import step` and


### PR DESCRIPTION
The `tt-studio-cli` skill's file map had fallen behind `tt_setup/` — it was missing `switch.py`, `image_source.py` and `config_store.py`. That matters because the skill tells readers to "treat this skill's table as the current layout," so the stale row was actively misleading.

Also links the two CLI skills to each other. They cover complementary ground — `cli-design` is the repo-neutral design language, `tt-studio-cli` is the mechanics for this repo — but neither mentioned the other, so a reader of one never learned the other existed.

- [x] Add the three missing modules to the standalone-modules row
- [x] Note in `tt-studio-cli` that it's TT-Studio-specific, and point at `cli-design` for other repos
- [x] Point `cli-design` at `tt-studio-cli` for the concrete mechanics
- [x] Verified: frontmatter parses and `name` matches each directory; every module named in the map exists in `tt_setup/`, and no top-level `tt_setup` module is omitted (16/16 in sync); both cross-referenced skill directories exist

Docs-only, so app endpoint checks are N/A — no launcher code changed.

Both skills were also packaged for the DX team marketplace (tenstorrent/dx-team#3); this keeps that copy and this one from diverging.