### PR TITLE
fix(docker-control): keep container listing alive when an image lookup 404s

### DIFF
--- a/docker-control-service/services/container_service.py
+++ b/docker-control-service/services/container_service.py
@@ -213,9 +213,22 @@ class ContainerService:
 
             container_list = []
             for container in containers:
-                # Get image tags
-                image_tags = container.image.tags if container.image.tags else []
-                image = image_tags[0] if image_tags else container.image.short_id
+                # Resolving `container.image` is a separate image-inspect call
+                # that 404s when the image was pruned or rebuilt underneath a
+                # still-running container. One such container must not empty
+                # the whole listing (the backend reads an empty list as "nothing
+                # is running" and reconciles every deployment to stopped), so
+                # fall back to the image ref recorded in the container config.
+                try:
+                    image_tags = container.image.tags or []
+                    image = image_tags[0] if image_tags else container.image.short_id
+                except docker.errors.APIError as img_err:
+                    image_tags = []
+                    image = (container.attrs.get("Config", {}) or {}).get("Image") or ""
+                    logger.warning(
+                        f"Image lookup failed for container {container.name} "
+                        f"({container.short_id}); using config ref '{image}': {img_err}"
+                    )
 
                 # Build comprehensive container info for backend compatibility
                 container_list.append({

--- a/docker-control-service/services/container_service.py
+++ b/docker-control-service/services/container_service.py
@@ -222,12 +222,19 @@ class ContainerService:
                 try:
                     image_tags = container.image.tags or []
                     image = image_tags[0] if image_tags else container.image.short_id
-                except docker.errors.APIError as img_err:
-                    image_tags = []
-                    image = (container.attrs.get("Config", {}) or {}).get("Image") or ""
+                except (docker.errors.ImageNotFound, docker.errors.NotFound) as img_err:
+                    image = (
+                        (container.attrs.get("Config") or {}).get("Image")
+                        or container.attrs.get("Image")
+                        or ""
+                    )
+                    image_tags = [image] if image else []
                     logger.warning(
-                        f"Image lookup failed for container {container.name} "
-                        f"({container.short_id}); using config ref '{image}': {img_err}"
+                        "Image lookup failed for container %s (%s); using config ref %r: %s",
+                        container.name,
+                        container.short_id,
+                        image,
+                        img_err,
                     )
 
                 # Build comprehensive container info for backend compatibility


### PR DESCRIPTION
Healthy model containers were disappearing from the UI mid-warmup. The docker-control-service list endpoint resolves \`container.image\` for every container, which is a separate image-inspect call. Once the frontend/backend/agent images had been rebuilt under the still-running prod containers, that call 404'd, the whole listing was abandoned, and the service returned an empty container list with HTTP 200. The backend reads an empty list as "nothing is running" and reconciled every active deployment to stopped after its 30s grace window.

- [x] Resolve the image per container; on a failed lookup fall back to the image ref from the container config and log a warning instead of failing the listing
- [x] Verified on a P300x2 box with three prod containers whose images had been pruned: listing returns all containers again, the warning fires per affected container with the right tag, and \`/docker/deployments/\` shows the model containers that had been demoted