### PR TITLE
fix: pre-create HF_HOME in the model volume for token-less media deploys

### DIFF
--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -2443,6 +2443,64 @@ def _acquire_run_lock(job_id: str) -> None:
                 entry["waiting_for_job_id"] = _active_run_job_id
 
 
+# Container-side cache root: matches setup_config.cache_root and
+# HF_HOME=<cache_root>/huggingface in the artifact's run_docker_server.py.
+_CONTAINER_CACHE_ROOT = "/home/container_app_user/cache_root"
+
+
+def _ensure_volume_hf_home(job_id, model, device, impl, initial_argv):
+    """Pre-create HF_HOME inside the model's docker volume for token-less deploys.
+
+    Workaround for tt-media-server's base_device_runner: when HF_TOKEN is unset,
+    its no-token warning check evaluates any(os.scandir(HF_HOME)) — and on a
+    fresh cache_root volume that directory doesn't exist yet, so the scan raises
+    FileNotFoundError and kills the device worker before weights ever load.
+    Creating the directory up front degrades the check to the warning it was
+    meant to be.
+
+    Runs a one-shot `mkdir -p` container with the deploy's own image (needed
+    anyway, so no extra pull) mounted at the same path the real server uses, so
+    a fresh volume is initialized with the image's ownership rather than root's.
+    Best-effort: any failure is logged and the deploy proceeds unchanged.
+    Remove once deployed media images carry the guarded-scandir fix upstream.
+    """
+    image = None
+    if "--override-docker-image" in initial_argv:
+        image = initial_argv[initial_argv.index("--override-docker-image") + 1]
+    try:
+        spec, _, _ = get_runtime_model_spec(model, device, impl=impl)
+        image = image or getattr(spec, "docker_image", None)
+        if not image:
+            logger.info(
+                "Job %s: no docker image known; skipping HF_HOME pre-create", job_id
+            )
+            return
+        # Same naming as the artifact's generate_docker_volume_name().
+        volume_name = f"volume_id_{spec.impl.impl_id}-{spec.model_name}"
+        client = docker.from_env()
+        hf_home = f"{_CONTAINER_CACHE_ROOT}/huggingface"
+        client.containers.run(
+            image,
+            # chmod 2775 to match the volume's other dirs (e.g. logs/): the
+            # server runs as container_app_user, whose write access to the
+            # root-owned volume comes through its root group membership.
+            entrypoint=["sh", "-c", f"mkdir -p {hf_home} && chmod 2775 {hf_home}"],
+            volumes={volume_name: {"bind": _CONTAINER_CACHE_ROOT, "mode": "rw"}},
+            remove=True,
+        )
+        logger.info(
+            "Job %s: ensured HF_HOME exists in docker volume %s (no HF token configured)",
+            job_id,
+            volume_name,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Job %s: could not pre-create HF_HOME in the model volume: %s",
+            job_id,
+            exc,
+        )
+
+
 @app.post("/run")
 async def run_inference(request: RunRequest):
     deployment_log_handler = None
@@ -2646,6 +2704,15 @@ async def run_inference(request: RunRequest):
                 else "using --host-volume"
             )
             logger.info("Job %s: skipping --host-hf-cache (%s)", job_id, reason)
+
+        # Token-less deploys: make sure the container's HF_HOME exists in the
+        # model's named volume (see _ensure_volume_hf_home). --host-volume mode
+        # bind-mounts cache_root from the host instead and never uses the volume.
+        if not env_vars_to_set.get("HF_TOKEN") and "--host-volume" not in initial_argv:
+            _ensure_volume_hf_home(
+                job_id, request.model, normalized_device, request.impl, initial_argv
+            )
+
         def _run_job_in_background():
             global _active_run_job_id
             weights_stop_event = threading.Event()

--- a/inference-api/tests/test_volume_hf_home.py
+++ b/inference-api/tests/test_volume_hf_home.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for _ensure_volume_hf_home — the token-less media-deploy workaround
+that pre-creates HF_HOME inside the model's docker volume so tt-media-server's
+no-token check (any(os.scandir(HF_HOME))) warns instead of crashing the worker."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _api():
+    return pytest.importorskip(
+        "api", reason="requires the tt-inference-server artifact on sys.path"
+    )
+
+
+def _spec(
+    impl_id="tt_transformers", model_name="Wan2.2-T2V-A14B-Diffusers", image=None
+):
+    return SimpleNamespace(
+        impl=SimpleNamespace(impl_id=impl_id), model_name=model_name, docker_image=image
+    )
+
+
+class TestEnsureVolumeHfHome:
+    def test_mkdir_runs_with_override_image_and_volume(self):
+        api = _api()
+        client = mock.Mock()
+        argv = ["run.py", "--override-docker-image", "ghcr.io/x/media:1"]
+        with mock.patch.object(
+            api, "get_runtime_model_spec", return_value=(_spec(), None, None)
+        ), mock.patch.object(api.docker, "from_env", return_value=client):
+            api._ensure_volume_hf_home(
+                "job1", "Wan2.2-T2V-A14B-Diffusers", "p300x2", None, argv
+            )
+
+        client.containers.run.assert_called_once()
+        args, kwargs = client.containers.run.call_args
+        assert args[0] == "ghcr.io/x/media:1"
+        assert kwargs["entrypoint"] == [
+            "sh",
+            "-c",
+            "mkdir -p /home/container_app_user/cache_root/huggingface"
+            " && chmod 2775 /home/container_app_user/cache_root/huggingface",
+        ]
+        assert kwargs["volumes"] == {
+            "volume_id_tt_transformers-Wan2.2-T2V-A14B-Diffusers": {
+                "bind": "/home/container_app_user/cache_root",
+                "mode": "rw",
+            }
+        }
+        assert kwargs["remove"] is True
+
+    def test_falls_back_to_spec_docker_image(self):
+        api = _api()
+        client = mock.Mock()
+        with mock.patch.object(
+            api,
+            "get_runtime_model_spec",
+            return_value=(_spec(image="ghcr.io/x/from-spec:2"), None, None),
+        ), mock.patch.object(api.docker, "from_env", return_value=client):
+            api._ensure_volume_hf_home(
+                "job2", "Wan2.2-T2V-A14B-Diffusers", "p300x2", None, ["run.py"]
+            )
+
+        assert client.containers.run.call_args[0][0] == "ghcr.io/x/from-spec:2"
+
+    def test_skips_when_no_image_known(self):
+        api = _api()
+        client = mock.Mock()
+        with mock.patch.object(
+            api, "get_runtime_model_spec", return_value=(_spec(image=None), None, None)
+        ), mock.patch.object(api.docker, "from_env", return_value=client):
+            api._ensure_volume_hf_home("job3", "SomeModel", "p150", None, ["run.py"])
+
+        client.containers.run.assert_not_called()
+
+    def test_spec_lookup_failure_is_nonfatal(self):
+        api = _api()
+        with mock.patch.object(
+            api, "get_runtime_model_spec", side_effect=ValueError("not in catalog")
+        ):
+            api._ensure_volume_hf_home("job4", "UnknownModel", "p150", None, ["run.py"])
+
+    def test_docker_failure_is_nonfatal(self):
+        api = _api()
+        client = mock.Mock()
+        client.containers.run.side_effect = RuntimeError("docker down")
+        argv = ["run.py", "--override-docker-image", "ghcr.io/x/media:1"]
+        with mock.patch.object(
+            api, "get_runtime_model_spec", return_value=(_spec(), None, None)
+        ), mock.patch.object(api.docker, "from_env", return_value=client):
+            api._ensure_volume_hf_home(
+                "job5", "Wan2.2-T2V-A14B-Diffusers", "p300x2", None, argv
+            )


### PR DESCRIPTION
Token-less Wan2.2 deploys reach the media container fine (after #1290) but the device worker dies at init: tt-media-server's base_device_runner warns about a missing HF_TOKEN by evaluating `any(os.scandir(HF_HOME))`, and on a fresh cache_root volume that directory doesn't exist yet — the scan raises FileNotFoundError and kills the worker before weights ever load.

This is the tt-studio-side workaround until deployed media images carry the upstream guard: before a token-less deploy, run a one-shot `mkdir -p && chmod 2775` container (the deploy's own image, so nothing extra is pulled) against the model's named volume so the check degrades to the warning it was meant to be. chmod 2775 matches the volume's other dirs — the server runs as container_app_user, which writes through its root group membership. Best-effort: any failure logs a warning and the deploy proceeds unchanged.

- [x] `_ensure_volume_hf_home` helper + call in the /run prep path, gated on no resolved HF token and named-volume mode
- [x] Unit tests for image selection, volume naming, and failure tolerance (28/28 suite passing)
- [x] Verified live on p300x2: applied the same one-shot container to the stuck Wan2.2 volume, restarted the container, and the worker got past init and proceeded to weight loading (previously it crashed instantly with `[Errno 2] ... cache_root/huggingface`)