### PR TITLE
feat: drive external image models over the API they actually serve

### DIFF
--- a/app/backend/docker_control/deployment_store.py
+++ b/app/backend/docker_control/deployment_store.py
@@ -207,6 +207,7 @@ class _Manager:
                 "jwt_secret": kwargs.get("jwt_secret", None),
                 "model_type": kwargs.get("model_type", None),
                 "hf_model_id": kwargs.get("hf_model_id", None),
+                "service_route": kwargs.get("service_route", None),
             }
             data["next_id"] += 1
             data["records"].append(record)
@@ -259,6 +260,9 @@ class ModelDeployment:
         # catalog. "unknown" means we could not identify what the container serves.
         self.model_type: Optional[str] = None
         self.hf_model_id: Optional[str] = None
+        # The route the container was observed to serve, when it differs from the
+        # per-type convention (e.g. a tt-dit image server serving /generate).
+        self.service_route: Optional[str] = None
 
     @classmethod
     def _from_dict(cls, d: dict) -> "ModelDeployment":
@@ -283,6 +287,7 @@ class ModelDeployment:
         obj.failure_reason = d.get("failure_reason")
         obj.failure_message = d.get("failure_message")
         obj.tool_calling_enabled = d.get("tool_calling_enabled", False)
+        obj.service_route = d.get("service_route")
         obj.jwt_secret = d.get("jwt_secret")
         obj.model_type = d.get("model_type")
         obj.hf_model_id = d.get("hf_model_id")
@@ -309,6 +314,7 @@ class ModelDeployment:
             "jwt_secret": self.jwt_secret,
             "model_type": self.model_type,
             "hf_model_id": self.hf_model_id,
+            "service_route": self.service_route,
         }
 
     def save(self) -> None:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -903,6 +903,7 @@ def _external_model_impl(con_id, con):
         hf_model_id=dep.hf_model_id,
         service_port=dep.port or 7000,
         tool_calling_enabled=bool(getattr(dep, "tool_calling_enabled", False)),
+        service_route=getattr(dep, "service_route", None),
     )
     logger.debug(
         f"Using external model_impl for '{con['name']}' "

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2704,6 +2704,28 @@ class RegisterExternalModelView(APIView):
                 except Exception as e:
                     logger.warning(f"Could not check HF model ID against catalog: {e}")
 
+            # What the container serves is a physical fact about it, so read the
+            # routes before falling back to guessing from names. This is also the
+            # only way to learn a route that diverges from the per-type convention
+            # (a tt-dit image server serves /generate, not /v1/images/generations),
+            # which is why the route is kept even when the type came from elsewhere.
+            served_api = _detect_served_api(service_port)
+            service_route = served_api.get("service_route") or None
+            served_type = served_api.get("model_type")
+            if served_type and served_type != model_type:
+                if model_type:
+                    corrections.append(
+                        f"Model type corrected from '{model_type}' to '{served_type}' "
+                        f"based on the routes the container actually serves "
+                        f"({service_route})."
+                    )
+                else:
+                    corrections.append(
+                        f"Model type '{served_type}' detected from the container's "
+                        f"own API ({service_route})."
+                    )
+                model_type = served_type
+
             # Derive any remaining identity fields, then settle on a model type
             if not model_type and hf_model_id:
                 model_type = _infer_model_type(hf_model_id)
@@ -2815,6 +2837,7 @@ class RegisterExternalModelView(APIView):
                     rec.jwt_secret = jwt_secret
                     rec.model_type = model_type
                     rec.hf_model_id = hf_model_id
+                    rec.service_route = service_route
                     rec.save()
                     corrections.append("Reused this container's existing deployment record.")
                     logger.info(f"Updated existing deployment record for '{container_name}' to device_ids={device_ids}")
@@ -2833,6 +2856,7 @@ class RegisterExternalModelView(APIView):
                         jwt_secret=jwt_secret,
                         model_type=model_type,
                         hf_model_id=hf_model_id,
+                        service_route=service_route,
                     )
                     logger.info(f"Created deployment record for external container '{container_name}' on device_ids={device_ids}")
             except Exception as e:
@@ -3533,6 +3557,60 @@ def _hf_from_container(container_info: dict):
     return None
 
 
+def _detect_served_api(host_port) -> dict:
+    """Read a container's OpenAPI document and report the API it actually serves.
+
+    Returns {"routes": [...], "service_route": str, "model_type": str} for a
+    container whose served routes identify a contract TT Studio can drive, else
+    whatever subset could be determined ({} when the container has no OpenAPI doc).
+
+    This is the strongest identity signal available and needs no name heuristics:
+    a server that answers on ``/generate`` + ``/jobs/<id>/image`` is an image
+    generator whatever its weights are called, and one that serves no route we
+    recognise is not something we should offer an interaction page for.
+    """
+    if not host_port:
+        return {}
+    try:
+        resp = requests.get(
+            f"http://host.docker.internal:{host_port}/openapi.json", timeout=3
+        )
+        resp.raise_for_status()
+        paths = resp.json().get("paths") or {}
+    except Exception:
+        return {}
+
+    result = {"routes": sorted(paths)}
+
+    # Image dialects are the case where the served route genuinely diverges from
+    # the per-type convention, so consult the dialect table rather than
+    # duplicating its route knowledge here.
+    try:
+        from model_control.image_dialects import dialect_from_openapi
+
+        dialect = dialect_from_openapi(paths)
+    except Exception:
+        dialect = None
+    if dialect is not None:
+        result["service_route"] = dialect.submit_route
+        result["model_type"] = "image_generation"
+        return result
+
+    # Otherwise fall back to the routes that identify the remaining types.
+    for route, model_type in (
+        ("/v1/chat/completions", "chat"),
+        ("/v1/audio/transcriptions", "speech_recognition"),
+        ("/v1/audio/speech", "tts"),
+        ("/v1/videos/generations", "video_generation"),
+        ("/objdetection_v2", "object_detection"),
+    ):
+        if route in paths:
+            result["service_route"] = route
+            result["model_type"] = model_type
+            break
+    return result
+
+
 def _detect_model_info(docker_client, container_id, container_info=None) -> dict:
     """Detect {hf_model_id, model_type, port, source} for a running container.
 
@@ -3582,6 +3660,16 @@ def _detect_model_info(docker_client, container_id, container_info=None) -> dict
             result.setdefault("source", "logs")
         if parsed.get("port") and not result.get("port"):
             result["port"] = parsed["port"]
+
+    # What the container serves beats what its weights are named: a DiT image
+    # server and a vLLM chat server can both be called "<org>/<model>", but they
+    # do not expose the same routes.
+    served = _detect_served_api(host_port)
+    if served.get("model_type"):
+        result["model_type"] = served["model_type"]
+        result["service_route"] = served["service_route"]
+        result.setdefault("source", "openapi")
+        return result
 
     if result.get("hf_model_id"):
         result["model_type"] = _infer_model_type(result["hf_model_id"])

--- a/app/backend/model_control/image_dialects.py
+++ b/app/backend/model_control/image_dialects.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Image-generation API dialects.
+
+TT Studio drives image models over three different HTTP contracts, because the
+serving stacks below it were designed independently:
+
+* ``openai`` — ``POST /v1/images/generations``, synchronous, base64 in the JSON
+  response. What tt-media-server exposes for its OpenAI-compatible image models.
+* ``media``  — ``POST /enqueue`` → poll ``/status/<id>`` → ``GET /fetch_image/<id>``.
+  tt-media-server's older job API.
+* ``tt_dit`` — ``POST /generate`` → poll ``/jobs/<id>`` → ``GET /jobs/<id>/image``.
+  tt-metal's DiT models (``models.tt_dit.server.*``) serving HTTP directly,
+  without tt-media-server in front. Diffusion on accelerators takes minutes per
+  image, so this stack is job-based by design and exposes diffusion-native knobs
+  (steps, guidance scale, seed, height, width) that the OpenAI image contract
+  has no place for.
+
+A dialect is data, not control flow: adding a fourth serving stack should mean
+adding a row here, not another branch in the inference view. Keeping the job
+polling in one place also means a new stack inherits the terminal-state and
+error handling the existing ones already have.
+"""
+
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+# Optional generation parameters we forward when the caller supplies them, keyed
+# by the request field TT Studio accepts. Only the tt_dit contract models these;
+# the others silently ignore anything beyond the prompt.
+_DIT_PARAMS = {
+    "num_inference_steps": "num_inference_steps",
+    "guidance_scale": "guidance_scale",
+    "seed": "seed",
+    "height": "height",
+    "width": "width",
+}
+
+
+@dataclass(frozen=True)
+class ImageDialect:
+    """One image-generation HTTP contract.
+
+    ``mode`` is "sync" (the image comes back on the submit call) or "job" (submit
+    returns an id, then poll for a terminal state and fetch the bytes). Templates
+    are relative to the server root, so they compose with whatever host/port the
+    deployment happens to be on.
+    """
+
+    name: str
+    submit_route: str
+    mode: str
+    job_id_field: str = ""
+    status_template: str = ""
+    image_template: str = ""
+    # Compared case-insensitively: tt-media-server says "Completed", tt_dit "done".
+    done_states: frozenset = frozenset()
+    error_states: frozenset = frozenset()
+    extra_params: Mapping[str, str] = field(default_factory=dict)
+    # Image media type to report when the server does not say (the sync dialect
+    # hands us raw base64 with no content type of its own).
+    default_content_type: str = "image/png"
+    default_filename: str = "image.png"
+
+
+OPENAI = ImageDialect(
+    name="openai",
+    submit_route="/v1/images/generations",
+    mode="sync",
+    # Historic behaviour: the base64 payload is re-served as JPEG.
+    default_content_type="image/jpeg",
+    default_filename="image.jpg",
+)
+
+MEDIA = ImageDialect(
+    name="media",
+    submit_route="/enqueue",
+    mode="job",
+    job_id_field="task_id",
+    status_template="/status/{job_id}",
+    image_template="/fetch_image/{job_id}",
+    done_states=frozenset({"completed"}),
+    error_states=frozenset({"failed", "error", "cancelled"}),
+)
+
+TT_DIT = ImageDialect(
+    name="tt_dit",
+    submit_route="/generate",
+    mode="job",
+    job_id_field="job_id",
+    status_template="/jobs/{job_id}",
+    image_template="/jobs/{job_id}/image",
+    # models/tt_dit/server/flux2/jobs.py: JobStatus = queued|running|done|error|cancelled
+    done_states=frozenset({"done"}),
+    error_states=frozenset({"error", "cancelled"}),
+    extra_params=_DIT_PARAMS,
+)
+
+# Longest submit_route first so "/v1/images/generations" is tested before any
+# shorter route that could also appear as a suffix.
+DIALECTS = tuple(sorted((OPENAI, MEDIA, TT_DIT), key=lambda d: -len(d.submit_route)))
+
+# Routes we can recognise in a container's OpenAPI document, most specific first.
+_ROUTE_TO_DIALECT = {d.submit_route: d for d in DIALECTS}
+
+
+def split_route(internal_url: str) -> tuple[str, str]:
+    """Split a stored internal_url into (server_root, route).
+
+    ``internal_url`` is built as ``<host>:<port><service_route>``, so the route is
+    just its path. Returns ("", url) when the url carries no path to speak of.
+    """
+    parts = urlsplit(internal_url)
+    path = parts.path or ""
+    root = urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+    return root, path
+
+
+def resolve_dialect(internal_url: str) -> ImageDialect:
+    """Pick the dialect for a deployment's stored internal_url.
+
+    Matches on the route the deployment was registered with. Falls back to MEDIA,
+    which is what this code path did unconditionally before other stacks existed —
+    an unrecognised route is more likely an older media server than a new contract
+    we would only guess at.
+    """
+    _, path = split_route(internal_url)
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if path.endswith(route):
+            return dialect
+    return MEDIA
+
+
+def dialect_from_openapi(paths) -> Optional[ImageDialect]:
+    """Identify the dialect a live container serves from its OpenAPI paths.
+
+    ``paths`` is the ``paths`` object of an OpenAPI document (any mapping of route
+    -> operations). Returns None when the container serves no image route we know,
+    which is a positive signal in its own right: there is no point registering it
+    as an image model TT Studio can drive.
+    """
+    served = set(paths or ())
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if route in served:
+            return dialect
+    return None

--- a/app/backend/model_control/test_image_dialects.py
+++ b/app/backend/model_control/test_image_dialects.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for image-generation dialect resolution.
+
+The route shapes and job-status values here are taken from real servers:
+tt-media-server's ``/enqueue`` + ``/v1/images/generations`` contracts, and
+tt-metal's DiT server (``models/tt_dit/server/flux2/``), whose OpenAPI document
+and ``JobStatus`` enum were read off a running FLUX.2-dev container.
+"""
+
+from model_control.image_dialects import (
+    MEDIA,
+    OPENAI,
+    TT_DIT,
+    dialect_from_openapi,
+    resolve_dialect,
+    split_route,
+)
+
+# The paths object served by a real FLUX.2-dev tt-dit container.
+FLUX2_PATHS = [
+    "/health",
+    "/generate",
+    "/jobs",
+    "/jobs/{job_id}",
+    "/jobs/{job_id}/image",
+    "/jobs/{job_id}/cancel",
+]
+
+
+class TestResolveDialect:
+    def test_tt_dit_generate_route(self):
+        assert resolve_dialect("http://flux2:7010/generate") is TT_DIT
+
+    def test_openai_images_route(self):
+        assert resolve_dialect("http://sd:7000/v1/images/generations") is OPENAI
+
+    def test_media_enqueue_route(self):
+        assert resolve_dialect("http://media:7000/enqueue") is MEDIA
+
+    def test_unrecognised_route_falls_back_to_media(self):
+        # Back-compat: this code path was unconditionally the media contract
+        # before other stacks existed.
+        assert resolve_dialect("http://thing:7000/something-else") is MEDIA
+
+    def test_resolves_without_a_scheme(self):
+        # internal_url is stored as "<host>:<port><route>".
+        assert resolve_dialect("flux2:7010/generate") is TT_DIT
+
+
+class TestSplitRoute:
+    def test_splits_root_from_route(self):
+        root, path = split_route("http://flux2:7010/generate")
+        assert root == "http://flux2:7010"
+        assert path == "/generate"
+
+    def test_job_templates_compose_onto_the_root(self):
+        root, _ = split_route("http://flux2:7010/generate")
+        assert root + TT_DIT.status_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc"
+        )
+        assert root + TT_DIT.image_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc/image"
+        )
+
+
+class TestDialectFromOpenapi:
+    def test_identifies_tt_dit_from_served_routes(self):
+        assert dialect_from_openapi(FLUX2_PATHS) is TT_DIT
+
+    def test_identifies_openai_image_server(self):
+        assert dialect_from_openapi(["/v1/images/generations", "/health"]) is OPENAI
+
+    def test_chat_server_is_not_an_image_dialect(self):
+        # A vLLM container serves no image route: returning None is what keeps it
+        # from being registered as an image model.
+        assert dialect_from_openapi(["/v1/models", "/v1/chat/completions"]) is None
+
+    def test_no_paths(self):
+        assert dialect_from_openapi([]) is None
+        assert dialect_from_openapi(None) is None
+
+
+class TestJobStateVocabulary:
+    def test_tt_dit_terminal_states_match_the_server_enum(self):
+        # models/tt_dit/server/flux2/jobs.py: queued|running|done|error|cancelled
+        assert "done" in TT_DIT.done_states
+        assert {"error", "cancelled"} <= TT_DIT.error_states
+        assert not ({"queued", "running"} & (TT_DIT.done_states | TT_DIT.error_states))
+
+    def test_media_completed_state_is_matched_lowercased(self):
+        # tt-media-server reports "Completed"; the view lowercases before comparing.
+        assert "Completed".lower() in MEDIA.done_states
+
+    def test_only_tt_dit_forwards_diffusion_params(self):
+        assert "num_inference_steps" in TT_DIT.extra_params
+        assert not MEDIA.extra_params
+        assert not OPENAI.extra_params

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -46,6 +46,7 @@ class IgnoreClientContentNegotiation(DefaultContentNegotiation):
 
 from .serializers import InferenceSerializer, ModelWeightsSerializer
 from .log_classifier import classify_startup_phase
+from .image_dialects import resolve_dialect, split_route
 
 
 # Module-level latch: tracks the highest phase + cached state we've ever seen
@@ -683,6 +684,11 @@ class ObjectDetectionInferenceCloudView(APIView):
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 
+# Upper bound on a single image-generation job. FLUX.2 at 1024x1024/50 steps is
+# minutes of work, so this is a stuck-job backstop, not a performance budget.
+IMAGE_JOB_TIMEOUT_SECONDS = 30 * 60
+
+
 class ImageGenerationInferenceView(APIView):
     def post(self, request, *args, **kwargs):
         """special image generation inference view that performs special file handling"""
@@ -697,8 +703,14 @@ class ImageGenerationInferenceView(APIView):
             try:
                 headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
 
-                if "/v1/images/generations" in internal_url:
-                    # Synchronous OpenAI-compatible API — returns base64 JSON immediately
+                dialect = resolve_dialect(internal_url)
+                server_root, _ = split_route(internal_url)
+                logger.info(
+                    f"image generation via '{dialect.name}' dialect at {internal_url}"
+                )
+
+                if dialect.mode == "sync":
+                    # The image comes back on the submit call as base64 JSON.
                     inference_data = requests.post(
                         internal_url,
                         json={"prompt": prompt},
@@ -712,34 +724,81 @@ class ImageGenerationInferenceView(APIView):
                     else:
                         b64_image = resp_json["data"][0]["b64_json"]
                     image_bytes = base64.b64decode(b64_image)
-                    django_response = HttpResponse(image_bytes, content_type="image/jpeg")
-                    django_response["Content-Disposition"] = "attachment; filename=image.jpg"
-                    return django_response
-                else:
-                    # Legacy enqueue/poll/fetch API
-                    inference_data = requests.post(
-                        internal_url, json={"prompt": prompt}, headers=headers, timeout=5
+                    django_response = HttpResponse(
+                        image_bytes, content_type=dialect.default_content_type
                     )
-                    inference_data.raise_for_status()
-
-                    ready_latest = False
-                    task_id = inference_data.json().get("task_id")
-                    get_status_url = internal_url.replace("/enqueue", f"/status/{task_id}")
-                    while not ready_latest:
-                        latest_prompt = requests.get(get_status_url, headers=headers)
-                        if latest_prompt.status_code != status.HTTP_404_NOT_FOUND:
-                            latest_prompt.raise_for_status()
-                            if latest_prompt.json()["status"] == "Completed":
-                                ready_latest = True
-                        time.sleep(1)
-
-                    get_image_url = internal_url.replace("/enqueue", f"/fetch_image/{task_id}")
-                    latest_image = requests.get(get_image_url, headers=headers, stream=True)
-                    latest_image.raise_for_status()
-                    content_type = latest_image.headers.get("Content-Type", "application/octet-stream")
-                    django_response = HttpResponse(latest_image.content, content_type=content_type)
-                    django_response["Content-Disposition"] = "attachment; filename=image.png"
+                    django_response["Content-Disposition"] = (
+                        f"attachment; filename={dialect.default_filename}"
+                    )
                     return django_response
+
+                # Job dialects: submit -> poll for a terminal state -> fetch bytes.
+                payload = {"prompt": prompt}
+                for req_field, server_field in dialect.extra_params.items():
+                    value = data.get(req_field)
+                    if value is not None:
+                        payload[server_field] = value
+
+                inference_data = requests.post(
+                    internal_url, json=payload, headers=headers, timeout=30
+                )
+                inference_data.raise_for_status()
+                job_id = inference_data.json().get(dialect.job_id_field)
+                if not job_id:
+                    logger.error(
+                        f"{dialect.name}: submit response carried no "
+                        f"'{dialect.job_id_field}'; cannot track the job"
+                    )
+                    return Response(status=status.HTTP_502_BAD_GATEWAY)
+
+                status_url = server_root + dialect.status_template.format(job_id=job_id)
+                image_url = server_root + dialect.image_template.format(job_id=job_id)
+
+                # Diffusion on accelerators runs for minutes, so this poll is bounded
+                # generously; it exists to stop a wedged job from hanging the request
+                # forever, not to second-guess a slow-but-healthy generation.
+                deadline = time.time() + IMAGE_JOB_TIMEOUT_SECONDS
+                while True:
+                    if time.time() > deadline:
+                        logger.error(
+                            f"{dialect.name}: job {job_id} did not finish within "
+                            f"{IMAGE_JOB_TIMEOUT_SECONDS}s"
+                        )
+                        return Response(status=status.HTTP_504_GATEWAY_TIMEOUT)
+
+                    poll = requests.get(status_url, headers=headers, timeout=30)
+                    # A job id can briefly 404 before the server registers it.
+                    if poll.status_code != status.HTTP_404_NOT_FOUND:
+                        poll.raise_for_status()
+                        job_state = str(poll.json().get("status", "")).lower()
+                        if job_state in dialect.done_states:
+                            break
+                        if job_state in dialect.error_states:
+                            detail = poll.json().get("error")
+                            logger.error(
+                                f"{dialect.name}: job {job_id} ended as "
+                                f"'{job_state}': {detail}"
+                            )
+                            return Response(
+                                {"error": detail or f"Generation {job_state}."},
+                                status=status.HTTP_502_BAD_GATEWAY,
+                            )
+                    time.sleep(1)
+
+                latest_image = requests.get(
+                    image_url, headers=headers, stream=True, timeout=120
+                )
+                latest_image.raise_for_status()
+                content_type = latest_image.headers.get(
+                    "Content-Type", dialect.default_content_type
+                )
+                django_response = HttpResponse(
+                    latest_image.content, content_type=content_type
+                )
+                django_response["Content-Disposition"] = (
+                    f"attachment; filename={dialect.default_filename}"
+                )
+                return django_response
 
             except requests.exceptions.HTTPError as http_err:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -81,17 +81,29 @@ def build_external_model_impl(
     hf_model_id: Optional[str] = None,
     service_port: int = 7000,
     tool_calling_enabled: bool = False,
+    service_route: Optional[str] = None,
 ) -> ExternalModelImpl:
     """Build the stand-in impl for an externally-registered container.
 
     An UNKNOWN type still gets an impl (so the container is tracked) but keeps a
     bare service route: nothing in the UI offers inference against it, and health
     is reported as unknown rather than probing a guessed endpoint.
+
+    ``service_route`` overrides the per-type default when registration observed the
+    route the container actually serves (read from its OpenAPI document). The
+    per-type default is only a convention, and stacks that predate or ignore it --
+    tt-metal's DiT image servers serve ``/generate``, not
+    ``/v1/images/generations`` -- would otherwise be handed a route that 404s.
     """
     resolved_type = normalize_external_model_type(
         getattr(model_type, "value", model_type)
     )
-    service_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    resolved_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    # An observed route only applies to a type we can actually drive; UNKNOWN keeps
+    # its bare route so no UI offers inference against it.
+    if service_route and resolved_type is not ModelTypes.UNKNOWN:
+        resolved_route = service_route
+    service_route = resolved_route
     return ExternalModelImpl(
         model_name=model_name,
         model_id=f"id_external-{model_name}",


### PR DESCRIPTION
## Summary
Externally registered image models came up unusable — labelled as chat models, with a service route that 404s. tt-metal's DiT image servers (models.tt_dit) serve `POST /generate` plus `/jobs/<id>` polling rather than `/v1/images/generations`, and our name-based type guess falls back to chat when it recognises nothing.

Registration now reads the container's OpenAPI document to derive both the model type and the route it actually serves, which beats guessing from weight names. The two hardcoded branches in the image view become a dialect table, so a new
serving stack is a new row instead of another branch.

## Changes
- Derive model type and service route from the container's OpenAPI document
- Persist the observed route so it survives a backend restart
- Replace the hardcoded image branches with a dialect table (openai / media / tt_dit)
- Forward diffusion params (steps, guidance, seed, size) where the server accepts them
- Bound the job poll so a wedged generation can't hang the request
- Verified against a running FLUX.2-dev container: 202 + job_id → done → valid PNG
- 30 backend tests passing (14 new)