### PR TITLE
chore: added individual machine labels as CI runners

### DIFF
--- a/.github/workflows/deploy-healthcheck.yml
+++ b/.github/workflows/deploy-healthcheck.yml
@@ -30,8 +30,12 @@ on:
         default: "2h"
       runner_label:
         description: "Self-hosted runner label to target."
-        type: string
+        type: choice
         default: "pool"
+        options:
+          - pool
+          - qbge-devex-01
+          - qbge-devex-02
 
 # Serialize per runner label so two runs never fight over the same board.
 concurrency:


### PR DESCRIPTION
## Summary
Added `qbge-devex-01` and `qbge-devex-02` as individual runner labels in deploy health check CI script.