### PR TITLE
feat: register external model containers not in catalog

### DIFF
--- a/app/backend/docker_control/deployment_store.py
+++ b/app/backend/docker_control/deployment_store.py
@@ -205,6 +205,8 @@ class _Manager:
                 "workflow_log_path": kwargs.get("workflow_log_path", None),
                 "tool_calling_enabled": kwargs.get("tool_calling_enabled", False),
                 "jwt_secret": kwargs.get("jwt_secret", None),
+                "model_type": kwargs.get("model_type", None),
+                "hf_model_id": kwargs.get("hf_model_id", None),
             }
             data["next_id"] += 1
             data["records"].append(record)
@@ -252,6 +254,11 @@ class ModelDeployment:
         self.failure_message: Optional[str] = None
         self.tool_calling_enabled: bool = False
         self.jwt_secret: Optional[str] = None   # Set for externally-registered containers only
+        # Identity derived from the container at registration time. Only set for
+        # externally-registered models, whose type/id cannot be recovered from the
+        # catalog. "unknown" means we could not identify what the container serves.
+        self.model_type: Optional[str] = None
+        self.hf_model_id: Optional[str] = None
 
     @classmethod
     def _from_dict(cls, d: dict) -> "ModelDeployment":
@@ -277,6 +284,8 @@ class ModelDeployment:
         obj.failure_message = d.get("failure_message")
         obj.tool_calling_enabled = d.get("tool_calling_enabled", False)
         obj.jwt_secret = d.get("jwt_secret")
+        obj.model_type = d.get("model_type")
+        obj.hf_model_id = d.get("hf_model_id")
         return obj
 
     def _to_dict(self) -> dict:
@@ -298,6 +307,8 @@ class ModelDeployment:
             "failure_message": self.failure_message,
             "tool_calling_enabled": self.tool_calling_enabled,
             "jwt_secret": self.jwt_secret,
+            "model_type": self.model_type,
+            "hf_model_id": self.hf_model_id,
         }
 
     def save(self) -> None:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -13,6 +13,7 @@ from django.core.cache import caches
 from shared_config.device_config import DeviceConfigurations
 from shared_config.logger_config import get_logger
 from shared_config.model_config import model_implmentations, _impl_selector
+from shared_config.external_model_config import build_external_model_impl
 from shared_config.backend_config import backend_config
 from shared_config.model_type_config import ModelTypes
 from shared_config.user_config import get_tavily_api_key
@@ -699,6 +700,23 @@ def get_managed_containers():
     containers_list = response.get("containers", []) if isinstance(response, dict) else []
 
     managed_images = set([impl.image_version for impl in model_implmentations.values()])
+
+    # Containers TT Studio was explicitly told about. An externally-registered
+    # container can run an arbitrary image with none of the env vars checked
+    # below (nothing forces it to be a tt-inference-server image), so without
+    # this it never appears in the listing and get_canonical_deployments
+    # reconciles its perfectly healthy record to "stopped".
+    registered_ids, registered_names = set(), set()
+    try:
+        for dep in ModelDeployment.objects.filter(status__in=["starting", "running"]):
+            if dep.container_id:
+                registered_ids.add(dep.container_id)
+                registered_ids.add(dep.container_id[:12])
+            if dep.container_name:
+                registered_names.add(dep.container_name)
+    except Exception as e:
+        logger.warning(f"Could not load registered containers: {e}")
+
     managed_containers = []
 
     for container_data in containers_list:
@@ -739,8 +757,14 @@ def get_managed_containers():
         # Method 1: Check if container uses a managed image (legacy models)
         if managed_images.intersection(set(container.image.tags)):
             managed_containers.append(container)
+        # Method 2: it has an active deployment record (deployed or registered by us)
+        elif (
+            (container.id and (container.id in registered_ids or container.id[:12] in registered_ids))
+            or (container.name and container.name in registered_names)
+        ):
+            managed_containers.append(container)
         else:
-            # Method 2: Check for TT Inference Server containers by environment variables
+            # Method 3: Check for TT Inference Server containers by environment variables
             # TT Inference Server containers have specific env vars like CACHE_ROOT, TT_CACHE_PATH
             env_list = container.attrs.get("Config", {}).get("Env", [])
             if not env_list:
@@ -849,6 +873,44 @@ def get_container_status():
     return data
 
 
+def _external_model_impl(con_id, con):
+    """Synthetic model_impl for a container registered via Register Model whose
+    model has no catalog entry. Returns None when the container was not
+    externally registered (so callers keep their existing "unmatched" behaviour).
+
+    The identity was derived from the container at registration time and stored on
+    the deployment record, so we don't have to re-inspect the container here.
+    """
+    try:
+        # Match on either id form: registration stores whatever id the caller
+        # passed (usually the short one), the live listing keys on the full one.
+        active = ModelDeployment.objects.filter(
+            device="external", status__in=["running", "starting"]
+        )
+        dep = (
+            active.filter(container_id__in=[con_id, con_id[:12]]).first()
+            or active.filter(container_name=con["name"]).first()
+        )
+    except Exception as e:
+        logger.warning(f"Could not look up external deployment for {con_id}: {e}")
+        return None
+    if dep is None:
+        return None
+
+    impl = build_external_model_impl(
+        model_name=dep.model_name or con["name"],
+        model_type=dep.model_type,
+        hf_model_id=dep.hf_model_id,
+        service_port=dep.port or 7000,
+        tool_calling_enabled=bool(getattr(dep, "tool_calling_enabled", False)),
+    )
+    logger.debug(
+        f"Using external model_impl for '{con['name']}' "
+        f"(type={impl.model_type.value}, not in catalog)"
+    )
+    return impl
+
+
 def _enrich_container_with_model_impl(con, con_id):
     """Resolve ``model_impl`` for a live Docker container and populate the
     derived fields (``model_id``, ``weights_id``, ``model_impl``,
@@ -933,6 +995,8 @@ def _enrich_container_with_model_impl(con, con_id):
                         )
 
                 if not model_impl:
+                    model_impl = _external_model_impl(con_id, con)
+                if not model_impl:
                     logger.warning(
                         f"Could not match TT Inference Server container {con['name']} to any model_impl."
                     )
@@ -949,11 +1013,14 @@ def _enrich_container_with_model_impl(con, con_id):
                     if v.image_version == con["image_name"]
                 ]
             if not candidates:
-                logger.warning(
-                    f"Cannot find model_impl for container {con['name']} with image {con['image_name']}"
-                )
-                return False
-            model_impl = candidates[0]
+                model_impl = _external_model_impl(con_id, con)
+                if not model_impl:
+                    logger.warning(
+                        f"Cannot find model_impl for container {con['name']} with image {con['image_name']}"
+                    )
+                    return False
+            else:
+                model_impl = candidates[0]
 
     con["model_id"] = model_impl.model_id
     con["weights_id"] = con["env_vars"].get("MODEL_WEIGHTS_ID")

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -941,7 +941,18 @@ def _enrich_container_with_model_impl(con, con_id):
             deployment_found = False
             try:
                 from docker_control.models import ModelDeployment
-                deployment = ModelDeployment.objects.filter(container_id=con_id).first()
+                # Match on either id form (records may hold the short id the
+                # caller passed) and fall back to the name. Registration does not
+                # rename the container, so the record is the only link between a
+                # container and the model it serves — this lookup has to be robust.
+                deployment = (
+                    ModelDeployment.objects.filter(
+                        container_id__in=[con_id, con_id[:12]]
+                    ).first()
+                    or ModelDeployment.objects.filter(
+                        container_name=con["name"]
+                    ).first()
+                )
 
                 if deployment:
                     for _k, v in model_implmentations.items():

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2704,9 +2704,16 @@ class RegisterExternalModelView(APIView):
                 except Exception as e:
                     logger.warning(f"Could not check HF model ID against catalog: {e}")
 
-            # Derive any remaining identity fields, then validate
+            # Derive any remaining identity fields, then settle on a model type
             if not model_type and hf_model_id:
                 model_type = _infer_model_type(hf_model_id)
+            if not model_type:
+                # No HF id to go on — fall back to the container's name/image.
+                model_type = _infer_model_type_from_container(container_info)
+                if model_type:
+                    corrections.append(
+                        f"Model type '{model_type}' inferred from the container image."
+                    )
             if not model_name:
                 model_name = (
                     hf_model_id.split("/")[-1]
@@ -2714,16 +2721,20 @@ class RegisterExternalModelView(APIView):
                     else (container_info.get("name") or container_id).lstrip("/")
                 )
 
-            if not model_type:
-                return Response(
-                    {"status": "error", "message": "Could not determine the model type from the container. Please specify model_type."},
-                    status=status.HTTP_400_BAD_REQUEST,
+            # An unidentifiable model is still registerable: it is tracked, shown
+            # with its status and manageable (logs/delete), just with no
+            # interaction UI. Only a type we can actually route is kept.
+            if model_type and model_type not in self._VALID_MODEL_TYPES and model_type != "mock":
+                corrections.append(
+                    f"Model type '{model_type}' is not one TT Studio can drive — "
+                    "registering it without an interaction page."
                 )
-            if model_type not in self._VALID_MODEL_TYPES and model_type != "mock":
-                valid_types = ", ".join(sorted(self._VALID_MODEL_TYPES))
-                return Response(
-                    {"status": "error", "message": f"Invalid model_type '{model_type}'. Valid types: {valid_types}"},
-                    status=status.HTTP_400_BAD_REQUEST,
+                model_type = ""
+            if not model_type:
+                model_type = "unknown"
+                corrections.append(
+                    "Could not determine what this container serves. It is registered "
+                    "for monitoring only — no chat/TTS page will be offered."
                 )
 
             # Record if the model was launched with tool-calling capability and
@@ -2796,12 +2807,18 @@ class RegisterExternalModelView(APIView):
             try:
                 from docker_control.models import ModelDeployment
 
-                # Check for duplicate registration
+                # Reuse any record already pointing at this container, whatever its
+                # status: re-registering the same container must revive its record
+                # rather than leave a stopped duplicate behind for every attempt.
                 existing = ModelDeployment.objects.filter(
-                    container_id=container_id, status="running"
-                )
+                    container_id__in=[container_id, container_id[:12]]
+                ).order_by("-deployed_at")
                 if existing.exists():
                     rec = list(existing)[0]
+                    rec.status = "running"
+                    rec.stopped_at = None
+                    rec.stopped_by_user = False
+                    rec.container_name = container_name
                     rec.device = "external"
                     rec.device_id = device_id
                     rec.device_ids = device_ids
@@ -2809,8 +2826,10 @@ class RegisterExternalModelView(APIView):
                     rec.port = int(service_port) if service_port else 7000
                     rec.tool_calling_enabled = tool_calling_enabled
                     rec.jwt_secret = jwt_secret
+                    rec.model_type = model_type
+                    rec.hf_model_id = hf_model_id
                     rec.save()
-                    corrections.append("Deployment record already existed — updated device mapping.")
+                    corrections.append("Reused this container's existing deployment record.")
                     logger.info(f"Updated existing deployment record for '{container_name}' to device_ids={device_ids}")
                 else:
                     ModelDeployment.objects.create(
@@ -2825,6 +2844,8 @@ class RegisterExternalModelView(APIView):
                         port=int(service_port) if service_port else 7000,
                         tool_calling_enabled=tool_calling_enabled,
                         jwt_secret=jwt_secret,
+                        model_type=model_type,
+                        hf_model_id=hf_model_id,
                     )
                     logger.info(f"Created deployment record for external container '{container_name}' on device_ids={device_ids}")
             except Exception as e:
@@ -3440,6 +3461,42 @@ def _infer_model_type(hf_id: str) -> str:
     return "chat"
 
 
+# Keyword -> model_type, applied to a container's name/image when the model has
+# no HF id to infer from. Ordered: earlier entries win (a "*_tts" name contains
+# "speech", so TTS must be tested before speech recognition).
+_IMAGE_TYPE_HINTS = (
+    (("-tts-", "_tts", "tts-", "tts_", "xtts", "bark", "speecht5", "fastspeech"), "tts"),
+    (("whisper", "wav2vec", "-asr", "speech-recognition", "speech_recognition", "-stt"), "speech_recognition"),
+    (("llava", "idefics", "vision", "blip", "-vl-", "-vl:"), "vlm"),
+    (("stable-diffusion", "sdxl", "flux", "image-generation"), "image_generation"),
+    (("yolo", "objdetection", "object-detection"), "object_detection"),
+    (("wan2", "video-generation", "mochi"), "video_generation"),
+    (("embed", "-e5-", "bge-", "gte-"), "embedding"),
+    (("vllm", "llama", "qwen", "mistral", "gemma", "phi-", "deepseek"), "chat"),
+)
+
+
+def _infer_model_type_from_container(container_info: dict) -> str:
+    """Best-effort model_type from a container's name and image, for models with
+    no HF id to go on. Returns "" when nothing recognisable is found — unlike
+    _infer_model_type there is no chat default, because a wrong guess here would
+    offer an interaction page that cannot work."""
+    config_image = (container_info.get("Config") or {}).get("Image")
+    haystack = " ".join(
+        str(v or "").lower()
+        for v in (
+            container_info.get("name"),
+            container_info.get("image"),
+            container_info.get("image_name"),
+            config_image,
+        )
+    )
+    for keywords, model_type in _IMAGE_TYPE_HINTS:
+        if any(kw in haystack for kw in keywords):
+            return model_type
+    return ""
+
+
 def _parse_vllm_logs(text: str) -> dict:
     """Extract the model id and serving port from vLLM startup log lines."""
     result = {}
@@ -3541,6 +3598,12 @@ def _detect_model_info(docker_client, container_id, container_info=None) -> dict
 
     if result.get("hf_model_id"):
         result["model_type"] = _infer_model_type(result["hf_model_id"])
+    else:
+        # No model id anywhere — the container's name/image is all that's left.
+        # Registration applies the same fallback, so the form shows what it will do.
+        inferred = _infer_model_type_from_container(container_info)
+        if inferred:
+            result["model_type"] = inferred
     return result
 
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2794,11 +2794,14 @@ class RegisterExternalModelView(APIView):
                 # Reuse any record already pointing at this container, whatever its
                 # status: re-registering the same container must revive its record
                 # rather than leave a stopped duplicate behind for every attempt.
-                existing = ModelDeployment.objects.filter(
-                    container_id__in=[container_id, container_id[:12]]
-                ).order_by("-deployed_at")
-                if existing.exists():
-                    rec = list(existing)[0]
+                rec = (
+                    ModelDeployment.objects.filter(
+                        container_id__in=[container_id, container_id[:12]]
+                    )
+                    .order_by("-deployed_at")
+                    .first()
+                )
+                if rec is not None:
                     rec.status = "running"
                     rec.stopped_at = None
                     rec.stopped_by_user = False

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2754,26 +2754,10 @@ class RegisterExternalModelView(APIView):
             if jwt_secret:
                 corrections.append("Detected the container's JWT secret for authenticated inference.")
 
-            # --- Rename container based on model name ---
-            current_name = container_info.get("name", container_id)
-            if current_name.startswith("/"):
-                current_name = current_name[1:]
-
-            # Sanitize desired name: lowercase, replace problematic chars
-            desired_name = model_name.lower().replace("/", "-").replace(" ", "_")
-            # Remove any chars that aren't alphanumeric, hyphens, or underscores
-            desired_name = "".join(c for c in desired_name if c.isalnum() or c in "-_.")
-
-            container_name = current_name
-            if desired_name and current_name != desired_name:
-                try:
-                    docker_client.rename_container(container_id, desired_name)
-                    corrections.append(f"Container renamed from '{current_name}' to '{desired_name}'")
-                    container_name = desired_name
-                    logger.info(f"Renamed container '{current_name}' to '{desired_name}'")
-                except Exception as e:
-                    logger.warning(f"Could not rename container: {e}")
-                    container_name = current_name
+            # --- Container name ---
+            # Left exactly as the launching tool set it. TT Studio identifies the
+            # container by id (the deployment record carries the model name for display)
+            container_name = container_info.get("name", container_id).lstrip("/")
 
             # --- Connect container to tt_studio_network ---
             network_name = backend_config.docker_bridge_network_name

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -138,6 +138,7 @@ from model_control.model_utils import (
     stream_to_cloud_model,
 )
 from shared_config.model_config import model_implmentations
+from shared_config.model_type_config import ModelTypes
 from shared_config.logger_config import get_logger
 from shared_config.backend_config import backend_config
 from shared_config.user_config import get_tts_api_key, get_tavily_api_key
@@ -185,6 +186,13 @@ class InferenceView(View):
 
         deploy_id = data.pop("deploy_id")
         deploy = get_deploy_cache()[deploy_id]
+        # A registered container whose model we could not identify has no known
+        # request shape — never guess one at it.
+        if getattr(deploy.get("model_impl"), "model_type", None) == ModelTypes.UNKNOWN:
+            return JsonResponse(
+                {"error": "This container's model was not identified, so TT Studio cannot run inference against it."},
+                status=400,
+            )
         internal_url = "http://" + deploy["internal_url"]
         auth_token = token_for(deploy.get("jwt_secret"))
         logger.info(f"internal_url:= {internal_url}")
@@ -347,6 +355,16 @@ class ModelHealthView(APIView):
         if serializer.is_valid():
             deploy_id = data.get("deploy_id")
             deploy = get_deploy_cache()[deploy_id]
+            # An externally-registered container whose model we could not identify
+            # has no known health route, so report health as unknown (the client
+            # treats any other status that way) rather than probing a guess and
+            # rendering a running container as unavailable.
+            model_impl = deploy.get("model_impl")
+            if getattr(model_impl, "model_type", None) == ModelTypes.UNKNOWN:
+                return Response(
+                    {"message": "Unknown", "details": "This container's model was not identified, so its health cannot be probed."},
+                    status=status.HTTP_501_NOT_IMPLEMENTED,
+                )
             health_url = "http://" + deploy["health_url"]
             check_passed, health_content = health_check(health_url, json_data=None, auth_token=token_for(deploy.get('jwt_secret')))
             if check_passed is True:

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -42,13 +42,23 @@ def is_coding_agent_eligible(model_impl) -> bool:
     """True if a deployed model is usable via the coding-agent gateway.
 
     Operates on a ModelImpl object (reads .model_type / .model_name).
+
+    Catalog models are allowlisted by name: we know which of them we have
+    verified against coding agents. An externally-registered model has no
+    catalog entry to allowlist, so it qualifies on structure instead — a chat or
+    VLM container the user explicitly registered. Whether it can actually be
+    driven is a separate question answered by `tool_calling_enabled`, which every
+    caller here already filters on (see _running_coding_agent_deploys); that
+    keeps a tool-calling-less container out of the usable list while still
+    letting the UI explain how to relaunch it.
     """
     if model_impl is None:
         return False
-    return (
-        getattr(model_impl, "model_type", None) in CODING_AGENT_MODEL_TYPES
-        and getattr(model_impl, "model_name", None) in CODING_AGENT_ELIGIBLE_MODELS
-    )
+    if getattr(model_impl, "model_type", None) not in CODING_AGENT_MODEL_TYPES:
+        return False
+    if getattr(model_impl, "is_external", False):
+        return True
+    return getattr(model_impl, "model_name", None) in CODING_AGENT_ELIGIBLE_MODELS
 
 
 def get_reasoning_parser(model_name) -> str | None:

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -27,7 +27,9 @@ _TYPE_ROUTING = {
     ModelTypes.MOCK: ("/v1/chat/completions", "vllm"),
     ModelTypes.VLM: ("/v1/chat/completions", "vllm"),
     ModelTypes.CNN: ("/v1/chat/completions", "forge"),
-    ModelTypes.EMBEDDING: ("/v1/chat/completions", "vllm"),
+    # Embedding models on the media server take /enqueue, not a chat route.
+    # TT Studio has no embedding UI, so this is for identification/parity only.
+    ModelTypes.EMBEDDING: ("/enqueue", "media"),
     ModelTypes.TTS: ("/v1/audio/speech", "media"),
     ModelTypes.SPEECH_RECOGNITION: ("/v1/audio/transcriptions", "media"),
     ModelTypes.IMAGE_GENERATION: ("/v1/images/generations", "media"),
@@ -82,9 +84,9 @@ def build_external_model_impl(
 ) -> ExternalModelImpl:
     """Build the stand-in impl for an externally-registered container.
 
-    An UNKNOWN type still gets an impl (so the container is tracked and its
-    health can be probed) but keeps a bare service route: nothing in the UI
-    offers inference against it.
+    An UNKNOWN type still gets an impl (so the container is tracked) but keeps a
+    bare service route: nothing in the UI offers inference against it, and health
+    is reported as unknown rather than probing a guessed endpoint.
     """
     resolved_type = normalize_external_model_type(
         getattr(model_type, "value", model_type)

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Synthetic model implementations for externally-registered containers.
+
+A container registered through the Register Model flow may serve a model that is
+not in the tt-inference-server catalog, so no ``ModelImpl`` exists for it. The
+rest of the backend (deploy cache, health probe, inference views) only reads a
+handful of attributes off ``model_impl``, so we hand it a lightweight stand-in
+built from what the container itself told us.
+
+This is deliberately NOT a ``ModelImpl``: that class carries deploy-time concerns
+(docker config, volumes, image tags) which have no meaning for a container we did
+not start.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+from shared_config.model_type_config import ModelTypes
+
+# Per-type service route and inference engine, mirroring how the catalog
+# describes the same model types (see models_from_inference_server.json).
+_TYPE_ROUTING = {
+    ModelTypes.CHAT: ("/v1/chat/completions", "vllm"),
+    ModelTypes.MOCK: ("/v1/chat/completions", "vllm"),
+    ModelTypes.VLM: ("/v1/chat/completions", "vllm"),
+    ModelTypes.CNN: ("/v1/chat/completions", "forge"),
+    ModelTypes.EMBEDDING: ("/v1/chat/completions", "vllm"),
+    ModelTypes.TTS: ("/v1/audio/speech", "media"),
+    ModelTypes.SPEECH_RECOGNITION: ("/v1/audio/transcriptions", "media"),
+    ModelTypes.IMAGE_GENERATION: ("/v1/images/generations", "media"),
+    ModelTypes.VIDEO: ("/v1/videos/generations", "media"),
+    ModelTypes.OBJECT_DETECTION: ("/objdetection_v2", "vllm"),
+}
+
+# Model types we can actually drive from the UI. Anything else registers as
+# UNKNOWN: visible and manageable, but with no interaction surface.
+SUPPORTED_EXTERNAL_MODEL_TYPES = frozenset(_TYPE_ROUTING)
+
+
+def normalize_external_model_type(value) -> ModelTypes:
+    """Coerce a model_type string into a ModelTypes we can route, or UNKNOWN."""
+    try:
+        model_type = ModelTypes(str(value or "").lower())
+    except ValueError:
+        return ModelTypes.UNKNOWN
+    return model_type if model_type in SUPPORTED_EXTERNAL_MODEL_TYPES else ModelTypes.UNKNOWN
+
+
+@dataclass(frozen=True)
+class ExternalModelImpl:
+    """Minimal model_impl for a container TT Studio registered but did not deploy."""
+
+    model_name: str
+    model_id: str
+    model_type: ModelTypes
+    service_route: str
+    hf_model_id: Optional[str] = None
+    health_route: str = "/health"
+    service_port: int = 7000
+    inference_engine: str = "vllm"
+    display_model_type: str = "EXTERNAL"
+    param_count: Optional[int] = None
+    # Whether the container was launched with vLLM tool-calling support, detected
+    # at registration. Coding agents and marketplace apps require it.
+    tool_calling_enabled: bool = False
+    # True for every instance — lets callers tell a synthetic impl from a catalog one.
+    is_external: bool = True
+
+    def asdict(self):
+        return asdict(self)
+
+
+def build_external_model_impl(
+    model_name: str,
+    model_type,
+    hf_model_id: Optional[str] = None,
+    service_port: int = 7000,
+    tool_calling_enabled: bool = False,
+) -> ExternalModelImpl:
+    """Build the stand-in impl for an externally-registered container.
+
+    An UNKNOWN type still gets an impl (so the container is tracked and its
+    health can be probed) but keeps a bare service route: nothing in the UI
+    offers inference against it.
+    """
+    resolved_type = normalize_external_model_type(
+        getattr(model_type, "value", model_type)
+    )
+    service_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    return ExternalModelImpl(
+        model_name=model_name,
+        model_id=f"id_external-{model_name}",
+        model_type=resolved_type,
+        service_route=service_route,
+        hf_model_id=hf_model_id or model_name,
+        service_port=service_port,
+        inference_engine=engine,
+        tool_calling_enabled=tool_calling_enabled,
+    )

--- a/app/backend/shared_config/model_type_config.py
+++ b/app/backend/shared_config/model_type_config.py
@@ -17,3 +17,6 @@ class ModelTypes(Enum):
     EMBEDDING = "embedding"
     CNN = "cnn"
     TRAINING = "training"
+    # Registered external container whose model type could not be determined.
+    # It is tracked and manageable, but no interaction UI is offered for it.
+    UNKNOWN = "unknown"

--- a/app/backend/shared_config/test_external_model_config.py
+++ b/app/backend/shared_config/test_external_model_config.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for external_model_config.py — the stand-in model_impl used for containers
+registered through Register Model that have no catalog entry.
+"""
+
+from shared_config.coding_agent_config import is_coding_agent_eligible
+from shared_config.external_model_config import (
+    build_external_model_impl,
+    normalize_external_model_type,
+)
+from shared_config.model_type_config import ModelTypes
+
+
+class TestNormalizeExternalModelType:
+    def test_known_type(self):
+        assert normalize_external_model_type("tts") == ModelTypes.TTS
+
+    def test_case_insensitive(self):
+        assert normalize_external_model_type("Speech_Recognition") == (
+            ModelTypes.SPEECH_RECOGNITION
+        )
+
+    def test_unroutable_type_is_unknown(self):
+        # A valid ModelTypes value TT Studio has no external routing for.
+        assert normalize_external_model_type("training") == ModelTypes.UNKNOWN
+
+    def test_garbage_and_empty_are_unknown(self):
+        assert normalize_external_model_type("not-a-type") == ModelTypes.UNKNOWN
+        assert normalize_external_model_type(None) == ModelTypes.UNKNOWN
+        assert normalize_external_model_type("") == ModelTypes.UNKNOWN
+
+
+class TestBuildExternalModelImpl:
+    def test_identified_model_gets_its_type_route_and_engine(self):
+        impl = build_external_model_impl("my-tts", "tts", "org/my-tts", 8000)
+        assert impl.model_type == ModelTypes.TTS
+        assert impl.service_route == "/v1/audio/speech"
+        assert impl.inference_engine == "media"
+        assert impl.service_port == 8000
+        assert impl.hf_model_id == "org/my-tts"
+
+    def test_chat_model_routes_like_a_catalog_chat_model(self):
+        impl = build_external_model_impl("some-llm", "chat")
+        assert impl.service_route == "/v1/chat/completions"
+        assert impl.inference_engine == "vllm"
+
+    def test_unidentified_model_still_gets_an_impl(self):
+        impl = build_external_model_impl("mystery-container", None)
+        assert impl.model_type == ModelTypes.UNKNOWN
+        # Bare route: nothing in the UI offers inference against it.
+        assert impl.service_route == "/"
+        assert impl.health_route == "/health"
+        # hf_model_id falls back to the name so callers always have a label.
+        assert impl.hf_model_id == "mystery-container"
+
+    def test_accepts_a_model_types_enum(self):
+        impl = build_external_model_impl("x", ModelTypes.VLM)
+        assert impl.model_type == ModelTypes.VLM
+
+    def test_asdict_is_serializable_shape(self):
+        d = build_external_model_impl("x", "chat").asdict()
+        assert d["model_name"] == "x"
+        assert d["model_type"] == ModelTypes.CHAT
+        assert d["is_external"] is True
+
+
+class TestCodingAgentEligibility:
+    """An external chat/VLM model is coding-agent eligible on structure, since it
+    has no catalog entry to be allowlisted by. Catalog models keep the allowlist."""
+
+    def test_external_chat_model_is_eligible(self):
+        impl = build_external_model_impl("some-off-catalog-llm", "chat", tool_calling_enabled=True)
+        assert is_coding_agent_eligible(impl) is True
+
+    def test_external_vlm_is_eligible(self):
+        assert is_coding_agent_eligible(build_external_model_impl("x", "vlm")) is True
+
+    def test_external_non_chat_types_are_not_eligible(self):
+        assert is_coding_agent_eligible(build_external_model_impl("x", "tts")) is False
+        assert is_coding_agent_eligible(build_external_model_impl("x", None)) is False
+
+    def test_tool_calling_flag_is_carried_not_gating(self):
+        # Eligibility is structural; callers filter on tool_calling_enabled so a
+        # container launched without it can still be explained in the UI.
+        impl = build_external_model_impl("x", "chat", tool_calling_enabled=False)
+        assert is_coding_agent_eligible(impl) is True
+        assert impl.tool_calling_enabled is False
+
+    def test_catalog_models_still_use_the_allowlist(self):
+        class FakeCatalogImpl:
+            model_type = ModelTypes.CHAT
+            def __init__(self, name):
+                self.model_name = name
+
+        assert is_coding_agent_eligible(FakeCatalogImpl("Qwen3-32B")) is True
+        assert is_coding_agent_eligible(FakeCatalogImpl("Some-Unvetted-Model")) is False
+
+    def test_none_impl(self):
+        assert is_coding_agent_eligible(None) is False

--- a/app/backend/shared_config/test_external_model_config.py
+++ b/app/backend/shared_config/test_external_model_config.py
@@ -42,6 +42,13 @@ class TestBuildExternalModelImpl:
         assert impl.service_port == 8000
         assert impl.hf_model_id == "org/my-tts"
 
+    def test_embedding_uses_the_media_enqueue_contract(self):
+        # Not a chat route: media embedding models serve /enqueue, and TT Studio
+        # has no embedding UI to drive a chat endpoint anyway.
+        impl = build_external_model_impl("some-embedder", "embedding")
+        assert impl.service_route == "/enqueue"
+        assert impl.inference_engine == "media"
+
     def test_chat_model_routes_like_a_catalog_chat_model(self):
         impl = build_external_model_impl("some-llm", "chat")
         assert impl.service_route == "/v1/chat/completions"

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -66,6 +66,8 @@ export const ModelType = {
   Embedding: "Embedding",
   CNN: "CNN",
   Training: "Training",
+  /** Registered container whose model could not be identified: status only, no interaction page. */
+  Unknown: "Unknown",
 };
 
 /**
@@ -98,6 +100,8 @@ export const getModelTypeFromBackendType = (backendType: string): string => {
       return ModelType.CNN;
     case "training":
       return ModelType.Training;
+    case "unknown":
+      return ModelType.Unknown;
     default:
       return ModelType.ChatModel;
   }

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -71,6 +71,18 @@ export const ModelType = {
 };
 
 /**
+ * Model types TT Studio has no interaction page for. Embedding models have no UI
+ * at all (they are consumed by RAG, not driven directly), and an unidentified
+ * container has no known request shape — offering either a Chat page or the
+ * chat-shaped API page for them would only lead somewhere that cannot work.
+ * Such models still show their status and keep Logs/Delete.
+ */
+const MODEL_TYPES_WITHOUT_UI: string[] = [ModelType.Embedding, ModelType.Unknown];
+
+export const hasInteractionPage = (frontendModelType: string): boolean =>
+  !MODEL_TYPES_WITHOUT_UI.includes(frontendModelType);
+
+/**
  * Map backend model_type strings (from catalog/API) to frontend ModelType constants.
  * Normalizes casing so values like SPEECH_RECOGNITION still map correctly.
  * Falls back to ChatModel for unknown types.

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -65,6 +65,7 @@ import {
   ModelType,
   getModelTypeFromName,
   getModelTypeFromBackendType,
+  hasInteractionPage,
   fetchModelHealth,
 } from "../api/modelsDeployedApis";
 import type { HealthStatus } from "../types/models";
@@ -384,15 +385,18 @@ export default function NavBar() {
   }, [modelIdsKey]);
 
   // Only models that are actually healthy/usable should surface in the navbar.
-  // Externally-registered containers whose model we could not identify have no
-  // interaction page, so they are managed from the Models page only.
+  // Model types with no interaction page (embeddings, and containers whose model
+  // could not be identified) are managed from the Models page only — a nav entry
+  // for them would route to a page that cannot drive them.
   const healthyModels = useMemo(
     () =>
-      models.filter(
-        (m) =>
-          healthById[m.id] === "healthy" &&
-          m.model_type !== "unknown"
-      ),
+      models.filter((m) => {
+        if (healthById[m.id] !== "healthy") return false;
+        const t = m.model_type
+          ? getModelTypeFromBackendType(m.model_type)
+          : getModelTypeFromName(m.name, m.image);
+        return hasInteractionPage(t);
+      }),
     [models, healthById]
   );
 

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -384,8 +384,15 @@ export default function NavBar() {
   }, [modelIdsKey]);
 
   // Only models that are actually healthy/usable should surface in the navbar.
+  // Externally-registered containers whose model we could not identify have no
+  // interaction page, so they are managed from the Models page only.
   const healthyModels = useMemo(
-    () => models.filter((m) => healthById[m.id] === "healthy"),
+    () =>
+      models.filter(
+        (m) =>
+          healthById[m.id] === "healthy" &&
+          m.model_type !== "unknown"
+      ),
     [models, healthById]
   );
 

--- a/app/frontend/src/components/models/ModelsDeployedCard.tsx
+++ b/app/frontend/src/components/models/ModelsDeployedCard.tsx
@@ -266,10 +266,25 @@ export default function ModelsDeployedCard(): JSX.Element {
     seenLiveIdsRef.current.clear();
   }
 
-  const failedMap = useMemo<Record<string, FailedDeploymentInfo>>(() => {
-    const next: Record<string, FailedDeploymentInfo> = {};
+  // Newest history record per container. A container can accumulate several
+  // records (a re-registration, a redeploy under the same id), and only the
+  // latest describes its current state — without this, one old stopped record
+  // marked a live, running container as "Died Unexpectedly" forever.
+  const latestHistoryByContainer = useMemo(() => {
+    const latest = new Map<string, HistoryRecord>();
     for (const d of history) {
       if (!d.container_id || d.container_id.startsWith("pending_")) continue;
+      const prev = latest.get(d.container_id);
+      if (!prev || (d.deployed_at ?? "") >= (prev.deployed_at ?? "")) {
+        latest.set(d.container_id, d);
+      }
+    }
+    return latest;
+  }, [history]);
+
+  const failedMap = useMemo<Record<string, FailedDeploymentInfo>>(() => {
+    const next: Record<string, FailedDeploymentInfo> = {};
+    for (const d of latestHistoryByContainer.values()) {
       if (d.stopped_by_user) continue;
       // Only flag deployments we've actually seen alive this session OR that
       // are still in the live set (so a row that's currently visible can flip
@@ -295,8 +310,8 @@ export default function ModelsDeployedCard(): JSX.Element {
       }
     }
     console.debug(
-      "[failed-detect] history:",
-      history.length,
+      "[failed-detect] containers:",
+      latestHistoryByContainer.size,
       "live:",
       liveContainerIds.size,
       "seen-this-session:",
@@ -305,7 +320,7 @@ export default function ModelsDeployedCard(): JSX.Element {
       Object.keys(next),
     );
     return next;
-  }, [history, liveContainerIds]);
+  }, [latestHistoryByContainer, liveContainerIds]);
 
   // Build synthetic rows ONLY for failed containers that were alive in this
   // session but have since disappeared from /docker-api/status/. This keeps
@@ -313,9 +328,8 @@ export default function ModelsDeployedCard(): JSX.Element {
   // failure and click Remove. We do not surface historical failures.
   const syntheticFailedRows = useMemo<ModelRow[]>(() => {
     const out: ModelRow[] = [];
-    for (const d of history) {
+    for (const d of latestHistoryByContainer.values()) {
       const cid = d.container_id;
-      if (!cid || cid.startsWith("pending_")) continue;
       if (!failedMap[cid]) continue;
       if (liveContainerIds.has(cid)) continue;
       if (!seenLiveIdsRef.current.has(cid)) continue;
@@ -329,7 +343,7 @@ export default function ModelsDeployedCard(): JSX.Element {
       });
     }
     return out;
-  }, [history, failedMap, liveContainerIds, resetAllNonce]);
+  }, [latestHistoryByContainer, failedMap, liveContainerIds, resetAllNonce]);
 
   const effectiveHealthMap = useMemo<Record<string, HealthStatus>>(() => {
     const merged: Record<string, HealthStatus> = { ...healthMap };

--- a/app/frontend/src/components/models/ModelsTable.tsx
+++ b/app/frontend/src/components/models/ModelsTable.tsx
@@ -40,7 +40,15 @@ import {
   TooltipTrigger,
 } from "../ui/tooltip";
 
-function HealthStatusCell({ health }: { health?: HealthStatus }) {
+function HealthStatusCell({
+  health,
+  unidentified,
+}: {
+  health?: HealthStatus;
+  // Registered container whose model TT Studio could not identify: there is no
+  // known health route to probe, so explain the permanent "unknown" badge.
+  unidentified?: boolean;
+}) {
   const status = health ?? "unknown";
 
   const getBgColor = () => {
@@ -83,7 +91,9 @@ function HealthStatusCell({ health }: { health?: HealthStatus }) {
     ? "The container exited without being stopped by the user. This may indicate an out-of-memory error, a crash, or a hardware issue. Open logs for details, or remove this entry."
     : isDisconnected
       ? "This model was disconnected from tt_studio_network and can't be reached. Open Register Model in the sidebar to reconnect it."
-      : `Model Health: ${status}`;
+      : unidentified
+        ? "This container's model could not be identified, so TT Studio doesn't know how to probe its health. Open logs to see what it's doing."
+        : `Model Health: ${status}`;
 
   return (
     <TooltipProvider>
@@ -325,7 +335,10 @@ export default function ModelsTable({
                   </TableCell>
                 ) : null}
                 <TableCell className="text-right">
-                  <HealthStatusCell health={healthMap[row.id]} />
+                  <HealthStatusCell
+                    health={healthMap[row.id]}
+                    unidentified={row.model_type === "unknown"}
+                  />
                 </TableCell>
                 {ports ? (
                   <TableCell className="text-right">

--- a/app/frontend/src/components/models/RegisterModelForm.tsx
+++ b/app/frontend/src/components/models/RegisterModelForm.tsx
@@ -306,7 +306,8 @@ export default function RegisterModelForm({ onSuccess }: RegisterModelFormProps)
 
           {/* Model identity — derived from the container. Name is always derived
               server-side (never asked). Type is derived too; we only ask for it
-              (and the HF id) as a last resort when the model can't be identified. */}
+              (and the HF id) as a last resort when the model can't be identified.
+              Both stay optional: an unidentified model registers as status-only. */}
           {selectedContainerId && (
             detecting ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground py-1">
@@ -333,7 +334,9 @@ export default function RegisterModelForm({ onSuccess }: RegisterModelFormProps)
                   <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                   <span>
                     Add the model's HuggingFace ID to auto-fill everything, or just
-                    pick its type.
+                    pick its type. Leave both blank to register the container for
+                    monitoring only — you'll get its status, logs and delete, but
+                    no chat/TTS page.
                   </span>
                 </div>
                 <div className="space-y-2">

--- a/app/frontend/src/components/models/row-cells/ManageCell.tsx
+++ b/app/frontend/src/components/models/row-cells/ManageCell.tsx
@@ -93,6 +93,9 @@ export default React.memo(function ManageCell({
   const modelType = model_type
     ? getModelTypeFromBackendType(model_type)
     : getModelTypeFromName(name ?? "");
+  // An externally-registered container whose model we could not identify has no
+  // interaction page and no known API shape, so only management actions apply.
+  const isUnidentified = modelType === ModelType.Unknown;
   const openLabel =
     modelType === ModelType.ImageGeneration
       ? "Image Gen"
@@ -208,30 +211,34 @@ export default React.memo(function ManageCell({
 
   return (
     <div className="relative flex items-center justify-center gap-2 flex-wrap">
-      <Button
-        variant="outline"
-        size="sm"
-        effect="expandIcon"
-        icon={FileCode2}
-        iconPlacement="right"
-        onClick={() => onOpenApi(id)}
-        disabled={health !== "healthy"}
-        className={`${baseBtn} ${blueBtn}`}
-      >
-        API
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        effect="expandIcon"
-        icon={OpenIcon}
-        iconPlacement="left"
-        onClick={() => onNavigateToModel(id, name ?? id)}
-        disabled={health !== "healthy"}
-        className={`${baseBtn} ${amberBtn}`}
-      >
-        {openLabel}
-      </Button>
+      {!isUnidentified && (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            effect="expandIcon"
+            icon={FileCode2}
+            iconPlacement="right"
+            onClick={() => onOpenApi(id)}
+            disabled={health !== "healthy"}
+            className={`${baseBtn} ${blueBtn}`}
+          >
+            API
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            effect="expandIcon"
+            icon={OpenIcon}
+            iconPlacement="left"
+            onClick={() => onNavigateToModel(id, name ?? id)}
+            disabled={health !== "healthy"}
+            className={`${baseBtn} ${amberBtn}`}
+          >
+            {openLabel}
+          </Button>
+        </>
+      )}
       <Button
         variant="outline"
         size="sm"

--- a/app/frontend/src/components/models/row-cells/ManageCell.tsx
+++ b/app/frontend/src/components/models/row-cells/ManageCell.tsx
@@ -20,6 +20,7 @@ import type { HealthStatus } from "../../../types/models";
 import {
   getModelTypeFromName,
   getModelTypeFromBackendType,
+  hasInteractionPage,
   ModelType,
 } from "../../../api/modelsDeployedApis";
 import {
@@ -93,9 +94,9 @@ export default React.memo(function ManageCell({
   const modelType = model_type
     ? getModelTypeFromBackendType(model_type)
     : getModelTypeFromName(name ?? "");
-  // An externally-registered container whose model we could not identify has no
-  // interaction page and no known API shape, so only management actions apply.
-  const isUnidentified = modelType === ModelType.Unknown;
+  // Embedding models have no UI, and an unidentified container has no known API
+  // shape — neither gets an interaction or API button, only management actions.
+  const noInteraction = !hasInteractionPage(modelType);
   const openLabel =
     modelType === ModelType.ImageGeneration
       ? "Image Gen"
@@ -211,7 +212,7 @@ export default React.memo(function ManageCell({
 
   return (
     <div className="relative flex items-center justify-center gap-2 flex-wrap">
-      {!isUnidentified && (
+      {!noInteraction && (
         <>
           <Button
             variant="outline"


### PR DESCRIPTION
## Register any running model container, not just catalog ones

## Background
With a docker serving path added to [tt-model-manager PR #37](https://github.com/tenstorrent/tt-model-manager/pull/37), it was important to allow tt-studio to register them. Doing this allows a user to visually see the model's status, interact with it via tt-studio GUI, and use the highly accessible marketplace integrations. 

## PR Summary
Register Model previously required the container to match a tt-inference-server catalog entry. Anything else either failed to register or registered into a dead end: no `model_impl` meant no routing, no health, no navbar entry.

A registered container is now identified from itself — its launch args, live `/v1/models`, logs, then name/image — and mapped onto a model type. If we can identify it, it behaves like any deployed model. If we can't, it still registers: status, logs and delete, with no interaction page offered.

### What changed

- **Synthetic model impl** (`shared_config/external_model_config.py`) — a lightweight stand-in for the catalog `ModelImpl`, giving off-catalog containers the same routes, health probe and inference path as catalog models.
- **Unidentifiable models are registerable** — new `ModelTypes.UNKNOWN`. The UI hides Chat/API for them, and health/inference refuse rather than guessing a request shape at the container.
- **Chat models reach the gateway and marketplace** — an external chat/VLM model is coding-agent eligible on structure rather than by catalog allowlist, so opencode, Claude Code, and other marketplace apps can use it. Tool calling is still required to be usable, and a container launched without it is explained in the UI instead of hidden.
- **Containers are no longer renamed on registration** — the rename existed only to prop up a name-based catalog lookup. That lookup now resolves by container id, so the name the launching tool chose is left alone and it can keep tracking and stopping its own container.

### Fixes

- Externally-registered containers were invisible to `get_managed_containers()` unless they used a catalog image or carried tt-inference-server env vars, so a healthy model was reconciled to `stopped` and vanished from Models Deployed seconds after registering.
- Re-registering a container appended a duplicate deployment record, and one stale record marked a live, serving container "Died Unexpectedly" forever. Registration now revives the existing record, and failure state is read from the newest record per container.

### Testing

- New unit tests for the synthetic impl, type normalization and eligibility.
- Verified on hardware with an off-catalog Qwen3-Coder-30B container: registers, shows healthy, chat streams, and it resolves through the LiteLLM gateway on  both the OpenAI and Anthropic surfaces and as the marketplace default model.