### PR TITLE
feat: enable compatible p300x2 models on p150x4

### DIFF
--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -136,6 +136,44 @@ WHOLE_BOARD_DEFAULT_BOARDS = {"T3K", "T3000", "N300x4", "N150X4", "GALAXY", "GAL
 # mesh deployments let the inference server claim the full board itself.
 _SINGLE_CHIP_DEVICE_NAMES = {"n150", "n300", "e150", "p100", "p150", "p300"}
 
+# vLLM spec-name fallback between four-chip Blackhole meshes. The vLLM plugin
+# maps both labels to a (1, 4) mesh, so a chat model that only publishes a
+# p300x2 spec can still be asked for on p150x4 hardware (and vice versa) by
+# sending the other name.
+_VLLM_MESH_SPEC_FALLBACK = {
+    "p150x4": ("p300x2",),
+    "p300x2": ("p150x4",),
+}
+
+# Trace region size (bytes) to force where a model_spec under-allocates it, which
+# stops the deploy during traced warmup with a TT_FATAL error.
+_TRACE_REGION_OVERRIDES = {
+    # p150x4 spec is stale at 0.10.x with 30000000; traced decode needs 56557568.
+    # Value matches the maintained p300x2 spec for the same four-chip mesh.
+    ("Llama-3.3-70B-Instruct", "p150x4"): 402653184,
+    # Both P150X4 FLUX configs omit this setting and inherit 34.5 MB. Traced
+    # warmup needs 50,724,864 bytes; 51 MB matches their maintained P300X2 specs.
+    ("FLUX.1-dev", "p150x4"): 51_000_000,
+    ("FLUX.1-schnell", "p150x4"): 51_000_000,
+}
+
+# Docker images to force where the per-device model_spec resolves to one whose API
+# this backend can no longer drive. Keyed by (model_name, device); a device of "*"
+# applies to every device for that model.
+_MEDIA_IMAGE_OVERRIDES = {
+    # Wan T2V on every board: 0.17.0 carries the MODEL_WEIGHTS_DIR fix (#4107), so
+    # it reads the mounted host HF cache instead of re-downloading ~118GB.
+    ("Wan2.2-T2V-A14B-Diffusers", "*"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+    ),
+    # FLUX on p150x4: that spec resolves to 0.10.0-555f240, so override to the newer image.
+    ("FLUX.1-dev", "p150x4"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+    ),
+    ("FLUX.1-schnell", "p150x4"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76"
+    ),
+}
 
 def map_board_type_to_device_name(board_type):
     """Map our internal board type names to TT Inference Server device names"""
@@ -304,6 +342,82 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
         return {"status": "error", "message": error_msg}
 
 
+def _supported_devices(impl):
+    """Inference-server device names this model declares a model_spec for."""
+    return {map_board_type_to_device_name(cfg.name) for cfg in impl.device_configurations}
+
+
+def _vllm_mesh_fallback_allowed(impl):
+    """True for vLLM chat models; media/forge pin to one board topology."""
+    engine = getattr(impl, "inference_engine", None)
+    if engine:
+        return str(engine).lower() == "vllm"
+    return impl.model_type == ModelTypes.CHAT
+
+
+def equivalent_mesh_device(impl, device):
+    """For vLLM, swap `device` for the other four-chip Blackhole spec if needed.
+
+    Returns `device` untouched when the model already declares it, when the
+    engine is not vLLM, or when no fallback spec exists. Media models such as
+    FLUX keep the board's own name even if they only list the other mesh.
+    """
+    if not _vllm_mesh_fallback_allowed(impl):
+        return device
+    supported = _supported_devices(impl)
+    if device in supported:
+        return device
+    for alt in _VLLM_MESH_SPEC_FALLBACK.get(device, ()):
+        if alt in supported:
+            logger.info(
+                f"{impl.model_name}: no '{device}' vLLM model_spec; using "
+                f"'{alt}' (four-chip Blackhole mesh fallback)"
+            )
+            return alt
+    return device
+
+
+def vllm_mesh_fallback_fits(impl, board_type):
+    """True when a vLLM model has no native spec for `board_type` but does for
+    the other four-chip Blackhole mesh, so the catalog can still offer it."""
+    if not _vllm_mesh_fallback_allowed(impl):
+        return False
+    board_device = map_board_type_to_device_name(board_type)
+    supported = _supported_devices(impl)
+    if board_device in supported:
+        return False
+    return any(alt in supported for alt in _VLLM_MESH_SPEC_FALLBACK.get(board_device, ()))
+
+
+def claims_whole_board(device, board_device):
+    """True when `device` takes every chip: the board's own name or a vLLM fallback."""
+    return device == board_device or device in _VLLM_MESH_SPEC_FALLBACK.get(
+        board_device, ()
+    )
+
+
+def trace_region_override(model_name, device):
+    """Forced trace region size (bytes) for this pair, or None."""
+    size = _TRACE_REGION_OVERRIDES.get((model_name, device))
+    if size:
+        logger.info(f"{model_name} on {device}: forcing trace_region_size {size} B")
+    return size
+
+
+def media_image_override(model_name, device):
+    """Docker image to force for this model/device pair, or None.
+
+    Shared by run_container and the media pre-pull resolver so the image whose
+    download the UI reports progress for is the image the deploy actually runs.
+    """
+    image = _MEDIA_IMAGE_OVERRIDES.get(
+        (model_name, device)
+    ) or _MEDIA_IMAGE_OVERRIDES.get((model_name, "*"))
+    if image:
+        logger.info(f"{model_name} on {device}: pinning docker image {image}")
+    return image
+
+
 def infer_inference_server_device(impl, board_type=None):
     """The inference-server device name (n150/p300/…) for `impl`. Single source of
     truth shared by run_container and the pre-pull image resolver so they never
@@ -312,18 +426,19 @@ def infer_inference_server_device(impl, board_type=None):
     if board_type is None:
         board_type = detect_board_type()
     chips_required = infer_chips_required(impl.device_configurations)
+    board_device = map_board_type_to_device_name(board_type)
     if chips_required == 1:
         device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
         # A constituent single-chip device (e.g. p150 on a P300x2 board) is only valid
         # if the model actually declares support for it. Media models like FLUX have no
         # p150 spec — only the whole-board mesh (p300x2). When the single chip isn't a
         # supported device for this model but the whole board is, deploy on the board mesh.
-        supported = {map_board_type_to_device_name(cfg.name) for cfg in impl.device_configurations}
-        board_device = map_board_type_to_device_name(board_type)
+        supported = _supported_devices(impl)
         if device not in supported and board_device in supported:
             device = board_device
     else:
-        device = map_board_type_to_device_name(board_type)
+        device = board_device
+    device = equivalent_mesh_device(impl, device)
     # Speech models need a single n150-class chip even on n300-based boards.
     if impl.model_type in [ModelTypes.TTS, ModelTypes.SPEECH_RECOGNITION]:
         if device == "n300" and board_type in {"T3K", "T3000", "N300x4", "GALAXY", "GALAXY_T3K"}:
@@ -401,9 +516,12 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         if device in _SINGLE_CHIP_DEVICE_NAMES:
             payload["device_id"] = str(device_id)
 
-        # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
-        if impl.model_name == "Qwen3-32B" and device == "p300x2":
-            payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+        # The inference server merges override_tt_config over the spec's, key by key.
+        trace_region_size = trace_region_override(impl.model_name, device)
+        if trace_region_size:
+            payload["override_tt_config"] = json.dumps(
+                {"trace_region_size": trace_region_size}
+            )
 
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:
@@ -417,12 +535,11 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # if use_image_override and impl.model_name in {"whisper-large-v3", "speecht5_tts"} and board_type == "P300x2":
         #     payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:qb2_launch-6900b0c-dev"
 
-        # Wan T2V pinned to the 0.17.0 media image: carries the MODEL_WEIGHTS_DIR fix
-        # (#4107) so it uses the mounted host HF cache instead of re-downloading ~118GB.
-        # Pinned explicitly because per-device resolution would otherwise pick older
-        # images on some boards (e.g. 0.10.0-555f240 for Wan on p150x4) that lack the fix.
-        if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+        # Some per-device model_specs resolve to an image too old to serve our
+        # requests, so force the known-good one.
+        pinned_image = media_image_override(impl.model_name, device)
+        if pinned_image:
+            payload["override_docker_image"] = pinned_image
 
         # Disambiguate the target model_spec. Some models share a name+device across
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training

--- a/app/backend/docker_control/tests.py
+++ b/app/backend/docker_control/tests.py
@@ -11,12 +11,25 @@ from rest_framework.test import APIClient
 
 from docker_control.chip_allocator import ChipSlotAllocator
 from docker_control.deployment_sync import _classify_failure
+from docker_control.docker_utils import (
+    claims_whole_board,
+    deploys_whole_board,
+    equivalent_mesh_device,
+    infer_inference_server_device,
+    media_image_override,
+    trace_region_override,
+    vllm_mesh_fallback_fits,
+)
 from docker_control.views import (
     _LLAMA_V014_IMAGE,
     _resolve_artifact_ref,
     _resolve_override_docker_image,
 )
-from shared_config.model_config import model_implmentations
+from shared_config.model_config import (
+    DeviceConfigurations,
+    ModelTypes,
+    model_implmentations,
+)
 
 
 @dataclass
@@ -242,3 +255,193 @@ class ArtifactRefResolutionTests(SimpleTestCase):
     def test_empty_ref_map(self):
         impl = _FakeModelImpl(requires_dev_catalog=True, inference_artifact_ref={})
         self.assertIsNone(_resolve_artifact_ref(impl, "p150", "P150"))
+
+
+@dataclass
+class _FakeDeviceImpl:
+    """Only what device resolution reads — a real ModelImpl's __post_init__ builds
+    volume mounts and env this never touches."""
+    model_name: str
+    model_type: ModelTypes
+    device_configurations: set
+    inference_engine: str = None
+
+
+def _device_impl(config_names, model_type=ModelTypes.CHAT, model_name="SomeModel", inference_engine=None):
+    return _FakeDeviceImpl(
+        model_name=model_name,
+        model_type=model_type,
+        device_configurations={DeviceConfigurations[n] for n in config_names},
+        inference_engine=inference_engine,
+    )
+
+
+class MeshEquivalentDeviceTests(SimpleTestCase):
+    """vLLM can reuse the other four-chip Blackhole spec when this board has none.
+    Media models must not: P150x4 and P300x2 are different topologies."""
+
+    def test_p300x2_only_vllm_model_resolves_to_p300x2_on_p150x4(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P300x2"]), "P150X4"), "p300x2"
+        )
+
+    def test_fallback_holds_in_the_other_direction_for_vllm(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X4"]), "P300x2"), "p150x4"
+        )
+
+    def test_native_spec_is_preferred_over_the_fallback(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X4", "P300x2"]), "P150X4"),
+            "p150x4",
+        )
+
+    def test_flux_keeps_the_board_device_even_without_a_native_mesh_spec(self):
+        """FLUX.1-schnell is complete on p300x2 and listed for p150x4, but the
+        p150x4 media spec is a different image/MESH_DEVICE — never rewrite it."""
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-schnell",
+            inference_engine="media",
+        )
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150x4")
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_flux_with_both_specs_uses_the_native_one(self):
+        impl = _device_impl(
+            ["P150X4", "P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-dev",
+            inference_engine="media",
+        )
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150x4")
+        self.assertEqual(infer_inference_server_device(impl, "P300x2"), "p300x2")
+
+    def test_single_chip_model_still_takes_the_single_chip(self):
+        impl = _device_impl(["P150", "P150X4", "P300x2"])
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150")
+        self.assertFalse(deploys_whole_board(impl, "P150X4"))
+
+    def test_mesh_only_vllm_model_claims_the_whole_board(self):
+        self.assertTrue(deploys_whole_board(_device_impl(["P300x2"]), "P150X4"))
+
+    def test_no_fallback_across_chip_counts(self):
+        """p150x8 is eight chips; it must not satisfy a four-chip board."""
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X8"]), "P150X4"), "p150x4"
+        )
+
+    def test_wormhole_model_is_untouched(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["T3K"]), "P150X4"), "p150x4"
+        )
+
+
+class EquivalentMeshDeviceTests(SimpleTestCase):
+    """equivalent_mesh_device is what the chat deploy path calls directly."""
+
+    def test_p300x2_only_vllm_model_is_swapped(self):
+        impl = _device_impl(["P300x2"], model_name="Qwen3.8-27B")
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p300x2")
+
+    def test_declared_device_is_never_swapped(self):
+        impl = _device_impl(["P150X4", "P300x2"])
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_media_model_is_never_swapped(self):
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-dev",
+            inference_engine="media",
+        )
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_single_chip_device_is_never_promoted(self):
+        """A pinned chip must not become a whole-board deploy: the chat path
+        reserves one slot for it (mesh_whole_board excludes CHAT models)."""
+        impl = _device_impl(["N150X4", "N300"], model_name="Qwen2.5-7B")
+        self.assertEqual(equivalent_mesh_device(impl, "n150"), "n150")
+
+    def test_device_with_no_fallback_is_unchanged(self):
+        self.assertEqual(equivalent_mesh_device(_device_impl(["T3K"]), "t3k"), "t3k")
+        self.assertEqual(
+            equivalent_mesh_device(_device_impl(["P150X8"]), "p150x4"), "p150x4"
+        )
+
+
+class ClaimsWholeBoardTests(SimpleTestCase):
+    def test_board_own_name_and_equivalent_both_claim_it(self):
+        self.assertTrue(claims_whole_board("p150x4", "p150x4"))
+        self.assertTrue(claims_whole_board("p300x2", "p150x4"))
+
+    def test_single_chip_does_not_claim_the_board(self):
+        self.assertFalse(claims_whole_board("p150", "p150x4"))
+        self.assertFalse(claims_whole_board("n150", "n150x4"))
+
+
+class VllmMeshFallbackFitsTests(SimpleTestCase):
+    def test_p300x2_only_vllm_fits_p150x4(self):
+        self.assertTrue(vllm_mesh_fallback_fits(_device_impl(["P300x2"]), "P150X4"))
+
+    def test_media_p300x2_only_does_not_fit_p150x4(self):
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            inference_engine="media",
+        )
+        self.assertFalse(vllm_mesh_fallback_fits(impl, "P150X4"))
+
+    def test_native_p150x4_is_not_a_fallback(self):
+        self.assertFalse(
+            vllm_mesh_fallback_fits(_device_impl(["P150X4", "P300x2"]), "P150X4")
+        )
+
+
+class MediaImageOverrideTests(SimpleTestCase):
+    """The p150x4 FLUX specs resolve to 0.10.0-555f240, whose image API 404s
+    /v1/models and 422s a prompt-only /v1/images/generations."""
+
+    def test_flux_dev_on_p150x4_is_pinned_to_the_p300x2_image(self):
+        self.assertEqual(
+            media_image_override("FLUX.1-dev", "p150x4"),
+            "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+        )
+
+    def test_flux_schnell_on_p150x4_is_pinned_to_its_own_newer_image(self):
+        self.assertEqual(
+            media_image_override("FLUX.1-schnell", "p150x4"),
+            "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76",
+        )
+
+    def test_flux_on_p300x2_keeps_the_spec_image(self):
+        """p300x2 already resolves to 0.17.0/0.18.0, so pinning there would only
+        create a second place to update."""
+        self.assertIsNone(media_image_override("FLUX.1-dev", "p300x2"))
+        self.assertIsNone(media_image_override("FLUX.1-schnell", "p300x2"))
+
+    def test_wan_is_pinned_on_every_device(self):
+        image = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+        for device in ("p150x4", "p300x2", "t3k", "galaxy"):
+            self.assertEqual(
+                media_image_override("Wan2.2-T2V-A14B-Diffusers", device), image
+            )
+
+    def test_unpinned_model_returns_none(self):
+        self.assertIsNone(media_image_override("whisper-large-v3", "p150"))
+        self.assertIsNone(media_image_override("Llama-3.1-8B-Instruct", "p150x4"))
+
+
+class MediaTraceRegionOverrideTests(SimpleTestCase):
+    def test_both_flux_variants_reserve_p300x2_trace_region_on_p150x4(self):
+        self.assertEqual(
+            trace_region_override("FLUX.1-dev", "p150x4"), 51_000_000
+        )
+        self.assertEqual(
+            trace_region_override("FLUX.1-schnell", "p150x4"), 51_000_000
+        )
+
+    def test_other_devices_and_models_keep_their_spec_setting(self):
+        self.assertIsNone(trace_region_override("FLUX.1-dev", "p300x2"))
+        self.assertIsNone(trace_region_override("whisper-large-v3", "p150"))

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -37,6 +37,11 @@ from .docker_utils import (
     map_board_type_to_device_name,
     infer_inference_server_device,
     deploys_whole_board,
+    claims_whole_board,
+    equivalent_mesh_device,
+    media_image_override,
+    trace_region_override,
+    vllm_mesh_fallback_fits,
     _BOARD_TO_SINGLE_CHIP_DEVICE,
     WHOLE_BOARD_DEFAULT_BOARDS,
     update_deploy_cache,
@@ -285,6 +290,9 @@ class ContainersView(APIView):
             'P300': [DeviceConfigurations.P300],
 
             # Blackhole multi-device
+            # Do not list P300x2 here: four chips is not the same topology (4×P150 vs
+            # 2×P300), and media specs (FLUX, Wan) fail if we pretend they are. vLLM
+            # models that only have the other mesh still show via vllm_mesh_fallback_fits.
             'P150X4': [DeviceConfigurations.P150X4, DeviceConfigurations.P150],
             'P150X8': [DeviceConfigurations.P150X8, DeviceConfigurations.P150],
             # P300x2/P300Cx4: include P150 so single-chip models (--tt-device p150) show as compatible
@@ -312,12 +320,16 @@ class ContainersView(APIView):
             else:
                 # Check if any of the current board's device configurations are in the model's configurations
                 is_compatible = bool(current_board_devices.intersection(impl.device_configurations))
+                if not is_compatible:
+                    is_compatible = vllm_mesh_fallback_fits(impl, current_board)
                 logger.info(f"Model {impl.model_name}: is_compatible={is_compatible}")
             
             # Get all boards this model can run on
             compatible_boards = []
             for board, devices in board_to_device_map.items():
-                if board != 'unknown' and bool(set(devices).intersection(impl.device_configurations)):
+                if board == 'unknown':
+                    continue
+                if bool(set(devices).intersection(impl.device_configurations)) or vllm_mesh_fallback_fits(impl, board):
                     compatible_boards.append(board)
 
             # Manual override: always show certain models as compatible (e.g. whisper when sync JSON is incomplete)
@@ -689,6 +701,12 @@ class DeployView(APIView):
                         # User pinned a slot, or a per-chip-default board (e.g. P300x2) —
                         # use the single constituent chip device.
                         device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
+                    # Chat deploys resolve the device here instead of via
+                    # infer_inference_server_device, so apply the vLLM mesh fallback
+                    # too or a p300x2-only chat model sends --device p150x4 and 404s
+                    # on spec lookup. Mesh names only: never promotes a pinned chip,
+                    # and media models are not rewritten.
+                    device = equivalent_mesh_device(impl, device)
                     # QB2 paired-chip path: Llama-3.1-8B on either P300 card pair
                     # (device-id 0,1 or 2,3) should run with --tt-device p300 (not p150).
                     if (
@@ -704,15 +722,24 @@ class DeployView(APIView):
                     whole_board_device = map_board_type_to_device_name(board_type)
                     single_chip_device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
                     is_multi_chip_board = whole_board_device != single_chip_device
-                    if device == whole_board_device and is_multi_chip_board:
+                    # A vLLM fallback name still claims every chip, so it omits
+                    # device_id exactly as the board's own name would.
+                    if claims_whole_board(device, whole_board_device) and is_multi_chip_board:
                         inference_device_id = None
                     else:
                         inference_device_id = ",".join(str(d) for d in occupied_device_ids)
-                # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+                # Sent two ways on purpose: override_tt_config is the documented
+                # field, but run.py only mounts the resolved runtime spec in dev mode
+                # / --custom-weights, so on an ordinary deploy the container re-reads
+                # the stale spec baked into its image and drops it. The same value on
+                # the container's own vllm command line wins over the spec default.
                 override_tt_config = None
-                qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
-                if qwen32b_p300x2:
-                    override_tt_config = '{"trace_region_size": 53000000}'
+                overrides = {}
+                trace_region_size = trace_region_override(impl.model_name, device)
+                if trace_region_size:
+                    tt_config = {"trace_region_size": trace_region_size}
+                    override_tt_config = json.dumps(tt_config)
+                    overrides["override_tt_config"] = tt_config
                 # Enable vLLM tool calling for chat-completions models so coding
                 # agents (Claude Code, Cursor) that send tool_choice:"auto" work.
                 # Only for /v1/chat/completions models with a known parser — base
@@ -720,7 +747,6 @@ class DeployView(APIView):
                 vllm_override_args = None
                 tool_calling_supported = False
                 if impl.service_route == "/v1/chat/completions":
-                    overrides = {}
                     tool_parser = tool_call_parser_for(
                         impl.model_name, getattr(impl, "hf_model_id", "")
                     )
@@ -733,8 +759,8 @@ class DeployView(APIView):
                     if reasoning_parser:
                         overrides["reasoning-parser"] = reasoning_parser
                     overrides.update(_local_weights_overrides(impl))
-                    if overrides:
-                        vllm_override_args = json.dumps(overrides)
+                if overrides:
+                    vllm_override_args = json.dumps(overrides)
                 override_docker_image = _resolve_override_docker_image(impl)
                 artifact_ref = _resolve_artifact_ref(impl, device, board_type)
                 chat_deploy_kwargs = dict(
@@ -915,7 +941,15 @@ class DeployView(APIView):
                 # resolve-image declares `impl: Optional[str]` and matches on
                 # impl_name. See the matching guard in docker_utils.run_container.
                 inference_impl = _impl_selector(getattr(impl, "inference_impl", None))
-                deploy_image = resolve_deploy_image(impl.model_name, media_device, impl=inference_impl) or impl.image_version
+                # A pinned image wins over what the server would resolve: run_container
+                # sends it as override_docker_image, so pre-pulling the spec's image
+                # would show progress for layers the deploy never uses and then stall
+                # while run.py pulls the pinned one untracked.
+                deploy_image = (
+                    media_image_override(impl.model_name, media_device)
+                    or resolve_deploy_image(impl.model_name, media_device, impl=inference_impl)
+                    or impl.image_version
+                )
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False
                 if image_name:

--- a/ci/deploy_healthcheck.py
+++ b/ci/deploy_healthcheck.py
@@ -221,7 +221,9 @@ def resolve_model_id(client, model_name, explicit_id):
     """Return the deploy model_id. Model ids are generated at runtime, so we
     resolve by human-readable model_name against the live catalog rather than
     hardcoding an id that could drift."""
-    st, data = client.get("catalog", timeout=30)
+    # Generous: the catalog probes every catalogued image against the Docker API,
+    # which is ~30s at 60+ models — the default 30s raced it.
+    st, data = client.get("catalog", timeout=180)
     if st != 200 or data.get("status") != "success":
         raise SmokeTestError(f"catalog fetch failed (HTTP {st}): {data}")
     models = data.get("models", {})

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -265,6 +265,38 @@ except ImportError as e:
         f"Ensure TT_INFERENCE_ARTIFACT_PATH or tt-inference-server/ provides run and workflows."
     ) from e
 
+# Media and forge runners read configuration from container environment
+# variables rather than vLLM's additional_config. Preserve the artifact's
+# override merge, then mirror trace_region_size into the env_vars that
+# run_docker_server passes as Docker -e arguments.
+import workflows.model_spec as _model_spec_module  # noqa: E402
+
+_orig_apply_model_spec_overrides = _model_spec_module.ModelSpec.apply_overrides
+
+
+def _patched_apply_model_spec_overrides(self, runtime_config):
+    result = _orig_apply_model_spec_overrides(self, runtime_config)
+    if runtime_config.override_tt_config and self.inference_engine in (
+        "media",
+        "forge",
+    ):
+        trace_region_size = self.device_model_spec.override_tt_config.get(
+            "trace_region_size"
+        )
+        if trace_region_size is not None:
+            object.__setattr__(
+                self,
+                "env_vars",
+                {
+                    **self.env_vars,
+                    "TRACE_REGION_SIZE": str(trace_region_size),
+                },
+            )
+    return result
+
+
+_model_spec_module.ModelSpec.apply_overrides = _patched_apply_model_spec_overrides
+
 # Patch HostSetupManager.check_model_weights_dir to guard against partially-downloaded
 #
 # Two on-disk layouts must be handled:

--- a/inference-api/artifact_refs.py
+++ b/inference-api/artifact_refs.py
@@ -135,6 +135,29 @@ def _download(url: str, dest: Path, ref: str) -> None:
     os.replace(tmp, dest)
 
 
+def _link_safe_data_filter(member: tarfile.TarInfo, dest_path: str):
+    """The ``data`` filter, minus link members.
+
+    tt-inference-server source archives -- the pinned release and every feature
+    branch alike -- carry four relative symlinks under ``.claude/skills`` and
+    ``.cursor/skills`` whose targets begin with ``..``. Before CPython gh-107845
+    (fixed in 3.10.13, 3.11.5 and 3.12.0) ``data_filter`` resolved a symlink's
+    target against the extraction root instead of against the symlink's own
+    directory, so *any* ``..`` in a linkname read as an escape and aborted the
+    whole extraction with LinkOutsideDestinationError. inference-api runs on
+    whatever ``python3`` built its venv -- 3.10.12 on Ubuntu 22.04 -- so that
+    older filter is the common case here, not the exception.
+
+    Nothing needed to run an artifact is a link (the structural check is
+    ``workflows/utils.py``); those four are editor tooling. Dropping every link
+    member is therefore both stricter than ``data`` and identical on every
+    Python, which is what makes the fetch version-independent.
+    """
+    if member.issym() or member.islnk():
+        return None
+    return tarfile.data_filter(member, dest_path)
+
+
 def _extract(tarball: Path, refs_root: Path, dest: Path, ref: str, url: str) -> None:
     """Extract `tarball` and move the resulting tree into `dest` atomically.
 
@@ -148,9 +171,15 @@ def _extract(tarball: Path, refs_root: Path, dest: Path, ref: str, url: str) -> 
             with tarfile.open(tarball, "r:gz") as tar:
                 # "data" refuses members that would escape the destination via
                 # absolute paths, "..", or links -- worth having on an archive
-                # fetched over the network. Feature-detected because the argument
-                # only exists on newer Pythons (it becomes the default in 3.14).
-                extract_kwargs = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
+                # fetched over the network. Wrapped to also drop link members, so
+                # the result does not depend on the running Python's data_filter
+                # vintage (see _link_safe_data_filter). Feature-detected because
+                # the argument only exists on newer Pythons (default in 3.14).
+                extract_kwargs = (
+                    {"filter": _link_safe_data_filter}
+                    if hasattr(tarfile, "data_filter")
+                    else {}
+                )
                 tar.extractall(staging, **extract_kwargs)
         except Exception as e:
             raise ArtifactRefError(

--- a/inference-api/tests/test_artifact_refs.py
+++ b/inference-api/tests/test_artifact_refs.py
@@ -151,3 +151,46 @@ def test_commit_sha_uses_bare_archive_path():
     assert artifact_refs._archive_url("my-branch").endswith(
         "/archive/refs/heads/my-branch.tar.gz"
     )
+
+
+def _add_skill_symlinks(root: Path) -> None:
+    """Reproduce the relative symlinks real tt-inference-server archives carry.
+
+    Both the pinned release tarball and every feature branch ship these four under
+    .claude/skills and .cursor/skills; their targets start with "..".
+    """
+    for d in (".claude/skills", ".cursor/skills"):
+        (root / d).mkdir(parents=True, exist_ok=True)
+    (root / ".claude" / "skills" / "build-blaze-images").symlink_to(
+        "../../tt-media-server/cpp_server/.cursor/skills/build-blaze-images"
+    )
+    (root / ".cursor" / "skills" / "extend-workflow-engine").symlink_to(
+        "../../.claude/skills/extend-workflow-engine"
+    )
+
+
+def test_relative_symlinks_do_not_block_extraction(tmp_path, monkeypatch):
+    """A '..' in a symlink target must not abort the fetch.
+
+    Before CPython gh-107845 (fixed in 3.10.13/3.11.5/3.12.0) tarfile's "data"
+    filter resolved a symlink target against the extraction root rather than the
+    symlink's own directory, so these links raised LinkOutsideDestinationError and
+    every artifact_ref fetch failed on Ubuntu 22.04's python3 (3.10.12).
+    """
+    root = tmp_path / "src" / "tt-inference-server-linky"
+    (root / "workflows").mkdir(parents=True)
+    (root / "workflows" / "utils.py").write_text("# stand-in\n")
+    _add_skill_symlinks(root)
+
+    tarball = tmp_path / "archive.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(root, arcname=root.name)
+    monkeypatch.setattr(artifact_refs, "_archive_url", lambda ref: tarball.as_uri())
+
+    result = resolve_artifact_dir("linky", tmp_path / ".artifacts")
+
+    assert (result / "workflows" / "utils.py").is_file()
+    # Links are dropped rather than recreated, so the outcome does not depend on
+    # which data_filter vintage the running Python ships.
+    assert not (result / ".claude" / "skills" / "build-blaze-images").exists()
+    assert not any(p.is_symlink() for p in result.rglob("*"))

--- a/inference-api/tests/test_media_trace_region_override.py
+++ b/inference-api/tests/test_media_trace_region_override.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import api  # noqa: E402
+from workflows.runtime_config import RuntimeConfig  # noqa: E402
+
+
+def _flux_p150x4_spec():
+    return copy.deepcopy(
+        next(
+            spec
+            for spec in api.MODEL_SPECS.values()
+            if spec.model_name == "FLUX.1-dev"
+            and spec.device_type.name.lower() == "p150x4"
+        )
+    )
+
+
+def test_media_trace_region_override_is_mirrored_to_container_env():
+    spec = _flux_p150x4_spec()
+    runtime_config = RuntimeConfig(
+        model=spec.model_name,
+        workflow="server",
+        device="p150x4",
+        override_tt_config='{"trace_region_size": 51000000}',
+    )
+
+    spec.apply_overrides(runtime_config)
+
+    assert spec.device_model_spec.override_tt_config["trace_region_size"] == 51_000_000
+    assert spec.env_vars["TRACE_REGION_SIZE"] == "51000000"
+
+
+def test_media_env_is_unchanged_without_runtime_override():
+    spec = _flux_p150x4_spec()
+    runtime_config = RuntimeConfig(
+        model=spec.model_name,
+        workflow="server",
+        device="p150x4",
+    )
+
+    spec.apply_overrides(runtime_config)
+
+    assert "TRACE_REGION_SIZE" not in spec.env_vars


### PR DESCRIPTION
## Summary
P150x4 and P300x2 are the same four-chip Blackhole mesh for vLLM, so chat models that only ship a p300x2 spec can now deploy on P150x4 (and the other way around). Media models stay on the board's own spec.

- Fall back to the other four-chip vLLM spec when this board has none, and surface those models in the catalog
- Pin FLUX/Wan images and raise trace_region_size on P150x4 so traced warmup does not TT_FATAL
- Mirror media trace_region overrides into TRACE_REGION_SIZE for the container
- Skip editor-skill symlinks when extracting inference-server artifacts (fixes Ubuntu 22.04 / Python 3.10.12)
- Give the CI catalog fetch a 180s timeout so it does not race a full Docker probe