### PR TITLE
fix: don't block ungated model deploys when no HF token is saved

### DIFF
--- a/app/backend/api/hf_access.py
+++ b/app/backend/api/hf_access.py
@@ -49,6 +49,11 @@ def check_hf_repos(token: str, repos: List[str]) -> List[Dict]:
 
     Mirrors DeployView's gate, including its model_index.json retry: diffusers
     repos have no root config.json, so a gated one would read as "error".
+
+    Works without a token too: public repos answer 200 anonymously, so an
+    ungated model reads "granted" even with nothing saved. An anonymous
+    401/403 means the repo is gated and no token exists — that's "no_token",
+    not a bad credential.
     """
     labels = {repo: label for repo, label, _ in HF_GATED_MODELS}
     results: List[Dict] = []
@@ -56,10 +61,13 @@ def check_hf_repos(token: str, repos: List[str]) -> List[Dict]:
         code = _check_repo(token, repo)
         if code == 404:
             code = _check_repo(token, repo, "model_index.json")
+        status = _status_from_code(code)
+        if not token and status in ("auth_failed", "denied"):
+            status = "no_token"
         results.append({
             "label": labels.get(repo, repo.split("/")[-1]),
             "repo": repo,
-            "status": _status_from_code(code),
+            "status": status,
             "http_status": code,
             "url": f"https://huggingface.co/{repo}",
         })

--- a/app/backend/api/tests.py
+++ b/app/backend/api/tests.py
@@ -106,3 +106,45 @@ class SettingsViewGetTests(SimpleTestCase):
         tts = response.data["tts_api_key"]
         self.assertFalse(tts["editable"])
         self.assertIsNone(tts["value"])
+
+
+@patch("api.views.get_hf_token", return_value="")
+class HfCheckViewNoTokenTests(SimpleTestCase):
+    """With no token saved, explicit repos are still checked anonymously so
+    public (ungated) models don't get falsely blocked from deploying."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    @patch("api.hf_access._check_repo", return_value=200)
+    def test_public_repo_is_granted_without_token(self, _repo_mock, _token_mock):
+        response = self.client.post(
+            "/settings/hf-check/", {"repos": ["Qwen/Qwen3.5-9B"]}, format="json"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["ok"])
+        self.assertEqual(response.data["results"][0]["status"], "granted")
+
+    @patch("api.hf_access._check_repo", return_value=401)
+    def test_gated_repo_reads_no_token_not_auth_failed(self, _repo_mock, _token_mock):
+        # Anonymous 401 means "gated and no token saved", not a bad credential.
+        response = self.client.post(
+            "/settings/hf-check/",
+            {"repos": ["meta-llama/Llama-3.1-8B-Instruct"]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["ok"])
+        self.assertEqual(response.data["results"][0]["status"], "no_token")
+
+    def test_default_gated_set_short_circuits_without_network(self, _token_mock):
+        # No repos requested: keep the old behavior — the default set is all
+        # gated, so answer no_token for each without calling Hugging Face.
+        with patch("api.hf_access._check_repo") as repo_mock:
+            response = self.client.post("/settings/hf-check/", {}, format="json")
+        repo_mock.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["ok"])
+        self.assertTrue(
+            all(r["status"] == "no_token" for r in response.data["results"])
+        )

--- a/app/backend/api/views.py
+++ b/app/backend/api/views.py
@@ -143,8 +143,15 @@ class HfCheckView(APIView):
             for r in (raw_repos or [])
             if isinstance(r, str) and r.strip()
         ][: self.MAX_REPOS]
+        # With explicit repos, check them even without a token: public repos
+        # answer 200 anonymously, so ungated models (Qwen, Wan, …) must not be
+        # reported as blocked just because no token is saved yet.
+        if not token and repos:
+            results = check_hf_repos("", repos)
+            ok = all(r["status"] == "granted" for r in results)
+            return Response({"ok": ok, "results": results})
         if not token:
-            no_token_repos = repos or [repo for repo, _label, _f in HF_GATED_MODELS]
+            no_token_repos = [repo for repo, _label, _f in HF_GATED_MODELS]
             labels = {repo: label for repo, label, _f in HF_GATED_MODELS}
             return Response(
                 {


### PR DESCRIPTION
With no HF token saved, the deploy step's access check marked every model's repo as blocked without ever asking Hugging Face, so public models like Qwen3.5-9B showed "Hugging Face Access Required" and couldn't be deployed. Public repos answer 200 to anonymous requests, so a token isn't needed for them.

- [x] Check explicitly requested repos anonymously when no token is saved; public repos read granted, gated ones read no_token (an anonymous 401 is a missing token, not a bad credential)
- [x] Welcome-flow default check (all-gated set) keeps its no-network short-circuit
- [x] Added HfCheckView tests; full `manage.py test api` passes
- [x] Verified against the live dev stack: `/settings/hf-check/` now returns granted for Qwen/Qwen3.5-9B and no_token for meta-llama/Llama-3.1-8B-Instruct with no token saved