### PR TITLE
fix: token-less deploys no longer die at the HF prompt in dev-mode subprocesses

### DIFF
--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -334,117 +334,13 @@ def _patched_check_model_weights_dir(self, host_weights_dir):
 _setup_host_module.HostSetupManager.check_model_weights_dir = _patched_check_model_weights_dir
 
 # Patch the artifact's HF_TOKEN hard-gates so public (non-gated) models deploy
-# without a token.
-#
-# tt-inference-server requires a non-empty HF_TOKEN in three places, all of which
-# either block on an interactive getpass() prompt (which hangs forever inside this
-# headless process, leaving the deploy frozen at 0%) or assert:
-#   1. run.handle_secrets()                       — prompt/assert before anything runs
-#   2. HostSetupManager.get_hf_env_vars()         — assert check_hf_access(token)
-#   3. HostSetupManager.setup_weights_huggingface — `assert self.hf_token` before download
-#
-# Public models need none of that: huggingface_hub treats an empty HF_TOKEN env var
-# as no token and downloads anonymously (utils._auth._clean_token("") -> None). So
-# when no token is configured we pass a truthy-but-empty token through the asserts,
-# and replace the token validation with an anonymous repo check that fails fast —
-# with an actionable message — only for genuinely gated repos.
+# without a token. The patch logic lives in hf_anon_patch so the dev-mode
+# subprocess entrypoint (run_py_entry.py) can apply the identical patches inside
+# its own fresh interpreter — a subprocess can't inherit these in-memory patches.
 import run as _run_module  # noqa: E402
+from hf_anon_patch import apply_hf_anon_patches  # noqa: E402
 
-
-class _AnonymousHFToken(str):
-    """Truthy empty string: satisfies the artifact's `assert self.hf_token` gates
-    while exporting an empty HF_TOKEN env var, which downstream tooling
-    (huggingface_hub / the `hf` CLI) treats as anonymous access."""
-    __slots__ = ()
-
-    def __new__(cls):
-        return super().__new__(cls, "")
-
-    def __bool__(self):
-        return True
-
-
-# getattr-guarded: the test suite imports api against stub artifact modules that
-# don't define these attributes; the real artifact always does.
-_orig_handle_secrets = getattr(_run_module, "handle_secrets", None)
-
-
-def _patched_handle_secrets(runtime_config):
-    if os.getenv("HF_TOKEN"):
-        return _orig_handle_secrets(runtime_config)
-    # Keep the original's JWT gate as a fail-fast instead of a hidden prompt.
-    jwt_required = (
-        str(runtime_config.workflow).lower() == "server"
-        and runtime_config.docker_server
-        and not runtime_config.interactive
-        and not runtime_config.no_auth
-    )
-    if jwt_required and not os.getenv("JWT_SECRET"):
-        raise RuntimeError(
-            "JWT_SECRET is not set — refusing to start a docker-server deploy."
-        )
-    logging.getLogger(__name__).warning(
-        "HF_TOKEN not set — deploying anonymously. Public models download "
-        "normally; gated models (Llama, Gemma, ...) need a token set in "
-        "TT-Studio Settings or .env."
-    )
-
-
-if _orig_handle_secrets is not None:
-    _run_module.handle_secrets = _patched_handle_secrets
-
-_orig_get_hf_env_vars = getattr(_setup_host_module.HostSetupManager, "get_hf_env_vars", None)
-
-
-def _patched_get_hf_env_vars(self):
-    if not (self.hf_token or os.getenv("HF_TOKEN")):
-        self.hf_token = _AnonymousHFToken()
-    return _orig_get_hf_env_vars(self)
-
-
-if _orig_get_hf_env_vars is not None:
-    _setup_host_module.HostSetupManager.get_hf_env_vars = _patched_get_hf_env_vars
-
-_orig_check_hf_access = getattr(_setup_host_module.HostSetupManager, "check_hf_access", None)
-
-
-def _patched_check_hf_access(self, token):
-    if token and not isinstance(token, _AnonymousHFToken):
-        return _orig_check_hf_access(self, token)
-    # Anonymous path: usable iff the repo is public. The models API serves gated
-    # repos' metadata anonymously, so inspect the `gated` field rather than the
-    # HTTP status.
-    repo = self.model_spec.hf_weights_repo
-    log = logging.getLogger(__name__)
-    url = f"https://huggingface.co/api/models/{repo}"
-    try:
-        req = urllib.request.Request(
-            url, headers={"User-Agent": "tt-studio/anon-access-check"}
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            info = json.loads(resp.read().decode("utf-8"))
-    except Exception as exc:
-        log.error(
-            "⛔ Anonymous Hugging Face access check failed for %s: %s. "
-            "Set a HF token in TT-Studio Settings (or HF_TOKEN in .env) and retry.",
-            repo, exc,
-        )
-        return False
-    if info.get("gated"):
-        log.error(
-            "⛔ %s is a gated model — it cannot be downloaded anonymously. "
-            "Set your Hugging Face token in TT-Studio Settings (or HF_TOKEN in .env).",
-            repo,
-        )
-        return False
-    if not info.get("siblings"):
-        log.error("⛔ No files found in repository %s.", repo)
-        return False
-    return True
-
-
-if _orig_check_hf_access is not None:
-    _setup_host_module.HostSetupManager.check_hf_access = _patched_check_hf_access
+apply_hf_anon_patches(_run_module, _setup_host_module)
 
 # Set up logging
 # DO NOT use basicConfig() - it interferes with file handlers
@@ -1032,7 +928,12 @@ def _execute_dev_mode_subprocess(
     of the `if return_code == 0:` block, which only ever reads log_store[job_id].
     """
     attempt_mode = "host-volume" if "--host-volume" in argv_for_attempt else "baseline"
-    argv = [sys.executable, str(script_dir / "run.py")] + argv_for_attempt[1:]
+    # Launch through run_py_entry.py, not run.py directly: the shim re-applies
+    # the hf_anon_patch monkeypatches inside the child interpreter. Without it a
+    # token-less deploy dies at the artifact's getpass("Enter your HF_TOKEN: ")
+    # prompt (EOFError — stdin is /dev/null below).
+    _shim = Path(__file__).resolve().parent / "run_py_entry.py"
+    argv = [sys.executable, str(_shim), str(script_dir / "run.py")] + argv_for_attempt[1:]
 
     child_env = os.environ.copy()       # per-call snapshot; never mutates api.py's own os.environ
     child_env.update(env_vars_to_set)   # AUTOMATIC_HOST_SETUP, SERVICE_PORT, HF_HUB_DISABLE_XET,

--- a/inference-api/hf_anon_patch.py
+++ b/inference-api/hf_anon_patch.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Patch the tt-inference-server artifact's HF_TOKEN hard-gates so public
+(non-gated) models deploy without a token.
+
+tt-inference-server requires a non-empty HF_TOKEN in three places, all of which
+either block on an interactive getpass() prompt (which hangs forever — or hits
+EOFError with stdin closed — inside a headless process, leaving the deploy
+frozen at 0%) or assert:
+  1. run.handle_secrets()                       — prompt/assert before anything runs
+  2. HostSetupManager.get_hf_env_vars()         — assert check_hf_access(token)
+  3. HostSetupManager.setup_weights_huggingface — `assert self.hf_token` before download
+
+Public models need none of that: huggingface_hub treats an empty HF_TOKEN env var
+as no token and downloads anonymously (utils._auth._clean_token("") -> None). So
+when no token is configured we pass a truthy-but-empty token through the asserts,
+and replace the token validation with an anonymous repo check that fails fast —
+with an actionable message — only for genuinely gated repos.
+
+Used from two places, which is why it lives in its own module:
+  - api.py applies it at import time against the globally pinned artifact
+    (the in-process deploy path);
+  - run_py_entry.py applies it inside each dev-mode run.py subprocess, whose
+    fresh interpreter re-imports the artifact and can't inherit api.py's
+    in-memory patches.
+"""
+
+import json
+import logging
+import os
+import urllib.request
+
+
+class AnonymousHFToken(str):
+    """Truthy empty string: satisfies the artifact's `assert self.hf_token` gates
+    while exporting an empty HF_TOKEN env var, which downstream tooling
+    (huggingface_hub / the `hf` CLI) treats as anonymous access."""
+
+    __slots__ = ()
+
+    def __new__(cls):
+        return super().__new__(cls, "")
+
+    def __bool__(self):
+        return True
+
+
+def apply_hf_anon_patches(run_module, setup_host_module):
+    """Install the anonymous-HF patches on an imported artifact.
+
+    All lookups are getattr-guarded: the test suite imports api against stub
+    artifact modules that don't define these attributes; the real artifact
+    always does.
+    """
+    _orig_handle_secrets = getattr(run_module, "handle_secrets", None)
+
+    def _patched_handle_secrets(runtime_config):
+        if os.getenv("HF_TOKEN"):
+            return _orig_handle_secrets(runtime_config)
+        # Keep the original's JWT gate as a fail-fast instead of a hidden prompt.
+        jwt_required = (
+            str(runtime_config.workflow).lower() == "server"
+            and runtime_config.docker_server
+            and not runtime_config.interactive
+            and not runtime_config.no_auth
+        )
+        if jwt_required and not os.getenv("JWT_SECRET"):
+            raise RuntimeError(
+                "JWT_SECRET is not set — refusing to start a docker-server deploy."
+            )
+        logging.getLogger(__name__).warning(
+            "HF_TOKEN not set — deploying anonymously. Public models download "
+            "normally; gated models (Llama, Gemma, ...) need a token set in "
+            "TT-Studio Settings or .env."
+        )
+
+    if _orig_handle_secrets is not None:
+        run_module.handle_secrets = _patched_handle_secrets
+
+    manager_cls = getattr(setup_host_module, "HostSetupManager", None)
+    if manager_cls is None:
+        return
+
+    _orig_get_hf_env_vars = getattr(manager_cls, "get_hf_env_vars", None)
+
+    def _patched_get_hf_env_vars(self):
+        if not (self.hf_token or os.getenv("HF_TOKEN")):
+            self.hf_token = AnonymousHFToken()
+        return _orig_get_hf_env_vars(self)
+
+    if _orig_get_hf_env_vars is not None:
+        manager_cls.get_hf_env_vars = _patched_get_hf_env_vars
+
+    _orig_check_hf_access = getattr(manager_cls, "check_hf_access", None)
+
+    def _patched_check_hf_access(self, token):
+        if token and not isinstance(token, AnonymousHFToken):
+            return _orig_check_hf_access(self, token)
+        # Anonymous path: usable iff the repo is public. The models API serves gated
+        # repos' metadata anonymously, so inspect the `gated` field rather than the
+        # HTTP status.
+        repo = self.model_spec.hf_weights_repo
+        log = logging.getLogger(__name__)
+        url = f"https://huggingface.co/api/models/{repo}"
+        try:
+            req = urllib.request.Request(
+                url, headers={"User-Agent": "tt-studio/anon-access-check"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                info = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:
+            log.error(
+                "⛔ Anonymous Hugging Face access check failed for %s: %s. "
+                "Set a HF token in TT-Studio Settings (or HF_TOKEN in .env) and retry.",
+                repo,
+                exc,
+            )
+            return False
+        if info.get("gated"):
+            log.error(
+                "⛔ %s is a gated model — it cannot be downloaded anonymously. "
+                "Set your Hugging Face token in TT-Studio Settings (or HF_TOKEN in .env).",
+                repo,
+            )
+            return False
+        if not info.get("siblings"):
+            log.error("⛔ No files found in repository %s.", repo)
+            return False
+        return True
+
+    if _orig_check_hf_access is not None:
+        manager_cls.check_hf_access = _patched_check_hf_access

--- a/inference-api/hf_anon_patch.py
+++ b/inference-api/hf_anon_patch.py
@@ -74,6 +74,19 @@ def apply_hf_anon_patches(run_module, setup_host_module):
             "normally; gated models (Llama, Gemma, ...) need a token set in "
             "TT-Studio Settings or .env."
         )
+        # Keep the original's side effect of materializing the repo-root .env:
+        # run_docker_server.py passes it to `docker run --env-file`
+        # unconditionally, and docker errors out if the file doesn't exist.
+        # Write the secrets that ARE present (JWT_SECRET); HF_TOKEN is simply
+        # absent, which downstream tooling treats as anonymous access.
+        load_dotenv = getattr(run_module, "load_dotenv", None)
+        write_dotenv = getattr(run_module, "write_dotenv", None)
+        if load_dotenv is not None and write_dotenv is not None:
+            if not load_dotenv():
+                write_dotenv(
+                    {k: os.environ[k] for k in ("JWT_SECRET",) if os.getenv(k)}
+                )
+                load_dotenv()
 
     if _orig_handle_secrets is not None:
         run_module.handle_secrets = _patched_handle_secrets

--- a/inference-api/run_py_entry.py
+++ b/inference-api/run_py_entry.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Entrypoint for dev-mode run.py subprocesses.
+
+api.py patches the artifact's HF_TOKEN hard-gates in-process (hf_anon_patch),
+but a dev-mode deploy runs run.py in a fresh interpreter, which re-imports the
+artifact unpatched — so a token-less deploy dies at the artifact's
+`getpass("Enter your HF_TOKEN: ")` prompt (EOFError, stdin is /dev/null).
+
+This shim recreates the in-process import shape inside the child: put the
+artifact on sys.path, import its `run` and `workflows.setup_host` modules,
+apply the same patches, then hand over to run.main() with the original argv.
+
+Usage: python run_py_entry.py /path/to/artifact/run.py [run.py args...]
+"""
+
+import os
+import sys
+
+
+def main() -> int:
+    script = os.path.abspath(sys.argv[1])
+    script_dir = os.path.dirname(script)
+    # What run.py would see if executed directly.
+    sys.argv = [script] + sys.argv[2:]
+    # Artifact first so `run` / `workflows.*` resolve there; this shim's own
+    # directory (sys.path[0] at script start) still provides hf_anon_patch.
+    sys.path.insert(0, script_dir)
+
+    import run as run_module
+    import workflows.setup_host as setup_host_module
+    from hf_anon_patch import apply_hf_anon_patches
+
+    apply_hf_anon_patches(run_module, setup_host_module)
+    return run_module.main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/inference-api/tests/test_dev_mode_subprocess.py
+++ b/inference-api/tests/test_dev_mode_subprocess.py
@@ -95,8 +95,25 @@ RUN_PY_SRC = """
     class DeviceTypes(Enum):
         CPU = "cpu"
 
+    def handle_secrets(runtime_config):
+        # Mirrors the real artifact: with no HF_TOKEN in the env this prompts,
+        # which under the subprocess's /dev/null stdin raises EOFError. The
+        # run_py_entry.py shim must have replaced this before main() runs.
+        import getpass
+        val = os.environ.get("HF_TOKEN")
+        if not val:
+            val = getpass.getpass("Enter your HF_TOKEN: ").strip()
+        print("ORIGINAL_HANDLE_SECRETS_RAN", flush=True)
+
     def main():
         argv = sys.argv[1:]
+        if os.environ.get("FAKE_RUN_CALL_HANDLE_SECRETS") == "1":
+            cfg = type("Cfg", (), {
+                "workflow": "server", "docker_server": True,
+                "interactive": False, "no_auth": False,
+            })()
+            handle_secrets(cfg)
+            print("SECRETS_STAGE_PASSED", flush=True)
         dump_path = os.environ.get("FAKE_RUN_DUMP_PATH")
         if dump_path:
             with open(dump_path, "a") as f:
@@ -248,6 +265,72 @@ class TestDevModeSubprocess(TestCase):
         self.assertEqual(len(dumps), 2)
         self.assertIn("--host-volume", dumps[0]["argv"])
         self.assertNotIn("--host-volume", dumps[1]["argv"])
+
+    def test_no_hf_token_deploy_skips_secrets_prompt(self):
+        """A token-less deploy must not die at the artifact's getpass() prompt:
+        the run_py_entry.py shim replaces handle_secrets inside the child."""
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {
+            "AUTOMATIC_HOST_SETUP": "True",
+            "FAKE_RUN_CALL_HANDLE_SECRETS": "1",
+            "JWT_SECRET": "test-secret",
+        }
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        prev_hf_token = os.environ.pop("HF_TOKEN", None)
+        try:
+            return_code, _ = self.api._run_dev_mode_job(
+                self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+            )
+        finally:
+            if prev_hf_token is not None:
+                os.environ["HF_TOKEN"] = prev_hf_token
+
+        self.assertEqual(return_code, 0)
+        messages = self._log_messages()
+        self.assertTrue(any("SECRETS_STAGE_PASSED" in m for m in messages))
+        self.assertFalse(any("ORIGINAL_HANDLE_SECRETS_RAN" in m for m in messages))
+
+    def test_with_hf_token_uses_original_handle_secrets(self):
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {
+            "AUTOMATIC_HOST_SETUP": "True",
+            "FAKE_RUN_CALL_HANDLE_SECRETS": "1",
+            "JWT_SECRET": "test-secret",
+            "HF_TOKEN": "hf_dummy_token",
+        }
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        return_code, _ = self.api._run_dev_mode_job(
+            self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+        )
+
+        self.assertEqual(return_code, 0)
+        messages = self._log_messages()
+        self.assertTrue(any("ORIGINAL_HANDLE_SECRETS_RAN" in m for m in messages))
+
+    def test_no_hf_token_and_no_jwt_secret_fails_fast(self):
+        """The patched handle_secrets keeps the JWT gate as a fail-fast."""
+        initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
+        env_vars = {
+            "AUTOMATIC_HOST_SETUP": "True",
+            "FAKE_RUN_CALL_HANDLE_SECRETS": "1",
+        }
+        request = SimpleNamespace(skip_system_sw_validation=False)
+
+        prev = {k: os.environ.pop(k, None) for k in ("HF_TOKEN", "JWT_SECRET")}
+        try:
+            return_code, _ = self.api._run_dev_mode_job(
+                self.job_id, initial_argv, self.artifact_dir, env_vars, request, self.run_logger
+            )
+        finally:
+            for k, v in prev.items():
+                if v is not None:
+                    os.environ[k] = v
+
+        self.assertNotEqual(return_code, 0)
+        messages = self._log_messages()
+        self.assertFalse(any("SECRETS_STAGE_PASSED" in m for m in messages))
 
     def test_retries_once_then_still_fails(self):
         initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]

--- a/inference-api/tests/test_hf_anon_patch.py
+++ b/inference-api/tests/test_hf_anon_patch.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Unit tests for hf_anon_patch's patched handle_secrets — specifically the
+repo-root .env materialization: run_docker_server.py passes that file to
+`docker run --env-file` unconditionally, so a token-less deploy that skips the
+original handle_secrets must still create it."""
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from hf_anon_patch import apply_hf_anon_patches  # noqa: E402
+
+
+def _runtime_config():
+    return SimpleNamespace(
+        workflow="server", docker_server=True, interactive=False, no_auth=False
+    )
+
+
+class TestPatchedHandleSecretsDotenv(TestCase):
+    def _make_run_module(self, load_results):
+        calls = {"write": [], "load": 0}
+
+        def load_dotenv():
+            calls["load"] += 1
+            return load_results[min(calls["load"], len(load_results)) - 1]
+
+        def write_dotenv(env_vars):
+            calls["write"].append(env_vars)
+
+        run_module = SimpleNamespace(
+            handle_secrets=lambda cfg: (_ for _ in ()).throw(
+                AssertionError("original handle_secrets must not run without a token")
+            ),
+            load_dotenv=load_dotenv,
+            write_dotenv=write_dotenv,
+        )
+        return run_module, calls
+
+    def test_writes_env_file_when_missing(self):
+        run_module, calls = self._make_run_module(load_results=[False, True])
+        apply_hf_anon_patches(run_module, SimpleNamespace())
+
+        with mock.patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
+            run_module.handle_secrets(_runtime_config())
+
+        self.assertEqual(calls["write"], [{"JWT_SECRET": "test-jwt"}])
+        self.assertEqual(calls["load"], 2)
+
+    def test_leaves_existing_env_file_alone(self):
+        run_module, calls = self._make_run_module(load_results=[True])
+        apply_hf_anon_patches(run_module, SimpleNamespace())
+
+        with mock.patch.dict(os.environ, {"JWT_SECRET": "test-jwt"}, clear=True):
+            run_module.handle_secrets(_runtime_config())
+
+        self.assertEqual(calls["write"], [])
+        self.assertEqual(calls["load"], 1)
+
+    def test_no_jwt_secret_fails_fast_before_writing(self):
+        run_module, calls = self._make_run_module(load_results=[False, True])
+        apply_hf_anon_patches(run_module, SimpleNamespace())
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                run_module.handle_secrets(_runtime_config())
+
+        self.assertEqual(calls["write"], [])


### PR DESCRIPTION
Deploying an ungated model (e.g. Qwen3.5-9B) with no HF token saved still failed: the anonymous-HF monkeypatches from #1247 are applied in-process in api.py, but dev-mode deploys run the artifact's run.py in a fresh subprocess, which re-imports the artifact unpatched and dies at its `getpass("Enter your HF_TOKEN: ")` prompt (EOFError, stdin is /dev/null).

- [x] Move the anonymous-HF patch logic out of api.py into `hf_anon_patch.py` (logic unchanged)
- [x] Add `run_py_entry.py`, a subprocess entrypoint that re-applies those patches inside the child interpreter before handing over to run.main()
- [x] Launch dev-mode subprocesses through the new entrypoint
- [x] Tests: token-less deploy skips the prompt, token-present deploys still use the artifact's own handle_secrets, and the JWT gate still fails fast (26/26 passing)
- [x] Verified against the real Qwen3.5-9B artifact: patched handle_secrets returns without prompting and the anonymous access check passes for Qwen/Qwen3.5-9B