### PR TITLE
feat: bumped to inf server v0.21.0 and made progress bar changes accordingly

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.20.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.21.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -48,7 +48,7 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
         return "mistral"
     if "deepseek" in s:
         return "deepseek_v3"
-    if "gemma-4-" in s:
+    if "gemma-4-" in s or "diffusiongemma" in s:
         return "gemma4"
     return None
 

--- a/app/backend/model_control/marketplace_utils.py
+++ b/app/backend/model_control/marketplace_utils.py
@@ -341,6 +341,19 @@ def launch_blocked_reason(app: MarketplaceApp) -> Optional[str]:
     # Short-circuits before default_model(), so only the apps that pin one model
     # pay for the deploy scan.
     if app.requires_model and default_model() is None:
+        # A chat model can be deployed and still not be one this app can drive.
+        # Saying "none is deployed" there contradicts the Models page and sends
+        # the user off to deploy a second model that would be just as unusable.
+        from model_control.views import _running_coding_agent_deploys
+
+        if _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
+            return (
+                f"{app.name} needs a model it can drive with tool calling. The "
+                f"deployed model was launched without it — redeploy it from the "
+                f"Home page, then launch {app.name}."
+            )
         return (
             f"{app.name} needs a chat model to connect to, and none is deployed "
             f"yet. Deploy one from the Home page, then launch {app.name}."

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -1845,6 +1845,7 @@ class ModelAPIInfoView(APIView):
 # Coding-agent gateway support (LiteLLM). Eligibility (the model allowlist + rule)
 # is the SSOT in shared_config.coding_agent_config.
 from shared_config.coding_agent_config import (  # noqa: E402
+    CODING_AGENT_MODEL_TYPES,
     is_coding_agent_eligible,
     get_gateway_model_names,
     resolve_thinking_variant,
@@ -1860,7 +1861,9 @@ _rr_lock = threading.Lock()
 _rr_counters: dict[str, int] = {}
 
 
-def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tuple[str, dict]]:
+def _running_coding_agent_deploys(
+    require_tool_calling: bool = True, require_vetted: bool = True
+) -> list[tuple[str, dict]]:
     """Return [(deploy_id, entry), ...] for running, coding-agent-eligible deployments.
 
     Eligibility is decided by is_coding_agent_eligible (shared_config SSOT). By
@@ -1868,6 +1871,13 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
     workflow agents send tool_choice:"auto" and a container launched without vLLM
     tool-calling support would silently fail. Pass require_tool_calling=False to
     also get eligible-but-incapable deploys (e.g. to explain why they're unusable).
+
+    require_vetted=False widens it once more, to any running chat/VLM deployment.
+    The allowlist answers "have we verified this against coding agents", which is
+    not the same question as "is a chat model deployed" — a caller that reports
+    deployment state to the user has to ask the second one or it ends up claiming
+    nothing is deployed while a model is serving.
+
     Resilient to deploy-cache failures (e.g. docker-control-service down): logs
     and returns an empty list so callers degrade gracefully instead of 500ing.
     """
@@ -1879,7 +1889,12 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
         return out
     for deploy_id, entry in cache.items():
         impl = entry.get("model_impl")
-        if not entry.get("internal_url") or not is_coding_agent_eligible(impl):
+        if not entry.get("internal_url"):
+            continue
+        if require_vetted:
+            if not is_coding_agent_eligible(impl):
+                continue
+        elif getattr(impl, "model_type", None) not in CODING_AGENT_MODEL_TYPES:
             continue
         if require_tool_calling and not entry.get("tool_calling_enabled"):
             continue
@@ -2050,19 +2065,22 @@ class CodingAgentsView(APIView):
             except requests.RequestException:
                 health = "unreachable"
 
-        # Eligible models split into usable (tool-calling capable) and unavailable
-        # (launched without tool-calling support) so the UI can explain the latter
-        # instead of advertising models that would silently fail.
+        # Every deployed chat model, split into usable (vetted and tool-calling
+        # capable) and unavailable, so the UI can explain the latter instead of
+        # either advertising models that would silently fail or -- worse --
+        # reporting nothing deployed while one is serving.
         models = []
         unavailable = []
         seen = set()
-        for _, entry in _running_coding_agent_deploys(require_tool_calling=False):
+        for _, entry in _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
             impl = entry.get("model_impl")
             name = getattr(impl, "model_name", None)
             if not name:
                 continue
             mtype = getattr(getattr(impl, "model_type", None), "value", "chat")
-            capable = bool(entry.get("tool_calling_enabled"))
+            capable = bool(entry.get("tool_calling_enabled")) and is_coding_agent_eligible(impl)
             # Context window + max_tokens ceiling, same policy the gateway and InferenceView enforce
             context_window = entry.get("max_model_len") or get_max_tokens_limit(
                 getattr(impl, "param_count", None)
@@ -2079,7 +2097,7 @@ class CodingAgentsView(APIView):
                         "context_window": context_window,
                         "max_tokens": max_tokens,
                     })
-                else:
+                elif not entry.get("tool_calling_enabled"):
                     unavailable.append({
                         "name": exposed,
                         "type": mtype,
@@ -2087,6 +2105,15 @@ class CodingAgentsView(APIView):
                         "relaunch_with": tool_calling_launch_flags(
                             name, getattr(impl, "hf_model_id", "") or ""
                         ),
+                    })
+                else:
+                    # Can answer tool calls, just not one we have verified against
+                    # coding agents -- so no relaunch flags would help.
+                    unavailable.append({
+                        "name": exposed,
+                        "type": mtype,
+                        "reason": "not_verified",
+                        "relaunch_with": None,
                     })
 
         return Response(

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -17,7 +17,8 @@ CODING_AGENT_ELIGIBLE_MODELS = {
     "Llama-3.3-70B-Instruct",
     "Qwen3.6-27B",
     "Qwen3.8-27B",
-    "gemma-4-31B-it"
+    "gemma-4-31B-it",
+    "diffusiongemma-26B-A4B-it",
 }
 
 # Model types coding agents can talk to.
@@ -31,6 +32,7 @@ REASONING_MODELS = {
     "Qwen3.6-27B": "qwen3",
     "Qwen3.8-27B": "qwen3",
     "gemma-4-31B-it": "gemma4",
+    "diffusiongemma-26B-A4B-it": "gemma4",
 }
 
 # Suffix that selects thinking mode for a reasoning model over the gateway,

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,10 +1,38 @@
 {
   "source": {
-    "artifact_version": "0.20.0",
-    "generated_at": "2026-08-17T18:22:32.785689+00:00"
+    "artifact_version": "0.21.0",
+    "generated_at": "2026-08-31T19:53:30.158974+00:00"
   },
-  "total_models": 59,
+  "total_models": 71,
   "models": [
+    {
+      "model_name": "DeepSeek-R1-Distill-Llama-70B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+      "inference_engine": "vLLM",
+      "impl": "llama3-70b-galaxy",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 70
+    },
     {
       "model_name": "distil-large-v3",
       "model_type": "SPEECH_RECOGNITION",
@@ -73,6 +101,62 @@
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
+    },
+    {
+      "model_name": "Llama-3.1-70B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "meta-llama/Llama-3.1-70B",
+      "inference_engine": "vLLM",
+      "impl": "llama3-70b-galaxy",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 70
+    },
+    {
+      "model_name": "Llama-3.1-70B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "meta-llama/Llama-3.1-70B-Instruct",
+      "inference_engine": "vLLM",
+      "impl": "llama3-70b-galaxy",
+      "status": "COMPLETE",
+      "version": "0.16.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 70
     },
     {
       "model_name": "Llama-3.1-8B-Instruct",
@@ -181,6 +265,49 @@
       "param_count": null
     },
     {
+      "model_name": "mochi-1-preview",
+      "model_type": "VIDEO",
+      "display_model_type": "VIDEO",
+      "device_configurations": [
+        "GALAXY",
+        "P150X4",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "genmo/mochi-1-preview",
+      "inference_engine": "media",
+      "impl": null,
+      "status": "COMPLETE",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240",
+      "service_route": "/v1/videos/generations",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "Motif-Image-6B-Preview",
+      "model_type": "IMAGE_GENERATION",
+      "display_model_type": "IMAGE",
+      "device_configurations": [
+        "GALAXY",
+        "P150X8",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "Motif-Technologies/Motif-Image-6B-Preview",
+      "inference_engine": "media",
+      "impl": null,
+      "status": "COMPLETE",
+      "version": "0.9.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
+      "service_route": "/v1/images/generations",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": 6
+    },
+    {
       "model_name": "Qwen3-32B",
       "model_type": "CHAT",
       "display_model_type": "LLM",
@@ -195,8 +322,8 @@
       "inference_engine": "vLLM",
       "impl": "qwen3-32b-galaxy",
       "status": "COMPLETE",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
+      "version": "0.21.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-bc4c4df-be7d805",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -390,6 +517,25 @@
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/audio/transcriptions",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "yolox_nano",
+      "model_type": "CNN",
+      "display_model_type": "CNN",
+      "device_configurations": [
+        "N150",
+        "P150"
+      ],
+      "hf_model_id": "yolox_nano",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "COMPLETE",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
+      "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
@@ -713,6 +859,34 @@
       "param_count": 72
     },
     {
+      "model_name": "Qwen3-8B",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "N150",
+        "N300",
+        "P300",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-8B",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "FUNCTIONAL",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 8
+    },
+    {
       "model_name": "Qwen3-VL-32B-Instruct",
       "model_type": "VLM",
       "display_model_type": "VLM",
@@ -853,6 +1027,36 @@
       "param_count": null
     },
     {
+      "model_name": "bge-m3",
+      "model_type": "EMBEDDING",
+      "display_model_type": "EMBEDDING",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "BAAI/bge-m3",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "MODEL_RUNNER": "vllmforge_bge_m3",
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "128",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "8",
+        "BENCHMARK_MAX_CONCURRENCY": "32",
+        "MAX_BATCH_SIZE": "8",
+        "TT_MESH_GRAPH_DESC_PATH": "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+        "USE_DYNAMIC_BATCHER": "false",
+        "DEFAULT_THROTTLE_LEVEL": "0",
+        "TT_METAL_INSPECTOR_RPC": "0"
+      },
+      "param_count": null
+    },
+    {
       "model_name": "DeepSeek-R1-0528",
       "model_type": "CHAT",
       "display_model_type": "LLM",
@@ -876,6 +1080,44 @@
       "param_count": null
     },
     {
+      "model_name": "diffusiongemma-26B-A4B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/diffusiongemma-26B-A4B-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.21.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-bc4c4df-be7d805",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "1800000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+        "DISABLE_METAL_OP_TIMEOUT": "1",
+        "DG_VLLM_GUMBEL_MODE": "device",
+        "DG_UPFRONT_CAPTURE": "1",
+        "DG_MODEL_OWNED_HYBRID_KV": "1",
+        "DG_UPFRONT_COARSE_PREFILL_BUCKETS": "1",
+        "DG_UPFRONT_LAZY_PREFILL_RECAPTURE": "1",
+        "DG_PREFILL_FIXED_CHUNKS": "1",
+        "DG_PREFILL_CHUNK_SIZE": "4096",
+        "DG_PREFILL_RAGGED_CHUNK": "1024",
+        "DG_DENOISE_REVEAL_PMAX": "262144",
+        "DG_DENOISE_SLIDING_WINDOW": "1",
+        "DG_UPFRONT_PREFILL_WARMUP_LENS": "32,64,96",
+        "DG_TRACE_REGION_SIZE": "3758096384"
+      },
+      "param_count": 4
+    },
+    {
       "model_name": "efficientnet",
       "model_type": "CNN",
       "display_model_type": "CNN",
@@ -893,6 +1135,36 @@
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
+    },
+    {
+      "model_name": "Falcon3-7B-Instruct",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P150"
+      ],
+      "hf_model_id": "tiiuae/Falcon3-7B-Instruct",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.18.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "MAX_MODEL_LENGTH": "32768",
+        "MAX_NUM_SEQS": "32",
+        "GPU_MEMORY_UTILIZATION": "0.35",
+        "TT_KV_POOL_GB": "32",
+        "OPTIMIZATION_LEVEL": "1",
+        "CPU_SAMPLING": "false",
+        "ENABLE_TRACE": "true",
+        "KV_CACHE_DTYPE": "bfp_bf8",
+        "PREFILL_CHUNK_SIZE": "1024",
+        "MIN_NUM_SEQS": "1",
+        "PREFILL_BATCH_THRESHOLD": "16"
+      },
+      "param_count": 7
     },
     {
       "model_name": "gemma-3-1b-it",
@@ -992,6 +1264,32 @@
       },
       "param_count": 31,
       "requires_dev_catalog": true
+    },
+    {
+      "model_name": "gpt-oss-120b",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "openai/gpt-oss-120b",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
+      },
+      "param_count": 120
     },
     {
       "model_name": "gpt-oss-20b",
@@ -1274,6 +1572,65 @@
       "param_count": 4
     },
     {
+      "model_name": "Qwen3-Embedding-0.6B",
+      "model_type": "EMBEDDING",
+      "display_model_type": "EMBEDDING",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "Qwen/Qwen3-Embedding-0.6B",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "MODEL_RUNNER": "vllmforge_qwen_embedding_0_6b",
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "128",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "8",
+        "BENCHMARK_MAX_CONCURRENCY": "32",
+        "MAX_BATCH_SIZE": "8",
+        "TT_MESH_GRAPH_DESC_PATH": "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
+        "USE_DYNAMIC_BATCHER": "false",
+        "DEFAULT_THROTTLE_LEVEL": "0",
+        "TT_METAL_INSPECTOR_RPC": "0"
+      },
+      "param_count": 0
+    },
+    {
+      "model_name": "Qwen3-Embedding-4B",
+      "model_type": "EMBEDDING",
+      "display_model_type": "EMBEDDING",
+      "device_configurations": [
+        "GALAXY",
+        "N150",
+        "N300",
+        "P300x2",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-Embedding-4B",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.20.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "1024",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "1",
+        "MAX_BATCH_SIZE": "1",
+        "DEFAULT_THROTTLE_LEVEL": "0"
+      },
+      "param_count": 4
+    },
+    {
       "model_name": "Qwen3-Embedding-8B",
       "model_type": "EMBEDDING",
       "display_model_type": "EMBEDDING",
@@ -1334,6 +1691,7 @@
       "model_type": "CHAT",
       "display_model_type": "LLM",
       "device_configurations": [
+        "P150X8",
         "P300x2"
       ],
       "hf_model_id": "Qwen/Qwen3.6-27B",
@@ -1355,52 +1713,6 @@
         "QWEN36_MAX_TOKENS_ALL_USERS": "525312"
       },
       "param_count": 27
-    },
-    {
-      "model_name": "unet",
-      "model_type": "CNN",
-      "display_model_type": "CNN",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "unet",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "Qwen3-Embedding-4B",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "GALAXY",
-        "N150",
-        "N300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-Embedding-4B",
-      "inference_engine": "forge",
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "1024",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "1",
-        "MAX_BATCH_SIZE": "1",
-        "DEFAULT_THROTTLE_LEVEL": "0"
-      },
-      "param_count": 4
     },
     {
       "model_name": "Qwen3.8-27B",
@@ -1433,6 +1745,25 @@
       "inference_artifact_ref": {
         "P300x2": "tt-studio/qwen3.8-27b-p300x2"
       }
+    },
+    {
+      "model_name": "unet",
+      "model_type": "CNN",
+      "display_model_type": "CNN",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "unet",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
     }
   ]
 }

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,38 +1,10 @@
 {
   "source": {
-    "artifact_version": "0.21.0",
-    "generated_at": "2026-08-31T19:53:30.158974+00:00"
+    "artifact_version": "0.20.0",
+    "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 71,
+  "total_models": 60,
   "models": [
-    {
-      "model_name": "DeepSeek-R1-Distill-Llama-70B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-      "inference_engine": "vLLM",
-      "impl": "llama3-70b-galaxy",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
-    },
     {
       "model_name": "distil-large-v3",
       "model_type": "SPEECH_RECOGNITION",
@@ -101,62 +73,6 @@
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
-    },
-    {
-      "model_name": "Llama-3.1-70B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "meta-llama/Llama-3.1-70B",
-      "inference_engine": "vLLM",
-      "impl": "llama3-70b-galaxy",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
-    },
-    {
-      "model_name": "Llama-3.1-70B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "meta-llama/Llama-3.1-70B-Instruct",
-      "inference_engine": "vLLM",
-      "impl": "llama3-70b-galaxy",
-      "status": "COMPLETE",
-      "version": "0.16.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.16.0-669d59e-3334377",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 70
     },
     {
       "model_name": "Llama-3.1-8B-Instruct",
@@ -265,49 +181,6 @@
       "param_count": null
     },
     {
-      "model_name": "mochi-1-preview",
-      "model_type": "VIDEO",
-      "display_model_type": "VIDEO",
-      "device_configurations": [
-        "GALAXY",
-        "P150X4",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "genmo/mochi-1-preview",
-      "inference_engine": "media",
-      "impl": null,
-      "status": "COMPLETE",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.10.0-555f240",
-      "service_route": "/v1/videos/generations",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "Motif-Image-6B-Preview",
-      "model_type": "IMAGE_GENERATION",
-      "display_model_type": "IMAGE",
-      "device_configurations": [
-        "GALAXY",
-        "P150X8",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "Motif-Technologies/Motif-Image-6B-Preview",
-      "inference_engine": "media",
-      "impl": null,
-      "status": "COMPLETE",
-      "version": "0.9.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.9.0-c180ef7",
-      "service_route": "/v1/images/generations",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": 6
-    },
-    {
       "model_name": "Qwen3-32B",
       "model_type": "CHAT",
       "display_model_type": "LLM",
@@ -322,8 +195,8 @@
       "inference_engine": "vLLM",
       "impl": "qwen3-32b-galaxy",
       "status": "COMPLETE",
-      "version": "0.21.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-bc4c4df-be7d805",
+      "version": "0.17.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
       "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {
@@ -517,25 +390,6 @@
       "version": "0.17.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
       "service_route": "/v1/audio/transcriptions",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
-    },
-    {
-      "model_name": "yolox_nano",
-      "model_type": "CNN",
-      "display_model_type": "CNN",
-      "device_configurations": [
-        "N150",
-        "P150"
-      ],
-      "hf_model_id": "yolox_nano",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "COMPLETE",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
-      "service_route": "/v1/chat/completions",
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
@@ -859,34 +713,6 @@
       "param_count": 72
     },
     {
-      "model_name": "Qwen3-8B",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "GALAXY_T3K",
-        "N150",
-        "N300",
-        "P300",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-8B",
-      "inference_engine": "vLLM",
-      "impl": null,
-      "status": "FUNCTIONAL",
-      "version": "0.10.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1"
-      },
-      "param_count": 8
-    },
-    {
       "model_name": "Qwen3-VL-32B-Instruct",
       "model_type": "VLM",
       "display_model_type": "VLM",
@@ -1027,36 +853,6 @@
       "param_count": null
     },
     {
-      "model_name": "bge-m3",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "BAAI/bge-m3",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.20.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "MODEL_RUNNER": "vllmforge_bge_m3",
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "128",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "8",
-        "BENCHMARK_MAX_CONCURRENCY": "32",
-        "MAX_BATCH_SIZE": "8",
-        "TT_MESH_GRAPH_DESC_PATH": "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
-        "USE_DYNAMIC_BATCHER": "false",
-        "DEFAULT_THROTTLE_LEVEL": "0",
-        "TT_METAL_INSPECTOR_RPC": "0"
-      },
-      "param_count": null
-    },
-    {
       "model_name": "DeepSeek-R1-0528",
       "model_type": "CHAT",
       "display_model_type": "LLM",
@@ -1135,36 +931,6 @@
       "health_route": "/health",
       "env_vars": {},
       "param_count": null
-    },
-    {
-      "model_name": "Falcon3-7B-Instruct",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "P150"
-      ],
-      "hf_model_id": "tiiuae/Falcon3-7B-Instruct",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.18.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.18.0-c49bb76",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "MAX_MODEL_LENGTH": "32768",
-        "MAX_NUM_SEQS": "32",
-        "GPU_MEMORY_UTILIZATION": "0.35",
-        "TT_KV_POOL_GB": "32",
-        "OPTIMIZATION_LEVEL": "1",
-        "CPU_SAMPLING": "false",
-        "ENABLE_TRACE": "true",
-        "KV_CACHE_DTYPE": "bfp_bf8",
-        "PREFILL_CHUNK_SIZE": "1024",
-        "MIN_NUM_SEQS": "1",
-        "PREFILL_BATCH_THRESHOLD": "16"
-      },
-      "param_count": 7
     },
     {
       "model_name": "gemma-3-1b-it",
@@ -1264,32 +1030,6 @@
       },
       "param_count": 31,
       "requires_dev_catalog": true
-    },
-    {
-      "model_name": "gpt-oss-120b",
-      "model_type": "CHAT",
-      "display_model_type": "LLM",
-      "device_configurations": [
-        "GALAXY",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "openai/gpt-oss-120b",
-      "inference_engine": "vLLM",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.17.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.17.0-8c48a10-f52987a",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM_CONFIGURE_LOGGING": "1",
-        "VLLM_RPC_TIMEOUT": "900000",
-        "VLLM_TARGET_DEVICE": "tt",
-        "TORCHDYNAMO_DISABLE": "1",
-        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1"
-      },
-      "param_count": 120
     },
     {
       "model_name": "gpt-oss-20b",
@@ -1572,65 +1312,6 @@
       "param_count": 4
     },
     {
-      "model_name": "Qwen3-Embedding-0.6B",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "P300x2"
-      ],
-      "hf_model_id": "Qwen/Qwen3-Embedding-0.6B",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.20.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "MODEL_RUNNER": "vllmforge_qwen_embedding_0_6b",
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "128",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "8",
-        "BENCHMARK_MAX_CONCURRENCY": "32",
-        "MAX_BATCH_SIZE": "8",
-        "TT_MESH_GRAPH_DESC_PATH": "/home/container_app_user/app/server/venv-worker/lib/python3.12/site-packages/pjrt_plugin_tt/tt-metal/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto",
-        "USE_DYNAMIC_BATCHER": "false",
-        "DEFAULT_THROTTLE_LEVEL": "0",
-        "TT_METAL_INSPECTOR_RPC": "0"
-      },
-      "param_count": 0
-    },
-    {
-      "model_name": "Qwen3-Embedding-4B",
-      "model_type": "EMBEDDING",
-      "display_model_type": "EMBEDDING",
-      "device_configurations": [
-        "GALAXY",
-        "N150",
-        "N300",
-        "P300x2",
-        "T3K"
-      ],
-      "hf_model_id": "Qwen/Qwen3-Embedding-4B",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.20.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {
-        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
-        "VLLM__MAX_MODEL_LENGTH": "1024",
-        "VLLM__MIN_CONTEXT_LENGTH": "32",
-        "VLLM__MAX_NUM_SEQS": "1",
-        "MAX_BATCH_SIZE": "1",
-        "DEFAULT_THROTTLE_LEVEL": "0"
-      },
-      "param_count": 4
-    },
-    {
       "model_name": "Qwen3-Embedding-8B",
       "model_type": "EMBEDDING",
       "display_model_type": "EMBEDDING",
@@ -1691,7 +1372,6 @@
       "model_type": "CHAT",
       "display_model_type": "LLM",
       "device_configurations": [
-        "P150X8",
         "P300x2"
       ],
       "hf_model_id": "Qwen/Qwen3.6-27B",
@@ -1713,6 +1393,52 @@
         "QWEN36_MAX_TOKENS_ALL_USERS": "525312"
       },
       "param_count": 27
+    },
+    {
+      "model_name": "unet",
+      "model_type": "CNN",
+      "display_model_type": "CNN",
+      "device_configurations": [
+        "N150",
+        "N300"
+      ],
+      "hf_model_id": "unet",
+      "inference_engine": "forge",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {},
+      "param_count": null
+    },
+    {
+      "model_name": "Qwen3-Embedding-4B",
+      "model_type": "EMBEDDING",
+      "display_model_type": "EMBEDDING",
+      "device_configurations": [
+        "GALAXY",
+        "N150",
+        "N300",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-Embedding-4B",
+      "inference_engine": "forge",
+      "status": "EXPERIMENTAL",
+      "version": "0.12.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
+        "VLLM__MAX_MODEL_LENGTH": "1024",
+        "VLLM__MIN_CONTEXT_LENGTH": "32",
+        "VLLM__MAX_NUM_SEQS": "1",
+        "MAX_BATCH_SIZE": "1",
+        "DEFAULT_THROTTLE_LEVEL": "0"
+      },
+      "param_count": 4
     },
     {
       "model_name": "Qwen3.8-27B",
@@ -1745,25 +1471,6 @@
       "inference_artifact_ref": {
         "P300x2": "tt-studio/qwen3.8-27b-p300x2"
       }
-    },
-    {
-      "model_name": "unet",
-      "model_type": "CNN",
-      "display_model_type": "CNN",
-      "device_configurations": [
-        "N150",
-        "N300"
-      ],
-      "hf_model_id": "unet",
-      "inference_engine": "forge",
-      "impl": null,
-      "status": "EXPERIMENTAL",
-      "version": "0.12.0",
-      "docker_image": "ghcr.io/tenstorrent/tt-shield/tt-media-inference-server-forge:a9b09e0b611da6deb4d8972e8296148fd864e5fd_98dcf62_60920940673",
-      "service_route": "/v1/chat/completions",
-      "health_route": "/health",
-      "env_vars": {},
-      "param_count": null
     }
   ]
 }

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -102,6 +102,22 @@ const tagProseThinking = (
   return isStreamFinished ? `<think>${content}</think>` : `<think>${content}`;
 };
 
+/** Close a thinking block the stream ended inside, so it stays readable.
+ *
+ * Belt to runInference's braces: any path that leaves an unterminated <think>
+ * (a stopped stream, a reply restored from history, a model whose reasoning
+ * never gave way to an answer) would otherwise fail the closed-tag regex below,
+ * be stripped from the reply text, and vanish along with the live panel. */
+const closeUnterminatedThinking = (
+  content: string,
+  isStreamFinished: boolean
+): string => {
+  if (!isStreamFinished) return content;
+  const openIdx = content.lastIndexOf("<think>");
+  if (openIdx === -1 || content.includes("</think>", openIdx)) return content;
+  return `${content}</think>`;
+};
+
 const processContent = (content: string): ProcessedContent => {
   const thinkingBlocks: string[] = [];
 
@@ -159,7 +175,11 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
   }) {
     // Everything below reasons about thinking in terms of <think> tags, so
     // normalize prose scratchpads into tags once, up front.
-    const taggedContent = tagProseThinking(content, isStreamFinished);
+    const streamOver = isStreamFinished || Boolean(isStopped);
+    const taggedContent = closeUnterminatedThinking(
+      tagProseThinking(content, streamOver),
+      streamOver
+    );
 
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
@@ -204,7 +224,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
 
       // Check if thinking is actively streaming (has <think> but no closing </think>)
       const hasIncompleteThinking =
-        !isStreamFinished && /<think>(?!.*<\/think>)/is.test(taggedContent);
+        !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
       setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
@@ -237,6 +257,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     }, [
       taggedContent,
       isStreamFinished,
+      streamOver,
       renderNextChunk,
       renderedContent,
       onThinkingBlocksChange,

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -526,6 +526,18 @@ export const runInference = async (
       reader.releaseLock();
     }
 
+    // The closing </think> is synthesized when the first content delta arrives,
+    // so a reply that ends while still in the reasoning channel never gets one:
+    // a truncated answer (finish_reason "length"), or a block-diffusion model
+    // like diffusiongemma that emits its whole block as reasoning and no
+    // content. Left open, processContent drops the block and the reply renders
+    // empty, losing the reasoning the model did produce.
+    if (thinkingText && !thinkingDone) {
+      thinkingDone = true;
+      accumulatedText = `<think>${thinkingText}</think>${contentText}`;
+      scheduleUiUpdate();
+    }
+
     t.end = performance.now();
     const ms = (key: string) => (t[key] != null ? `${Math.round(t[key] - t.start)}ms` : "—");
     const serverTtftMs = inferenceStats?.user_ttft_s != null

--- a/app/frontend/src/pages/AppsPage.tsx
+++ b/app/frontend/src/pages/AppsPage.tsx
@@ -36,6 +36,7 @@ import { customToast } from "../components/CustomToaster";
 import {
   fetchCodingAgentsInfo,
   type CodingAgentsInfo,
+  type UnavailableCodingAgentModel,
 } from "../api/modelsDeployedApis";
 import {
   fetchMarketplaceApps,
@@ -138,6 +139,10 @@ export default function AppsPage() {
 
   const models = useMemo(() => gateway?.models ?? [], [gateway]);
   const modelNames = useMemo(() => models.map((m) => m.name), [models]);
+  // Deployed chat models the apps here cannot drive. They are still deployed, so
+  // they decide between "nothing to talk to" and "something to talk to, once you
+  // relaunch it" -- the two used to be conflated into the first message.
+  const unavailable = useMemo(() => gateway?.unavailable ?? [], [gateway]);
   const activeModel =
     selectedModel && modelNames.includes(selectedModel)
       ? selectedModel
@@ -248,7 +253,11 @@ export default function AppsPage() {
               onSelectModel={setSelectedModel}
             />
 
-            {modelNames.length === 0 && (
+            {modelNames.length === 0 && unavailable.length > 0 && (
+              <UnusableModelsNote unavailable={unavailable} />
+            )}
+
+            {modelNames.length === 0 && unavailable.length === 0 && (
               <div className="flex flex-col gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:gap-4">
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
                   <AlertCircle className="h-5 w-5" />
@@ -354,6 +363,59 @@ export default function AppsPage() {
           )}
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+// Chat models are deployed, but none can be driven from here yet. Says which
+// and why, rather than the old "no chat model is deployed" -- which contradicts
+// the Models page and sends the user off to deploy a second one.
+function UnusableModelsNote({
+  unavailable,
+}: {
+  unavailable: UnavailableCodingAgentModel[];
+}) {
+  // -thinking variants repeat their base model's reason; one row each is enough.
+  const rows = unavailable.filter((m) => !m.name.endsWith("-thinking"));
+  const relaunchFlags = rows.find((m) => m.relaunch_with)?.relaunch_with;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
+          <AlertCircle className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+            {rows.length === 1 ? "A deployed model" : "Deployed models"} cannot be
+            used by apps yet
+          </p>
+          <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+            {rows.map((model) => (
+              <li key={model.name}>
+                <code className="font-mono text-xs text-gray-900 dark:text-gray-200">
+                  {model.name}
+                </code>{" "}
+                —{" "}
+                {model.reason === "tool_calling_disabled"
+                  ? "was launched without tool calling; redeploy it from the Home page to turn it on"
+                  : "has not been verified against the apps here yet"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {relaunchFlags && (
+        <div className="pl-12">
+          <div className="mb-1.5 text-[11px] uppercase tracking-wide text-gray-500">
+            Flags a redeploy adds
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white px-3 py-2 font-mono text-xs dark:border-gray-800 dark:bg-black">
+            <CopyableText text={relaunchFlags} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -1884,6 +1884,11 @@ def _process_run_output_line(
             stage = "container_started"
             progress = 60
             message = "Container is running..."
+        # Defence in depth for the v0.21.0 readiness gate (see TT_SERVER_BOOT_ATTEMPTS in run_inference).
+        elif "waiting for inference server readiness" in message.lower():
+            stage = "container_started"
+            progress = 61
+            message = "Container is running..."
         elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
             stage = "container_started"
             progress = 64
@@ -2506,6 +2511,19 @@ async def run_inference(request: RunRequest):
         # (e.g., /home/username/.cache/huggingface instead of /root/.cache/huggingface)
         env_vars_to_set = {
             "AUTOMATIC_HOST_SETUP": "True",
+            # tt-inference-server v0.21.0 added a readiness gate to ServerCommand
+            # (workflow_module/commands.py): with TT_SERVER_BOOT_ATTEMPTS > 1 -- its
+            # default of 2 -- bring-up blocks polling /health until the model is fully
+            # warm (up to TT_SERVER_READY_TIMEOUT_SECONDS, default 1h). We call
+            # run_main() in-process and only emit container_started / connect
+            # tt_studio_network / rename *after* it returns, so that gate freezes the
+            # deploy bar at container_setup for the entire warmup and defers the
+            # frontend's redirect to the end of the deploy. Forcing a single attempt
+            # restores v0.20.0's fire-and-forget return (the container is up, the model
+            # is still loading), which is the point we want to hand off from the deploy
+            # bar to the container-log classifier. Warmup progress and hang detection
+            # are already covered on our side by log_classifier + health_monitor.
+            "TT_SERVER_BOOT_ATTEMPTS": "1",
             "TT_PROGRESS_DEBUG": "1",  # Enable structured progress emission
             "TT_PROGRESS_SSE": "1",     # Enable SSE endpoint for real-time progress
             "SERVICE_PORT": request.service_port or "7000",  # Use requested port (per-slot)


### PR DESCRIPTION
## Summary
tt-inference-server released v0.21.0. This PR transitions tt-studio to that version.

## Important Changes
- adds diffusiongemma-26B-A4B-it on p300x2

## Code Changes
Set  "TT_SERVER_BOOT_ATTEMPTS": "1" env var since v0.21.0 gated the deploy healthcheck which prevented tt-studio from providing accurate deployment progress.