### PR TITLE
fix(chat): stream thinking process live for reasoning models

### DIFF
--- a/app/backend/model_control/model_utils.py
+++ b/app/backend/model_control/model_utils.py
@@ -440,46 +440,52 @@ async def stream_response_from_external_api(url: str, json_data: dict, auth_toke
             if te != "chunked":
                 logger.warning(f"Unexpected transfer-encoding from vLLM: {te!r}")
 
-            async for chunk in response.aiter_text():
-                logger.debug(f"stream_response_from_external_api chunk:={chunk}")
-                if chunk.startswith("data: "):
-                    new_chunk = chunk[len("data: "):].strip()
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                logger.debug(f"stream_response_from_external_api line:={line}")
+                if line.startswith("data: "):
+                    new_chunk = line[len("data: "):].strip()
 
                     if new_chunk == "[DONE]":
-                        yield chunk
+                        yield "data: [DONE]\n\n"
                         stats = tracker.get_stats()
                         logger.info(f"ttft and tpot stats: {stats}")
                         yield "data: " + json.dumps(stats) + "\n\n"
                         break
 
                     elif new_chunk != "":
-                        chunk_dict = json.loads(new_chunk)
+                        try:
+                            chunk_dict = json.loads(new_chunk)
 
-                        # Track TTFT/TPOT from content delta chunks
-                        choices = chunk_dict.get("choices") or []
-                        if choices:
-                            delta = choices[0].get("delta", {})
-                            delta_reasoning = (
-                                delta.get("reasoning_content")
-                                or delta.get("reasoning")
-                                or delta.get("thinking")
-                            )
-                            if delta_reasoning:
-                                tracker.record_thinking_token()
-                            # chat completions: choices[0].delta.content
-                            # base/completions:  choices[0].text
-                            delta_content = delta.get("content") or choices[0].get("text") or ""
-                            if delta_content:
-                                tracker.record_content_token()
-                                logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
+                            # Track TTFT/TPOT from content delta chunks
+                            choices = chunk_dict.get("choices") or []
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                delta_reasoning = (
+                                    delta.get("reasoning_content")
+                                    or delta.get("reasoning")
+                                    or delta.get("thinking")
+                                )
+                                if delta_reasoning:
+                                    tracker.record_thinking_token()
+                                # chat completions: choices[0].delta.content
+                                # base/completions:  choices[0].text
+                                delta_content = delta.get("content") or choices[0].get("text") or ""
+                                if delta_content:
+                                    tracker.record_content_token()
+                                    logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
 
-                        # Capture prompt_tokens from usage chunk
-                        usage = chunk_dict.get("usage") or {}
-                        prompt_tokens = usage.get("prompt_tokens", 0)
-                        if prompt_tokens > 0:
-                            tracker.set_prompt_tokens(prompt_tokens)
+                            # Capture prompt_tokens from usage chunk
+                            usage = chunk_dict.get("usage") or {}
+                            prompt_tokens = usage.get("prompt_tokens", 0)
+                            if prompt_tokens > 0:
+                                tracker.set_prompt_tokens(prompt_tokens)
+                        except json.JSONDecodeError as e:
+                            logger.warning(f"Failed to parse SSE data JSON: {e}, data: {new_chunk[:100]}")
 
-                    yield chunk
+                    yield f"data: {new_chunk}\n\n"
 
         logger.info("stream_response_from_external_api done")
 

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -79,10 +79,12 @@ const PROSE_THINKING_HEADING = /^[\s#*_]*(?:thinking|thought)\s+process\s*:/i;
 // within the outline are separated by a single blank line.
 const PROSE_THINKING_END = /\n[ \t]*\n[ \t]*\n/;
 
-/** Normalize any variant thinking tags (<thought>, <reasoning>) to <think> */
+/** Normalize any variant thinking tags (<thought>, <reasoning>) and uppercase tags to lowercase <think> */
 const normalizeThinkingTags = (content: string): string => {
   if (!content) return content;
   return content
+    .replace(/<think>/gi, "<think>")
+    .replace(/<\/think>/gi, "</think>")
     .replace(/<thought>/gi, "<think>")
     .replace(/<\/thought>/gi, "</think>")
     .replace(/<reasoning>/gi, "<think>")
@@ -195,9 +197,11 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
     const [showSearchDetails, setShowSearchDetails] = useState(false);
-    // Check if thinking is actively streaming (has <think> but no closing </think>)
+    // Check if thinking is actively streaming (has <think> after the last </think>)
+    const lastThinkOpen = !streamOver ? taggedContent.lastIndexOf("<think>") : -1;
+    const lastThinkClose = !streamOver ? taggedContent.lastIndexOf("</think>") : -1;
     const isThinkingActive =
-      !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
+      lastThinkOpen !== -1 && lastThinkOpen > lastThinkClose;
     const contentRef = useRef(processContent(taggedContent).cleanedContent);
     const thinkingBlocksRef = useRef<string[]>([]);
     const intervalRef = useRef<number | null>(null);
@@ -282,9 +286,10 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // });
 
     // Extract live thinking text from incomplete <think> block during streaming
-    const lastThinkOpen = isThinkingActive ? taggedContent.lastIndexOf("<think>") : -1;
     const liveThinkingText =
-      lastThinkOpen !== -1 ? taggedContent.slice(lastThinkOpen + 7) : null;
+      isThinkingActive && lastThinkOpen !== -1
+        ? taggedContent.slice(lastThinkOpen + 7)
+        : null;
 
     // Detect whether the thinking block represents a web search
     const liveSearchInfo = liveThinkingText ? parseSearchInfo(liveThinkingText) : null;

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -79,6 +79,16 @@ const PROSE_THINKING_HEADING = /^[\s#*_]*(?:thinking|thought)\s+process\s*:/i;
 // within the outline are separated by a single blank line.
 const PROSE_THINKING_END = /\n[ \t]*\n[ \t]*\n/;
 
+/** Normalize any variant thinking tags (<thought>, <reasoning>) to <think> */
+const normalizeThinkingTags = (content: string): string => {
+  if (!content) return content;
+  return content
+    .replace(/<thought>/gi, "<think>")
+    .replace(/<\/thought>/gi, "</think>")
+    .replace(/<reasoning>/gi, "<think>")
+    .replace(/<\/reasoning>/gi, "</think>");
+};
+
 /** Tag an untagged prose scratchpad so it renders in the thinking panel. */
 const tagProseThinking = (
   content: string,
@@ -176,15 +186,18 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // Everything below reasons about thinking in terms of <think> tags, so
     // normalize prose scratchpads into tags once, up front.
     const streamOver = isStreamFinished || Boolean(isStopped);
+    const normalizedContent = normalizeThinkingTags(content);
     const taggedContent = closeUnterminatedThinking(
-      tagProseThinking(content, streamOver),
+      tagProseThinking(normalizedContent, streamOver),
       streamOver
     );
 
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
     const [showSearchDetails, setShowSearchDetails] = useState(false);
-    const [isThinkingActive, setIsThinkingActive] = useState(false);
+    // Check if thinking is actively streaming (has <think> but no closing </think>)
+    const isThinkingActive =
+      !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
     const contentRef = useRef(processContent(taggedContent).cleanedContent);
     const thinkingBlocksRef = useRef<string[]>([]);
     const intervalRef = useRef<number | null>(null);
@@ -221,11 +234,6 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
           processed.thinkingBlocks
         );
       }
-
-      // Check if thinking is actively streaming (has <think> but no closing </think>)
-      const hasIncompleteThinking =
-        !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
-      setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
         setRenderedContent(contentRef.current);
@@ -274,8 +282,9 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // });
 
     // Extract live thinking text from incomplete <think> block during streaming
-    const liveThinkMatch = !isStreamFinished ? taggedContent.match(/^<think>([\s\S]*)$/i) : null;
-    const liveThinkingText = liveThinkMatch ? liveThinkMatch[1] : null;
+    const lastThinkOpen = isThinkingActive ? taggedContent.lastIndexOf("<think>") : -1;
+    const liveThinkingText =
+      lastThinkOpen !== -1 ? taggedContent.slice(lastThinkOpen + 7) : null;
 
     // Detect whether the thinking block represents a web search
     const liveSearchInfo = liveThinkingText ? parseSearchInfo(liveThinkingText) : null;

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -439,7 +439,7 @@ export const runInference = async (
           const rawReasoning = delta?.reasoning_content ?? delta?.reasoning ?? delta?.thinking;
           const reasoning =
             typeof rawReasoning === "string"
-              ? rawReasoning.replace(/<\/?think>/gi, "")
+              ? rawReasoning.replace(/<\/?(think|thought|reasoning)>/gi, "")
               : null;
 
           if (reasoning && !thinkingDone) {
@@ -454,7 +454,7 @@ export const runInference = async (
           // Regular content tokens
           const rawContent = delta?.content ?? jsonData.choices?.[0]?.text ?? "";
           const content = rawContent
-            .replace(/[\[<|]*python_tag[\]>|]*/gi, "")
+            .replace(/[[<|]*python_tag[\]>|]*/gi, "")
             .replace(/\{\s*"name"\s*:\s*"[^"]*(?:tavily|search)[^"]*"\s*,\s*"(?:parameters|arguments)"\s*:\s*\{[^}]*\}\s*\}/gi, "");
           if (content) {
             if (thinkingText && !thinkingDone) {


### PR DESCRIPTION
## Description

Reasoning models like `diffusiongemma-26B-A4B-it` weren't streaming their thinking process in real time—the chat UI stayed blank while reasoning, and then rendered the thinking block and response all at once after generation finished.
 - Fixes #1298
## What changed
- **StreamingMessage.tsx**:
  - Sliced live thinking text by index instead of using an anchored `^<think>` regex (which failed whenever leading whitespace or newlines were present).
  - Derived `isThinkingActive` synchronously on render to eliminate the 1-tick `useEffect` delay.
  - Normalized `<thought>` and `<reasoning>` tags to support Gemma-style thinking blocks.
- **runInference.ts**:
  - Stripped variant thinking tags from `reasoning_content` deltas.
- **model_utils.py**:
  - Switched from `aiter_text()` to `aiter_lines()` in the SSE streaming proxy so chunk boundaries don't drop tokens or fail JSON parsing.

## How it was tested
- Since I don't have physical TT hardware, I mocked the inference server and SSE stream to test and validate the end-to-end flow locally in the browser.
- Verified that reasoning tokens stream incrementally inside the thinking box.
- Verified that the thinking panel collapses to "Show thinking process" and the answer streams smoothly underneath once reasoning finishes.
- Confirmed `npm run type-check` and `npm run build` pass cleanly.

## Working

https://github.com/user-attachments/assets/0fd1377c-a08d-4c8d-8c39-c0467282e219



