### PR TITLE
Rc v2.10.2

### DIFF
--- a/.claude/skills/cli-design/SKILL.md
+++ b/.claude/skills/cli-design/SKILL.md
@@ -47,7 +47,9 @@ python3 reference/cli_skeleton.py --help   # the command surface  (then: no flag
 | `reference/test_cli_output.py` | copy into `tests/`: pure helpers, stream parsing, PTY + non-TTY render checks |
 
 Reference implementation in the wild: TT-Studio's `tt_setup/` (+ its house-rules doc
-`dev-docs/launcher-terminal-design.md`).
+`dev-docs/launcher-terminal-design.md`). When you're working in this repo, the
+companion **`tt-studio-cli`** skill has the concrete mechanics — package map, flag
+plumbing, hardware detection.
 
 ---
 

--- a/.claude/skills/tt-studio-cli/SKILL.md
+++ b/.claude/skills/tt-studio-cli/SKILL.md
@@ -22,6 +22,10 @@ deprecated.
 > Read this before touching the launcher. For the terminal-output design system
 > specifically, `dev-docs/launcher-terminal-design.md` is the canonical reference —
 > this skill covers the broader "how the launcher is built and how we like CLIs."
+>
+> This skill is TT-Studio-specific — it names real paths, modules and hardware in
+> this repo. The same design language with nothing repo-specific in it, plus runnable
+> reference files, is the **`cli-design`** skill; use that one for any other CLI.
 
 ## Architecture
 
@@ -39,7 +43,7 @@ The package is split into focused **subpackages**, each with an `__init__.py` th
 | Inference-server artifact | `inference_server/` (`_catalog`, `_config`, `_env`, `_git`, `_metadata`, `_privileges`, `_orchestrator`) |
 | Stop / purge teardown | `cleanup/` (`_runtime`, `_orchestrate`, `_resource_ops`) |
 | Docker build/failure diag | `docker_diag/` (`_build_progress`, `_diagnostics`) |
-| Standalone modules | `bootstrap.py`, `shell.py`, `startup_checks.py`, `docker.py`, `constants.py`, `logging.py`, `monitor.py`/`monitor_app.py` (`--status` TUI), `bug_report.py` (`--report-bug`), `shortcut.py` (`--install-shortcut`), `spdx.py`, `settings.py`, `venv_utils.py` |
+| Standalone modules | `bootstrap.py`, `shell.py`, `startup_checks.py`, `docker.py`, `constants.py`, `logging.py`, `monitor.py`/`monitor_app.py` (`--status` TUI), `bug_report.py` (`--report-bug`), `shortcut.py` (`--install-shortcut`), `switch.py` (`--switch`), `image_source.py` (prebuilt-vs-local image choice), `config_store.py`, `spdx.py`, `settings.py`, `venv_utils.py` |
 
 **The re-export rule.** A package's `__init__.py` imports and re-exports the names
 its submodules define, so `from tt_setup.console import step` and

--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.20.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.21.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,10 @@ services via `host.docker.internal`. Health checks: backend `GET /up/` and
 
 ```bash
 python run.py                 # full setup + start (venv, .env, artifact, Docker)
+python run.py run <model>     # setup + start + deploy <model> in one step, from the terminal (stage progress + endpoint shown; --browser to deploy via the web UI instead; omit <model> to pick interactively; --device-id 0 or --device-id 0,1 to pin chips)
 python run.py --dev           # dev mode: hot-reload frontend & backend, mount source
 python run.py --stop          # stop containers, keep the persistent volume
+python run.py --stop-model    # stop one deployed model + reset its chip(s); bare flag opens a picker, or pass a name
 python run.py --purge-all     # wipe containers, volumes, HF-cached models and .env
 python run.py --purge-model   # uninstall specific model(s); bare flag opens a picker
 python run.py --logs          # stream all container logs (docker compose logs -f, env-file wired)

--- a/app/backend/docker_control/deployment_store.py
+++ b/app/backend/docker_control/deployment_store.py
@@ -207,6 +207,7 @@ class _Manager:
                 "jwt_secret": kwargs.get("jwt_secret", None),
                 "model_type": kwargs.get("model_type", None),
                 "hf_model_id": kwargs.get("hf_model_id", None),
+                "service_route": kwargs.get("service_route", None),
             }
             data["next_id"] += 1
             data["records"].append(record)
@@ -259,6 +260,9 @@ class ModelDeployment:
         # catalog. "unknown" means we could not identify what the container serves.
         self.model_type: Optional[str] = None
         self.hf_model_id: Optional[str] = None
+        # The route the container was observed to serve, when it differs from the
+        # per-type convention (e.g. a tt-dit image server serving /generate).
+        self.service_route: Optional[str] = None
 
     @classmethod
     def _from_dict(cls, d: dict) -> "ModelDeployment":
@@ -283,6 +287,7 @@ class ModelDeployment:
         obj.failure_reason = d.get("failure_reason")
         obj.failure_message = d.get("failure_message")
         obj.tool_calling_enabled = d.get("tool_calling_enabled", False)
+        obj.service_route = d.get("service_route")
         obj.jwt_secret = d.get("jwt_secret")
         obj.model_type = d.get("model_type")
         obj.hf_model_id = d.get("hf_model_id")
@@ -309,6 +314,7 @@ class ModelDeployment:
             "jwt_secret": self.jwt_secret,
             "model_type": self.model_type,
             "hf_model_id": self.hf_model_id,
+            "service_route": self.service_route,
         }
 
     def save(self) -> None:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -903,6 +903,7 @@ def _external_model_impl(con_id, con):
         hf_model_id=dep.hf_model_id,
         service_port=dep.port or 7000,
         tool_calling_enabled=bool(getattr(dep, "tool_calling_enabled", False)),
+        service_route=getattr(dep, "service_route", None),
     )
     logger.debug(
         f"Using external model_impl for '{con['name']}' "

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -136,6 +136,44 @@ WHOLE_BOARD_DEFAULT_BOARDS = {"T3K", "T3000", "N300x4", "N150X4", "GALAXY", "GAL
 # mesh deployments let the inference server claim the full board itself.
 _SINGLE_CHIP_DEVICE_NAMES = {"n150", "n300", "e150", "p100", "p150", "p300"}
 
+# vLLM spec-name fallback between four-chip Blackhole meshes. The vLLM plugin
+# maps both labels to a (1, 4) mesh, so a chat model that only publishes a
+# p300x2 spec can still be asked for on p150x4 hardware (and vice versa) by
+# sending the other name.
+_VLLM_MESH_SPEC_FALLBACK = {
+    "p150x4": ("p300x2",),
+    "p300x2": ("p150x4",),
+}
+
+# Trace region size (bytes) to force where a model_spec under-allocates it, which
+# stops the deploy during traced warmup with a TT_FATAL error.
+_TRACE_REGION_OVERRIDES = {
+    # p150x4 spec is stale at 0.10.x with 30000000; traced decode needs 56557568.
+    # Value matches the maintained p300x2 spec for the same four-chip mesh.
+    ("Llama-3.3-70B-Instruct", "p150x4"): 402653184,
+    # Both P150X4 FLUX configs omit this setting and inherit 34.5 MB. Traced
+    # warmup needs 50,724,864 bytes; 51 MB matches their maintained P300X2 specs.
+    ("FLUX.1-dev", "p150x4"): 51_000_000,
+    ("FLUX.1-schnell", "p150x4"): 51_000_000,
+}
+
+# Docker images to force where the per-device model_spec resolves to one whose API
+# this backend can no longer drive. Keyed by (model_name, device); a device of "*"
+# applies to every device for that model.
+_MEDIA_IMAGE_OVERRIDES = {
+    # Wan T2V on every board: 0.17.0 carries the MODEL_WEIGHTS_DIR fix (#4107), so
+    # it reads the mounted host HF cache instead of re-downloading ~118GB.
+    ("Wan2.2-T2V-A14B-Diffusers", "*"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+    ),
+    # FLUX on p150x4: that spec resolves to 0.10.0-555f240, so override to the newer image.
+    ("FLUX.1-dev", "p150x4"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+    ),
+    ("FLUX.1-schnell", "p150x4"): (
+        "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76"
+    ),
+}
 
 def map_board_type_to_device_name(board_type):
     """Map our internal board type names to TT Inference Server device names"""
@@ -304,6 +342,82 @@ def _run_direct_container(impl, weights_id, device_id=0, host_port=None):
         return {"status": "error", "message": error_msg}
 
 
+def _supported_devices(impl):
+    """Inference-server device names this model declares a model_spec for."""
+    return {map_board_type_to_device_name(cfg.name) for cfg in impl.device_configurations}
+
+
+def _vllm_mesh_fallback_allowed(impl):
+    """True for vLLM chat models; media/forge pin to one board topology."""
+    engine = getattr(impl, "inference_engine", None)
+    if engine:
+        return str(engine).lower() == "vllm"
+    return impl.model_type == ModelTypes.CHAT
+
+
+def equivalent_mesh_device(impl, device):
+    """For vLLM, swap `device` for the other four-chip Blackhole spec if needed.
+
+    Returns `device` untouched when the model already declares it, when the
+    engine is not vLLM, or when no fallback spec exists. Media models such as
+    FLUX keep the board's own name even if they only list the other mesh.
+    """
+    if not _vllm_mesh_fallback_allowed(impl):
+        return device
+    supported = _supported_devices(impl)
+    if device in supported:
+        return device
+    for alt in _VLLM_MESH_SPEC_FALLBACK.get(device, ()):
+        if alt in supported:
+            logger.info(
+                f"{impl.model_name}: no '{device}' vLLM model_spec; using "
+                f"'{alt}' (four-chip Blackhole mesh fallback)"
+            )
+            return alt
+    return device
+
+
+def vllm_mesh_fallback_fits(impl, board_type):
+    """True when a vLLM model has no native spec for `board_type` but does for
+    the other four-chip Blackhole mesh, so the catalog can still offer it."""
+    if not _vllm_mesh_fallback_allowed(impl):
+        return False
+    board_device = map_board_type_to_device_name(board_type)
+    supported = _supported_devices(impl)
+    if board_device in supported:
+        return False
+    return any(alt in supported for alt in _VLLM_MESH_SPEC_FALLBACK.get(board_device, ()))
+
+
+def claims_whole_board(device, board_device):
+    """True when `device` takes every chip: the board's own name or a vLLM fallback."""
+    return device == board_device or device in _VLLM_MESH_SPEC_FALLBACK.get(
+        board_device, ()
+    )
+
+
+def trace_region_override(model_name, device):
+    """Forced trace region size (bytes) for this pair, or None."""
+    size = _TRACE_REGION_OVERRIDES.get((model_name, device))
+    if size:
+        logger.info(f"{model_name} on {device}: forcing trace_region_size {size} B")
+    return size
+
+
+def media_image_override(model_name, device):
+    """Docker image to force for this model/device pair, or None.
+
+    Shared by run_container and the media pre-pull resolver so the image whose
+    download the UI reports progress for is the image the deploy actually runs.
+    """
+    image = _MEDIA_IMAGE_OVERRIDES.get(
+        (model_name, device)
+    ) or _MEDIA_IMAGE_OVERRIDES.get((model_name, "*"))
+    if image:
+        logger.info(f"{model_name} on {device}: pinning docker image {image}")
+    return image
+
+
 def infer_inference_server_device(impl, board_type=None):
     """The inference-server device name (n150/p300/…) for `impl`. Single source of
     truth shared by run_container and the pre-pull image resolver so they never
@@ -312,18 +426,19 @@ def infer_inference_server_device(impl, board_type=None):
     if board_type is None:
         board_type = detect_board_type()
     chips_required = infer_chips_required(impl.device_configurations)
+    board_device = map_board_type_to_device_name(board_type)
     if chips_required == 1:
         device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
         # A constituent single-chip device (e.g. p150 on a P300x2 board) is only valid
         # if the model actually declares support for it. Media models like FLUX have no
         # p150 spec — only the whole-board mesh (p300x2). When the single chip isn't a
         # supported device for this model but the whole board is, deploy on the board mesh.
-        supported = {map_board_type_to_device_name(cfg.name) for cfg in impl.device_configurations}
-        board_device = map_board_type_to_device_name(board_type)
+        supported = _supported_devices(impl)
         if device not in supported and board_device in supported:
             device = board_device
     else:
-        device = map_board_type_to_device_name(board_type)
+        device = board_device
+    device = equivalent_mesh_device(impl, device)
     # Speech models need a single n150-class chip even on n300-based boards.
     if impl.model_type in [ModelTypes.TTS, ModelTypes.SPEECH_RECOGNITION]:
         if device == "n300" and board_type in {"T3K", "T3000", "N300x4", "GALAXY", "GALAXY_T3K"}:
@@ -401,9 +516,12 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         if device in _SINGLE_CHIP_DEVICE_NAMES:
             payload["device_id"] = str(device_id)
 
-        # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
-        if impl.model_name == "Qwen3-32B" and device == "p300x2":
-            payload["override_tt_config"] = '{"trace_region_size": 53000000}'
+        # The inference server merges override_tt_config over the spec's, key by key.
+        trace_region_size = trace_region_override(impl.model_name, device)
+        if trace_region_size:
+            payload["override_tt_config"] = json.dumps(
+                {"trace_region_size": trace_region_size}
+            )
 
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:
@@ -417,12 +535,11 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # if use_image_override and impl.model_name in {"whisper-large-v3", "speecht5_tts"} and board_type == "P300x2":
         #     payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:qb2_launch-6900b0c-dev"
 
-        # Wan T2V pinned to the 0.17.0 media image: carries the MODEL_WEIGHTS_DIR fix
-        # (#4107) so it uses the mounted host HF cache instead of re-downloading ~118GB.
-        # Pinned explicitly because per-device resolution would otherwise pick older
-        # images on some boards (e.g. 0.10.0-555f240 for Wan on p150x4) that lack the fix.
-        if impl.model_name in {"Wan2.2-T2V-A14B-Diffusers"}:
-            payload["override_docker_image"] = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+        # Some per-device model_specs resolve to an image too old to serve our
+        # requests, so force the known-good one.
+        pinned_image = media_image_override(impl.model_name, device)
+        if pinned_image:
+            payload["override_docker_image"] = pinned_image
 
         # Disambiguate the target model_spec. Some models share a name+device across
         # engines (e.g. Llama-3.1-8B has both a vLLM chat spec and a forge training

--- a/app/backend/docker_control/tests.py
+++ b/app/backend/docker_control/tests.py
@@ -11,12 +11,25 @@ from rest_framework.test import APIClient
 
 from docker_control.chip_allocator import ChipSlotAllocator
 from docker_control.deployment_sync import _classify_failure
+from docker_control.docker_utils import (
+    claims_whole_board,
+    deploys_whole_board,
+    equivalent_mesh_device,
+    infer_inference_server_device,
+    media_image_override,
+    trace_region_override,
+    vllm_mesh_fallback_fits,
+)
 from docker_control.views import (
     _LLAMA_V014_IMAGE,
     _resolve_artifact_ref,
     _resolve_override_docker_image,
 )
-from shared_config.model_config import model_implmentations
+from shared_config.model_config import (
+    DeviceConfigurations,
+    ModelTypes,
+    model_implmentations,
+)
 
 
 @dataclass
@@ -242,3 +255,193 @@ class ArtifactRefResolutionTests(SimpleTestCase):
     def test_empty_ref_map(self):
         impl = _FakeModelImpl(requires_dev_catalog=True, inference_artifact_ref={})
         self.assertIsNone(_resolve_artifact_ref(impl, "p150", "P150"))
+
+
+@dataclass
+class _FakeDeviceImpl:
+    """Only what device resolution reads — a real ModelImpl's __post_init__ builds
+    volume mounts and env this never touches."""
+    model_name: str
+    model_type: ModelTypes
+    device_configurations: set
+    inference_engine: str = None
+
+
+def _device_impl(config_names, model_type=ModelTypes.CHAT, model_name="SomeModel", inference_engine=None):
+    return _FakeDeviceImpl(
+        model_name=model_name,
+        model_type=model_type,
+        device_configurations={DeviceConfigurations[n] for n in config_names},
+        inference_engine=inference_engine,
+    )
+
+
+class MeshEquivalentDeviceTests(SimpleTestCase):
+    """vLLM can reuse the other four-chip Blackhole spec when this board has none.
+    Media models must not: P150x4 and P300x2 are different topologies."""
+
+    def test_p300x2_only_vllm_model_resolves_to_p300x2_on_p150x4(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P300x2"]), "P150X4"), "p300x2"
+        )
+
+    def test_fallback_holds_in_the_other_direction_for_vllm(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X4"]), "P300x2"), "p150x4"
+        )
+
+    def test_native_spec_is_preferred_over_the_fallback(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X4", "P300x2"]), "P150X4"),
+            "p150x4",
+        )
+
+    def test_flux_keeps_the_board_device_even_without_a_native_mesh_spec(self):
+        """FLUX.1-schnell is complete on p300x2 and listed for p150x4, but the
+        p150x4 media spec is a different image/MESH_DEVICE — never rewrite it."""
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-schnell",
+            inference_engine="media",
+        )
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150x4")
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_flux_with_both_specs_uses_the_native_one(self):
+        impl = _device_impl(
+            ["P150X4", "P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-dev",
+            inference_engine="media",
+        )
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150x4")
+        self.assertEqual(infer_inference_server_device(impl, "P300x2"), "p300x2")
+
+    def test_single_chip_model_still_takes_the_single_chip(self):
+        impl = _device_impl(["P150", "P150X4", "P300x2"])
+        self.assertEqual(infer_inference_server_device(impl, "P150X4"), "p150")
+        self.assertFalse(deploys_whole_board(impl, "P150X4"))
+
+    def test_mesh_only_vllm_model_claims_the_whole_board(self):
+        self.assertTrue(deploys_whole_board(_device_impl(["P300x2"]), "P150X4"))
+
+    def test_no_fallback_across_chip_counts(self):
+        """p150x8 is eight chips; it must not satisfy a four-chip board."""
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["P150X8"]), "P150X4"), "p150x4"
+        )
+
+    def test_wormhole_model_is_untouched(self):
+        self.assertEqual(
+            infer_inference_server_device(_device_impl(["T3K"]), "P150X4"), "p150x4"
+        )
+
+
+class EquivalentMeshDeviceTests(SimpleTestCase):
+    """equivalent_mesh_device is what the chat deploy path calls directly."""
+
+    def test_p300x2_only_vllm_model_is_swapped(self):
+        impl = _device_impl(["P300x2"], model_name="Qwen3.8-27B")
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p300x2")
+
+    def test_declared_device_is_never_swapped(self):
+        impl = _device_impl(["P150X4", "P300x2"])
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_media_model_is_never_swapped(self):
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            model_name="FLUX.1-dev",
+            inference_engine="media",
+        )
+        self.assertEqual(equivalent_mesh_device(impl, "p150x4"), "p150x4")
+
+    def test_single_chip_device_is_never_promoted(self):
+        """A pinned chip must not become a whole-board deploy: the chat path
+        reserves one slot for it (mesh_whole_board excludes CHAT models)."""
+        impl = _device_impl(["N150X4", "N300"], model_name="Qwen2.5-7B")
+        self.assertEqual(equivalent_mesh_device(impl, "n150"), "n150")
+
+    def test_device_with_no_fallback_is_unchanged(self):
+        self.assertEqual(equivalent_mesh_device(_device_impl(["T3K"]), "t3k"), "t3k")
+        self.assertEqual(
+            equivalent_mesh_device(_device_impl(["P150X8"]), "p150x4"), "p150x4"
+        )
+
+
+class ClaimsWholeBoardTests(SimpleTestCase):
+    def test_board_own_name_and_equivalent_both_claim_it(self):
+        self.assertTrue(claims_whole_board("p150x4", "p150x4"))
+        self.assertTrue(claims_whole_board("p300x2", "p150x4"))
+
+    def test_single_chip_does_not_claim_the_board(self):
+        self.assertFalse(claims_whole_board("p150", "p150x4"))
+        self.assertFalse(claims_whole_board("n150", "n150x4"))
+
+
+class VllmMeshFallbackFitsTests(SimpleTestCase):
+    def test_p300x2_only_vllm_fits_p150x4(self):
+        self.assertTrue(vllm_mesh_fallback_fits(_device_impl(["P300x2"]), "P150X4"))
+
+    def test_media_p300x2_only_does_not_fit_p150x4(self):
+        impl = _device_impl(
+            ["P300x2"],
+            model_type=ModelTypes.IMAGE_GENERATION,
+            inference_engine="media",
+        )
+        self.assertFalse(vllm_mesh_fallback_fits(impl, "P150X4"))
+
+    def test_native_p150x4_is_not_a_fallback(self):
+        self.assertFalse(
+            vllm_mesh_fallback_fits(_device_impl(["P150X4", "P300x2"]), "P150X4")
+        )
+
+
+class MediaImageOverrideTests(SimpleTestCase):
+    """The p150x4 FLUX specs resolve to 0.10.0-555f240, whose image API 404s
+    /v1/models and 422s a prompt-only /v1/images/generations."""
+
+    def test_flux_dev_on_p150x4_is_pinned_to_the_p300x2_image(self):
+        self.assertEqual(
+            media_image_override("FLUX.1-dev", "p150x4"),
+            "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10",
+        )
+
+    def test_flux_schnell_on_p150x4_is_pinned_to_its_own_newer_image(self):
+        self.assertEqual(
+            media_image_override("FLUX.1-schnell", "p150x4"),
+            "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76",
+        )
+
+    def test_flux_on_p300x2_keeps_the_spec_image(self):
+        """p300x2 already resolves to 0.17.0/0.18.0, so pinning there would only
+        create a second place to update."""
+        self.assertIsNone(media_image_override("FLUX.1-dev", "p300x2"))
+        self.assertIsNone(media_image_override("FLUX.1-schnell", "p300x2"))
+
+    def test_wan_is_pinned_on_every_device(self):
+        image = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+        for device in ("p150x4", "p300x2", "t3k", "galaxy"):
+            self.assertEqual(
+                media_image_override("Wan2.2-T2V-A14B-Diffusers", device), image
+            )
+
+    def test_unpinned_model_returns_none(self):
+        self.assertIsNone(media_image_override("whisper-large-v3", "p150"))
+        self.assertIsNone(media_image_override("Llama-3.1-8B-Instruct", "p150x4"))
+
+
+class MediaTraceRegionOverrideTests(SimpleTestCase):
+    def test_both_flux_variants_reserve_p300x2_trace_region_on_p150x4(self):
+        self.assertEqual(
+            trace_region_override("FLUX.1-dev", "p150x4"), 51_000_000
+        )
+        self.assertEqual(
+            trace_region_override("FLUX.1-schnell", "p150x4"), 51_000_000
+        )
+
+    def test_other_devices_and_models_keep_their_spec_setting(self):
+        self.assertIsNone(trace_region_override("FLUX.1-dev", "p300x2"))
+        self.assertIsNone(trace_region_override("whisper-large-v3", "p150"))

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -48,7 +48,7 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
         return "mistral"
     if "deepseek" in s:
         return "deepseek_v3"
-    if "gemma-4-" in s:
+    if "gemma-4-" in s or "diffusiongemma" in s:
         return "gemma4"
     return None
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2704,6 +2704,28 @@ class RegisterExternalModelView(APIView):
                 except Exception as e:
                     logger.warning(f"Could not check HF model ID against catalog: {e}")
 
+            # What the container serves is a physical fact about it, so read the
+            # routes before falling back to guessing from names. This is also the
+            # only way to learn a route that diverges from the per-type convention
+            # (a tt-dit image server serves /generate, not /v1/images/generations),
+            # which is why the route is kept even when the type came from elsewhere.
+            served_api = _detect_served_api(service_port)
+            service_route = served_api.get("service_route") or None
+            served_type = served_api.get("model_type")
+            if served_type and served_type != model_type:
+                if model_type:
+                    corrections.append(
+                        f"Model type corrected from '{model_type}' to '{served_type}' "
+                        f"based on the routes the container actually serves "
+                        f"({service_route})."
+                    )
+                else:
+                    corrections.append(
+                        f"Model type '{served_type}' detected from the container's "
+                        f"own API ({service_route})."
+                    )
+                model_type = served_type
+
             # Derive any remaining identity fields, then settle on a model type
             if not model_type and hf_model_id:
                 model_type = _infer_model_type(hf_model_id)
@@ -2815,6 +2837,7 @@ class RegisterExternalModelView(APIView):
                     rec.jwt_secret = jwt_secret
                     rec.model_type = model_type
                     rec.hf_model_id = hf_model_id
+                    rec.service_route = service_route
                     rec.save()
                     corrections.append("Reused this container's existing deployment record.")
                     logger.info(f"Updated existing deployment record for '{container_name}' to device_ids={device_ids}")
@@ -2833,6 +2856,7 @@ class RegisterExternalModelView(APIView):
                         jwt_secret=jwt_secret,
                         model_type=model_type,
                         hf_model_id=hf_model_id,
+                        service_route=service_route,
                     )
                     logger.info(f"Created deployment record for external container '{container_name}' on device_ids={device_ids}")
             except Exception as e:
@@ -3533,6 +3557,60 @@ def _hf_from_container(container_info: dict):
     return None
 
 
+def _detect_served_api(host_port) -> dict:
+    """Read a container's OpenAPI document and report the API it actually serves.
+
+    Returns {"routes": [...], "service_route": str, "model_type": str} for a
+    container whose served routes identify a contract TT Studio can drive, else
+    whatever subset could be determined ({} when the container has no OpenAPI doc).
+
+    This is the strongest identity signal available and needs no name heuristics:
+    a server that answers on ``/generate`` + ``/jobs/<id>/image`` is an image
+    generator whatever its weights are called, and one that serves no route we
+    recognise is not something we should offer an interaction page for.
+    """
+    if not host_port:
+        return {}
+    try:
+        resp = requests.get(
+            f"http://host.docker.internal:{host_port}/openapi.json", timeout=3
+        )
+        resp.raise_for_status()
+        paths = resp.json().get("paths") or {}
+    except Exception:
+        return {}
+
+    result = {"routes": sorted(paths)}
+
+    # Image dialects are the case where the served route genuinely diverges from
+    # the per-type convention, so consult the dialect table rather than
+    # duplicating its route knowledge here.
+    try:
+        from model_control.image_dialects import dialect_from_openapi
+
+        dialect = dialect_from_openapi(paths)
+    except Exception:
+        dialect = None
+    if dialect is not None:
+        result["service_route"] = dialect.submit_route
+        result["model_type"] = "image_generation"
+        return result
+
+    # Otherwise fall back to the routes that identify the remaining types.
+    for route, model_type in (
+        ("/v1/chat/completions", "chat"),
+        ("/v1/audio/transcriptions", "speech_recognition"),
+        ("/v1/audio/speech", "tts"),
+        ("/v1/videos/generations", "video_generation"),
+        ("/objdetection_v2", "object_detection"),
+    ):
+        if route in paths:
+            result["service_route"] = route
+            result["model_type"] = model_type
+            break
+    return result
+
+
 def _detect_model_info(docker_client, container_id, container_info=None) -> dict:
     """Detect {hf_model_id, model_type, port, source} for a running container.
 
@@ -3582,6 +3660,16 @@ def _detect_model_info(docker_client, container_id, container_info=None) -> dict
             result.setdefault("source", "logs")
         if parsed.get("port") and not result.get("port"):
             result["port"] = parsed["port"]
+
+    # What the container serves beats what its weights are named: a DiT image
+    # server and a vLLM chat server can both be called "<org>/<model>", but they
+    # do not expose the same routes.
+    served = _detect_served_api(host_port)
+    if served.get("model_type"):
+        result["model_type"] = served["model_type"]
+        result["service_route"] = served["service_route"]
+        result.setdefault("source", "openapi")
+        return result
 
     if result.get("hf_model_id"):
         result["model_type"] = _infer_model_type(result["hf_model_id"])

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -37,6 +37,11 @@ from .docker_utils import (
     map_board_type_to_device_name,
     infer_inference_server_device,
     deploys_whole_board,
+    claims_whole_board,
+    equivalent_mesh_device,
+    media_image_override,
+    trace_region_override,
+    vllm_mesh_fallback_fits,
     _BOARD_TO_SINGLE_CHIP_DEVICE,
     WHOLE_BOARD_DEFAULT_BOARDS,
     update_deploy_cache,
@@ -285,6 +290,9 @@ class ContainersView(APIView):
             'P300': [DeviceConfigurations.P300],
 
             # Blackhole multi-device
+            # Do not list P300x2 here: four chips is not the same topology (4×P150 vs
+            # 2×P300), and media specs (FLUX, Wan) fail if we pretend they are. vLLM
+            # models that only have the other mesh still show via vllm_mesh_fallback_fits.
             'P150X4': [DeviceConfigurations.P150X4, DeviceConfigurations.P150],
             'P150X8': [DeviceConfigurations.P150X8, DeviceConfigurations.P150],
             # P300x2/P300Cx4: include P150 so single-chip models (--tt-device p150) show as compatible
@@ -312,12 +320,16 @@ class ContainersView(APIView):
             else:
                 # Check if any of the current board's device configurations are in the model's configurations
                 is_compatible = bool(current_board_devices.intersection(impl.device_configurations))
+                if not is_compatible:
+                    is_compatible = vllm_mesh_fallback_fits(impl, current_board)
                 logger.info(f"Model {impl.model_name}: is_compatible={is_compatible}")
             
             # Get all boards this model can run on
             compatible_boards = []
             for board, devices in board_to_device_map.items():
-                if board != 'unknown' and bool(set(devices).intersection(impl.device_configurations)):
+                if board == 'unknown':
+                    continue
+                if bool(set(devices).intersection(impl.device_configurations)) or vllm_mesh_fallback_fits(impl, board):
                     compatible_boards.append(board)
 
             # Manual override: always show certain models as compatible (e.g. whisper when sync JSON is incomplete)
@@ -689,6 +701,12 @@ class DeployView(APIView):
                         # User pinned a slot, or a per-chip-default board (e.g. P300x2) —
                         # use the single constituent chip device.
                         device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
+                    # Chat deploys resolve the device here instead of via
+                    # infer_inference_server_device, so apply the vLLM mesh fallback
+                    # too or a p300x2-only chat model sends --device p150x4 and 404s
+                    # on spec lookup. Mesh names only: never promotes a pinned chip,
+                    # and media models are not rewritten.
+                    device = equivalent_mesh_device(impl, device)
                     # QB2 paired-chip path: Llama-3.1-8B on either P300 card pair
                     # (device-id 0,1 or 2,3) should run with --tt-device p300 (not p150).
                     if (
@@ -704,15 +722,24 @@ class DeployView(APIView):
                     whole_board_device = map_board_type_to_device_name(board_type)
                     single_chip_device = _BOARD_TO_SINGLE_CHIP_DEVICE.get(board_type, "cpu")
                     is_multi_chip_board = whole_board_device != single_chip_device
-                    if device == whole_board_device and is_multi_chip_board:
+                    # A vLLM fallback name still claims every chip, so it omits
+                    # device_id exactly as the board's own name would.
+                    if claims_whole_board(device, whole_board_device) and is_multi_chip_board:
                         inference_device_id = None
                     else:
                         inference_device_id = ",".join(str(d) for d in occupied_device_ids)
-                # Qwen3-32B on p300x2 exceeds the 50MB default trace region size
+                # Sent two ways on purpose: override_tt_config is the documented
+                # field, but run.py only mounts the resolved runtime spec in dev mode
+                # / --custom-weights, so on an ordinary deploy the container re-reads
+                # the stale spec baked into its image and drops it. The same value on
+                # the container's own vllm command line wins over the spec default.
                 override_tt_config = None
-                qwen32b_p300x2 = impl.model_name == "Qwen3-32B" and device == "p300x2"
-                if qwen32b_p300x2:
-                    override_tt_config = '{"trace_region_size": 53000000}'
+                overrides = {}
+                trace_region_size = trace_region_override(impl.model_name, device)
+                if trace_region_size:
+                    tt_config = {"trace_region_size": trace_region_size}
+                    override_tt_config = json.dumps(tt_config)
+                    overrides["override_tt_config"] = tt_config
                 # Enable vLLM tool calling for chat-completions models so coding
                 # agents (Claude Code, Cursor) that send tool_choice:"auto" work.
                 # Only for /v1/chat/completions models with a known parser — base
@@ -720,7 +747,6 @@ class DeployView(APIView):
                 vllm_override_args = None
                 tool_calling_supported = False
                 if impl.service_route == "/v1/chat/completions":
-                    overrides = {}
                     tool_parser = tool_call_parser_for(
                         impl.model_name, getattr(impl, "hf_model_id", "")
                     )
@@ -733,8 +759,8 @@ class DeployView(APIView):
                     if reasoning_parser:
                         overrides["reasoning-parser"] = reasoning_parser
                     overrides.update(_local_weights_overrides(impl))
-                    if overrides:
-                        vllm_override_args = json.dumps(overrides)
+                if overrides:
+                    vllm_override_args = json.dumps(overrides)
                 override_docker_image = _resolve_override_docker_image(impl)
                 artifact_ref = _resolve_artifact_ref(impl, device, board_type)
                 chat_deploy_kwargs = dict(
@@ -915,7 +941,15 @@ class DeployView(APIView):
                 # resolve-image declares `impl: Optional[str]` and matches on
                 # impl_name. See the matching guard in docker_utils.run_container.
                 inference_impl = _impl_selector(getattr(impl, "inference_impl", None))
-                deploy_image = resolve_deploy_image(impl.model_name, media_device, impl=inference_impl) or impl.image_version
+                # A pinned image wins over what the server would resolve: run_container
+                # sends it as override_docker_image, so pre-pulling the spec's image
+                # would show progress for layers the deploy never uses and then stall
+                # while run.py pulls the pinned one untracked.
+                deploy_image = (
+                    media_image_override(impl.model_name, media_device)
+                    or resolve_deploy_image(impl.model_name, media_device, impl=inference_impl)
+                    or impl.image_version
+                )
                 image_name, image_tag = _split_image_version(deploy_image)
                 need_pull = False
                 if image_name:

--- a/app/backend/model_control/image_dialects.py
+++ b/app/backend/model_control/image_dialects.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Image-generation API dialects.
+
+TT Studio drives image models over three different HTTP contracts, because the
+serving stacks below it were designed independently:
+
+* ``openai`` — ``POST /v1/images/generations``, synchronous, base64 in the JSON
+  response. What tt-media-server exposes for its OpenAI-compatible image models.
+* ``media``  — ``POST /enqueue`` → poll ``/status/<id>`` → ``GET /fetch_image/<id>``.
+  tt-media-server's older job API.
+* ``tt_dit`` — ``POST /generate`` → poll ``/jobs/<id>`` → ``GET /jobs/<id>/image``.
+  tt-metal's DiT models (``models.tt_dit.server.*``) serving HTTP directly,
+  without tt-media-server in front. Diffusion on accelerators takes minutes per
+  image, so this stack is job-based by design and exposes diffusion-native knobs
+  (steps, guidance scale, seed, height, width) that the OpenAI image contract
+  has no place for.
+
+A dialect is data, not control flow: adding a fourth serving stack should mean
+adding a row here, not another branch in the inference view. Keeping the job
+polling in one place also means a new stack inherits the terminal-state and
+error handling the existing ones already have.
+"""
+
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+# Optional generation parameters we forward when the caller supplies them, keyed
+# by the request field TT Studio accepts. Only the tt_dit contract models these;
+# the others silently ignore anything beyond the prompt.
+_DIT_PARAMS = {
+    "num_inference_steps": "num_inference_steps",
+    "guidance_scale": "guidance_scale",
+    "seed": "seed",
+    "height": "height",
+    "width": "width",
+}
+
+
+@dataclass(frozen=True)
+class ImageDialect:
+    """One image-generation HTTP contract.
+
+    ``mode`` is "sync" (the image comes back on the submit call) or "job" (submit
+    returns an id, then poll for a terminal state and fetch the bytes). Templates
+    are relative to the server root, so they compose with whatever host/port the
+    deployment happens to be on.
+    """
+
+    name: str
+    submit_route: str
+    mode: str
+    job_id_field: str = ""
+    status_template: str = ""
+    image_template: str = ""
+    # Compared case-insensitively: tt-media-server says "Completed", tt_dit "done".
+    done_states: frozenset = frozenset()
+    error_states: frozenset = frozenset()
+    extra_params: Mapping[str, str] = field(default_factory=dict)
+    # Image media type to report when the server does not say (the sync dialect
+    # hands us raw base64 with no content type of its own).
+    default_content_type: str = "image/png"
+    default_filename: str = "image.png"
+
+
+OPENAI = ImageDialect(
+    name="openai",
+    submit_route="/v1/images/generations",
+    mode="sync",
+    # Historic behaviour: the base64 payload is re-served as JPEG.
+    default_content_type="image/jpeg",
+    default_filename="image.jpg",
+)
+
+MEDIA = ImageDialect(
+    name="media",
+    submit_route="/enqueue",
+    mode="job",
+    job_id_field="task_id",
+    status_template="/status/{job_id}",
+    image_template="/fetch_image/{job_id}",
+    done_states=frozenset({"completed"}),
+    error_states=frozenset({"failed", "error", "cancelled"}),
+)
+
+TT_DIT = ImageDialect(
+    name="tt_dit",
+    submit_route="/generate",
+    mode="job",
+    job_id_field="job_id",
+    status_template="/jobs/{job_id}",
+    image_template="/jobs/{job_id}/image",
+    # models/tt_dit/server/flux2/jobs.py: JobStatus = queued|running|done|error|cancelled
+    done_states=frozenset({"done"}),
+    error_states=frozenset({"error", "cancelled"}),
+    extra_params=_DIT_PARAMS,
+)
+
+# Longest submit_route first so "/v1/images/generations" is tested before any
+# shorter route that could also appear as a suffix.
+DIALECTS = tuple(sorted((OPENAI, MEDIA, TT_DIT), key=lambda d: -len(d.submit_route)))
+
+# Routes we can recognise in a container's OpenAPI document, most specific first.
+_ROUTE_TO_DIALECT = {d.submit_route: d for d in DIALECTS}
+
+
+def split_route(internal_url: str) -> tuple[str, str]:
+    """Split a stored internal_url into (server_root, route).
+
+    ``internal_url`` is built as ``<host>:<port><service_route>``, so the route is
+    just its path. Returns ("", url) when the url carries no path to speak of.
+    """
+    parts = urlsplit(internal_url)
+    path = parts.path or ""
+    root = urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+    return root, path
+
+
+def resolve_dialect(internal_url: str) -> ImageDialect:
+    """Pick the dialect for a deployment's stored internal_url.
+
+    Matches on the route the deployment was registered with. Falls back to MEDIA,
+    which is what this code path did unconditionally before other stacks existed —
+    an unrecognised route is more likely an older media server than a new contract
+    we would only guess at.
+    """
+    _, path = split_route(internal_url)
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if path.endswith(route):
+            return dialect
+    return MEDIA
+
+
+def dialect_from_openapi(paths) -> Optional[ImageDialect]:
+    """Identify the dialect a live container serves from its OpenAPI paths.
+
+    ``paths`` is the ``paths`` object of an OpenAPI document (any mapping of route
+    -> operations). Returns None when the container serves no image route we know,
+    which is a positive signal in its own right: there is no point registering it
+    as an image model TT Studio can drive.
+    """
+    served = set(paths or ())
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if route in served:
+            return dialect
+    return None

--- a/app/backend/model_control/marketplace_utils.py
+++ b/app/backend/model_control/marketplace_utils.py
@@ -341,6 +341,19 @@ def launch_blocked_reason(app: MarketplaceApp) -> Optional[str]:
     # Short-circuits before default_model(), so only the apps that pin one model
     # pay for the deploy scan.
     if app.requires_model and default_model() is None:
+        # A chat model can be deployed and still not be one this app can drive.
+        # Saying "none is deployed" there contradicts the Models page and sends
+        # the user off to deploy a second model that would be just as unusable.
+        from model_control.views import _running_coding_agent_deploys
+
+        if _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
+            return (
+                f"{app.name} needs a model it can drive with tool calling. The "
+                f"deployed model was launched without it — redeploy it from the "
+                f"Home page, then launch {app.name}."
+            )
         return (
             f"{app.name} needs a chat model to connect to, and none is deployed "
             f"yet. Deploy one from the Home page, then launch {app.name}."

--- a/app/backend/model_control/model_utils.py
+++ b/app/backend/model_control/model_utils.py
@@ -440,46 +440,52 @@ async def stream_response_from_external_api(url: str, json_data: dict, auth_toke
             if te != "chunked":
                 logger.warning(f"Unexpected transfer-encoding from vLLM: {te!r}")
 
-            async for chunk in response.aiter_text():
-                logger.debug(f"stream_response_from_external_api chunk:={chunk}")
-                if chunk.startswith("data: "):
-                    new_chunk = chunk[len("data: "):].strip()
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                logger.debug(f"stream_response_from_external_api line:={line}")
+                if line.startswith("data: "):
+                    new_chunk = line[len("data: "):].strip()
 
                     if new_chunk == "[DONE]":
-                        yield chunk
+                        yield "data: [DONE]\n\n"
                         stats = tracker.get_stats()
                         logger.info(f"ttft and tpot stats: {stats}")
                         yield "data: " + json.dumps(stats) + "\n\n"
                         break
 
                     elif new_chunk != "":
-                        chunk_dict = json.loads(new_chunk)
+                        try:
+                            chunk_dict = json.loads(new_chunk)
 
-                        # Track TTFT/TPOT from content delta chunks
-                        choices = chunk_dict.get("choices") or []
-                        if choices:
-                            delta = choices[0].get("delta", {})
-                            delta_reasoning = (
-                                delta.get("reasoning_content")
-                                or delta.get("reasoning")
-                                or delta.get("thinking")
-                            )
-                            if delta_reasoning:
-                                tracker.record_thinking_token()
-                            # chat completions: choices[0].delta.content
-                            # base/completions:  choices[0].text
-                            delta_content = delta.get("content") or choices[0].get("text") or ""
-                            if delta_content:
-                                tracker.record_content_token()
-                                logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
+                            # Track TTFT/TPOT from content delta chunks
+                            choices = chunk_dict.get("choices") or []
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                delta_reasoning = (
+                                    delta.get("reasoning_content")
+                                    or delta.get("reasoning")
+                                    or delta.get("thinking")
+                                )
+                                if delta_reasoning:
+                                    tracker.record_thinking_token()
+                                # chat completions: choices[0].delta.content
+                                # base/completions:  choices[0].text
+                                delta_content = delta.get("content") or choices[0].get("text") or ""
+                                if delta_content:
+                                    tracker.record_content_token()
+                                    logger.debug(f"Recorded token: count={tracker.num_tokens}, TTFT={tracker.get_ttft():.4f}s, TPOT={tracker.get_tpot():.4f}s")
 
-                        # Capture prompt_tokens from usage chunk
-                        usage = chunk_dict.get("usage") or {}
-                        prompt_tokens = usage.get("prompt_tokens", 0)
-                        if prompt_tokens > 0:
-                            tracker.set_prompt_tokens(prompt_tokens)
+                            # Capture prompt_tokens from usage chunk
+                            usage = chunk_dict.get("usage") or {}
+                            prompt_tokens = usage.get("prompt_tokens", 0)
+                            if prompt_tokens > 0:
+                                tracker.set_prompt_tokens(prompt_tokens)
+                        except json.JSONDecodeError as e:
+                            logger.warning(f"Failed to parse SSE data JSON: {e}, data: {new_chunk[:100]}")
 
-                    yield chunk
+                    yield f"data: {new_chunk}\n\n"
 
         logger.info("stream_response_from_external_api done")
 

--- a/app/backend/model_control/pipeline_views.py
+++ b/app/backend/model_control/pipeline_views.py
@@ -8,6 +8,7 @@ Accepts multipart/form-data and streams SSE events to the client.
 
 import base64
 import json
+import re
 import time
 
 import requests
@@ -110,6 +111,10 @@ class VoicePipelineView(APIView):
                 "messages": messages,
                 "stream": True,
                 "max_tokens": 512,
+                # Spoken replies must be fast and speakable: keep reasoning models
+                # (Qwen3 / Qwen3.5) from thinking out loud. Templates without the
+                # flag ignore it.
+                "chat_template_kwargs": {"enable_thinking": False},
             }
 
             llm_full_text = ""
@@ -151,6 +156,12 @@ class VoicePipelineView(APIView):
             metrics["llm_ttfb_ms"] = round((llm_first_chunk_time - llm_start) * 1000) if llm_first_chunk_time else 0
             metrics["llm_total_ms"] = round((llm_end - llm_start) * 1000)
             metrics["llm_tokens"] = llm_chunk_count
+            # Belt and braces: if the model still emitted a reasoning block, never
+            # send it to TTS. Qwen-style templates open <think> in the prompt, so
+            # the stream may carry only the closing tag.
+            llm_full_text = re.sub(r"<think>.*?</think>", "", llm_full_text, flags=re.S)
+            llm_full_text = re.sub(r"^.*?</think>", "", llm_full_text, flags=re.S)
+            llm_full_text = re.sub(r"<think>.*$", "", llm_full_text, flags=re.S)
 
             # ------------------------------------------------------------------
             # Step 3: TTS (optional)

--- a/app/backend/model_control/test_image_dialects.py
+++ b/app/backend/model_control/test_image_dialects.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for image-generation dialect resolution.
+
+The route shapes and job-status values here are taken from real servers:
+tt-media-server's ``/enqueue`` + ``/v1/images/generations`` contracts, and
+tt-metal's DiT server (``models/tt_dit/server/flux2/``), whose OpenAPI document
+and ``JobStatus`` enum were read off a running FLUX.2-dev container.
+"""
+
+from model_control.image_dialects import (
+    MEDIA,
+    OPENAI,
+    TT_DIT,
+    dialect_from_openapi,
+    resolve_dialect,
+    split_route,
+)
+
+# The paths object served by a real FLUX.2-dev tt-dit container.
+FLUX2_PATHS = [
+    "/health",
+    "/generate",
+    "/jobs",
+    "/jobs/{job_id}",
+    "/jobs/{job_id}/image",
+    "/jobs/{job_id}/cancel",
+]
+
+
+class TestResolveDialect:
+    def test_tt_dit_generate_route(self):
+        assert resolve_dialect("http://flux2:7010/generate") is TT_DIT
+
+    def test_openai_images_route(self):
+        assert resolve_dialect("http://sd:7000/v1/images/generations") is OPENAI
+
+    def test_media_enqueue_route(self):
+        assert resolve_dialect("http://media:7000/enqueue") is MEDIA
+
+    def test_unrecognised_route_falls_back_to_media(self):
+        # Back-compat: this code path was unconditionally the media contract
+        # before other stacks existed.
+        assert resolve_dialect("http://thing:7000/something-else") is MEDIA
+
+    def test_resolves_without_a_scheme(self):
+        # internal_url is stored as "<host>:<port><route>".
+        assert resolve_dialect("flux2:7010/generate") is TT_DIT
+
+
+class TestSplitRoute:
+    def test_splits_root_from_route(self):
+        root, path = split_route("http://flux2:7010/generate")
+        assert root == "http://flux2:7010"
+        assert path == "/generate"
+
+    def test_job_templates_compose_onto_the_root(self):
+        root, _ = split_route("http://flux2:7010/generate")
+        assert root + TT_DIT.status_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc"
+        )
+        assert root + TT_DIT.image_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc/image"
+        )
+
+
+class TestDialectFromOpenapi:
+    def test_identifies_tt_dit_from_served_routes(self):
+        assert dialect_from_openapi(FLUX2_PATHS) is TT_DIT
+
+    def test_identifies_openai_image_server(self):
+        assert dialect_from_openapi(["/v1/images/generations", "/health"]) is OPENAI
+
+    def test_chat_server_is_not_an_image_dialect(self):
+        # A vLLM container serves no image route: returning None is what keeps it
+        # from being registered as an image model.
+        assert dialect_from_openapi(["/v1/models", "/v1/chat/completions"]) is None
+
+    def test_no_paths(self):
+        assert dialect_from_openapi([]) is None
+        assert dialect_from_openapi(None) is None
+
+
+class TestJobStateVocabulary:
+    def test_tt_dit_terminal_states_match_the_server_enum(self):
+        # models/tt_dit/server/flux2/jobs.py: queued|running|done|error|cancelled
+        assert "done" in TT_DIT.done_states
+        assert {"error", "cancelled"} <= TT_DIT.error_states
+        assert not ({"queued", "running"} & (TT_DIT.done_states | TT_DIT.error_states))
+
+    def test_media_completed_state_is_matched_lowercased(self):
+        # tt-media-server reports "Completed"; the view lowercases before comparing.
+        assert "Completed".lower() in MEDIA.done_states
+
+    def test_only_tt_dit_forwards_diffusion_params(self):
+        assert "num_inference_steps" in TT_DIT.extra_params
+        assert not MEDIA.extra_params
+        assert not OPENAI.extra_params

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -46,6 +46,7 @@ class IgnoreClientContentNegotiation(DefaultContentNegotiation):
 
 from .serializers import InferenceSerializer, ModelWeightsSerializer
 from .log_classifier import classify_startup_phase
+from .image_dialects import resolve_dialect, split_route
 
 
 # Module-level latch: tracks the highest phase + cached state we've ever seen
@@ -683,6 +684,11 @@ class ObjectDetectionInferenceCloudView(APIView):
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 
+# Upper bound on a single image-generation job. FLUX.2 at 1024x1024/50 steps is
+# minutes of work, so this is a stuck-job backstop, not a performance budget.
+IMAGE_JOB_TIMEOUT_SECONDS = 30 * 60
+
+
 class ImageGenerationInferenceView(APIView):
     def post(self, request, *args, **kwargs):
         """special image generation inference view that performs special file handling"""
@@ -697,8 +703,14 @@ class ImageGenerationInferenceView(APIView):
             try:
                 headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
 
-                if "/v1/images/generations" in internal_url:
-                    # Synchronous OpenAI-compatible API — returns base64 JSON immediately
+                dialect = resolve_dialect(internal_url)
+                server_root, _ = split_route(internal_url)
+                logger.info(
+                    f"image generation via '{dialect.name}' dialect at {internal_url}"
+                )
+
+                if dialect.mode == "sync":
+                    # The image comes back on the submit call as base64 JSON.
                     inference_data = requests.post(
                         internal_url,
                         json={"prompt": prompt},
@@ -712,34 +724,81 @@ class ImageGenerationInferenceView(APIView):
                     else:
                         b64_image = resp_json["data"][0]["b64_json"]
                     image_bytes = base64.b64decode(b64_image)
-                    django_response = HttpResponse(image_bytes, content_type="image/jpeg")
-                    django_response["Content-Disposition"] = "attachment; filename=image.jpg"
-                    return django_response
-                else:
-                    # Legacy enqueue/poll/fetch API
-                    inference_data = requests.post(
-                        internal_url, json={"prompt": prompt}, headers=headers, timeout=5
+                    django_response = HttpResponse(
+                        image_bytes, content_type=dialect.default_content_type
                     )
-                    inference_data.raise_for_status()
-
-                    ready_latest = False
-                    task_id = inference_data.json().get("task_id")
-                    get_status_url = internal_url.replace("/enqueue", f"/status/{task_id}")
-                    while not ready_latest:
-                        latest_prompt = requests.get(get_status_url, headers=headers)
-                        if latest_prompt.status_code != status.HTTP_404_NOT_FOUND:
-                            latest_prompt.raise_for_status()
-                            if latest_prompt.json()["status"] == "Completed":
-                                ready_latest = True
-                        time.sleep(1)
-
-                    get_image_url = internal_url.replace("/enqueue", f"/fetch_image/{task_id}")
-                    latest_image = requests.get(get_image_url, headers=headers, stream=True)
-                    latest_image.raise_for_status()
-                    content_type = latest_image.headers.get("Content-Type", "application/octet-stream")
-                    django_response = HttpResponse(latest_image.content, content_type=content_type)
-                    django_response["Content-Disposition"] = "attachment; filename=image.png"
+                    django_response["Content-Disposition"] = (
+                        f"attachment; filename={dialect.default_filename}"
+                    )
                     return django_response
+
+                # Job dialects: submit -> poll for a terminal state -> fetch bytes.
+                payload = {"prompt": prompt}
+                for req_field, server_field in dialect.extra_params.items():
+                    value = data.get(req_field)
+                    if value is not None:
+                        payload[server_field] = value
+
+                inference_data = requests.post(
+                    internal_url, json=payload, headers=headers, timeout=30
+                )
+                inference_data.raise_for_status()
+                job_id = inference_data.json().get(dialect.job_id_field)
+                if not job_id:
+                    logger.error(
+                        f"{dialect.name}: submit response carried no "
+                        f"'{dialect.job_id_field}'; cannot track the job"
+                    )
+                    return Response(status=status.HTTP_502_BAD_GATEWAY)
+
+                status_url = server_root + dialect.status_template.format(job_id=job_id)
+                image_url = server_root + dialect.image_template.format(job_id=job_id)
+
+                # Diffusion on accelerators runs for minutes, so this poll is bounded
+                # generously; it exists to stop a wedged job from hanging the request
+                # forever, not to second-guess a slow-but-healthy generation.
+                deadline = time.time() + IMAGE_JOB_TIMEOUT_SECONDS
+                while True:
+                    if time.time() > deadline:
+                        logger.error(
+                            f"{dialect.name}: job {job_id} did not finish within "
+                            f"{IMAGE_JOB_TIMEOUT_SECONDS}s"
+                        )
+                        return Response(status=status.HTTP_504_GATEWAY_TIMEOUT)
+
+                    poll = requests.get(status_url, headers=headers, timeout=30)
+                    # A job id can briefly 404 before the server registers it.
+                    if poll.status_code != status.HTTP_404_NOT_FOUND:
+                        poll.raise_for_status()
+                        job_state = str(poll.json().get("status", "")).lower()
+                        if job_state in dialect.done_states:
+                            break
+                        if job_state in dialect.error_states:
+                            detail = poll.json().get("error")
+                            logger.error(
+                                f"{dialect.name}: job {job_id} ended as "
+                                f"'{job_state}': {detail}"
+                            )
+                            return Response(
+                                {"error": detail or f"Generation {job_state}."},
+                                status=status.HTTP_502_BAD_GATEWAY,
+                            )
+                    time.sleep(1)
+
+                latest_image = requests.get(
+                    image_url, headers=headers, stream=True, timeout=120
+                )
+                latest_image.raise_for_status()
+                content_type = latest_image.headers.get(
+                    "Content-Type", dialect.default_content_type
+                )
+                django_response = HttpResponse(
+                    latest_image.content, content_type=content_type
+                )
+                django_response["Content-Disposition"] = (
+                    f"attachment; filename={dialect.default_filename}"
+                )
+                return django_response
 
             except requests.exceptions.HTTPError as http_err:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -1845,6 +1845,7 @@ class ModelAPIInfoView(APIView):
 # Coding-agent gateway support (LiteLLM). Eligibility (the model allowlist + rule)
 # is the SSOT in shared_config.coding_agent_config.
 from shared_config.coding_agent_config import (  # noqa: E402
+    CODING_AGENT_MODEL_TYPES,
     is_coding_agent_eligible,
     get_gateway_model_names,
     resolve_thinking_variant,
@@ -1860,7 +1861,9 @@ _rr_lock = threading.Lock()
 _rr_counters: dict[str, int] = {}
 
 
-def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tuple[str, dict]]:
+def _running_coding_agent_deploys(
+    require_tool_calling: bool = True, require_vetted: bool = True
+) -> list[tuple[str, dict]]:
     """Return [(deploy_id, entry), ...] for running, coding-agent-eligible deployments.
 
     Eligibility is decided by is_coding_agent_eligible (shared_config SSOT). By
@@ -1868,6 +1871,13 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
     workflow agents send tool_choice:"auto" and a container launched without vLLM
     tool-calling support would silently fail. Pass require_tool_calling=False to
     also get eligible-but-incapable deploys (e.g. to explain why they're unusable).
+
+    require_vetted=False widens it once more, to any running chat/VLM deployment.
+    The allowlist answers "have we verified this against coding agents", which is
+    not the same question as "is a chat model deployed" — a caller that reports
+    deployment state to the user has to ask the second one or it ends up claiming
+    nothing is deployed while a model is serving.
+
     Resilient to deploy-cache failures (e.g. docker-control-service down): logs
     and returns an empty list so callers degrade gracefully instead of 500ing.
     """
@@ -1879,7 +1889,12 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
         return out
     for deploy_id, entry in cache.items():
         impl = entry.get("model_impl")
-        if not entry.get("internal_url") or not is_coding_agent_eligible(impl):
+        if not entry.get("internal_url"):
+            continue
+        if require_vetted:
+            if not is_coding_agent_eligible(impl):
+                continue
+        elif getattr(impl, "model_type", None) not in CODING_AGENT_MODEL_TYPES:
             continue
         if require_tool_calling and not entry.get("tool_calling_enabled"):
             continue
@@ -2050,19 +2065,22 @@ class CodingAgentsView(APIView):
             except requests.RequestException:
                 health = "unreachable"
 
-        # Eligible models split into usable (tool-calling capable) and unavailable
-        # (launched without tool-calling support) so the UI can explain the latter
-        # instead of advertising models that would silently fail.
+        # Every deployed chat model, split into usable (vetted and tool-calling
+        # capable) and unavailable, so the UI can explain the latter instead of
+        # either advertising models that would silently fail or -- worse --
+        # reporting nothing deployed while one is serving.
         models = []
         unavailable = []
         seen = set()
-        for _, entry in _running_coding_agent_deploys(require_tool_calling=False):
+        for _, entry in _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
             impl = entry.get("model_impl")
             name = getattr(impl, "model_name", None)
             if not name:
                 continue
             mtype = getattr(getattr(impl, "model_type", None), "value", "chat")
-            capable = bool(entry.get("tool_calling_enabled"))
+            capable = bool(entry.get("tool_calling_enabled")) and is_coding_agent_eligible(impl)
             # Context window + max_tokens ceiling, same policy the gateway and InferenceView enforce
             context_window = entry.get("max_model_len") or get_max_tokens_limit(
                 getattr(impl, "param_count", None)
@@ -2079,7 +2097,7 @@ class CodingAgentsView(APIView):
                         "context_window": context_window,
                         "max_tokens": max_tokens,
                     })
-                else:
+                elif not entry.get("tool_calling_enabled"):
                     unavailable.append({
                         "name": exposed,
                         "type": mtype,
@@ -2087,6 +2105,15 @@ class CodingAgentsView(APIView):
                         "relaunch_with": tool_calling_launch_flags(
                             name, getattr(impl, "hf_model_id", "") or ""
                         ),
+                    })
+                else:
+                    # Can answer tool calls, just not one we have verified against
+                    # coding agents -- so no relaunch flags would help.
+                    unavailable.append({
+                        "name": exposed,
+                        "type": mtype,
+                        "reason": "not_verified",
+                        "relaunch_with": None,
                     })
 
         return Response(

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -17,7 +17,8 @@ CODING_AGENT_ELIGIBLE_MODELS = {
     "Llama-3.3-70B-Instruct",
     "Qwen3.6-27B",
     "Qwen3.8-27B",
-    "gemma-4-31B-it"
+    "gemma-4-31B-it",
+    "diffusiongemma-26B-A4B-it",
 }
 
 # Model types coding agents can talk to.
@@ -31,6 +32,7 @@ REASONING_MODELS = {
     "Qwen3.6-27B": "qwen3",
     "Qwen3.8-27B": "qwen3",
     "gemma-4-31B-it": "gemma4",
+    "diffusiongemma-26B-A4B-it": "gemma4",
 }
 
 # Suffix that selects thinking mode for a reasoning model over the gateway,

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -81,17 +81,29 @@ def build_external_model_impl(
     hf_model_id: Optional[str] = None,
     service_port: int = 7000,
     tool_calling_enabled: bool = False,
+    service_route: Optional[str] = None,
 ) -> ExternalModelImpl:
     """Build the stand-in impl for an externally-registered container.
 
     An UNKNOWN type still gets an impl (so the container is tracked) but keeps a
     bare service route: nothing in the UI offers inference against it, and health
     is reported as unknown rather than probing a guessed endpoint.
+
+    ``service_route`` overrides the per-type default when registration observed the
+    route the container actually serves (read from its OpenAPI document). The
+    per-type default is only a convention, and stacks that predate or ignore it --
+    tt-metal's DiT image servers serve ``/generate``, not
+    ``/v1/images/generations`` -- would otherwise be handed a route that 404s.
     """
     resolved_type = normalize_external_model_type(
         getattr(model_type, "value", model_type)
     )
-    service_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    resolved_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    # An observed route only applies to a type we can actually drive; UNKNOWN keeps
+    # its bare route so no UI offers inference against it.
+    if service_route and resolved_type is not ModelTypes.UNKNOWN:
+        resolved_route = service_route
+    service_route = resolved_route
     return ExternalModelImpl(
         model_name=model_name,
         model_id=f"id_external-{model_name}",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.20.0",
     "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 59,
+  "total_models": 60,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -874,6 +874,44 @@
         "TORCHDYNAMO_DISABLE": "1"
       },
       "param_count": null
+    },
+    {
+      "model_name": "diffusiongemma-26B-A4B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/diffusiongemma-26B-A4B-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.21.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-bc4c4df-be7d805",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "1800000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+        "DISABLE_METAL_OP_TIMEOUT": "1",
+        "DG_VLLM_GUMBEL_MODE": "device",
+        "DG_UPFRONT_CAPTURE": "1",
+        "DG_MODEL_OWNED_HYBRID_KV": "1",
+        "DG_UPFRONT_COARSE_PREFILL_BUCKETS": "1",
+        "DG_UPFRONT_LAZY_PREFILL_RECAPTURE": "1",
+        "DG_PREFILL_FIXED_CHUNKS": "1",
+        "DG_PREFILL_CHUNK_SIZE": "4096",
+        "DG_PREFILL_RAGGED_CHUNK": "1024",
+        "DG_DENOISE_REVEAL_PMAX": "262144",
+        "DG_DENOISE_SLIDING_WINDOW": "1",
+        "DG_UPFRONT_PREFILL_WARMUP_LENS": "32,64,96",
+        "DG_TRACE_REGION_SIZE": "3758096384"
+      },
+      "param_count": 4
     },
     {
       "model_name": "efficientnet",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1471,6 +1471,34 @@
       "inference_artifact_ref": {
         "P300x2": "tt-studio/qwen3.8-27b-p300x2"
       }
+    },
+    {
+      "model_name": "Qwen3-8B",
+      "hand_owned": true,
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "GALAXY",
+        "GALAXY_T3K",
+        "N150",
+        "N300",
+        "P300",
+        "T3K"
+      ],
+      "hf_model_id": "Qwen/Qwen3-8B",
+      "inference_engine": "vLLM",
+      "status": "FUNCTIONAL",
+      "version": "0.10.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.10.0-e0e0500-409b1cd",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "900000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1"
+      },
+      "param_count": 8
     }
   ]
 }

--- a/app/backend/vector_db_control/test_chunking.py
+++ b/app/backend/vector_db_control/test_chunking.py
@@ -80,6 +80,16 @@ class TestPdfPages:
         assert docs[0].metadata is not docs[1].metadata
         assert all(d.metadata["source"] == "x.pdf" for d in docs)
 
+    def test_empty_or_whitespace_pages_yield_no_documents(self):
+        docs = DocumentProcessor.pages_to_documents(
+            ["", "   \n\t  ", ""], {"source": "blank_or_image.pdf"}
+        )
+        assert docs == []
+
+    def test_empty_parents_yield_zero_child_chunks(self):
+        children = _build_children([], chunk_size=200, chunk_overlap=0)
+        assert children == []
+
 
 class TestIdsAndHeaders:
     def test_deterministic_chunk_id_stable_and_distinct(self):

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -414,6 +414,12 @@ class VectorCollectionsAPIView(ViewSet):
             }
             
             chunked_document = chunk_document(file_path=temp_file_path, metadata=base_metadata)
+            if not chunked_document:
+                raise ValueError(
+                    f"No extractable text found in '{filename}'. "
+                    "Scanned documents or image-only files are not supported."
+                )
+
             documents = [d.page_content for d in chunked_document]
             
             # Update each chunk's metadata to include the folder structure

--- a/app/frontend/src/components/DeploymentTray.tsx
+++ b/app/frontend/src/components/DeploymentTray.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Loader2, CheckCircle2, AlertTriangle, X, ChevronDown, Rocket, Copy, Check, Maximize2, Minimize2 } from "lucide-react";
 import { Progress } from "./ui/progress";
-import { compactPercent } from "../lib/deployProgress";
+import { compactPercent, transferDetailParts } from "../lib/deployProgress";
 import type {
   ActiveDeployment,
   DeploymentProgressData,
@@ -114,6 +114,17 @@ export function DeploymentTray({ deployments, progressByJob, onDismiss, onCancel
   );
 }
 
+const STAGE_LABELS: Record<string, string> = {
+  starting: "Starting",
+  initialization: "Initializing",
+  setup: "Setting up",
+  image_ready: "Image ready",
+  container_setup: "Starting container",
+  container_started: "Container started",
+  network_setup: "Connecting",
+  finalizing: "Finalizing",
+};
+
 function DeploymentTrayItem({
   deployment,
   progress,
@@ -141,6 +152,26 @@ function DeploymentTrayItem({
       : null;
 
   const statusLabel = isFailed ? "Failed" : isCompleted ? "Deployed" : `${pct}%`;
+
+  // What the deploy is doing right now, with byte-level detail while the Docker
+  // image or the model weights are downloading — so the tray answers "is it
+  // actually moving?" without opening the full progress card.
+  const detailLine = (() => {
+    if (isFailed || isCompleted || !progress) return null;
+    const stage = progress.stage;
+    const isDownload = stage === "pulling_image" || stage === "model_preparation";
+    const transfer = isDownload ? transferDetailParts(progress) : [];
+    const label =
+      stage === "pulling_image"
+        ? "Pulling Docker image"
+        : stage === "model_preparation"
+          ? transfer.length > 0
+            ? "Downloading weights"
+            : "Preparing model"
+          : STAGE_LABELS[stage] ?? null;
+    const parts = [label, ...transfer].filter(Boolean);
+    return parts.length > 0 ? parts.join(" · ") : null;
+  })();
 
   const fetchLogs = async () => {
     if (showLogs) {
@@ -222,6 +253,12 @@ function DeploymentTrayItem({
           </button>
         )}
       </div>
+
+      {detailLine && (
+        <p className="mt-1 truncate text-[11px] text-muted-foreground tabular-nums" title={detailLine}>
+          {detailLine}
+        </p>
+      )}
 
       <div className="mt-2 flex items-center gap-2">
         {deviceLabel && (

--- a/app/frontend/src/components/FirstStepForm.tsx
+++ b/app/frontend/src/components/FirstStepForm.tsx
@@ -97,8 +97,6 @@ const FirstFormSchema = z.object({
 export function FirstStepForm({
   setSelectedModel,
   setFormError,
-  autoDeployModel,
-  isAutoDeploying,
   chipMode,
   onModelNameChange,
   chipStatus,
@@ -106,8 +104,6 @@ export function FirstStepForm({
 }: {
   setSelectedModel: (model: string) => void;
   setFormError: (hasError: boolean) => void;
-  autoDeployModel?: string | null;
-  isAutoDeploying?: boolean;
   chipMode?: "single" | "multi";
   onModelNameChange?: (name: string) => void;
   chipStatus?: ChipStatus | null;
@@ -222,33 +218,6 @@ export function FirstStepForm({
       setIsSubmitting(false);
     }
   };
-
-  // Auto-select model when in auto-deploy mode
-  useEffect(() => {
-    if (autoDeployModel && models.length > 0 && isAutoDeploying) {
-      const targetModel = models.find(
-        (model) =>
-          model.name.toLowerCase().includes(autoDeployModel.toLowerCase()) ||
-          model.name === autoDeployModel
-      );
-
-      if (targetModel) {
-        console.log("Auto-selecting model:", targetModel.name);
-        form.setValue("model", targetModel.name);
-
-        // Auto-submit the form after a short delay
-        setTimeout(() => {
-          form.handleSubmit(onSubmit)();
-        }, 1000);
-      } else {
-        customToast.error(`Auto-deploy model "${autoDeployModel}" not found`);
-        console.error(
-          "Available models:",
-          models.map((m) => m.name)
-        );
-      }
-    }
-  }, [autoDeployModel, models, isAutoDeploying, form, onSubmit]);
 
   // Get current board info and group models by status and compatibility
   const currentBoard = models[0]?.current_board || "unknown";
@@ -375,18 +344,6 @@ export function FirstStepForm({
             onClose={() => setIsWarningDismissed(true)}
           />
         )} */}
-
-        {/* Auto-deploy indicator */}
-        {isAutoDeploying && autoDeployModel && (
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-4">
-            <div className="flex items-center gap-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-              <span className="text-blue-800 dark:text-blue-200 font-medium">
-                🤖 Auto-deploying: {autoDeployModel}
-              </span>
-            </div>
-          </div>
-        )}
 
         <FormField
           control={form.control}

--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -3,8 +3,8 @@
 
 import axios from "axios";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { useSearchParams, useNavigate } from "react-router-dom";
-import { Layers, Cpu, ArrowLeft, ChevronDown } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+import { Layers, Cpu, ArrowLeft, ChevronDown, Loader2, Rocket, AlertTriangle } from "lucide-react";
 import ElevatedCard from "./ui/elevated-card";
 import { Step, Stepper, useStepper } from "./ui/stepper";
 import { customToast } from "./CustomToaster";
@@ -22,6 +22,7 @@ import {
   getModelPlacement,
   isMultiChipModel,
 } from "../utils/deviceFit";
+import { parseDeviceIds } from "../utils/p300x2Placement";
 
 const dockerAPIURL = "/docker-api/";
 const deployUrl = `${dockerAPIURL}deploy/`;
@@ -56,7 +57,6 @@ function StepWatcher({ onChange }: { onChange: (step: number) => void }) {
 
 export default function StepperDemo() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
   const autoDeployModel = searchParams.get("auto-deploy");
   // ?resume=<modelId> opens straight to the deploy step for an in-flight model
   // (e.g. clicking a deployment in the tray) so its progress bar resumes.
@@ -183,6 +183,9 @@ export default function StepperDemo() {
   const [loading, setLoading] = useState(false);
   const [formError, setFormError] = useState(false);
   const [isAutoDeploying, setIsAutoDeploying] = useState(false);
+  // Phase of the CLI-triggered auto-deploy, surfaced in the overlay below.
+  const [autoDeployStatus, setAutoDeployStatus] = useState("Preparing…");
+  const [autoDeployError, setAutoDeployError] = useState<string | null>(null);
 
   // A tray click can change ?resume while this page is already mounted; keep the
   // selection in sync so the deploy step resumes the right model.
@@ -262,33 +265,66 @@ export default function StepperDemo() {
   const performAutoDeploy = async (modelName: string) => {
     try {
       console.log("🚀 Starting auto-deployment for model:", modelName);
+      setAutoDeployStatus(`Resolving “${modelName}” in the catalog…`);
 
-      // Find the model ID by name
+      // Find the model by name — exact match first, then a unique substring
+      // match, mirroring the CLI's resolve_model_id so both paths behave alike.
       const response = await axios.get("/docker-api/get_containers/");
-      const models = response.data;
-      const model = models.find(
-        (m: { id: string; name: string }) =>
-          m.name.toLowerCase().includes(modelName.toLowerCase()) ||
-          m.name === modelName
-      );
+      const models: { id: string; name: string }[] = response.data;
+      const needle = modelName.toLowerCase();
+      let model = models.find((m) => m.name.toLowerCase() === needle);
+      if (!model) {
+        const loose = models.filter((m) =>
+          m.name.toLowerCase().includes(needle)
+        );
+        if (loose.length === 1) {
+          model = loose[0];
+        } else if (loose.length > 1) {
+          const msg = `"${modelName}" matched multiple models: ${loose
+            .map((m) => m.name)
+            .join(", ")}. Re-run with an exact name.`;
+          customToast.error(`Auto-deploy: ${msg}`);
+          setAutoDeployError(msg);
+          return;
+        }
+      }
 
       if (!model) {
-        customToast.error(`Auto-deploy model "${modelName}" not found`);
+        const msg = `Model "${modelName}" not found in the catalog.`;
+        customToast.error(`Auto-deploy: ${msg}`);
+        setAutoDeployError(msg);
         console.error("Model not found:", modelName);
         return;
       }
 
       console.log("Found model for auto-deploy:", model);
 
-      // Deploy with default weights
-      const deviceIdParam = parseInt(searchParams.get("device-id") ?? "0", 10);
-      const deployPayload = {
+      // Deploy with default weights. Include device_id only when the CLI passed
+      // ?device-id=; omitting it lets the backend allocate based on the model.
+      const deployPayload: Record<string, unknown> = {
         model_id: model.id,
         weights_id: "", // Empty string for default weights
-        device_id: isNaN(deviceIdParam) ? 0 : deviceIdParam,
       };
+      // device-id may be a single chip ("0") or a comma-separated list ("0,1")
+      // for multi-chip models. Send a number for one chip, a joined string for
+      // several — matching the manual deploy path in DeployModelStep.
+      const deviceIdParam = searchParams.get("device-id");
+      if (deviceIdParam !== null && deviceIdParam !== "") {
+        const ids = parseDeviceIds(deviceIdParam);
+        if (ids.length === 1) {
+          deployPayload.device_id = ids[0];
+        } else if (ids.length > 1) {
+          deployPayload.device_id = ids.join(",");
+        }
+      } else {
+        // Same whole-card hint the manual flow sends for an unpinned deploy. The
+        // backend honours it only where it matters (Llama-3.1-8B on P300x2 dies
+        // on a lone chip) and ignores it everywhere else.
+        deployPayload.force_full_board = true;
+      }
 
       console.log("Auto-deploy payload:", deployPayload);
+      setAutoDeployStatus(`Starting deployment of ${model.name}…`);
 
       const deployResponse = await axios.post(
         "/docker-api/deploy/",
@@ -301,23 +337,87 @@ export default function StepperDemo() {
       );
 
       console.log("Auto-deploy response:", deployResponse);
-      customToast.success(`Model "${modelName}" deployment started!`);
+      const data = deployResponse.data ?? {};
+      if (data.status === "error") {
+        const msg: string = data.message || "Deployment failed";
+        customToast.error(`Auto-deploy: ${msg}`);
+        setAutoDeployError(msg);
+        return;
+      }
+      const jobId: string | undefined = data.job_id;
+      if (!jobId) {
+        const msg = "Deployment started but the backend returned no job id to track.";
+        customToast.error(`Auto-deploy: ${msg}`);
+        setAutoDeployError(msg);
+        return;
+      }
 
-      // Navigate to deployed models page after short delay
-      setTimeout(() => {
-        navigate("/models-deployed");
-      }, 1500);
+      // Devices this deploy occupies: the ones the CLI pinned, else whatever the
+      // backend allocated (a slot number, or "0,1" / [0, 1] for multi-chip models).
+      let deviceIds: number[] = [];
+      if (deviceIdParam !== null && deviceIdParam !== "") {
+        deviceIds = parseDeviceIds(deviceIdParam);
+      } else {
+        const allocated = data.allocated_device_id;
+        if (typeof allocated === "number") deviceIds = [allocated];
+        else if (typeof allocated === "string") deviceIds = parseDeviceIds(allocated);
+        else if (Array.isArray(allocated))
+          deviceIds = allocated.map(Number).filter((n) => Number.isFinite(n));
+      }
+
+      // Hand the job to the session-wide tracker (progress tray + chip reservations),
+      // then drop into the regular deploy step so the user sees the same image-pull /
+      // weights-download / container-start progress bar a manual deploy shows.
+      customToast.success(`Model "${model.name}" deployment started!`);
+      addDeployment({
+        jobId,
+        modelId: model.id,
+        modelName: model.name,
+        deviceIds,
+        startedAt: Date.now(),
+      });
+      setSelectedModel(model.id);
+      setSelectedModelName(model.name);
+      const next = new URLSearchParams(searchParams);
+      next.delete("auto-deploy");
+      next.delete("device-id");
+      next.set("view", "single");
+      next.set("resume", model.id);
+      setSearchParams(next, { replace: true });
+      setIsAutoDeploying(false);
     } catch (error) {
       console.error("Auto-deployment failed:", error);
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
+      // Prefer the backend's explanation over axios's "Request failed with
+      // status code 400": a refused deploy carries a specific message (HF access
+      // denied, chip conflict, allocation failure) and sometimes a link to act on.
+      let errorMessage = error instanceof Error ? error.message : "Unknown error";
+      if (axios.isAxiosError(error) && error.response?.data) {
+        const data = error.response.data as {
+          message?: string;
+          error_code?: string;
+          hf_url?: string;
+          conflicts?: { model?: string; slot?: number }[];
+        };
+        if (data.message) errorMessage = data.message;
+        if (data.error_code === "hf_access_denied" && data.hf_url) {
+          errorMessage += ` Request access at ${data.hf_url}, then deploy again.`;
+        }
+        if (data.conflicts?.length) {
+          errorMessage += ` Stop these first: ${data.conflicts
+            .map((c) => `${c.model ?? "Unknown"} (device ${c.slot ?? "?"})`)
+            .join(", ")}.`;
+        }
+      }
       customToast.error(`Auto-deployment failed: ${errorMessage}`);
+      setAutoDeployError(errorMessage);
     }
   };
 
-  // Auto-deploy detection effect
+  // Auto-deploy detection effect — fire at most once per page load.
+  const autoDeployFiredRef = useRef(false);
   useEffect(() => {
-    if (autoDeployModel) {
+    if (autoDeployModel && !autoDeployFiredRef.current) {
+      autoDeployFiredRef.current = true;
       setIsAutoDeploying(true);
       customToast.info(`🤖 Auto-deploying model: ${autoDeployModel}`);
       console.log("Auto-deploy mode detected for model:", autoDeployModel);
@@ -466,6 +566,73 @@ export default function StepperDemo() {
       return { success: false, job_id: jobId };
     }
   };
+
+  // CLI-triggered auto-deploy (?auto-deploy=<model>): take over the whole view with
+  // a clear status overlay so it's obvious the deploy was kicked off from the
+  // terminal and is running — rather than silently posting and redirecting.
+  if (isAutoDeploying) {
+    const failed = autoDeployError !== null;
+    return (
+      <div className="flex flex-col gap-4 w-full max-w-3xl mx-auto px-6 md:px-8 lg:px-12 pt-8 pb-4 md:pt-12 md:pb-8">
+        <ElevatedCard accent="neutral" depth="lg" className="h-auto py-10 px-8 md:px-12">
+          <div className="flex flex-col items-center text-center gap-5">
+            <div
+              className={`p-4 rounded-full ${
+                failed
+                  ? "bg-red-500/10 text-red-500"
+                  : "bg-TT-purple/10 dark:bg-TT-purple/20 text-TT-purple"
+              }`}
+            >
+              {failed ? (
+                <AlertTriangle className="w-8 h-8" />
+              ) : (
+                <Rocket className="w-8 h-8" />
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <h2 className="text-xl font-semibold">
+                {failed ? "Auto-deploy failed" : "Auto-deploying from the CLI"}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {failed ? (
+                  "You can deploy manually below instead."
+                ) : (
+                  <>
+                    Launched with{" "}
+                    <code className="px-1.5 py-0.5 rounded bg-stone-100 dark:bg-stone-800 font-mono text-xs">
+                      run {autoDeployModel}
+                    </code>
+                    . Bringing this model up — no clicks needed.
+                  </>
+                )}
+              </p>
+            </div>
+
+            {failed ? (
+              <>
+                <p className="text-sm text-red-500 max-w-md">{autoDeployError}</p>
+                <button
+                  onClick={() => {
+                    setIsAutoDeploying(false);
+                    setAutoDeployError(null);
+                  }}
+                  className="mt-1 rounded-lg border-[2px] border-TT-purple/40 px-4 py-2 text-sm font-medium text-TT-purple hover:bg-TT-purple/10 transition-colors"
+                >
+                  Deploy manually
+                </button>
+              </>
+            ) : (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>{autoDeployStatus}</span>
+              </div>
+            )}
+          </div>
+        </ElevatedCard>
+      </div>
+    );
+  }
 
   // Wait until the model catalog is known before deciding what to offer — avoids
   // flashing the Solutions card (or the single flow) before per-board compatibility
@@ -669,8 +836,6 @@ export default function StepperDemo() {
                   }}
                   onModelNameChange={setSelectedModelName}
                   setFormError={setFormError}
-                  autoDeployModel={autoDeployModel}
-                  isAutoDeploying={isAutoDeploying}
                   chipStatus={effectiveChipStatus}
                   deployingModelIds={deployingModelIds}
                 />

--- a/app/frontend/src/components/VoiceAgentSolutionStep.tsx
+++ b/app/frontend/src/components/VoiceAgentSolutionStep.tsx
@@ -34,6 +34,7 @@ import { Model, getModelsUrl } from "./SelectionSteps";
 import {
   isLlama31_8BModel,
   isP300x2Board,
+  isQwen3_8BModel,
 } from "../utils/p300x2Placement";
 import { runHfCheck, type HfCheckResult } from "../api/settingsApi";
 import type { ChipStatus } from "../types/chipStatus";
@@ -83,6 +84,20 @@ const STATUS_CONFIG = {
 };
 
 const STATUS_ORDER: Record<string, number> = { COMPLETE: 3, FUNCTIONAL: 2, EXPERIMENTAL: 1 };
+
+// Blackhole voice pipeline runs Qwen3.5-9B as its LLM. It is single-chip, so the
+// LLM, Whisper and SpeechT5 each take one device. Where Qwen3.5-9B is compatible
+// (Blackhole boards) it is pinned and the LLM card is fixed rather than a dropdown.
+const PINNED_VOICE_LLM = "Qwen3.5-9B";
+
+// Where Qwen3.5-9B is not compatible, prefer Qwen3-8B before falling through to
+// the Instruct-preferring chat default, so the pipeline still deploys.
+const FALLBACK_VOICE_LLM = "Qwen3-8B";
+
+// Qwen3-8B and Llama-3.1-8B run across a whole P300 card. On a P300x2 that card
+// is slots 0,1, which pushes Whisper to 2 and SpeechT5 to 3 and needs 4 slots.
+const usesCardPairLlm = (modelNameOrId: string) =>
+  isQwen3_8BModel(modelNameOrId) || isLlama31_8BModel(modelNameOrId);
 
 // ---- helpers --------------------------------------------------------------
 
@@ -343,7 +358,15 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
             models.find((m) => m.model_type === type && filter(m))?.id ?? ""
           );
         };
-        setSelectedLlmId(firstCompat("chat"));
+        // Prefer the pinned Qwen3.5-9B where the board supports it, then Qwen3-8B,
+        // then the compatible-chat default (Instruct-preferring).
+        const compatibleByName = (name: string) =>
+          models.find((m) => m.name === name && m.is_compatible === true);
+        setSelectedLlmId(
+          compatibleByName(PINNED_VOICE_LLM)?.id ??
+            compatibleByName(FALLBACK_VOICE_LLM)?.id ??
+            firstCompat("chat")
+        );
         setSelectedWhisperId(firstCompat("speech_recognition"));
         setSpeechT5Id(firstCompat("tts"));
       })
@@ -408,16 +431,22 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
   const ttsModels = allModels.filter((m) => m.model_type === "tts" && isSingleChip(m));
   const selectedLlmModel = allModels.find((m) => m.id === selectedLlmId);
   const speechT5Model = allModels.find((m) => m.id === speechT5Id);
+  // Pinned when the selected LLM is Qwen3.5-9B (Blackhole); the card is then fixed
+  // rather than a dropdown.
+  const isPinned = selectedLlmModel?.name === PINNED_VOICE_LLM;
   const currentBoard = allModels[0]?.current_board;
-  const useLlamaCardPair =
+  // Qwen3.5-9B is single-chip, so the pinned pipeline is one device per stage. The
+  // fallback LLMs take a whole P300 card, so on a P300x2 they occupy slots 0,1.
+  const useCardPair =
+    !isPinned &&
     isP300x2Board(currentBoard) &&
-    isLlama31_8BModel(selectedLlmModel?.name ?? selectedLlmModel?.id ?? "");
-  const llmDeviceId: number | string = useLlamaCardPair ? "0,1" : 0;
-  const whisperDeviceId = useLlamaCardPair ? 2 : 1;
-  const ttsDeviceId = useLlamaCardPair ? 3 : 2;
+    usesCardPairLlm(selectedLlmModel?.name ?? selectedLlmModel?.id ?? "");
+  const llmDeviceId: number | string = useCardPair ? "0,1" : 0;
+  const whisperDeviceId = useCardPair ? 2 : 1;
+  const ttsDeviceId = useCardPair ? 3 : 2;
 
   // Pre-flight: the pipeline pins fixed slots, so the board must expose enough of them.
-  const requiredSlots = useLlamaCardPair ? 4 : 3;
+  const requiredSlots = useCardPair ? 4 : 3;
   const insufficientDevices = totalSlots !== null && totalSlots < requiredSlots;
 
   // The backend refuses a gated deploy outright, so resolve access before offering
@@ -469,19 +498,20 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
     });
     return Array.from(unique.values());
   };
+  // A card-pair LLM occupies both slots of the card, so report it as "0,1".
   const withDisplayDeviceIds = (item: OccupiedDevice): OccupiedDevice =>
-    useLlamaCardPair && item.device_ids.includes(0)
+    useCardPair && item.device_ids.includes(0)
       ? { ...item, device_ids: [0, 1] }
       : item;
-  const llmOccupantsRaw = useLlamaCardPair
+  const llmOccupantsRaw = useCardPair
     ? dedupeOccupiedDevices([occupiedByDevice(0), occupiedByDevice(1)])
     : dedupeOccupiedDevices([occupiedByDevice(0)]);
-  const llmOccupants = useLlamaCardPair
+  const llmOccupants = useCardPair
     ? dedupeOccupiedDevices(llmOccupantsRaw.map(withDisplayDeviceIds))
     : llmOccupantsRaw;
   const whisperOccupants = dedupeOccupiedDevices([occupiedByDevice(whisperDeviceId)]);
   const ttsOccupants = dedupeOccupiedDevices([occupiedByDevice(ttsDeviceId)]);
-  const targetSlots = useLlamaCardPair ? [0, 1, 2, 3] : [0, 1, 2];
+  const targetSlots = useCardPair ? [0, 1, 2, 3] : [0, 1, 2];
   const occupiedSlots = dedupeOccupiedDevices(
     targetSlots
       .map((id) => occupiedByDevice(id))
@@ -624,9 +654,11 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
         <div>
           <h2 className="text-lg font-semibold mb-1">Voice Agent Solution</h2>
           <p className="text-sm text-muted-foreground">
-            {useLlamaCardPair
-              ? "Deploys the full voice pipeline: Llama 8B Instruct on devices 0,1, Whisper on device 2, SpeechT5 on device 3."
-              : "Deploys the full voice pipeline: LLM on device 0, Whisper on device 1, SpeechT5 on device 2."}
+            {isPinned
+              ? "Deploys the full voice pipeline: Qwen3.5-9B on device 0, Whisper on device 1, SpeechT5 on device 2."
+              : useCardPair
+                ? `Deploys the full voice pipeline: ${selectedLlmModel?.name ?? "LLM"} on devices 0,1, Whisper on device 2, SpeechT5 on device 3.`
+                : "Deploys the full voice pipeline: LLM on device 0, Whisper on device 1, SpeechT5 on device 2."}
           </p>
         </div>
 
@@ -646,21 +678,32 @@ export function VoiceAgentSolutionStep({ onBack }: VoiceAgentSolutionStepProps) 
               <ModelCard
                 icon={<Bot className="w-5 h-5" />}
                 label="LLM"
-                deviceLabel={useLlamaCardPair ? "Device 0,1" : "Device 0"}
+                deviceLabel={useCardPair ? "Device 0,1" : "Device 0"}
                 deployState={llmState}
                 accent="blue"
                 occupants={llmOccupants}
                 helperContent={
                   <>
                     <Info className="w-2.5 h-2.5 shrink-0 opacity-60" />
-                    <span>Instruct variants recommended for chat</span>
+                    <span>
+                      {isPinned
+                        ? "Qwen3.5-9B is experimental on Blackhole"
+                        : "Instruct variants recommended for chat"}
+                    </span>
                   </>
                 }
               >
-                <Select value={selectedLlmId} onValueChange={setSelectedLlmId} disabled={isDeploying || allDone}>
-                  <SelectTrigger className="w-full text-xs h-8"><SelectValue placeholder="Select LLM" /></SelectTrigger>
-                  <SelectContent><ModelSelectItems models={chatModels} /></SelectContent>
-                </Select>
+                {isPinned ? (
+                  <div className="flex items-center h-8 px-3 rounded-md border border-input bg-muted/50 text-xs text-muted-foreground">
+                    {selectedLlmModel?.name ?? PINNED_VOICE_LLM}
+                    <span className="ml-auto text-[10px] opacity-60">fixed</span>
+                  </div>
+                ) : (
+                  <Select value={selectedLlmId} onValueChange={setSelectedLlmId} disabled={isDeploying || allDone}>
+                    <SelectTrigger className="w-full text-xs h-8"><SelectValue placeholder="Select LLM" /></SelectTrigger>
+                    <SelectContent><ModelSelectItems models={chatModels} /></SelectContent>
+                  </Select>
+                )}
               </ModelCard>
 
               <ModelCard

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -79,6 +79,18 @@ const PROSE_THINKING_HEADING = /^[\s#*_]*(?:thinking|thought)\s+process\s*:/i;
 // within the outline are separated by a single blank line.
 const PROSE_THINKING_END = /\n[ \t]*\n[ \t]*\n/;
 
+/** Normalize any variant thinking tags (<thought>, <reasoning>) and uppercase tags to lowercase <think> */
+const normalizeThinkingTags = (content: string): string => {
+  if (!content) return content;
+  return content
+    .replace(/<think>/gi, "<think>")
+    .replace(/<\/think>/gi, "</think>")
+    .replace(/<thought>/gi, "<think>")
+    .replace(/<\/thought>/gi, "</think>")
+    .replace(/<reasoning>/gi, "<think>")
+    .replace(/<\/reasoning>/gi, "</think>");
+};
+
 /** Tag an untagged prose scratchpad so it renders in the thinking panel. */
 const tagProseThinking = (
   content: string,
@@ -176,15 +188,20 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // Everything below reasons about thinking in terms of <think> tags, so
     // normalize prose scratchpads into tags once, up front.
     const streamOver = isStreamFinished || Boolean(isStopped);
+    const normalizedContent = normalizeThinkingTags(content);
     const taggedContent = closeUnterminatedThinking(
-      tagProseThinking(content, streamOver),
+      tagProseThinking(normalizedContent, streamOver),
       streamOver
     );
 
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
     const [showSearchDetails, setShowSearchDetails] = useState(false);
-    const [isThinkingActive, setIsThinkingActive] = useState(false);
+    // Check if thinking is actively streaming (has <think> after the last </think>)
+    const lastThinkOpen = !streamOver ? taggedContent.lastIndexOf("<think>") : -1;
+    const lastThinkClose = !streamOver ? taggedContent.lastIndexOf("</think>") : -1;
+    const isThinkingActive =
+      lastThinkOpen !== -1 && lastThinkOpen > lastThinkClose;
     const contentRef = useRef(processContent(taggedContent).cleanedContent);
     const thinkingBlocksRef = useRef<string[]>([]);
     const intervalRef = useRef<number | null>(null);
@@ -221,11 +238,6 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
           processed.thinkingBlocks
         );
       }
-
-      // Check if thinking is actively streaming (has <think> but no closing </think>)
-      const hasIncompleteThinking =
-        !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
-      setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
         setRenderedContent(contentRef.current);
@@ -274,8 +286,10 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     // });
 
     // Extract live thinking text from incomplete <think> block during streaming
-    const liveThinkMatch = !isStreamFinished ? taggedContent.match(/^<think>([\s\S]*)$/i) : null;
-    const liveThinkingText = liveThinkMatch ? liveThinkMatch[1] : null;
+    const liveThinkingText =
+      isThinkingActive && lastThinkOpen !== -1
+        ? taggedContent.slice(lastThinkOpen + 7)
+        : null;
 
     // Detect whether the thinking block represents a web search
     const liveSearchInfo = liveThinkingText ? parseSearchInfo(liveThinkingText) : null;

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -102,6 +102,22 @@ const tagProseThinking = (
   return isStreamFinished ? `<think>${content}</think>` : `<think>${content}`;
 };
 
+/** Close a thinking block the stream ended inside, so it stays readable.
+ *
+ * Belt to runInference's braces: any path that leaves an unterminated <think>
+ * (a stopped stream, a reply restored from history, a model whose reasoning
+ * never gave way to an answer) would otherwise fail the closed-tag regex below,
+ * be stripped from the reply text, and vanish along with the live panel. */
+const closeUnterminatedThinking = (
+  content: string,
+  isStreamFinished: boolean
+): string => {
+  if (!isStreamFinished) return content;
+  const openIdx = content.lastIndexOf("<think>");
+  if (openIdx === -1 || content.includes("</think>", openIdx)) return content;
+  return `${content}</think>`;
+};
+
 const processContent = (content: string): ProcessedContent => {
   const thinkingBlocks: string[] = [];
 
@@ -159,7 +175,11 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
   }) {
     // Everything below reasons about thinking in terms of <think> tags, so
     // normalize prose scratchpads into tags once, up front.
-    const taggedContent = tagProseThinking(content, isStreamFinished);
+    const streamOver = isStreamFinished || Boolean(isStopped);
+    const taggedContent = closeUnterminatedThinking(
+      tagProseThinking(content, streamOver),
+      streamOver
+    );
 
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
@@ -204,7 +224,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
 
       // Check if thinking is actively streaming (has <think> but no closing </think>)
       const hasIncompleteThinking =
-        !isStreamFinished && /<think>(?!.*<\/think>)/is.test(taggedContent);
+        !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
       setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
@@ -237,6 +257,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     }, [
       taggedContent,
       isStreamFinished,
+      streamOver,
       renderNextChunk,
       renderedContent,
       onThinkingBlocksChange,

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -439,7 +439,7 @@ export const runInference = async (
           const rawReasoning = delta?.reasoning_content ?? delta?.reasoning ?? delta?.thinking;
           const reasoning =
             typeof rawReasoning === "string"
-              ? rawReasoning.replace(/<\/?think>/gi, "")
+              ? rawReasoning.replace(/<\/?(think|thought|reasoning)>/gi, "")
               : null;
 
           if (reasoning && !thinkingDone) {
@@ -454,7 +454,7 @@ export const runInference = async (
           // Regular content tokens
           const rawContent = delta?.content ?? jsonData.choices?.[0]?.text ?? "";
           const content = rawContent
-            .replace(/[\[<|]*python_tag[\]>|]*/gi, "")
+            .replace(/[[<|]*python_tag[\]>|]*/gi, "")
             .replace(/\{\s*"name"\s*:\s*"[^"]*(?:tavily|search)[^"]*"\s*,\s*"(?:parameters|arguments)"\s*:\s*\{[^}]*\}\s*\}/gi, "");
           if (content) {
             if (thinkingText && !thinkingDone) {

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -526,6 +526,18 @@ export const runInference = async (
       reader.releaseLock();
     }
 
+    // The closing </think> is synthesized when the first content delta arrives,
+    // so a reply that ends while still in the reasoning channel never gets one:
+    // a truncated answer (finish_reason "length"), or a block-diffusion model
+    // like diffusiongemma that emits its whole block as reasoning and no
+    // content. Left open, processContent drops the block and the reply renders
+    // empty, losing the reasoning the model did produce.
+    if (thinkingText && !thinkingDone) {
+      thinkingDone = true;
+      accumulatedText = `<think>${thinkingText}</think>${contentText}`;
+      scheduleUiUpdate();
+    }
+
     t.end = performance.now();
     const ms = (key: string) => (t[key] != null ? `${Math.round(t[key] - t.start)}ms` : "—");
     const serverTtftMs = inferenceStats?.user_ttft_s != null

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -227,6 +227,9 @@ export const runInference = async (
         top_p: request.top_p,
         max_tokens: request.max_tokens,
         ...(request.seed && request.seed > 0 ? { seed: request.seed } : {}),
+        ...(request.chat_template_kwargs
+          ? { chat_template_kwargs: request.chat_template_kwargs }
+          : {}),
         stream: true,
         stream_options: {
           include_usage: true,

--- a/app/frontend/src/components/chatui/types.ts
+++ b/app/frontend/src/components/chatui/types.ts
@@ -119,6 +119,9 @@ export interface InferenceRequest {
   top_p?: number; // 0-1, default 0.9
   top_k?: number; // 1-100, default 20
   seed?: number; // 0 = random, >0 = reproducible
+  // Passed through to vLLM's chat template (e.g. { enable_thinking: false } to
+  // keep reasoning models such as Qwen3 from thinking out loud).
+  chat_template_kwargs?: Record<string, unknown>;
   stream_options?: {
     include_usage: boolean;
     continuous_usage_stats: boolean;

--- a/app/frontend/src/components/rag/RagManagement.tsx
+++ b/app/frontend/src/components/rag/RagManagement.tsx
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// This file incorporates work covered by the following copyright and permission notice:
+//  SPDX-FileCopyrightText: Copyright (c) 2023 shadcn
+//  SPDX-License-Identifier: MIT
+
 import { Button } from "@/src/components/ui/button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "@/src/components/ui/card";
@@ -136,6 +140,7 @@ export default function RagManagement() {
     []
   );
   const [isDragging, setIsDragging] = useState(false);
+  const [uploadBoxKey, setUploadBoxKey] = useState(0);
 
   // State to track expanded rows
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
@@ -269,6 +274,9 @@ export default function RagManagement() {
       customToast.info(
         `Creating datasource "${collectionName}" and uploading document...`
       );
+    },
+    onSettled: () => {
+      setUploadBoxKey((prev) => prev + 1);
     },
     onError: (error: any, { file, collectionName }) => {
       setCollectionsUploading((prev) =>
@@ -417,6 +425,9 @@ export default function RagManagement() {
         prev.includes(collectionName) ? prev : [...prev, collectionName]
       );
       customToast.info("Uploading document...");
+    },
+    onSettled: () => {
+      setUploadBoxKey((prev) => prev + 1);
     },
     onError: (error: Error, { file, collectionName }) => {
       setCollectionsUploading((prev) =>
@@ -584,6 +595,7 @@ export default function RagManagement() {
         customToast.error(
           `Generated collection name "${collectionName}" is too short. Please rename the file.`
         );
+        setUploadBoxKey((prev) => prev + 1);
         return;
       }
 
@@ -953,7 +965,7 @@ export default function RagManagement() {
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
         >
-          <GentleFileUpload onChange={handleFileUpload} />
+          <GentleFileUpload key={uploadBoxKey} onChange={handleFileUpload} />
         </Card>
 
         <Card

--- a/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
+++ b/app/frontend/src/components/voiceAgent/VoiceAgentApp.tsx
@@ -475,6 +475,10 @@ export default function VoiceAgentApp() {
             temperature: 0.7,
             top_p: 0.9,
             top_k: 40,
+            // Voice turns need a fast, speakable answer. Reasoning models
+            // (Qwen3 / Qwen3.5) otherwise think out loud for tens of seconds
+            // and the transcript fills with their scratchpad.
+            chat_template_kwargs: { enable_thinking: false },
           },
           ragDatasource,
           localChatHistory,

--- a/app/frontend/src/components/voiceAgent/lib/cleanSpeech.ts
+++ b/app/frontend/src/components/voiceAgent/lib/cleanSpeech.ts
@@ -21,6 +21,9 @@ export function cleanLlmText(text: string): string {
     .replace(/\|(?:eot_id|start_header_id)\|/g, "")
     .replace(/<think>.*?<\/think>/gis, "")
     .replace(/<think>.*$/is, "")
+    // Qwen3-style templates open <think> inside the prompt, so a thinking
+    // model's stream carries only the closing tag: drop everything before it.
+    .replace(/^.*?<\/think>/is, "")
     .replace(/<\/think>/gi, "")
     .replace(/&(lt|gt);/g, "")
     .replace(LEAKED_TOOL_CALL_RE, "")

--- a/app/frontend/src/pages/AppsPage.tsx
+++ b/app/frontend/src/pages/AppsPage.tsx
@@ -36,6 +36,7 @@ import { customToast } from "../components/CustomToaster";
 import {
   fetchCodingAgentsInfo,
   type CodingAgentsInfo,
+  type UnavailableCodingAgentModel,
 } from "../api/modelsDeployedApis";
 import {
   fetchMarketplaceApps,
@@ -138,6 +139,10 @@ export default function AppsPage() {
 
   const models = useMemo(() => gateway?.models ?? [], [gateway]);
   const modelNames = useMemo(() => models.map((m) => m.name), [models]);
+  // Deployed chat models the apps here cannot drive. They are still deployed, so
+  // they decide between "nothing to talk to" and "something to talk to, once you
+  // relaunch it" -- the two used to be conflated into the first message.
+  const unavailable = useMemo(() => gateway?.unavailable ?? [], [gateway]);
   const activeModel =
     selectedModel && modelNames.includes(selectedModel)
       ? selectedModel
@@ -248,7 +253,11 @@ export default function AppsPage() {
               onSelectModel={setSelectedModel}
             />
 
-            {modelNames.length === 0 && (
+            {modelNames.length === 0 && unavailable.length > 0 && (
+              <UnusableModelsNote unavailable={unavailable} />
+            )}
+
+            {modelNames.length === 0 && unavailable.length === 0 && (
               <div className="flex flex-col gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:gap-4">
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
                   <AlertCircle className="h-5 w-5" />
@@ -354,6 +363,59 @@ export default function AppsPage() {
           )}
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+// Chat models are deployed, but none can be driven from here yet. Says which
+// and why, rather than the old "no chat model is deployed" -- which contradicts
+// the Models page and sends the user off to deploy a second one.
+function UnusableModelsNote({
+  unavailable,
+}: {
+  unavailable: UnavailableCodingAgentModel[];
+}) {
+  // -thinking variants repeat their base model's reason; one row each is enough.
+  const rows = unavailable.filter((m) => !m.name.endsWith("-thinking"));
+  const relaunchFlags = rows.find((m) => m.relaunch_with)?.relaunch_with;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
+          <AlertCircle className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+            {rows.length === 1 ? "A deployed model" : "Deployed models"} cannot be
+            used by apps yet
+          </p>
+          <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+            {rows.map((model) => (
+              <li key={model.name}>
+                <code className="font-mono text-xs text-gray-900 dark:text-gray-200">
+                  {model.name}
+                </code>{" "}
+                —{" "}
+                {model.reason === "tool_calling_disabled"
+                  ? "was launched without tool calling; redeploy it from the Home page to turn it on"
+                  : "has not been verified against the apps here yet"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {relaunchFlags && (
+        <div className="pl-12">
+          <div className="mb-1.5 text-[11px] uppercase tracking-wide text-gray-500">
+            Flags a redeploy adds
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white px-3 py-2 font-mono text-xs dark:border-gray-800 dark:bg-black">
+            <CopyableText text={relaunchFlags} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/frontend/src/routes/index.tsx
+++ b/app/frontend/src/routes/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
@@ -28,12 +28,23 @@ function FirstRunGuard({ children }: { children: React.ReactNode }) {
     retry: 0,
   });
 
+  // `python run.py run <model>` opens the app with ?auto-deploy=<model>. The CLI
+  // has already dealt with credentials on its side, and bouncing to /welcome here
+  // would drop the query string and swallow the deploy. Skip the first-run guide
+  // for that page session — the auto-deploy handler rewrites the URL to
+  // ?resume=<id> once the job is fired, so the decision has to be sticky.
+  const cliLaunchRef = useRef(false);
+  if (new URLSearchParams(location.search).has("auto-deploy")) {
+    cliLaunchRef.current = true;
+  }
+
   useEffect(() => {
     if (!data) return;
+    if (cliLaunchRef.current) return;
     if (!data.setup_complete && location.pathname !== "/welcome") {
       navigate("/welcome", { replace: true });
     }
-  }, [data, location.pathname, navigate]);
+  }, [data, location.pathname, location.search, navigate]);
 
   return <>{children}</>;
 }

--- a/app/frontend/src/utils/p300x2Placement.ts
+++ b/app/frontend/src/utils/p300x2Placement.ts
@@ -25,6 +25,12 @@ export function isLlama31_8BModel(modelNameOrId?: string | null): boolean {
   return token.includes("llama-3.1-8b") || token.includes("llama3.18b");
 }
 
+export function isQwen3_8BModel(modelNameOrId?: string | null): boolean {
+  if (!modelNameOrId) return false;
+  const token = normalizeToken(modelNameOrId);
+  return token.includes("qwen3-8b") || token.includes("qwen38b");
+}
+
 export function isFluxModel(modelNameOrId?: string | null): boolean {
   if (!modelNameOrId) return false;
   return normalizeToken(modelNameOrId).includes("flux");

--- a/ci/deploy_healthcheck.py
+++ b/ci/deploy_healthcheck.py
@@ -221,7 +221,9 @@ def resolve_model_id(client, model_name, explicit_id):
     """Return the deploy model_id. Model ids are generated at runtime, so we
     resolve by human-readable model_name against the live catalog rather than
     hardcoding an id that could drift."""
-    st, data = client.get("catalog", timeout=30)
+    # Generous: the catalog probes every catalogued image against the Docker API,
+    # which is ~30s at 60+ models — the default 30s raced it.
+    st, data = client.get("catalog", timeout=180)
     if st != 200 or data.get("status") != "success":
         raise SmokeTestError(f"catalog fetch failed (HTTP {st}): {data}")
     models = data.get("models", {})

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -28,37 +28,41 @@ The script will guide you through all configuration options and set up everythin
 - TAVILY_API_KEY for search functionality (optional)
 - Other optional configuration options
 
----
+### `run <model>` — one-command deploy
 
-## Command-Line Options
+```bash
+python run.py run Qwen3-32B                 # bring the stack up + deploy Qwen3-32B from the terminal
+python run.py run                           # omit the model to pick from the catalog interactively
+python run.py run Qwen3-32B --device-id 2   # pin to a specific chip slot
+python run.py run Llama3.1-8B --device-id 0,1 # pin a multi-chip model to chips 0 and 1
+python run.py run Qwen3-32B --browser       # deploy through the web UI instead (opens the browser)
+```
 
-The options below mirror `python run.py --help` exactly, grouped by the same help
-panels. Run with no flags for the default minimal setup; every flag is optional.
+`run <model>` brings the whole stack up and deploys the named model in one step.
+The model name is checked against the catalog up front (a typo fails fast with
+suggestions), and it supports shell completion. Omit `MODEL_NAME` entirely to get
+an interactive picker listing the catalog.
 
-### Setup & Configuration
+By default the deploy runs **in the terminal** and no browser opens. Each stage
+is shown as it happens — image pull and weights download with bytes and speed,
+then container start — and the run ends with a panel giving the model's
+endpoint (for example `http://localhost:7001/v1/chat/completions`), its health
+URL, the chips it occupies, and a copy-pasteable first request for chat models.
+Pass `--browser` to hand the deploy to the web UI instead: the browser opens and
+drives it, showing the same progress there. With `--browser --no-browser` the
+deploy URL is printed for you to open yourself.
 
-| Option | Description |
-| --- | --- |
-| `--help`, `-h` | Display the help message with all options grouped by panel. |
-| `--dev` | Development mode: hot-reload frontend & backend, mount source, offer suggested defaults. Also skips the release-branch sync requirement (see below), so a checkout behind `origin/main`/`origin/dev` still starts. |
-| `--configure-env` | Interactively configure **all** environment variables (secrets, modes, cloud endpoints). |
-| `--reconfigure-inference-server` (alias `--reconfig-inf`) | Reconfigure the TT Inference Server artifact (version/branch selection). Prompts only for the artifact source; verifies the release tag / branch / commit exists upstream before accepting it. |
-| `--install-shortcut` | Add a `tt-studio` shell shortcut (a function in your `~/.zshrc` / `~/.bashrc`) so you can launch from any directory without typing `python run.py`. |
-| `--switch REF` | Switch this checkout to a git branch or tag (e.g. `dev`, `v2.9.0-rc1`): fetches origin, checks the ref out (fast-forwarding branches), then exits — re-run to start on that version. Refuses if you have uncommitted changes. |
+If `--device-id` is omitted, the backend allocates a slot based on the model's
+chip requirements; pass it only to pin a specific chip. Multi-chip models take a
+comma-separated list (e.g. `--device-id 0,1`).
 
-### Model Deployment
+| `--auto-deploy MODEL_NAME` | Deploy the given model once the stack is up, from the terminal (see the [`run <model>`](#run-model--one-command-deploy) subcommand); add `--browser` to deploy through the web UI. Supports shell completion of catalog model names. |
+| `--device-id CHIP_IDS` | Chip slot(s) to target: a single slot (`0`) or a comma-separated list (`0,1`) for multi-chip models. Omit to let the backend allocate based on the model's chip requirements. |
+| `--browser` | With an auto-deploy, hand the deploy to the web UI (opens the browser) instead of running it in the terminal. `--headless` is the deprecated name for the now-default terminal deploy. |
 
-| Option | Description |
-| --- | --- |
-| `--auto-deploy MODEL_NAME` | Auto-deploy the given model once the stack is up. |
-| `--device-id CHIP_ID` | Chip slot index (0–7) to target with `--auto-deploy` (default `0`). |
-
-> **⚠️ Not yet available**: `--auto-deploy` (and its `--device-id`) is a
-> **work in progress and not fully developed**. The launcher currently only
-> forwards the request to the frontend as a URL parameter
-> (`?auto-deploy=<model>&device-id=<id>`); end-to-end automatic deployment is not
-> functional yet. Deploy models from the UI for now. This flag and note will be
-> updated once the feature lands.
+> **Tip**: `python run.py run <model>` is the ergonomic front door for this —
+> it brings the stack up and deploys the model in one command. See
+> [`run <model>`](#run-model--one-command-deploy) above.
 
 ### Lifecycle
 
@@ -66,6 +70,7 @@ panels. Run with no flags for the default minimal setup; every flag is optional.
 | --- | --- |
 | `--stop` | Stop TT Studio: tear down Docker containers and networks, keep the persistent volume. (Deprecated alias: `--cleanup`.) |
 | `--status` | Open the live monitor TUI for a running stack (health, ports, hardware). |
+| `--stop-model MODEL` | Stop **one deployed model** and reset the chip(s) it occupied, leaving the rest of the stack running. Repeat the flag to stop several. Run it bare to pick from an interactive list of what is deployed. Matches the container name or catalog model name (exact first, then a unique substring). |
 | `--logs` | Stream all container logs (`docker compose logs -f`). Wires up `--env-file` so there are no "variable is not set" warnings; add `--dev` to match a dev bring-up. |
 | `--info` | Re-show the "TT Studio is ready" summary panel (URLs, mode, classified hardware) from live probes — handy after the banner has scrolled away. |
 
@@ -194,6 +199,11 @@ python3 run.py
 
 You'll only be prompted for:
 - **HF_TOKEN**: Your Hugging Face token (required for downloading models)
+  A token you already have is picked up automatically and saved to `.env`, so
+  you are not prompted and the Welcome screen is skipped. Sources, in order:
+  `export HF_TOKEN=hf_...` in your shell, then the Hugging Face login store
+  written by `huggingface-cli login` or `tt-model login` (`HF_TOKEN_PATH`,
+  `$HF_HOME/token`, or `~/.cache/huggingface/token`).
 
 All other values are set automatically using defaults.
 

--- a/docker-control-service/services/container_service.py
+++ b/docker-control-service/services/container_service.py
@@ -213,9 +213,29 @@ class ContainerService:
 
             container_list = []
             for container in containers:
-                # Get image tags
-                image_tags = container.image.tags if container.image.tags else []
-                image = image_tags[0] if image_tags else container.image.short_id
+                # Resolving `container.image` is a separate image-inspect call
+                # that 404s when the image was pruned or rebuilt underneath a
+                # still-running container. One such container must not empty
+                # the whole listing (the backend reads an empty list as "nothing
+                # is running" and reconciles every deployment to stopped), so
+                # fall back to the image ref recorded in the container config.
+                try:
+                    image_tags = container.image.tags or []
+                    image = image_tags[0] if image_tags else container.image.short_id
+                except (docker.errors.ImageNotFound, docker.errors.NotFound) as img_err:
+                    image = (
+                        (container.attrs.get("Config") or {}).get("Image")
+                        or container.attrs.get("Image")
+                        or ""
+                    )
+                    image_tags = [image] if image else []
+                    logger.warning(
+                        "Image lookup failed for container %s (%s); using config ref %r: %s",
+                        container.name,
+                        container.short_id,
+                        image,
+                        img_err,
+                    )
 
                 # Build comprehensive container info for backend compatibility
                 container_list.append({

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -265,6 +265,38 @@ except ImportError as e:
         f"Ensure TT_INFERENCE_ARTIFACT_PATH or tt-inference-server/ provides run and workflows."
     ) from e
 
+# Media and forge runners read configuration from container environment
+# variables rather than vLLM's additional_config. Preserve the artifact's
+# override merge, then mirror trace_region_size into the env_vars that
+# run_docker_server passes as Docker -e arguments.
+import workflows.model_spec as _model_spec_module  # noqa: E402
+
+_orig_apply_model_spec_overrides = _model_spec_module.ModelSpec.apply_overrides
+
+
+def _patched_apply_model_spec_overrides(self, runtime_config):
+    result = _orig_apply_model_spec_overrides(self, runtime_config)
+    if runtime_config.override_tt_config and self.inference_engine in (
+        "media",
+        "forge",
+    ):
+        trace_region_size = self.device_model_spec.override_tt_config.get(
+            "trace_region_size"
+        )
+        if trace_region_size is not None:
+            object.__setattr__(
+                self,
+                "env_vars",
+                {
+                    **self.env_vars,
+                    "TRACE_REGION_SIZE": str(trace_region_size),
+                },
+            )
+    return result
+
+
+_model_spec_module.ModelSpec.apply_overrides = _patched_apply_model_spec_overrides
+
 # Patch HostSetupManager.check_model_weights_dir to guard against partially-downloaded
 #
 # Two on-disk layouts must be handled:

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -2389,7 +2389,23 @@ def sync_tokens_from_tt_studio():
     if ui_hf:
         tt_studio_hf = ui_hf
 
+    # Last resort: the process environment. run.py hands its shell's HF_TOKEN /
+    # JWT_SECRET to this server, so a token exported in the terminal still
+    # reaches the model container even when neither .env nor Settings has one.
+    if not tt_studio_hf:
+        tt_studio_hf = (os.environ.get("HF_TOKEN") or "").strip() or None
+    if not tt_studio_jwt:
+        tt_studio_jwt = (os.environ.get("JWT_SECRET") or "").strip() or None
+
     if not tt_studio_jwt and not tt_studio_hf:
+        # Nothing to sync, but the model launcher still passes this file to
+        # `docker run --env-file`, which fails outright when it is missing.
+        if not inference_server_env.exists():
+            try:
+                inference_server_env.parent.mkdir(parents=True, exist_ok=True)
+                inference_server_env.touch()
+            except OSError as e:
+                logger.warning(f"Could not create empty inference server .env at {inference_server_env}: {e}")
         return
     
     # Read inference server .env values

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -1884,6 +1884,11 @@ def _process_run_output_line(
             stage = "container_started"
             progress = 60
             message = "Container is running..."
+        # Defence in depth for the v0.21.0 readiness gate (see TT_SERVER_BOOT_ATTEMPTS in run_inference).
+        elif "waiting for inference server readiness" in message.lower():
+            stage = "container_started"
+            progress = 61
+            message = "Container is running..."
         elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
             stage = "container_started"
             progress = 64
@@ -2506,6 +2511,19 @@ async def run_inference(request: RunRequest):
         # (e.g., /home/username/.cache/huggingface instead of /root/.cache/huggingface)
         env_vars_to_set = {
             "AUTOMATIC_HOST_SETUP": "True",
+            # tt-inference-server v0.21.0 added a readiness gate to ServerCommand
+            # (workflow_module/commands.py): with TT_SERVER_BOOT_ATTEMPTS > 1 -- its
+            # default of 2 -- bring-up blocks polling /health until the model is fully
+            # warm (up to TT_SERVER_READY_TIMEOUT_SECONDS, default 1h). We call
+            # run_main() in-process and only emit container_started / connect
+            # tt_studio_network / rename *after* it returns, so that gate freezes the
+            # deploy bar at container_setup for the entire warmup and defers the
+            # frontend's redirect to the end of the deploy. Forcing a single attempt
+            # restores v0.20.0's fire-and-forget return (the container is up, the model
+            # is still loading), which is the point we want to hand off from the deploy
+            # bar to the container-log classifier. Warmup progress and hang detection
+            # are already covered on our side by log_classifier + health_monitor.
+            "TT_SERVER_BOOT_ATTEMPTS": "1",
             "TT_PROGRESS_DEBUG": "1",  # Enable structured progress emission
             "TT_PROGRESS_SSE": "1",     # Enable SSE endpoint for real-time progress
             "SERVICE_PORT": request.service_port or "7000",  # Use requested port (per-slot)

--- a/inference-api/artifact_refs.py
+++ b/inference-api/artifact_refs.py
@@ -135,6 +135,29 @@ def _download(url: str, dest: Path, ref: str) -> None:
     os.replace(tmp, dest)
 
 
+def _link_safe_data_filter(member: tarfile.TarInfo, dest_path: str):
+    """The ``data`` filter, minus link members.
+
+    tt-inference-server source archives -- the pinned release and every feature
+    branch alike -- carry four relative symlinks under ``.claude/skills`` and
+    ``.cursor/skills`` whose targets begin with ``..``. Before CPython gh-107845
+    (fixed in 3.10.13, 3.11.5 and 3.12.0) ``data_filter`` resolved a symlink's
+    target against the extraction root instead of against the symlink's own
+    directory, so *any* ``..`` in a linkname read as an escape and aborted the
+    whole extraction with LinkOutsideDestinationError. inference-api runs on
+    whatever ``python3`` built its venv -- 3.10.12 on Ubuntu 22.04 -- so that
+    older filter is the common case here, not the exception.
+
+    Nothing needed to run an artifact is a link (the structural check is
+    ``workflows/utils.py``); those four are editor tooling. Dropping every link
+    member is therefore both stricter than ``data`` and identical on every
+    Python, which is what makes the fetch version-independent.
+    """
+    if member.issym() or member.islnk():
+        return None
+    return tarfile.data_filter(member, dest_path)
+
+
 def _extract(tarball: Path, refs_root: Path, dest: Path, ref: str, url: str) -> None:
     """Extract `tarball` and move the resulting tree into `dest` atomically.
 
@@ -148,9 +171,15 @@ def _extract(tarball: Path, refs_root: Path, dest: Path, ref: str, url: str) -> 
             with tarfile.open(tarball, "r:gz") as tar:
                 # "data" refuses members that would escape the destination via
                 # absolute paths, "..", or links -- worth having on an archive
-                # fetched over the network. Feature-detected because the argument
-                # only exists on newer Pythons (it becomes the default in 3.14).
-                extract_kwargs = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
+                # fetched over the network. Wrapped to also drop link members, so
+                # the result does not depend on the running Python's data_filter
+                # vintage (see _link_safe_data_filter). Feature-detected because
+                # the argument only exists on newer Pythons (default in 3.14).
+                extract_kwargs = (
+                    {"filter": _link_safe_data_filter}
+                    if hasattr(tarfile, "data_filter")
+                    else {}
+                )
                 tar.extractall(staging, **extract_kwargs)
         except Exception as e:
             raise ArtifactRefError(

--- a/inference-api/tests/test_artifact_refs.py
+++ b/inference-api/tests/test_artifact_refs.py
@@ -151,3 +151,46 @@ def test_commit_sha_uses_bare_archive_path():
     assert artifact_refs._archive_url("my-branch").endswith(
         "/archive/refs/heads/my-branch.tar.gz"
     )
+
+
+def _add_skill_symlinks(root: Path) -> None:
+    """Reproduce the relative symlinks real tt-inference-server archives carry.
+
+    Both the pinned release tarball and every feature branch ship these four under
+    .claude/skills and .cursor/skills; their targets start with "..".
+    """
+    for d in (".claude/skills", ".cursor/skills"):
+        (root / d).mkdir(parents=True, exist_ok=True)
+    (root / ".claude" / "skills" / "build-blaze-images").symlink_to(
+        "../../tt-media-server/cpp_server/.cursor/skills/build-blaze-images"
+    )
+    (root / ".cursor" / "skills" / "extend-workflow-engine").symlink_to(
+        "../../.claude/skills/extend-workflow-engine"
+    )
+
+
+def test_relative_symlinks_do_not_block_extraction(tmp_path, monkeypatch):
+    """A '..' in a symlink target must not abort the fetch.
+
+    Before CPython gh-107845 (fixed in 3.10.13/3.11.5/3.12.0) tarfile's "data"
+    filter resolved a symlink target against the extraction root rather than the
+    symlink's own directory, so these links raised LinkOutsideDestinationError and
+    every artifact_ref fetch failed on Ubuntu 22.04's python3 (3.10.12).
+    """
+    root = tmp_path / "src" / "tt-inference-server-linky"
+    (root / "workflows").mkdir(parents=True)
+    (root / "workflows" / "utils.py").write_text("# stand-in\n")
+    _add_skill_symlinks(root)
+
+    tarball = tmp_path / "archive.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(root, arcname=root.name)
+    monkeypatch.setattr(artifact_refs, "_archive_url", lambda ref: tarball.as_uri())
+
+    result = resolve_artifact_dir("linky", tmp_path / ".artifacts")
+
+    assert (result / "workflows" / "utils.py").is_file()
+    # Links are dropped rather than recreated, so the outcome does not depend on
+    # which data_filter vintage the running Python ships.
+    assert not (result / ".claude" / "skills" / "build-blaze-images").exists()
+    assert not any(p.is_symlink() for p in result.rglob("*"))

--- a/inference-api/tests/test_dev_mode_subprocess.py
+++ b/inference-api/tests/test_dev_mode_subprocess.py
@@ -180,6 +180,35 @@ class TestDevModeSubprocess(TestCase):
     def _log_messages(self):
         return [e["message"] for e in self.api.log_store[self.job_id]]
 
+    def _sync_tokens_into(self, env_overrides):
+        """Run sync_tokens_from_tt_studio() against a throwaway TT_STUDIO_ROOT with
+        no .env, pointing the artifact .env at a fresh temp dir. Returns that file."""
+        with tempfile.TemporaryDirectory() as studio_root, tempfile.TemporaryDirectory() as art:
+            env = {k: v for k, v in os.environ.items() if k not in ("HF_TOKEN", "JWT_SECRET")}
+            env.update({"TT_STUDIO_ROOT": studio_root, **env_overrides})
+            from unittest.mock import patch
+            with patch.dict(os.environ, env, clear=True), \
+                 patch.object(self.api, "artifact_path", art), \
+                 patch.object(self.api, "_get_hf_token_from_user_config", return_value=None):
+                self.api.sync_tokens_from_tt_studio()
+            target = Path(art) / ".env"
+            return target.exists(), (target.read_text() if target.exists() else "")
+
+    def test_sync_tokens_falls_back_to_process_env_hf_token(self):
+        # No repo .env and no Settings token: the HF_TOKEN run.py handed this
+        # process (from the user's shell) must still reach the artifact .env that
+        # the model container is launched with.
+        exists, text = self._sync_tokens_into({"HF_TOKEN": "hf_from_shell"})
+        self.assertTrue(exists)
+        self.assertIn("HF_TOKEN=hf_from_shell", text)
+
+    def test_sync_tokens_creates_empty_env_when_nothing_to_sync(self):
+        # `docker run --env-file <artifact>/.env` fails hard when the file is
+        # missing, so an anonymous deploy still needs the file to exist.
+        exists, text = self._sync_tokens_into({})
+        self.assertTrue(exists)
+        self.assertNotIn("HF_TOKEN=", text)
+
     def test_happy_path_populates_log_and_progress_store(self):
         initial_argv = ["run.py", "--model", "TestModel", "--dev-mode", "--docker-server"]
         env_vars = {"AUTOMATIC_HOST_SETUP": "True"}

--- a/inference-api/tests/test_media_trace_region_override.py
+++ b/inference-api/tests/test_media_trace_region_override.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import api  # noqa: E402
+from workflows.runtime_config import RuntimeConfig  # noqa: E402
+
+
+def _flux_p150x4_spec():
+    return copy.deepcopy(
+        next(
+            spec
+            for spec in api.MODEL_SPECS.values()
+            if spec.model_name == "FLUX.1-dev"
+            and spec.device_type.name.lower() == "p150x4"
+        )
+    )
+
+
+def test_media_trace_region_override_is_mirrored_to_container_env():
+    spec = _flux_p150x4_spec()
+    runtime_config = RuntimeConfig(
+        model=spec.model_name,
+        workflow="server",
+        device="p150x4",
+        override_tt_config='{"trace_region_size": 51000000}',
+    )
+
+    spec.apply_overrides(runtime_config)
+
+    assert spec.device_model_spec.override_tt_config["trace_region_size"] == 51_000_000
+    assert spec.env_vars["TRACE_REGION_SIZE"] == "51000000"
+
+
+def test_media_env_is_unchanged_without_runtime_override():
+    spec = _flux_p150x4_spec()
+    runtime_config = RuntimeConfig(
+        model=spec.model_name,
+        workflow="server",
+        device="p150x4",
+    )
+
+    spec.apply_overrides(runtime_config)
+
+    assert "TRACE_REGION_SIZE" not in spec.env_vars

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,15 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 """Tests for the Typer CLI: parsing, help, and dispatch (logic mocked)."""
+import json
+import os
+import tempfile
+import types
 import re
 import unittest
 from unittest.mock import patch
 
+import typer
 from typer.testing import CliRunner
 
 from tt_setup import cli as M
@@ -13,8 +18,16 @@ from tt_setup import cli as M
 # patches must target it so _run's calls are intercepted.
 try:
     from tt_setup.cli import _run as _cli_run
+    from tt_setup.cli import _deploy as _cli_deploy
+    from tt_setup.cli import _stop_model as _cli_stop
 except ImportError:
     _cli_run = M
+# The `run` subcommand + `_validate_model_name` + the `_run` handoff live in _args;
+# patch there so the run-command tests don't touch the real orchestration/catalog.
+try:
+    from tt_setup.cli import _args as _cli_args
+except ImportError:
+    _cli_args = M
 
 runner = CliRunner()
 
@@ -33,7 +46,7 @@ class TestCli(unittest.TestCase):
         output_without_ansi = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         for flag in ("--dev", "--stop", "--purge-all", "--purge-model", "--help-env",
                      "--no-sudo", "--logs", "--info", "--uninstall", "--switch",
-                     "--build-images", "--no-clear"):
+                     "--build-images", "--no-clear", "--auto-deploy", "--browser"):
             self.assertIn(flag, output_without_ansi)
 
     def test_info_flag_dispatches_to_ready_panel(self):
@@ -160,6 +173,94 @@ class TestCli(unittest.TestCase):
         # Service-control flags live under Advanced now, not their own panel.
         self.assertNotIn("Service Control", result.output)
 
+    def test_run_help_shows_model_arg_and_options(self):
+        result = runner.invoke(M.app, ["run", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        # Strip ANSI: Rich interleaves color codes between characters when it
+        # forces color (e.g. in CI), splitting "--headless" across escapes.
+        output_without_ansi = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        self.assertIn("MODEL_NAME", output_without_ansi)
+        self.assertIn("--browser", output_without_ansi)
+        # Terminal deploy is the default; --headless is a hidden no-op alias.
+        self.assertNotIn("--headless", output_without_ansi)
+
+    def test_run_dispatches_terminal_deploy_by_default(self):
+        with patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(M.app, ["run", "Qwen3-32B"])
+        self.assertEqual(result.exit_code, 0)
+        # The callback guard must stop the default setup from also running.
+        run.assert_called_once()
+        ns = run.call_args[0][0]
+        self.assertEqual(ns.auto_deploy, "Qwen3-32B")
+        self.assertFalse(ns.browser)         # terminal-driven deploy by default
+        self.assertIsNone(ns.device_id)      # unset -> backend allocates by model
+
+    def test_run_browser_flag_selects_web_ui_deploy(self):
+        with patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(M.app, ["run", "Qwen3-32B", "--browser"])
+        self.assertEqual(result.exit_code, 0)
+        ns = run.call_args[0][0]
+        self.assertTrue(ns.browser)
+
+    def test_run_headless_alias_and_device_id(self):
+        # --headless is deprecated (hidden) but must still parse for old scripts.
+        with patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(
+                M.app, ["run", "Qwen3-32B", "--headless", "--device-id", "2"])
+        self.assertEqual(result.exit_code, 0)
+        ns = run.call_args[0][0]
+        self.assertTrue(ns.headless)
+        self.assertFalse(ns.browser)
+        self.assertEqual(ns.device_id, "2")   # kept as a string for multi-chip parity
+
+    def test_run_multi_chip_device_id(self):
+        # Multi-chip models take a comma-separated list, e.g. --device-id 0,1.
+        with patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(
+                M.app, ["run", "Llama3.1-8B", "--device-id", "0,1"])
+        self.assertEqual(result.exit_code, 0)
+        ns = run.call_args[0][0]
+        self.assertEqual(ns.device_id, "0,1")
+
+    def test_run_rejects_non_integer_device_id(self):
+        with patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(
+                M.app, ["run", "Qwen3-32B", "--device-id", "abc"])
+        self.assertNotEqual(result.exit_code, 0)
+        run.assert_not_called()
+
+    def test_model_alias_sets_auto_deploy(self):
+        # `--model` is a friendly alias for `--auto-deploy` on the default path.
+        for flag in ("--auto-deploy", "--model"):
+            with patch.object(_cli_args, "_validate_model_name"), \
+                 patch.object(_cli_args, "_run") as run:
+                result = runner.invoke(M.app, [flag, "Qwen3-32B"])
+            self.assertEqual(result.exit_code, 0, flag)
+            self.assertEqual(run.call_args[0][0].auto_deploy, "Qwen3-32B", flag)
+
+    def test_run_prompts_for_model_when_omitted(self):
+        # No MODEL_NAME -> interactive picker supplies it, then deploy proceeds.
+        with patch.object(_cli_args, "_prompt_for_model", return_value="Qwen3-32B") as pick, \
+             patch.object(_cli_args, "_validate_model_name"), \
+             patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(M.app, ["run"])
+        self.assertEqual(result.exit_code, 0)
+        pick.assert_called_once()
+        self.assertEqual(run.call_args[0][0].auto_deploy, "Qwen3-32B")
+
+    def test_bare_invocation_still_runs_default_setup(self):
+        # The subcommand guard must not break the no-subcommand default path.
+        with patch.object(_cli_args, "_run") as run:
+            result = runner.invoke(M.app, [])
+        self.assertEqual(result.exit_code, 0)
+        run.assert_called_once()
+        self.assertIsNone(run.call_args[0][0].auto_deploy)
+
     def test_uninstall_runs_purge_then_removes_shortcut(self):
         with patch.object(_cli_run, "cleanup_resources", return_value=True) as cleanup, \
              patch.object(_cli_run, "uninstall_shortcut") as remove:
@@ -236,6 +337,10 @@ class TestCli(unittest.TestCase):
             # With a value (either form) → untouched.
             (["--purge-model", "foo"], ["--purge-model", "foo"]),
             (["--purge-model=foo"], ["--purge-model=foo"]),
+            # --stop-model gets the same optional-value treatment.
+            (["--stop-model"], ["--stop-model", P]),
+            (["--stop-model", "-v"], ["--stop-model", P, "-v"]),
+            (["--stop-model", "Qwen3-32B"], ["--stop-model", "Qwen3-32B"]),
             # Not present → untouched.
             (["--stop"], ["--stop"]),
             ([], []),
@@ -260,5 +365,655 @@ class TestCli(unittest.TestCase):
         self.assertTrue(callable(M.main))
 
 
+class TestBuildArgs(unittest.TestCase):
+    """_build_args is the single source of truth for the args namespace shared by
+    the default callback and the `run` subcommand."""
+
+    def test_defaults(self):
+        ns = _cli_args._build_args()
+        self.assertIsNone(ns.auto_deploy)
+        self.assertIsNone(ns.device_id)
+        self.assertFalse(ns.headless)
+        self.assertFalse(ns.browser)
+        self.assertFalse(ns.cleanup)
+        self.assertFalse(ns.cleanup_all)
+        self.assertEqual(ns.browser_timeout, 60)
+
+    def test_overrides_apply_and_leave_others_default(self):
+        ns = _cli_args._build_args(auto_deploy="Model-X", device_id=3, headless=True)
+        self.assertEqual(ns.auto_deploy, "Model-X")
+        self.assertEqual(ns.device_id, 3)
+        self.assertTrue(ns.headless)
+        self.assertFalse(ns.dev)  # untouched field keeps its default
+
+    def test_field_set_matches_entry_namespace(self):
+        # The `run` command and `_entry` must agree on the field set, else _run
+        # hits an AttributeError. _build_args is that contract — assert it carries
+        # every field _run reads.
+        ns = _cli_args._build_args()
+        for field in ("dev", "cleanup", "cleanup_all", "auto_deploy", "device_id",
+                      "headless", "browser", "no_browser", "skip_fastapi", "wait_for_services"):
+            self.assertTrue(hasattr(ns, field), f"missing field: {field}")
+
+
+class TestPromptForModel(unittest.TestCase):
+    CATALOG = [
+        {"name": "Qwen3-32B", "group": "LLM", "boards": ["P300x2", "T3K"]},
+        {"name": "Llama-3.1-8B-Instruct", "group": "LLM", "boards": ["N150"]},
+        {"name": "FLUX.1-dev", "group": "IMAGE", "boards": ["P300x2"]},
+        {"name": "whisper-large-v3", "group": "AUDIO", "boards": ["N150"]},
+    ]
+
+    def test_filters_to_detected_board_and_numbers_across_groups(self):
+        # P300x2 shows only Qwen3-32B (LLM) and FLUX.1-dev (IMAGE); numbering runs
+        # continuously in group order (LLM before IMAGE), so #2 is FLUX.1-dev.
+        with patch.object(_cli_args, "_catalog_models", return_value=self.CATALOG), \
+             patch.object(_cli_args, "_detect_board", return_value="P300x2"), \
+             patch.object(_cli_args.typer, "prompt", return_value="2"):
+            self.assertEqual(_cli_args._prompt_for_model(), "FLUX.1-dev")
+
+    def test_no_board_shows_all_and_accepts_name(self):
+        with patch.object(_cli_args, "_catalog_models", return_value=self.CATALOG), \
+             patch.object(_cli_args, "_detect_board", return_value=""), \
+             patch.object(_cli_args.typer, "prompt", return_value="whisper-large-v3"):
+            self.assertEqual(_cli_args._prompt_for_model(), "whisper-large-v3")
+
+    def test_board_with_no_matches_falls_back_to_all(self):
+        # An unknown/incompatible board must not hide everything — show the full list.
+        with patch.object(_cli_args, "_catalog_models", return_value=self.CATALOG), \
+             patch.object(_cli_args, "_detect_board", return_value="E150"), \
+             patch.object(_cli_args.typer, "prompt", return_value="1"):
+            # All 4 shown, grouped LLM(2)->IMAGE(1)->AUDIO(1); #1 is a real name.
+            self.assertIn(_cli_args._prompt_for_model(), [m["name"] for m in self.CATALOG])
+
+
+class TestValidateModelName(unittest.TestCase):
+    def _catalog_names(self):
+        catalog = os.path.join(
+            _cli_args.TT_STUDIO_ROOT, "app", "backend", "shared_config",
+            "models_from_inference_server.json")
+        if not os.path.exists(catalog):
+            return None
+        with open(catalog) as f:
+            return [m.get("model_name") for m in json.load(f).get("models", []) if m.get("model_name")]
+
+    def test_accepts_a_real_catalog_model(self):
+        names = self._catalog_names()
+        if not names:
+            self.skipTest("catalog not synced")
+        _cli_args._validate_model_name(names[0])  # must not raise
+
+    def test_rejects_unknown_model(self):
+        names = self._catalog_names()
+        if not names:
+            self.skipTest("catalog not synced")
+        with self.assertRaises(typer.Exit):
+            _cli_args._validate_model_name("NotARealModel_zzz_9999")
+
+    def test_skips_silently_when_catalog_absent(self):
+        # Best-effort: on first run (artifact not fetched) validation is skipped so
+        # the live resolve_model_id check can handle it post-startup.
+        with tempfile.TemporaryDirectory() as d, \
+             patch.object(_cli_args, "TT_STUDIO_ROOT", d):
+            _cli_args._validate_model_name("anything-goes")  # must not raise
+
+
+class TestAutoDeployQuery(unittest.TestCase):
+    def test_without_device_id(self):
+        q = _cli_run._auto_deploy_query("Qwen3-32B", None)
+        self.assertIn("auto-deploy=Qwen3-32B", q)
+        self.assertNotIn("device-id", q)
+
+    def test_with_device_id(self):
+        q = _cli_run._auto_deploy_query("Qwen3-32B", "2")
+        self.assertIn("auto-deploy=Qwen3-32B", q)
+        self.assertIn("device-id=2", q)
+
+    def test_with_multi_chip_device_id(self):
+        # A comma-separated list is threaded verbatim (url-encoded) into the query.
+        q = _cli_run._auto_deploy_query("Llama3.1-8B", "0,1")
+        self.assertIn("device-id=0%2C1", q)
+
+
+class _FakeSmokeTestError(Exception):
+    pass
+
+
+_DEPLOYED_ENTRY = {
+    "model_impl": {"model_id": "model_ABC", "model_type": "chat",
+                   "service_route": "/v1/chat/completions", "health_route": "/health",
+                   "hf_model_id": "org/Model"},
+    "port_bindings": {"7000/tcp": [{"HostIp": "0.0.0.0", "HostPort": "7001"}]},
+    "device_ids": [0],
+}
+
+
+def _fake_driver(bodies, resolve_fn=None, progress_seq=None, deployed=None, health=200):
+    """A stand-in for ci/deploy_healthcheck.py that records deploy payloads and
+    answers the GETs a terminal deploy makes (progress, deployed, health)."""
+    seq = list(progress_seq or [{"status": "completed", "stage": "complete", "progress": 100}])
+    deployed_payload = {"dep-1": _DEPLOYED_ENTRY} if deployed is None else deployed
+
+    class FakeClient:
+        def __init__(self, base, proxy):
+            pass
+
+        def post(self, key, body, timeout=60):
+            bodies.append(body)
+            return 200, {"status": "success", "job_id": "job-1"}
+
+        def get(self, key, timeout=30, query=None, **fmt):
+            if key == "progress":
+                return 200, (seq.pop(0) if len(seq) > 1 else seq[0])
+            if key == "deployed":
+                return 200, deployed_payload
+            if key == "health":
+                return health, {"message": "ok"}
+            return 404, {}
+
+    def default_resolve(client, name, explicit):
+        return "model_ABC"
+
+    return types.SimpleNamespace(
+        SmokeTestError=_FakeSmokeTestError,
+        Client=FakeClient,
+        resolve_model_id=resolve_fn or default_resolve,
+        poll_progress=lambda client, job, timeout, interval: None,
+        fetch_deploy_logs=lambda client, job_id, tail=40: "(no logs)",
+    )
+
+
+class TestHeadlessDeploy(unittest.TestCase):
+    def test_omits_device_id_when_unset(self):
+        # The headline behavior: no --device-id -> backend allocates by model.
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B", device_id=None)
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._headless_deploy(args)
+        # Unpinned deploys carry the same whole-card hint the web UI sends.
+        self.assertEqual(bodies, [{"model_id": "model_ABC", "force_full_board": True}])
+
+    def test_includes_device_id_when_set(self):
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B", device_id="3")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._headless_deploy(args)
+        self.assertEqual(bodies, [{"model_id": "model_ABC", "device_id": "3"}])
+
+    def test_includes_multi_chip_device_id(self):
+        # Multi-chip list is passed straight through to the deploy payload.
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Llama3.1-8B", device_id="0,1")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._headless_deploy(args)
+        self.assertEqual(bodies, [{"model_id": "model_ABC", "device_id": "0,1"}])
+
+    def test_device_id_zero_is_explicit(self):
+        # 0 is a real slot, distinct from "unset" — it must reach the payload.
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B", device_id="0")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._headless_deploy(args)
+        self.assertEqual(bodies, [{"model_id": "model_ABC", "device_id": "0"}])
+
+    def test_missing_driver_is_a_noop(self):
+        args = _cli_args._build_args(auto_deploy="X")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=None):
+            _cli_run._headless_deploy(args)  # must not raise
+
+    def test_unresolved_model_does_not_deploy(self):
+        bodies = []
+
+        def boom(client, name, explicit):
+            raise _FakeSmokeTestError("no catalog model matches 'X'")
+
+        dh = _fake_driver(bodies, resolve_fn=boom)
+        args = _cli_args._build_args(auto_deploy="X")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._headless_deploy(args)
+        self.assertEqual(bodies, [])  # a real miss never posts a deploy
+
+    def test_retries_on_backend_warmup_then_succeeds(self):
+        bodies = []
+        calls = {"n": 0}
+
+        def flaky(client, name, explicit):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _FakeSmokeTestError("cannot reach http://localhost:8000/catalog/")
+            return "model_ABC"
+
+        dh = _fake_driver(bodies, resolve_fn=flaky)
+        args = _cli_args._build_args(auto_deploy="X")
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh), \
+             patch.object(_cli_run.time, "sleep"):
+            _cli_run._headless_deploy(args)
+        self.assertEqual(calls["n"], 2)          # retried once past the warmup error
+        self.assertEqual(len(bodies), 1)         # then deployed
+
+
+def _fake_chip_driver(slots, raise_get=False):
+    """A stand-in deploy driver whose Client.get returns a chip-status payload."""
+    class FakeClient:
+        def __init__(self, base, proxy):
+            pass
+
+        def get(self, key, timeout=30, query=None, **fmt):
+            if raise_get:
+                raise _FakeSmokeTestError("cannot reach http://localhost:8000/chip-status/")
+            return 200, {"board_type": "P300x2", "total_slots": 4, "slots": slots}
+
+    return types.SimpleNamespace(
+        SmokeTestError=_FakeSmokeTestError,
+        Client=FakeClient,
+    )
+
+
+class TestPreflightDeviceAvailability(unittest.TestCase):
+    def _run_preflight(self, dh, **args_kw):
+        args = _cli_args._build_args(**args_kw)
+        with patch.object(_cli_run, "_load_deploy_driver", return_value=dh):
+            _cli_run._preflight_device_availability(args)
+
+    def test_noop_without_device_id(self):
+        # No explicit slots -> nothing to pre-check; must not touch the driver.
+        with patch.object(_cli_run, "_load_deploy_driver") as loader:
+            _cli_run._preflight_device_availability(
+                _cli_args._build_args(auto_deploy="Qwen3-32B", device_id=None))
+        loader.assert_not_called()
+
+    def test_rejects_when_requested_chip_busy(self):
+        slots = [
+            {"slot_id": 0, "status": "occupied", "model_name": "Qwen3-32B"},
+            {"slot_id": 1, "status": "available"},
+        ]
+        with self.assertRaises(SystemExit) as cm:
+            self._run_preflight(_fake_chip_driver(slots),
+                                auto_deploy="Llama3.1-8B", device_id="0,1")
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_allows_when_requested_chips_free(self):
+        slots = [
+            {"slot_id": 0, "status": "available"},
+            {"slot_id": 1, "status": "available"},
+        ]
+        # Must return normally (no SystemExit) when the slots are free.
+        self._run_preflight(_fake_chip_driver(slots),
+                            auto_deploy="Llama3.1-8B", device_id="0,1")
+
+    def test_skips_when_backend_unreachable(self):
+        # Fresh boot: backend isn't up yet -> skip silently, let deploy-time guard run.
+        self._run_preflight(_fake_chip_driver([], raise_get=True),
+                            auto_deploy="Llama3.1-8B", device_id="0,1")
+
+
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDeployModeHelpers(unittest.TestCase):
+    """Pure decisions behind `run <model>`: where the deploy happens and whether a
+    browser opens."""
+
+    def test_no_model_means_no_deploy_and_normal_browser(self):
+        args = _cli_args._build_args()
+        self.assertIsNone(_cli_deploy.deploy_mode(args))
+        self.assertTrue(_cli_deploy.should_open_browser(args))
+        self.assertFalse(_cli_deploy.should_open_browser(_cli_args._build_args(no_browser=True)))
+
+    def test_model_defaults_to_terminal_and_never_opens_browser(self):
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B")
+        self.assertEqual(_cli_deploy.deploy_mode(args), "terminal")
+        self.assertFalse(_cli_deploy.should_open_browser(args))
+
+    def test_browser_flag_opens_ui_unless_no_browser(self):
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B", browser=True)
+        self.assertEqual(_cli_deploy.deploy_mode(args), "browser")
+        self.assertTrue(_cli_deploy.should_open_browser(args))
+        quiet = _cli_args._build_args(auto_deploy="Qwen3-32B", browser=True, no_browser=True)
+        self.assertFalse(_cli_deploy.should_open_browser(quiet))
+
+    def test_headless_alias_is_still_terminal(self):
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B", headless=True)
+        self.assertEqual(_cli_deploy.deploy_mode(args), "terminal")
+
+
+class TestDeployRendering(unittest.TestCase):
+    def test_stage_labels(self):
+        self.assertEqual(_cli_deploy.stage_label({"stage": "pulling_image"}), "Pulling Docker image")
+        self.assertEqual(_cli_deploy.stage_label({"stage": "model_preparation"}), "Preparing model")
+        self.assertEqual(
+            _cli_deploy.stage_label({"stage": "model_preparation", "downloaded_bytes": 10}),
+            "Downloading model weights")
+        self.assertEqual(_cli_deploy.stage_label({"stage": "some_new_stage"}), "Some new stage")
+
+    def test_download_detail_only_for_download_stages_with_bytes(self):
+        self.assertIsNone(_cli_deploy.download_detail({"stage": "container_setup", "downloaded_bytes": 5}))
+        self.assertIsNone(_cli_deploy.download_detail({"stage": "pulling_image"}))
+        d = _cli_deploy.download_detail({"stage": "pulling_image", "downloaded_bytes": 1_200_000_000,
+                                         "total_bytes": 23_300_000_000, "speed_bps": 85_000_000})
+        self.assertEqual(d, "1.2 GB / 23.3 GB · 85 MB/s")
+
+    def test_format_bytes(self):
+        self.assertEqual(_cli_deploy.format_bytes(0), "0 B")
+        self.assertEqual(_cli_deploy.format_bytes(999), "999 B")
+        self.assertEqual(_cli_deploy.format_bytes(1500), "1.5 KB")
+        self.assertEqual(_cli_deploy.format_bytes(85_000_000), "85 MB")
+        self.assertEqual(_cli_deploy.format_bytes(250_000_000), "250 MB")
+        self.assertEqual(_cli_deploy.format_bytes(None), "—")
+
+    def test_download_fraction(self):
+        self.assertIsNone(_cli_deploy.download_fraction({"downloaded_bytes": 1}))
+        self.assertAlmostEqual(_cli_deploy.download_fraction({"downloaded_bytes": 50, "total_bytes": 200}), 0.25)
+        self.assertEqual(_cli_deploy.download_fraction({"downloaded_bytes": 500, "total_bytes": 200}), 1.0)
+
+    def test_endpoint_for_uses_host_port_and_service_route(self):
+        ep = _cli_deploy.endpoint_for(_DEPLOYED_ENTRY, host="localhost")
+        self.assertEqual(ep["port"], "7001")
+        self.assertEqual(ep["url"], "http://localhost:7001/v1/chat/completions")
+        self.assertEqual(ep["health"], "http://localhost:7001/health")
+        self.assertEqual(ep["model_type"], "chat")
+
+    def test_endpoint_for_without_port_bindings(self):
+        ep = _cli_deploy.endpoint_for({"model_impl": {"service_route": "/v1"}})
+        self.assertIsNone(ep["url"])
+        self.assertIsNone(ep["port"])
+
+    def test_curl_example_only_for_chat(self):
+        self.assertIsNone(_cli_deploy.curl_example("http://x/v1/audio/speech", "tts"))
+        ex = _cli_deploy.curl_example("http://localhost:7001/v1/chat/completions", "chat", "org/Model")
+        self.assertIn("http://localhost:7001/v1/chat/completions", ex)
+        self.assertIn('"model":"org/Model"', ex)
+
+
+class TestWatchProgress(unittest.TestCase):
+    """The polling loop drives the fake client through a scripted deploy. stdout
+    is not a TTY under the test runner, so the plain change-only path renders."""
+
+    def _run(self, seq, health=200):
+        bodies = []
+        dh = _fake_driver(bodies, progress_seq=seq, health=health)
+        client = dh.Client("http://x", proxy=False)
+        with patch.object(_cli_deploy.time, "sleep"):
+            return _cli_deploy.watch_progress(dh, client, "job-1", timeout=60, interval=0)
+
+    def test_runs_to_completion_and_returns_final_payload(self):
+        seq = [
+            {"status": "running", "stage": "pulling_image", "progress": 5,
+             "downloaded_bytes": 100, "total_bytes": 1000},
+            {"status": "running", "stage": "model_preparation", "progress": 40,
+             "downloaded_bytes": 10, "total_bytes": 20},
+            {"status": "running", "stage": "container_setup", "progress": 70},
+            {"status": "completed", "stage": "complete", "progress": 100},
+        ]
+        final = self._run(seq)
+        self.assertEqual(final["status"], "completed")
+
+    def test_failure_raises_with_reason(self):
+        seq = [
+            {"status": "running", "stage": "starting", "progress": 0},
+            {"status": "failed", "stage": "error", "progress": 0, "message": "HF_TOKEN validation failed"},
+        ]
+        with self.assertRaises(_FakeSmokeTestError) as ctx:
+            self._run(seq)
+        self.assertIn("HF_TOKEN validation failed", str(ctx.exception))
+
+    def test_not_found_within_grace_keeps_waiting(self):
+        # The progress record can lag the POST by a few seconds.
+        seq = [
+            {"status": "not_found", "stage": "unknown", "progress": 0},
+            {"status": "running", "stage": "starting", "progress": 0},
+            {"status": "completed", "stage": "complete", "progress": 100},
+        ]
+        self.assertEqual(self._run(seq)["status"], "completed")
+
+    def test_not_found_past_grace_is_a_lost_job(self):
+        # An orphaned job must not spin for the whole timeout.
+        bodies = []
+        dh = _fake_driver(bodies, progress_seq=[{"status": "not_found", "stage": "unknown"}])
+        client = dh.Client("http://x", proxy=False)
+        clock = {"t": 1000.0}
+
+        def fake_time():
+            clock["t"] += _cli_deploy.NOT_FOUND_GRACE_S / 2 + 1
+            return clock["t"]
+        with patch.object(_cli_deploy.time, "sleep"), \
+             patch.object(_cli_deploy.time, "time", side_effect=fake_time):
+            with self.assertRaises(_FakeSmokeTestError) as ctx:
+                _cli_deploy.watch_progress(dh, client, "job-1", timeout=3600, interval=0)
+        self.assertIn("no longer reports this deploy job", str(ctx.exception))
+
+
+def _printed_text(con):
+    """Everything a patched console printed, with Rich renderables (panels)
+    flattened to plain text so assertions can look inside them."""
+    import io
+    from rich.console import Console
+    from tt_setup.console._theme import TT_THEME
+    out = []
+    for call in con.print.call_args_list:
+        for arg in call.args:
+            if isinstance(arg, str):
+                out.append(arg)
+            else:
+                buf = io.StringIO()
+                Console(file=buf, width=200, force_terminal=False, color_system=None, theme=TT_THEME).print(arg)
+                out.append(buf.getvalue())
+    return "\n".join(out)
+
+
+class TestRunHeadlessDeployEndToEnd(unittest.TestCase):
+    def test_success_reports_endpoint_and_returns_healthy(self):
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B")
+        with patch.object(_cli_deploy.time, "sleep"), \
+             patch.object(_cli_deploy, "console") as con:
+            ok = _cli_deploy.run_headless_deploy(dh, args, frontend=("localhost", 3000))
+        self.assertTrue(ok)
+        self.assertEqual(bodies, [{"model_id": "model_ABC", "force_full_board": True}])
+        # The ready panel carried the host-reachable endpoint.
+        printed = _printed_text(con)
+        self.assertIn("http://localhost:7001/v1/chat/completions", printed)
+
+    def test_refused_deploy_surfaces_backend_message(self):
+        bodies = []
+        dh = _fake_driver(bodies)
+
+        class RefusingClient(dh.Client):
+            def post(self, key, body, timeout=60):
+                return 400, {"error_code": "hf_access_denied",
+                             "message": "Your Hugging Face token does not have access to org/Model.",
+                             "hf_url": "https://huggingface.co/org/Model"}
+        dh.Client = RefusingClient
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B")
+        with patch.object(_cli_deploy, "console") as con:
+            ok = _cli_deploy.run_headless_deploy(dh, args)
+        self.assertFalse(ok)
+        printed = _printed_text(con)
+        self.assertIn("does not have access", printed)
+        self.assertIn("https://huggingface.co/org/Model", printed)
+
+    def test_ctrl_c_while_watching_exits_cleanly(self):
+        bodies = []
+        dh = _fake_driver(bodies)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B")
+        with patch.object(_cli_deploy, "watch_progress", side_effect=KeyboardInterrupt), \
+             patch.object(_cli_deploy, "console") as con:
+            ok = _cli_deploy.run_headless_deploy(dh, args, frontend=("localhost", 3000))
+        self.assertFalse(ok)
+        printed = _printed_text(con)
+        self.assertIn("Stopped watching", printed)
+        self.assertIn("--stop-model Qwen3-32B", printed)
+
+    def test_not_healthy_yet_still_reports_starting(self):
+        bodies = []
+        dh = _fake_driver(bodies, health=202)
+        args = _cli_args._build_args(auto_deploy="Qwen3-32B")
+        # Health never reaches 200; make the wait give up immediately.
+        with patch.object(_cli_deploy, "wait_for_health", return_value=False), \
+             patch.object(_cli_deploy, "console") as con:
+            ok = _cli_deploy.run_headless_deploy(dh, args)
+        self.assertFalse(ok)
+        printed = _printed_text(con)
+        self.assertIn("is starting", printed)
+
+
+class TestStopModelDispatch(unittest.TestCase):
+    def test_stop_model_dispatches_with_names_and_skips_teardown(self):
+        with patch.object(_cli_stop, "stop_models", return_value=0) as stop, \
+             patch.object(_cli_run, "cleanup_resources") as cleanup, \
+             patch.object(_cli_run, "purge_models") as purge:
+            result = runner.invoke(M.app, ["--stop-model", "foo", "--stop-model", "bar"])
+        self.assertEqual(result.exit_code, 0)
+        stop.assert_called_once()
+        cleanup.assert_not_called()
+        purge.assert_not_called()
+        ns = stop.call_args[0][0]
+        self.assertEqual(ns.stop_model, ["foo", "bar"])
+
+    def test_stop_model_nonzero_exit_propagates(self):
+        with patch.object(_cli_stop, "stop_models", return_value=1):
+            result = runner.invoke(M.app, ["--stop-model", "nope"])
+        self.assertEqual(result.exit_code, 1)
+
+    def test_help_lists_stop_model(self):
+        result = runner.invoke(M.app, ["--help"])
+        self.assertIn("--stop-model", re.sub(r"\x1b\[[0-9;]*m", "", result.output))
+
+
+_DEPLOYED_PAYLOAD = {
+    "c1": {"name": "speecht5_tts", "device_ids": [0],
+           "model_impl": {"model_name": "speecht5_tts", "model_type": "tts"}},
+    "c2": {"name": "tt-model-qwen3-32b", "device_ids": [1, 2],
+           "model_impl": {"model_name": "Qwen3-32B", "model_type": "chat"}},
+    "c3": {"name": "tt-model-qwen3-8b", "device_id": 3,
+           "model_impl": {"model_name": "Qwen3-8B", "model_type": "chat"}},
+}
+
+
+class TestStopModelHelpers(unittest.TestCase):
+    def test_summarize_orders_by_chip_and_fills_device_ids(self):
+        rows = _cli_stop.summarize_deployed(_DEPLOYED_PAYLOAD)
+        self.assertEqual([r["id"] for r in rows], ["c1", "c2", "c3"])
+        self.assertEqual(rows[2]["device_ids"], [3])   # legacy single device_id
+        self.assertEqual(rows[1]["model_name"], "Qwen3-32B")
+
+    def test_match_exact_then_unique_substring(self):
+        rows = _cli_stop.summarize_deployed(_DEPLOYED_PAYLOAD)
+        self.assertEqual(_cli_stop.match_deployed(rows, "qwen3-32b")[0]["id"], "c2")   # catalog name, any case
+        self.assertEqual(_cli_stop.match_deployed(rows, "tt-model-qwen3-8b")[0]["id"], "c3")  # container name
+        self.assertEqual(_cli_stop.match_deployed(rows, "speech")[0]["id"], "c1")      # unique substring
+        row, why = _cli_stop.match_deployed(rows, "qwen")
+        self.assertIsNone(row)
+        self.assertIn("ambiguous", why)
+        row, why = _cli_stop.match_deployed(rows, "llama")
+        self.assertIsNone(row)
+        self.assertIn("not deployed", why)
+
+    def test_parse_sse_yields_json_frames_only(self):
+        lines = [b"retry: 1000\n", b"\n", b'data: {"type": "step", "message": "Stopping"}\n', b"\n",
+                 b"data: not-json\n", b'data: {"type": "complete", "status": "success"}\n']
+        events = list(_cli_stop.parse_sse(lines))
+        self.assertEqual(events[0]["type"], "step")
+        self.assertEqual(events[1], {"type": "log", "message": "not-json"})
+        self.assertEqual(events[2]["status"], "success")
+
+    def test_parse_selection(self):
+        self.assertEqual(_cli_stop.parse_selection("1 3", 3), [1, 3])
+        self.assertEqual(_cli_stop.parse_selection("3,1,1", 3), [1, 3])
+        self.assertEqual(_cli_stop.parse_selection("all", 2), [1, 2])
+        self.assertEqual(_cli_stop.parse_selection("4", 3), [])
+        self.assertEqual(_cli_stop.parse_selection("x", 3), [])
+
+
+class TestStopModels(unittest.TestCase):
+    def _stream_ok(self, base, container_id):
+        yield {"type": "step", "message": f"Stopping {container_id}…"}
+        yield {"type": "log", "message": "docker rm"}
+        yield {"type": "step", "message": "Resetting device(s) 1, 2…"}
+        yield {"type": "complete", "status": "success", "message": "Model deleted and device(s) reset"}
+
+    def test_named_model_is_stopped_and_reset(self):
+        stopped = []
+
+        def stream(base, cid):
+            stopped.append(cid)
+            return self._stream_ok(base, cid)
+        args = _cli_args._build_args(stop_model=["Qwen3-32B"])
+        with patch.object(_cli_stop, "console"):
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD, stream=stream)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stopped, ["c2"])
+
+    def test_unknown_name_stops_nothing(self):
+        stopped = []
+        args = _cli_args._build_args(stop_model=["Llama-3.1-8B"])
+        with patch.object(_cli_stop, "console") as con:
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD,
+                                       stream=lambda b, c: stopped.append(c) or iter(()))
+        self.assertEqual(rc, 1)
+        self.assertEqual(stopped, [])
+        self.assertIn("not deployed", _printed_text(con))
+
+    def test_backend_failure_reports_error(self):
+        def stream(base, cid):
+            yield {"type": "step", "message": "Stopping"}
+            yield {"type": "complete", "status": "error", "message": "Stop failed: boom"}
+        args = _cli_args._build_args(stop_model=["speecht5_tts"])
+        with patch.object(_cli_stop, "console") as con:
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD, stream=stream)
+        self.assertEqual(rc, 1)
+        self.assertIn("boom", _printed_text(con))
+
+    def test_nothing_deployed_is_a_clean_noop(self):
+        args = _cli_args._build_args(stop_model=["anything"])
+        with patch.object(_cli_stop, "console"):
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: {}, stream=None)
+        self.assertEqual(rc, 0)
+
+    def test_unreachable_backend(self):
+        def fetch(base):
+            raise _cli_stop.StopModelError("cannot reach the TT Studio backend at http://x: refused")
+        args = _cli_args._build_args(stop_model=["x"])
+        with patch.object(_cli_stop, "console") as con:
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=fetch, stream=None)
+        self.assertEqual(rc, 1)
+        self.assertIn("python run.py", _printed_text(con))
+
+    def test_picker_without_tty_fails_with_hint(self):
+        from tt_setup.constants import _PURGE_MODEL_PICKER
+        args = _cli_args._build_args(stop_model=[_PURGE_MODEL_PICKER])
+        with patch.object(_cli_stop, "console") as con, \
+             patch.object(_cli_stop.sys.stdin, "isatty", return_value=False):
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD, stream=None)
+        self.assertEqual(rc, 1)
+        self.assertIn("--stop-model <name>", _printed_text(con))
+
+    def test_picker_selection_stops_chosen_rows(self):
+        from tt_setup.constants import _PURGE_MODEL_PICKER
+        stopped = []
+
+        def stream(base, cid):
+            stopped.append(cid)
+            return self._stream_ok(base, cid)
+        args = _cli_args._build_args(stop_model=[_PURGE_MODEL_PICKER])
+        with patch.object(_cli_stop, "console"), \
+             patch.object(_cli_stop.sys.stdin, "isatty", return_value=True), \
+             patch.object(_cli_stop, "ask", return_value="1 3"):
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD, stream=stream)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stopped, ["c1", "c3"])
+
+    def test_picker_cancel_is_clean(self):
+        from tt_setup.constants import _PURGE_MODEL_PICKER
+        args = _cli_args._build_args(stop_model=[_PURGE_MODEL_PICKER])
+        with patch.object(_cli_stop, "console"), \
+             patch.object(_cli_stop.sys.stdin, "isatty", return_value=True), \
+             patch.object(_cli_stop, "ask", return_value=""):
+            rc = _cli_stop.stop_models(args, base="http://x", fetch=lambda b: _DEPLOYED_PAYLOAD, stream=None)
+        self.assertEqual(rc, 0)

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -261,3 +261,115 @@ class TestSetAppVersionEnvImageTag(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAdoptHfTokenFromEnvironment(unittest.TestCase):
+    """A shell-exported HF_TOKEN is persisted into .env so the services that
+    only read .env (backend container, inference-api, model containers) see it."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
+        self.tmp.close()
+        self.p = patch.object(_ecfg_dotenv, "ENV_FILE_PATH", self.tmp.name)
+        self.p.start()
+
+    def tearDown(self):
+        self.p.stop()
+        os.unlink(self.tmp.name)
+
+    def _env_file_token(self):
+        return _ecfg_dotenv.get_existing_env_vars().get("HF_TOKEN")
+
+    def test_exported_token_is_written_to_env_file(self):
+        with patch.dict(os.environ, {"HF_TOKEN": "hf_fromshell"}):
+            self.assertTrue(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertEqual(self._env_file_token(), "hf_fromshell")
+
+    def _isolated_env(self, **extra):
+        """No shell token and no Hugging Face login store (the developer's real
+        ~/.cache/huggingface/token must not leak into these tests)."""
+        env = {k: v for k, v in os.environ.items() if k not in ("HF_TOKEN", "HF_TOKEN_PATH", "HF_HOME")}
+        env["HF_TOKEN_PATH"] = os.path.join(tempfile.gettempdir(), "tt-studio-tests-no-such-token")
+        env.update(extra)
+        return env
+
+    def test_no_export_leaves_env_file_alone(self):
+        with patch.dict(os.environ, self._isolated_env(), clear=True):
+            self.assertFalse(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertIsNone(self._env_file_token())
+
+    def test_empty_export_is_ignored(self):
+        with patch.dict(os.environ, self._isolated_env(HF_TOKEN="   "), clear=True):
+            self.assertFalse(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertIsNone(self._env_file_token())
+
+    def test_matching_value_is_not_rewritten(self):
+        _ecfg_dotenv.write_env_var("HF_TOKEN", "hf_same")
+        with patch.dict(os.environ, {"HF_TOKEN": "hf_same"}):
+            self.assertFalse(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+
+    def test_shell_value_wins_over_differing_env_file(self):
+        _ecfg_dotenv.write_env_var("HF_TOKEN", "hf_old")
+        with patch.dict(os.environ, {"HF_TOKEN": "hf_new"}):
+            self.assertTrue(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertEqual(self._env_file_token(), "hf_new")
+
+    # --- Hugging Face login store (huggingface-cli login / tt-model login) ---
+
+    def _no_shell_token_env(self, **extra):
+        env = {k: v for k, v in os.environ.items() if k not in ("HF_TOKEN", "HF_TOKEN_PATH", "HF_HOME")}
+        env.update(extra)
+        return env
+
+    def _write_store(self, directory, token, name="token"):
+        path = os.path.join(directory, name)
+        with open(path, "w") as f:
+            f.write(token + "\n")
+        return path
+
+    def test_login_store_via_hf_token_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = self._write_store(d, "hf_fromlogin", name="mytoken")
+            with patch.dict(os.environ, self._no_shell_token_env(HF_TOKEN_PATH=store), clear=True):
+                self.assertTrue(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertEqual(self._env_file_token(), "hf_fromlogin")
+
+    def test_login_store_via_hf_home(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_store(d, "hf_fromhfhome")
+            with patch.dict(os.environ, self._no_shell_token_env(HF_HOME=d), clear=True):
+                self.assertEqual(_ecfg_configure.hf_login_token_path(), os.path.join(d, "token"))
+                self.assertTrue(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertEqual(self._env_file_token(), "hf_fromhfhome")
+
+    def test_default_login_store_is_under_home_cache(self):
+        with tempfile.TemporaryDirectory() as home:
+            store_dir = os.path.join(home, ".cache", "huggingface")
+            os.makedirs(store_dir)
+            self._write_store(store_dir, "hf_default")
+            with patch.dict(os.environ, self._no_shell_token_env(), clear=True), \
+                 patch.object(_ecfg_configure.os.path, "expanduser", return_value=home):
+                self.assertEqual(_ecfg_configure.hf_login_token_path(), os.path.join(store_dir, "token"))
+                self.assertEqual(_ecfg_configure.read_hf_login_token(), "hf_default")
+
+    def test_shell_export_wins_over_login_store(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = self._write_store(d, "hf_fromlogin")
+            with patch.dict(os.environ, self._no_shell_token_env(HF_TOKEN="hf_shell", HF_TOKEN_PATH=store), clear=True):
+                self.assertTrue(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertEqual(self._env_file_token(), "hf_shell")
+
+    def test_missing_login_store_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            missing = os.path.join(d, "nope")
+            with patch.dict(os.environ, self._no_shell_token_env(HF_TOKEN_PATH=missing), clear=True):
+                self.assertIsNone(_ecfg_configure.read_hf_login_token())
+                self.assertFalse(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertIsNone(self._env_file_token())
+
+    def test_empty_login_store_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = self._write_store(d, "")
+            with patch.dict(os.environ, self._no_shell_token_env(HF_TOKEN_PATH=store), clear=True):
+                self.assertFalse(_ecfg_configure.adopt_hf_token_from_environment(quiet=True))
+        self.assertIsNone(self._env_file_token())

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -18,6 +18,51 @@ try:
 except ImportError:
     _ports_mod = M
 
+# Browser/health helpers live in the _health submodule; patch the names it looks
+# up (wait_for_service_health, webbrowser) there.
+try:
+    from tt_setup.services import _health as _health_mod
+except ImportError:
+    _health_mod = M
+
+
+class TestWaitForFrontendAndOpenBrowser(unittest.TestCase):
+    """URL assembly for the browser open — path + optional auto-deploy query."""
+
+    def _opened_url(self, **kwargs):
+        with patch.object(_health_mod, "wait_for_service_health", return_value=True), \
+             patch.object(_health_mod, "webbrowser") as wb:
+            ok = _health_mod.wait_for_frontend_and_open_browser(**kwargs)
+        self.assertTrue(ok)
+        wb.open.assert_called_once()
+        return wb.open.call_args[0][0]
+
+    def test_plain_root(self):
+        url = self._opened_url(host="localhost", port=3000)
+        self.assertEqual(url, "http://localhost:3000/")
+
+    def test_path_opens_subpage(self):
+        url = self._opened_url(host="localhost", port=3000, path="models-deployed")
+        self.assertEqual(url, "http://localhost:3000/models-deployed")
+
+    def test_auto_deploy_without_device_id(self):
+        url = self._opened_url(host="localhost", port=3000, auto_deploy_model="Qwen3-32B")
+        self.assertIn("auto-deploy=Qwen3-32B", url)
+        self.assertNotIn("device-id", url)  # unset -> backend allocates by model
+
+    def test_auto_deploy_with_device_id(self):
+        url = self._opened_url(host="localhost", port=3000,
+                               auto_deploy_model="Qwen3-32B", device_id=2)
+        self.assertIn("auto-deploy=Qwen3-32B", url)
+        self.assertIn("device-id=2", url)
+
+    def test_returns_false_when_frontend_never_ready(self):
+        with patch.object(_health_mod, "wait_for_service_health", return_value=False), \
+             patch.object(_health_mod, "webbrowser") as wb:
+            ok = _health_mod.wait_for_frontend_and_open_browser(timeout=0)
+        self.assertFalse(ok)
+        wb.open.assert_not_called()
+
 # Docker Control lifecycle helpers live in the _docker_control submodule.
 try:
     from tt_setup.services import _docker_control as _dc_mod

--- a/tt_setup/cli/_args.py
+++ b/tt_setup/cli/_args.py
@@ -3,6 +3,8 @@
 
 """Typer CLI surface: options, the entry callback, and main()."""
 
+import json
+import os
 import sys
 import typer
 from types import SimpleNamespace
@@ -11,6 +13,169 @@ from tt_setup.console import console, ensure_region_reset, set_no_clear, set_ver
 from tt_setup.constants import *
 from tt_setup.constants import _PURGE_MODEL_PICKER
 from tt_setup.cli._run import _run
+
+
+def _build_args(**overrides):
+    """Build the args namespace `_run()` consumes, from one canonical field list.
+
+    Both the default `_entry` callback and the `run` subcommand funnel through
+    here so their field sets never drift (`_run` reads several via attribute
+    access). Pass only the fields that differ from the defaults.
+    """
+    defaults = dict(
+        dev=False, cleanup=False, cleanup_all=False, yes=False, help_env=False,
+        reconfigure=False, reconfigure_inference_server=False,
+        resync=False, pull_branch=False, build_images=False, skip_fastapi=False,
+        skip_docker_control=False, no_sudo=False, no_browser=False,
+        wait_for_services=False, browser_timeout=60,
+        add_headers=False, check_headers=False, auto_deploy=None,
+        device_id=None, headless=False, browser=False, fix_docker=False, configure_env=False,
+        status=False, logs=False, info=False, report_bug=False,
+        install_shortcut=False, accept_terms=False, switch=None,
+        uninstall=False, purge_model=None, stop_model=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _catalog_models():
+    """Full catalog entries as {name, group, boards}. Empty list when the catalog
+    isn't fetched yet (first run) or can't be parsed. `group` is the display type
+    (LLM, VLM, IMAGE, …); `boards` are the device_configurations it supports."""
+    catalog = os.path.join(
+        TT_STUDIO_ROOT, "app", "backend", "shared_config",
+        "models_from_inference_server.json",
+    )
+    try:
+        with open(catalog) as f:
+            entries = json.load(f).get("models", [])
+    except (OSError, ValueError):
+        return []
+    out = []
+    for m in entries:
+        name = m.get("model_name", "")
+        if not name:
+            continue
+        out.append({
+            "name": name,
+            "group": m.get("display_model_type") or m.get("model_type") or "OTHER",
+            "boards": m.get("device_configurations", []) or [],
+        })
+    return out
+
+
+def _catalog_model_names():
+    """Sorted catalog model names (all boards). Empty when not synced yet."""
+    return sorted({m["name"] for m in _catalog_models()})
+
+
+def _complete_model(incomplete: str):
+    """Shell-completion callback: catalog model names matching the partial input.
+    Degrades to nothing when the catalog isn't synced or completion isn't set up."""
+    lo = incomplete.lower()
+    return [n for n in _catalog_model_names() if lo in n.lower()]
+
+
+def _detect_board():
+    """Best-effort board code (e.g. 'P300x2', 'N150') via tt-smi, in the same
+    vocabulary as the catalog's device_configurations. Empty string when tt-smi is
+    unavailable/unreadable or there's no local hardware (remote/cloud mode)."""
+    try:
+        from tt_setup.shell import check_tt_smi
+        status, _detail, board = check_tt_smi()
+    except Exception:
+        return ""
+    return board if status == "ok" else ""
+
+
+# Friendly group headers + display order for the interactive picker.
+_MODEL_GROUP_LABELS = {
+    "LLM": "LLMs", "VLM": "Vision-language", "IMAGE": "Image generation",
+    "VIDEO": "Video", "AUDIO": "Speech-to-text", "TEXT_TO_SPEECH": "Text-to-speech",
+    "EMBEDDING": "Embeddings", "CNN": "Vision (CNN)",
+}
+_MODEL_GROUP_ORDER = ["LLM", "VLM", "IMAGE", "VIDEO", "AUDIO", "TEXT_TO_SPEECH", "EMBEDDING", "CNN"]
+
+
+def _prompt_for_model():
+    """Interactively choose a model when `run` is invoked without one. Filters to
+    the detected board (via tt-smi, when available) to keep the list short, groups
+    by model type, and accepts a number or a name. Falls back to free-text entry
+    when the catalog isn't synced yet (the live resolve check vets it post-startup)."""
+    models = _catalog_models()
+    if not models:
+        return typer.prompt("Model to deploy").strip()
+
+    board = _detect_board()
+    shown = models
+    if board:
+        compatible = [m for m in models if board in m["boards"]]
+        if compatible:
+            shown = compatible
+            console.print(f"[muted]Filtered to models compatible with your board ({board}).[/muted]")
+
+    groups = {}
+    for m in shown:
+        groups.setdefault(m["group"], []).append(m["name"])
+    ordered_groups = [g for g in _MODEL_GROUP_ORDER if g in groups] + \
+        sorted(g for g in groups if g not in _MODEL_GROUP_ORDER)
+
+    console.print("[info]Available models:[/info]")
+    ordered_names = []
+    for g in ordered_groups:
+        console.print(f"\n[bold]{_MODEL_GROUP_LABELS.get(g, g.title())}[/bold]")
+        for name in sorted(groups[g]):
+            ordered_names.append(name)
+            console.print(f"  [bold]{len(ordered_names):>2}[/bold]  {name}")
+
+    choice = typer.prompt("\nSelect a model (number or name)").strip()
+    if choice.isdigit():
+        idx = int(choice)
+        if not 1 <= idx <= len(ordered_names):
+            raise typer.BadParameter(f"choice {idx} is out of range 1-{len(ordered_names)}")
+        return ordered_names[idx - 1]
+    return choice  # a name — _validate_model_name vets it next
+
+
+def _validate_model_name(model):
+    """Best-effort pre-startup catalog check so a typo fails fast instead of
+    after the ~2-min stack-up. Silently skips when the catalog isn't fetched yet
+    (first run) — resolve_model_id does the authoritative check post-startup.
+    """
+    names = _catalog_model_names()
+    if not names:
+        return  # catalog not synced yet — let the live check handle it
+    needle = model.lower()
+    if any(needle == n.lower() or needle in n.lower() for n in names):
+        return
+
+    import difflib
+    close = difflib.get_close_matches(model, names, n=5, cutoff=0.3)
+    console.print(f"[error]⛔ Model '{model}' is not in the catalog.[/error]")
+    if close:
+        console.print("[info]Did you mean:[/info]")
+        for n in close:
+            console.print(f"  [bold]{n}[/bold]")
+    else:
+        console.print(f"[muted]Available: {', '.join(names)}[/muted]")
+    raise typer.Exit(1)
+
+
+def _validate_device_id(value: Optional[str]) -> Optional[str]:
+    """Typer callback for `--device-id`. Accepts a single chip slot ("0") or a
+    comma-separated list ("0,1") for multi-chip models. Validates format only
+    (comma-separated non-negative integers) and returns the normalized string;
+    the backend serializer owns the authoritative hardware range check.
+    """
+    if value is None:
+        return None
+    parts = [p.strip() for p in value.split(",")]
+    if not all(p.isdigit() for p in parts):
+        raise typer.BadParameter(
+            f"'{value}' must be a chip slot like '0', or a comma-separated list "
+            "like '0,1' for multi-chip models."
+        )
+    return ",".join(parts)
 
 
 app = typer.Typer(
@@ -23,6 +188,7 @@ app = typer.Typer(
 
 @app.callback(invoke_without_command=True)
 def _entry(
+    ctx: typer.Context,
     # ── Setup & Configuration (the everyday flags) ───────────────────────────
     dev: bool = typer.Option(False, "--dev", help="Development mode (hot-reload, suggested defaults).", rich_help_panel="Setup & Configuration"),
     reconfigure_inference_server: bool = typer.Option(False, "--reconfigure-inference-server", "--reconfig-inf", help="Reconfigure the TT Inference Server artifact (short alias: --reconfig-inf).", rich_help_panel="Setup & Configuration"),
@@ -31,13 +197,16 @@ def _entry(
     install_shortcut: bool = typer.Option(False, "--install-shortcut", help="Add a `tt-studio` shell shortcut so you can skip typing `python run.py`.", rich_help_panel="Setup & Configuration"),
     switch: str = typer.Option(None, "--switch", metavar="REF", help="Switch this checkout to a git branch or tag (e.g. dev, v2.9.0-rc1), then exit; re-run to start.", rich_help_panel="Setup & Configuration"),
     # ── Model Deployment ─────────────────────────────────────────────────────
-    auto_deploy: str = typer.Option(None, "--auto-deploy", metavar="MODEL_NAME", help="Auto-deploy the given model after startup.", rich_help_panel="Model Deployment"),
-    device_id: int = typer.Option(0, "--device-id", metavar="CHIP_ID", help="Chip slot index (0-7) for --auto-deploy.", rich_help_panel="Model Deployment"),
+    auto_deploy: str = typer.Option(None, "--auto-deploy", "--model", metavar="MODEL_NAME", help="Deploy the given model after startup, from the terminal (progress and endpoint shown here; add --browser to deploy through the web UI instead). Or use the `run <model>` subcommand.", rich_help_panel="Model Deployment", autocompletion=_complete_model),
+    device_id: Optional[str] = typer.Option(None, "--device-id", metavar="CHIP_IDS", help="Chip slot(s) for the deploy, e.g. `0` or `0,1` for multi-chip models. Omit to let the backend allocate based on the model.", rich_help_panel="Model Deployment", callback=_validate_device_id),
+    browser: bool = typer.Option(False, "--browser", help="Deploy through the web UI: open the browser and let it drive the deploy.", rich_help_panel="Model Deployment"),
+    headless: bool = typer.Option(False, "--headless", hidden=True, help="Deprecated: the terminal deploy is now the default."),
     # ── Lifecycle ────────────────────────────────────────────────────────────
     stop: bool = typer.Option(False, "--stop", help="Stop TT Studio: tear down Docker containers and networks.", rich_help_panel="Lifecycle"),
     status: bool = typer.Option(False, "--status", help="Open the live monitor TUI for a running stack.", rich_help_panel="Lifecycle"),
     logs: bool = typer.Option(False, "--logs", help="Stream all container logs (docker compose logs -f).", rich_help_panel="Lifecycle"),
     info: bool = typer.Option(False, "--info", help="Re-show the 'TT Studio is ready' summary (URLs, mode, hardware).", rich_help_panel="Lifecycle"),
+    stop_model: Optional[List[str]] = typer.Option(None, "--stop-model", metavar="MODEL", help="Stop one deployed model and reset the chip(s) it was using; the stack keeps running. Repeatable; bare --stop-model opens an interactive picker.", rich_help_panel="Lifecycle"),
     # ── Reset (--purge-all) ──────────────────────────────────────────────────
     purge_all: bool = typer.Option(False, "--purge-all", help="Stop and wipe everything incl. persistent data and .env.", rich_help_panel="Reset (--purge-all)"),
     purge_model: Optional[List[str]] = typer.Option(None, "--purge-model", metavar="MODEL", help="Uninstall one model: weights, volume, env, container (image if unshared). Repeatable; bare --purge-model opens an interactive picker.", rich_help_panel="Reset (--purge-all)"),
@@ -69,6 +238,11 @@ def _entry(
     cleanup_all: bool = typer.Option(False, "--cleanup-all", hidden=True, help="Deprecated alias for --purge-all."),
 ):
     """Set up and launch TT Studio. With no flags, runs the default minimal setup."""
+    # A subcommand (e.g. `run`) was invoked — its handler owns the flow. Without
+    # this guard the callback would also run the full default setup.
+    if ctx.invoked_subcommand is not None:
+        return
+
     set_verbose(verbose or no_clear)   # --no-clear shows full step detail too
     set_no_clear(no_clear)
 
@@ -82,31 +256,68 @@ def _entry(
     full_teardown = purge_all or cleanup_all or uninstall
     stop_requested = stop or cleanup or full_teardown
 
-    args = SimpleNamespace(
+    if auto_deploy:
+        _validate_model_name(auto_deploy)
+
+    args = _build_args(
         dev=dev, cleanup=stop_requested, cleanup_all=full_teardown, yes=yes, help_env=help_env,
         reconfigure=reconfigure, reconfigure_inference_server=reconfigure_inference_server,
         resync=resync, pull_branch=pull_branch, build_images=build_images, skip_fastapi=skip_fastapi,
         skip_docker_control=skip_docker_control, no_sudo=no_sudo, no_browser=no_browser,
         wait_for_services=wait_for_services, browser_timeout=browser_timeout,
         add_headers=add_headers, check_headers=check_headers, auto_deploy=auto_deploy,
-        device_id=device_id, fix_docker=fix_docker, configure_env=configure_env,
-        status=status, logs=logs, info=info, report_bug=report_bug,
-        install_shortcut=install_shortcut, accept_terms=accept_terms,
-        switch=switch, uninstall=uninstall, purge_model=list(purge_model or []),
+        device_id=device_id, headless=headless, browser=browser, fix_docker=fix_docker,
+        configure_env=configure_env, status=status, logs=logs, info=info,
+        report_bug=report_bug, install_shortcut=install_shortcut,
+        accept_terms=accept_terms, switch=switch, uninstall=uninstall,
+        purge_model=list(purge_model or []), stop_model=list(stop_model or []),
     )
     _run(args)
 
 
+@app.command("run")
+def run_model_command(
+    model: Optional[str] = typer.Argument(None, metavar="MODEL_NAME", help="Model to deploy, e.g. Qwen3-32B. Omit to pick from the catalog interactively.", autocompletion=_complete_model),
+    device_id: Optional[str] = typer.Option(None, "--device-id", metavar="CHIP_IDS", help="Chip slot(s), e.g. `0` or `0,1` for multi-chip models. Omit to let the backend allocate based on the model.", callback=_validate_device_id),
+    browser: bool = typer.Option(False, "--browser", help="Deploy through the web UI: open the browser and let it drive the deploy."),
+    headless: bool = typer.Option(False, "--headless", hidden=True, help="Deprecated: the terminal deploy is now the default."),
+    dev: bool = typer.Option(False, "--dev", help="Development mode (hot-reload)."),
+    no_browser: bool = typer.Option(False, "--no-browser", help="With --browser, print the deploy URL instead of opening it."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show full per-phase output instead of the calm summary."),
+):
+    """Launch TT Studio and deploy a model in one command.
+
+    Brings the whole stack up and deploys the model from the terminal: each
+    stage (image pull, weights download, container start) is shown here and the
+    run ends with the model's endpoint. No browser opens. Pass --browser to
+    deploy through the web UI instead. Omit MODEL_NAME to choose from the
+    synced catalog interactively.
+    """
+    set_verbose(verbose)
+    if model is None:
+        model = _prompt_for_model()
+    _validate_model_name(model)
+    args = _build_args(
+        dev=dev, auto_deploy=model, device_id=device_id,
+        headless=headless, browser=browser, no_browser=no_browser,
+    )
+    _run(args)
+
+
+# Flags that take an optional model name: bare means "open the picker".
+_OPTIONAL_MODEL_FLAGS = ("--purge-model", "--stop-model")
+
+
 def _normalize_purge_model_argv(argv):
-    """Support bare `--purge-model` (no model name) meaning "open the picker".
-    The vendored click in this typer version can't express an option with an
-    optional value, so inject the picker sentinel whenever --purge-model is the
-    last token or is followed by another flag. `--purge-model NAME` and
-    `--purge-model=NAME` pass through untouched."""
+    """Support a bare `--purge-model` / `--stop-model` (no model name) meaning
+    "open the picker". The vendored click in this typer version can't express an
+    option with an optional value, so inject the picker sentinel whenever such a
+    flag is the last token or is followed by another flag. `--flag NAME` and
+    `--flag=NAME` pass through untouched."""
     out = []
     for i, token in enumerate(argv):
         out.append(token)
-        if token == "--purge-model" and (
+        if token in _OPTIONAL_MODEL_FLAGS and (
             i + 1 == len(argv) or argv[i + 1].startswith("-")
         ):
             out.append(_PURGE_MODEL_PICKER)

--- a/tt_setup/cli/_deploy.py
+++ b/tt_setup/cli/_deploy.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Terminal-driven model deploy for `python run.py run <model>`.
+
+Drives the backend deploy API directly (no browser, no frontend JS) and renders
+the deploy the way the rest of the launcher renders work: one collapsing line per
+stage, a live bar while the Docker image or the weights download, and a ready
+panel with the model's endpoint once it answers health checks.
+
+The HTTP plumbing (catalog resolve, endpoint map, error type) is borrowed from
+ci/deploy_healthcheck.py via the `dh` module handle so the CLI and CI exercise
+the same request path.
+"""
+
+import sys
+import time
+
+from rich.progress import BarColumn, Progress, TextColumn
+from tt_setup.console import console, is_verbose, notice_panel, ready_panel
+from tt_setup.console._theme import _real_console
+
+# Backend progress `stage` -> what the user sees. Mirrors the web UI's labels so a
+# terminal deploy and a browser deploy tell the same story.
+STAGE_LABELS = {
+    "starting": "Starting deployment",
+    "initialization": "Loading environment",
+    "setup": "Running workflow configuration",
+    "pulling_image": "Pulling Docker image",
+    "image_ready": "Image ready",
+    "model_preparation": "Preparing model",
+    "container_setup": "Starting container",
+    "container_started": "Container started",
+    "network_setup": "Connecting to network",
+    "finalizing": "Finalizing",
+    "complete": "Deployed",
+    "error": "Failed",
+    "unknown": "Working",
+}
+
+# Stages whose progress payload can carry byte-level download detail.
+DOWNLOAD_STAGES = {"pulling_image", "model_preparation"}
+
+PROGRESS_DONE = "completed"
+PROGRESS_FAIL = {"error", "failed", "timeout", "cancelled"}
+
+# How long a fresh deploy job may report `not_found` before it counts as gone.
+# The progress record can lag the deploy POST by a few seconds; past this, the
+# backend has genuinely forgotten the job (e.g. it restarted) and polling for
+# the full timeout would only spin.
+NOT_FOUND_GRACE_S = 30
+
+
+# ── pure helpers (unit-tested without a backend) ──────────────────────────────
+
+def deploy_mode(args):
+    """Where a `run <model>` deploy happens: "browser" (web UI drives it),
+    "terminal" (this process drives the backend API), or None (no model)."""
+    if not getattr(args, "auto_deploy", None):
+        return None
+    return "browser" if getattr(args, "browser", False) else "terminal"
+
+
+def should_open_browser(args):
+    """A terminal deploy never opens a browser — the terminal *is* the UI for that
+    run. Otherwise honour --no-browser as before."""
+    if deploy_mode(args) == "terminal":
+        return False
+    return not getattr(args, "no_browser", False)
+
+
+def format_bytes(n):
+    """Decimal units to match what Hugging Face and Docker report."""
+    if n is None or n < 0:
+        return "—"
+    value, unit = float(n), "B"
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1000 or unit == "TB":
+            break
+        value /= 1000
+    if unit == "B":
+        return f"{int(value)} B"
+    text = f"{value:.0f}" if value >= 100 else f"{value:.1f}".rstrip("0").rstrip(".")
+    return f"{text} {unit}"
+
+
+def stage_label(data):
+    """Headline for a progress payload. A weights download that is reporting
+    bytes gets a more specific label than the generic 'Preparing model'."""
+    stage = (data.get("stage") or "unknown").lower()
+    if stage == "model_preparation" and data.get("downloaded_bytes") is not None:
+        return "Downloading model weights"
+    return STAGE_LABELS.get(stage, stage.replace("_", " ").capitalize())
+
+
+def download_detail(data):
+    """'1.2 GB / 23.3 GB · 85 MB/s' while an image or weights download is
+    reporting bytes; None otherwise."""
+    stage = (data.get("stage") or "").lower()
+    if stage not in DOWNLOAD_STAGES or data.get("downloaded_bytes") is None:
+        return None
+    parts = [format_bytes(data["downloaded_bytes"])]
+    if data.get("total_bytes"):
+        parts[0] += f" / {format_bytes(data['total_bytes'])}"
+    if data.get("speed_bps"):
+        parts.append(f"{format_bytes(data['speed_bps'])}/s")
+    return " · ".join(parts)
+
+
+def download_fraction(data):
+    """0..1 completion of the current download, or None when bytes are unknown."""
+    total = data.get("total_bytes")
+    done = data.get("downloaded_bytes")
+    if not total or done is None:
+        return None
+    return max(0.0, min(1.0, done / total))
+
+
+def endpoint_for(entry, host="localhost"):
+    """Host-reachable URLs for a deployed-models entry (the dict served under
+    /models/deployed/<id>). Returns {"url", "health", "port", "model_type"} —
+    values are None when the entry doesn't expose them."""
+    impl = entry.get("model_impl") or {}
+    port = None
+    for bindings in (entry.get("port_bindings") or {}).values():
+        for b in bindings or []:
+            if b.get("HostPort"):
+                port = b["HostPort"]
+                break
+        if port:
+            break
+    route = impl.get("service_route") or ""
+    health_route = impl.get("health_route") or "/health"
+    base = f"http://{host}:{port}" if port else None
+    return {
+        "port": port,
+        "url": f"{base}{route}" if base else None,
+        "health": f"{base}{health_route}" if base else None,
+        "model_type": impl.get("model_type"),
+    }
+
+
+def curl_example(url, model_type, hf_model_id=None):
+    """A copy-pasteable first request for chat endpoints; None for other types."""
+    if not url or model_type != "chat":
+        return None
+    model = hf_model_id or "<model>"
+    return (
+        f'curl {url} -H "Content-Type: application/json" '
+        f'-d \'{{"model":"{model}","messages":[{{"role":"user","content":"Hello"}}]}}\''
+    )
+
+
+# ── backend interaction ───────────────────────────────────────────────────────
+
+def resolve_model_with_retry(dh, client, model_name, deadline_s=60, sleep=time.sleep):
+    """Resolve a catalog model id, retrying briefly while the backend is still
+    warming up right after the stack came up. A true miss is not retried."""
+    deadline = time.time() + deadline_s
+    last_err = None
+    while time.time() < deadline:
+        try:
+            return dh.resolve_model_id(client, model_name, None), None
+        except dh.SmokeTestError as e:
+            last_err = e
+            if "cannot reach" in str(e) or "catalog fetch failed" in str(e):
+                sleep(3)
+                continue
+            break
+    return None, last_err
+
+
+def watch_progress(dh, client, job_id, timeout=3600, interval=3, sleep=time.sleep):
+    """Poll the deploy until it completes, rendering stage transitions as
+    collapsed ✓ lines and the live stage (with download bytes) on a transient
+    bar. Falls back to change-only plain lines when stdout is not a terminal.
+
+    Returns the final progress payload; raises dh.SmokeTestError on failure."""
+    tty = sys.stdout.isatty()
+    started = time.time()
+    deadline = started + timeout
+    current_stage = None
+    current_label = STAGE_LABELS["starting"]
+    current_started = time.time()
+    last_total = None
+    last_plain = None
+
+    progress = None
+    task = None
+    if tty:
+        progress = Progress(
+            TextColumn("  [info]{task.description}[/info]"),
+            BarColumn(bar_width=24),
+            TextColumn("[muted]{task.fields[detail]}[/muted]"),
+            console=_real_console,
+            transient=True,
+        )
+        progress.start()
+        task = progress.add_task("Starting deployment", total=100, completed=0, detail="")
+
+    def _finish_stage(label, started, note=None):
+        elapsed = time.time() - started
+        suffix = f" [muted]({note})[/muted]" if note else ""
+        console.print(f"  [success]✓[/success] {label}{suffix} [muted]{elapsed:.0f}s[/muted]")
+
+    try:
+        while time.time() < deadline:
+            st, data = client.get("progress", timeout=15, job_id=job_id)
+            if st != 200 or not isinstance(data, dict):
+                sleep(interval)
+                continue
+            status_ = (data.get("status") or "").lower()
+            if status_ == "not_found":
+                # Nothing to render yet; either the record is still registering
+                # (keep waiting) or the backend has lost the job (give up).
+                if time.time() - started > NOT_FOUND_GRACE_S:
+                    raise dh.SmokeTestError(
+                        "deployment lost: the backend no longer reports this deploy job "
+                        f"(id {job_id}). It may have restarted; check the Deployed Models page."
+                    )
+                sleep(interval)
+                continue
+            stage = (data.get("stage") or "unknown").lower()
+            label = stage_label(data)
+            detail = download_detail(data)
+
+            if stage != current_stage:
+                if current_stage is not None:
+                    prev_note = None
+                    if current_stage in DOWNLOAD_STAGES and last_total:
+                        prev_note = format_bytes(last_total)
+                    _finish_stage(current_label, current_started, prev_note)
+                current_stage, current_label, current_started = stage, label, time.time()
+                last_total = None
+            if data.get("total_bytes"):
+                last_total = data["total_bytes"]
+            if stage in DOWNLOAD_STAGES:
+                current_label = label  # 'Preparing model' -> 'Downloading model weights'
+
+            if progress is not None:
+                frac = download_fraction(data)
+                pct = frac * 100 if frac is not None else float(data.get("progress") or 0)
+                progress.update(task, description=label, completed=pct, detail=detail or (data.get("message") or ""))
+            else:
+                line = f"  {label}" + (f" — {detail}" if detail else "")
+                if line != last_plain:
+                    console.print(line)
+                    last_plain = line
+
+            if status_ == PROGRESS_DONE:
+                # The terminal "complete" stage is the ready panel's job to announce.
+                if current_stage not in ("complete", "completed"):
+                    _finish_stage(current_label, current_started)
+                return data
+            if status_ in PROGRESS_FAIL:
+                reason = data.get("message") or status_
+                raise dh.SmokeTestError(
+                    f"deployment {status_}: {reason}\n  {dh.fetch_deploy_logs(client, job_id)}"
+                )
+            sleep(interval)
+    finally:
+        if progress is not None:
+            progress.stop()
+
+    raise dh.SmokeTestError(
+        f"deployment did not complete within {timeout}s\n  {dh.fetch_deploy_logs(client, job_id)}"
+    )
+
+
+def find_deployed_entry(client, model_id, timeout=120, interval=3, sleep=time.sleep):
+    """After 'completed', the container shows up under /models/deployed/ keyed by
+    its deploy id. Returns (deploy_id, entry) or (None, None) on timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            st, data = client.get("deployed", timeout=15)
+        except Exception:
+            st, data = None, None
+        if st == 200 and isinstance(data, dict):
+            for deploy_id, entry in data.items():
+                impl = entry.get("model_impl") or {}
+                if impl.get("model_id") == model_id:
+                    return deploy_id, entry
+        sleep(interval)
+    return None, None
+
+
+def wait_for_health(client, deploy_id, timeout=1800, interval=5, sleep=time.sleep):
+    """Poll /models/health/ until the model answers 200. 202 = still warming.
+    Returns True when healthy, False on timeout or a hard failure."""
+    deadline = time.time() + timeout
+    consecutive_503 = 0
+    while time.time() < deadline:
+        try:
+            st, _ = client.get("health", timeout=20, query={"deploy_id": deploy_id})
+        except Exception:
+            st = None
+        if st == 200:
+            return True
+        if st == 503:
+            consecutive_503 += 1
+            if consecutive_503 >= 3:
+                return False
+        else:
+            consecutive_503 = 0
+        sleep(interval)
+    return False
+
+
+def run_headless_deploy(dh, args, backend_url="http://localhost:8000", frontend=("localhost", 3000)):
+    """Deploy `args.auto_deploy` from the terminal and show where it is serving.
+
+    device_id is included only when the user set it; otherwise it's omitted so
+    the backend allocates a slot based on the model's chip requirements."""
+    client = dh.Client(backend_url, proxy=False)
+    model_name = args.auto_deploy
+    device_id = getattr(args, "device_id", None)
+    fe_host, fe_port = frontend
+
+    model_id, err = resolve_model_with_retry(dh, client, model_name)
+    if model_id is None:
+        console.print(notice_panel("Deploy failed", [str(err)], border_style="error"))
+        return False
+
+    body = {"model_id": model_id}
+    if device_id is not None:
+        body["device_id"] = device_id
+    else:
+        # Same whole-card hint the web UI sends for an unpinned deploy. The
+        # backend honours it only where it matters (Llama-3.1-8B on a P300x2
+        # dies on a lone chip) and ignores it everywhere else.
+        body["force_full_board"] = True
+    where = f"chip {device_id}" if device_id is not None else "auto-allocated slot"
+    web_ui = f"http://{fe_host}:{fe_port}/models-deployed"
+
+    try:
+        st, data = client.post("deploy", body, timeout=120)
+        if st not in (200, 201) or data.get("status") != "success":
+            msg = data.get("message") if isinstance(data, dict) else None
+            lines = [msg or f"deploy failed (HTTP {st}): {data}"]
+            if isinstance(data, dict) and data.get("hf_url"):
+                lines += ["", f"Request access at {data['hf_url']}, then run again."]
+            if isinstance(data, dict) and data.get("conflicts"):
+                busy = ", ".join(
+                    f"{c.get('model', 'another model')} (device {c.get('slot', '?')})"
+                    for c in data["conflicts"]
+                )
+                lines += ["", f"Stop these first: {busy}."]
+            console.print(notice_panel("Deploy refused", lines, border_style="error"))
+            return False
+        job_id = data.get("job_id")
+        if not job_id:
+            raise dh.SmokeTestError(f"deploy returned no job_id: {data}")
+
+        console.print(f"\n[bold accent]🚀 Deploying {model_name}[/bold accent] [muted]({where})[/muted]")
+        console.print("  [muted]Ctrl-C stops watching; the deploy keeps running in the backend.[/muted]")
+        watch_progress(dh, client, job_id)
+        deploy_id, entry = find_deployed_entry(client, model_id)
+        healthy = False
+        if deploy_id:
+            console.print("  [muted]Waiting for the model to answer health checks…[/muted]")
+            healthy = wait_for_health(client, deploy_id)
+    except dh.SmokeTestError as e:
+        console.print(notice_panel("Deploy failed", [str(e)], border_style="error"))
+        return False
+    except KeyboardInterrupt:
+        console.print()
+        console.print(notice_panel("Stopped watching", [
+            f"{model_name} keeps deploying in the backend.",
+            f"Follow it at {web_ui}, or run python run.py --status.",
+            f"To cancel it: python run.py --stop-model {model_name}",
+        ], border_style="warning"))
+        return False
+
+    ep = endpoint_for(entry or {}, host=fe_host)
+
+    impl = (entry or {}).get("model_impl") or {}
+    chips = (entry or {}).get("device_ids") or ([device_id] if device_id is not None else [])
+    rows = [("Model", model_name)]
+    if chips:
+        rows.append(("Chips", ", ".join(str(c) for c in chips)))
+    if ep["url"]:
+        rows.append(("Endpoint", ep["url"], "up" if healthy else "starting"))
+    if ep["health"]:
+        rows.append(("Health", ep["health"]))
+    rows.append(("Web UI", web_ui))
+
+    footer = []
+    if not healthy:
+        footer.append("[warning]The model is still warming up — the endpoint answers once health reports 200.[/warning]")
+    example = curl_example(ep["url"], ep["model_type"], impl.get("hf_model_id"))
+    if example:
+        footer.append("[muted]Try it:[/muted]")
+        footer.append(f"  [info]{example}[/info]")
+    footer.append("[muted]python run.py --stop to stop · python run.py --logs for logs[/muted]")
+
+    title = f"{model_name} is ready" if healthy else f"{model_name} is starting"
+    console.print()
+    console.print(ready_panel(title, rows, footer))
+    console.print()
+    if is_verbose() and deploy_id:
+        console.print(f"[muted]deploy id: {deploy_id}[/muted]")
+    return healthy

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -110,6 +110,101 @@ def show_ready_panel(args, run_start=None, hardware_label=None, is_deployed_mode
     console.print()
 
 
+def _auto_deploy_query(model, device_id):
+    """Build the `?auto-deploy=…` query string for the browser (UI-driven) path.
+    Includes device-id only when explicitly set; omitting it lets the backend
+    allocate a slot based on the model's requirements."""
+    from urllib.parse import urlencode
+
+    query = {"auto-deploy": model}
+    if device_id is not None:
+        query["device-id"] = device_id
+    return f"?{urlencode(query)}"
+
+
+def _preflight_device_availability(args):
+    """Fast-reject a `--device-id`-pinned deploy when the requested chip slots are
+    already occupied, *before* the full stack-up / browser open.
+
+    Only runs when a model and explicit chip slots are both set. Queries the
+    backend chip-status endpoint with a short timeout; if the backend isn't up
+    yet (fresh boot) or the check can't complete, it silently returns and lets
+    the deploy-time allocator stay the authoritative guard. This just moves the
+    common "chips busy" rejection to the front so a re-run against occupied
+    devices fails in a second instead of after a ~50s startup."""
+    model = getattr(args, "auto_deploy", None)
+    device_id = getattr(args, "device_id", None)
+    if not model or not device_id:
+        return
+    try:
+        requested = [int(x.strip()) for x in str(device_id).split(",") if x.strip() != ""]
+    except ValueError:
+        return  # malformed — Typer already validated; let the backend re-check
+    if not requested:
+        return
+
+    dh = _load_deploy_driver()
+    if dh is None:
+        return
+    client = dh.Client("http://localhost:8000", proxy=False)
+    try:
+        st, data = client.get("chip_status", timeout=5)
+    except Exception:
+        return  # backend not reachable yet — deploy-time guard will handle it
+    if st != 200 or not isinstance(data, dict):
+        return
+
+    slots = {s.get("slot_id"): s for s in data.get("slots", []) if isinstance(s, dict)}
+    busy = []
+    for slot in requested:
+        info = slots.get(slot)
+        if info and info.get("status") == "occupied":
+            occupant = info.get("model_name") or "another model"
+            busy.append(f"chip {slot} — in use by {occupant}")
+    if not busy:
+        return
+
+    lines = [f"Requested --device-id {device_id}, but:"] + busy
+    lines.append("")
+    lines.append("Free the chips (stop that model in the UI, or python run.py --stop) or")
+    lines.append("pick different slots, then re-run.")
+    console.print(notice_panel("Requested chips are busy", lines, border_style="error"))
+    sys.exit(1)
+
+
+def _load_deploy_driver():
+    """Import ci/deploy_healthcheck.py as a module (it's import-safe: all argparse/
+    tee/report machinery lives under a guarded main()). Returns the module, or
+    None if it's missing."""
+    import importlib.util
+
+    dh_path = os.path.join(TT_STUDIO_ROOT, "ci", "deploy_healthcheck.py")
+    if not os.path.exists(dh_path):
+        console.print(f"[warning]⚠  Headless deploy driver not found at {dh_path}; skipping auto-deploy.[/warning]")
+        return None
+    spec = importlib.util.spec_from_file_location("deploy_healthcheck", dh_path)
+    if spec is None or spec.loader is None:
+        console.print(f"[warning]⚠  Could not import headless deploy driver from {dh_path}; skipping auto-deploy.[/warning]")
+        return None
+    dh = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dh)
+    return dh
+
+
+def _headless_deploy(args):
+    """Deploy a model straight through the backend API — no browser, no frontend
+    JS — rendering stage progress in the terminal and finishing with the
+    model's endpoint. The rendering lives in tt_setup/cli/_deploy.py; this
+    wrapper only loads the shared ci/deploy_healthcheck.py driver."""
+    from tt_setup.cli._deploy import run_headless_deploy
+
+    dh = _load_deploy_driver()
+    if dh is None:
+        return False
+    fe_host, fe_port, _ = get_frontend_config()
+    return run_headless_deploy(dh, args, frontend=(fe_host, fe_port))
+
+
 def _run(args):
     """Orchestrate setup for the parsed arguments."""
     try:
@@ -249,6 +344,12 @@ def _run(args):
         if getattr(args, "switch", None):
             sys.exit(switch_checkout(args.switch))
 
+        # Stopping one model (and resetting its chips) must never fall through
+        # to the full-stack teardown either.
+        if getattr(args, "stop_model", None):
+            from tt_setup.cli._stop_model import stop_models
+            sys.exit(stop_models(args))
+
         # Must dispatch before the cleanup branches: purging one model must
         # never fall through to the full-stack teardown.
         if getattr(args, "purge_model", None):
@@ -279,7 +380,11 @@ def _run(args):
         if args.add_headers:
             add_spdx_headers()
             return
-        
+
+        # Fast reject a pinned deploy onto already-busy chips before any stack-up
+        # work (no-op on a fresh boot / unreachable backend).
+        _preflight_device_availability(args)
+
         run_start = time.monotonic()
 
         # Install the sticky-top stepper FIRST, on an empty screen — this is what
@@ -896,22 +1001,32 @@ def _run(args):
                 sys.exit(1)
         
         
-        # Control browser open only if service is healthy
-        if not args.no_browser:
-            # Get configurable frontend settings
-            host, port, timeout = get_frontend_config()
-            
-            # Use the new function that reuses existing infrastructure
-            device_id_val = getattr(args, "device_id", 0)
-            if not wait_for_frontend_and_open_browser(host, port, timeout, args.auto_deploy, device_id=device_id_val):
-                auto_deploy_param = f"?auto-deploy={args.auto_deploy}&device-id={device_id_val}" if args.auto_deploy else ""
-                print(f"\n{C_YELLOW}⚠️  Could not reach frontend at http://{host}:{port}{auto_deploy_param}{C_RESET}")
+        # Model auto-deploy has two modes. Terminal (default): drive the backend
+        # deploy API from here, render progress in the terminal, and never open a
+        # browser — the terminal is the UI for that run. --browser: open the web
+        # UI with ?auto-deploy= and let it perform the deploy.
+        from tt_setup.cli._deploy import deploy_mode, should_open_browser
+
+        mode = deploy_mode(args)
+        device_id_val = getattr(args, "device_id", None)
+        browser_deploy = mode == "browser"
+        headless_deploy = mode == "terminal"
+
+        host, port, timeout = get_frontend_config()
+        if should_open_browser(args):
+            # UI-driven deploy passes the model so the web UI performs the deploy.
+            browser_model = args.auto_deploy if browser_deploy else None
+            if not wait_for_frontend_and_open_browser(host, port, timeout, browser_model, device_id=device_id_val):
+                print(f"\n{C_YELLOW}⚠️  Could not reach frontend at http://{host}:{port}{C_RESET}")
                 print(f"{C_CYAN}💡 Run: {C_WHITE}python run.py --stop && python run.py{C_RESET}")
-        else:
-            host, port, _ = get_frontend_config()
-            device_id_val = getattr(args, "device_id", 0)
-            auto_deploy_param = f"?auto-deploy={args.auto_deploy}&device-id={device_id_val}" if args.auto_deploy else ""
+        elif not headless_deploy:
+            auto_deploy_param = _auto_deploy_query(args.auto_deploy, device_id_val) if browser_deploy else ""
             print(f"{C_BLUE}🌐 Automatic browser opening disabled. Access TT-Studio at: {C_CYAN}http://{host}:{port}{auto_deploy_param}{C_RESET}")
+
+        if headless_deploy:
+            if getattr(args, "headless", False) and show_detail():
+                console.print("[muted]--headless is now the default; pass --browser to deploy through the web UI instead.[/muted]")
+            _headless_deploy(args)
         
         # If in dev mode, show logs similar to startup.sh
         if args.dev:

--- a/tt_setup/cli/_stop_model.py
+++ b/tt_setup/cli/_stop_model.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""`python run.py --stop-model [MODEL]` — stop one deployed model and reset the
+chip(s) it occupied, without tearing the stack down.
+
+Talks to the running backend: /models/deployed/ to find the model, then the
+streaming stop endpoint (stop/stream/<container_id>/), which stops the container
+and runs the per-chip `tt-smi -r` reset, reporting each step as Server-Sent
+Events. Bare --stop-model opens a numbered picker of what is deployed.
+"""
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+from tt_setup.console import ask, console, is_verbose, notice_panel
+from tt_setup.constants import _PURGE_MODEL_PICKER
+from tt_setup.env_config import get_env_var
+
+
+class StopModelError(Exception):
+    pass
+
+
+def backend_url():
+    return f"http://localhost:{get_env_var('BACKEND_PORT', '8000') or '8000'}"
+
+
+# ── pure helpers ──────────────────────────────────────────────────────────────
+
+def summarize_deployed(payload):
+    """Flatten the /models/deployed/ dict into picker rows:
+    [{"id", "name", "model_name", "device_ids", "model_type"}], stable order."""
+    rows = []
+    for container_id, entry in (payload or {}).items():
+        impl = entry.get("model_impl") or {}
+        rows.append({
+            "id": container_id,
+            "name": entry.get("name") or impl.get("model_name") or container_id[:12],
+            "model_name": impl.get("model_name") or entry.get("name") or "",
+            "device_ids": entry.get("device_ids") or (
+                [entry["device_id"]] if entry.get("device_id") is not None else []),
+            "model_type": impl.get("model_type") or entry.get("model_type") or "",
+        })
+    rows.sort(key=lambda r: (r["device_ids"] or [999], r["name"]))
+    return rows
+
+
+def match_deployed(rows, wanted):
+    """Resolve a user-typed name against deployed rows: exact (case-insensitive)
+    on the container name or the catalog model name first, then a unique
+    substring match. Returns (row, None) or (None, reason)."""
+    needle = wanted.strip().lower()
+    if not needle:
+        return None, "empty model name"
+    exact = [r for r in rows if needle in (r["name"].lower(), r["model_name"].lower())]
+    if len(exact) == 1:
+        return exact[0], None
+    if len(exact) > 1:
+        return None, f'"{wanted}" matches several deployments: ' + ", ".join(r["name"] for r in exact)
+    loose = [r for r in rows if needle in r["name"].lower() or needle in r["model_name"].lower()]
+    if len(loose) == 1:
+        return loose[0], None
+    if len(loose) > 1:
+        return None, f'"{wanted}" is ambiguous: ' + ", ".join(r["name"] for r in loose) + ". Use an exact name."
+    return None, f'"{wanted}" is not deployed'
+
+
+def parse_sse(lines):
+    """Yield the JSON payload of each `data:` frame in an SSE byte/str stream."""
+    for raw in lines:
+        line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+        line = line.rstrip("\r\n")
+        if not line.startswith("data:"):
+            continue
+        body = line[len("data:"):].strip()
+        if not body:
+            continue
+        try:
+            yield json.loads(body)
+        except json.JSONDecodeError:
+            yield {"type": "log", "message": body}
+
+
+def parse_selection(raw, count):
+    """'1 3', '1,3' or 'all' -> sorted unique 1-based indices; [] when invalid."""
+    raw = (raw or "").strip().lower()
+    if raw == "all":
+        return list(range(1, count + 1))
+    picked = set()
+    for tok in raw.replace(",", " ").split():
+        if not tok.isdigit() or not 1 <= int(tok) <= count:
+            return []
+        picked.add(int(tok))
+    return sorted(picked)
+
+
+# ── backend interaction ───────────────────────────────────────────────────────
+
+def fetch_deployed(base):
+    try:
+        with urllib.request.urlopen(f"{base}/models/deployed/", timeout=15) as resp:
+            return json.loads(resp.read().decode() or "{}")
+    except urllib.error.URLError as e:
+        raise StopModelError(f"cannot reach the TT Studio backend at {base}: {e.reason}")
+
+
+def stream_stop(base, container_id, timeout=900):
+    """GET the stop stream and yield its parsed events until the connection ends."""
+    url = f"{base}/docker/stop/stream/{container_id}/"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            yield from parse_sse(resp)
+    except urllib.error.URLError as e:
+        raise StopModelError(f"stop request failed: {e.reason}")
+
+
+def stop_one(base, row, stream=stream_stop):
+    """Stop + reset one deployment, rendering the backend's steps. Returns True
+    when the backend reported success."""
+    chips = ", ".join(str(d) for d in row["device_ids"]) or "unknown"
+    console.print(f"\n[bold accent]⏹  Stopping {row['name']}[/bold accent] [muted](chips {chips})[/muted]")
+    final = None
+    for event in stream(base, row["id"]):
+        kind = event.get("type")
+        msg = event.get("message", "")
+        if kind == "step":
+            console.print(f"  [info]•[/info] {msg}")
+        elif kind == "log":
+            if is_verbose():
+                console.print(f"    [muted]{msg}[/muted]")
+        elif kind == "complete":
+            final = event
+            break
+    if final is None:
+        console.print("  [warning]⚠  The stop stream ended without a result — check the Deployed Models page.[/warning]")
+        return False
+    if final.get("status") == "success":
+        console.print(f"  [success]✓[/success] {final.get('message') or 'Stopped and reset'}")
+        return True
+    console.print(f"  [error]✗[/error] {final.get('message') or 'Stop failed'}")
+    return False
+
+
+def pick_interactively(rows):
+    """Numbered picker over deployed models. None when the user cancels."""
+    console.print("\n[bold]Deployed models[/bold]")
+    for i, r in enumerate(rows, start=1):
+        chips = ", ".join(str(d) for d in r["device_ids"]) or "—"
+        kind = f" [muted]{r['model_type']}[/muted]" if r["model_type"] else ""
+        console.print(f"  [bold]{i:>2}[/bold]  {r['name']}{kind}  [muted]chips {chips}[/muted]")
+    while True:
+        try:
+            raw = ask("Models to stop (e.g. '1 3', or 'all'; Enter to cancel)", default="")
+        except (KeyboardInterrupt, EOFError):
+            raw = ""
+        raw = (raw or "").strip()
+        if raw.lower() in ("", "q", "quit", "n", "no"):
+            console.print("\n[info]🛑 Aborted — nothing was stopped.[/info]")
+            return None
+        selection = parse_selection(raw, len(rows))
+        if selection:
+            return [rows[i - 1] for i in selection]
+        console.print(f"[muted]Enter numbers between 1 and {len(rows)} (space/comma separated), or 'all'.[/muted]")
+
+
+def stop_models(args, base=None, fetch=fetch_deployed, stream=stream_stop):
+    """Entry point for --stop-model. Exit code 0 on success or a clean abort; 1
+    when a name doesn't resolve (nothing is stopped in that case), the picker has
+    no terminal, the backend is unreachable, or a stop/reset did not succeed."""
+    base = base or backend_url()
+    requested = list(getattr(args, "stop_model", None) or [])
+    picker_requested = all(t == _PURGE_MODEL_PICKER for t in requested)
+
+    try:
+        rows = summarize_deployed(fetch(base))
+    except StopModelError as e:
+        console.print()
+        console.print(notice_panel("TT Studio isn't reachable", [
+            str(e), "",
+            "Start it with python run.py, then run --stop-model again.",
+        ], border_style="error"))
+        return 1
+
+    if not rows:
+        console.print("\n[info]No models are deployed — nothing to stop.[/info]")
+        return 0
+
+    if picker_requested:
+        if not sys.stdin.isatty():
+            console.print()
+            console.print(notice_panel("--stop-model needs a terminal for its picker", [
+                "Pass the model name instead: python run.py --stop-model <name>",
+                "Deployed now: " + ", ".join(r["name"] for r in rows),
+            ], border_style="error"))
+            return 1
+        selected = pick_interactively(rows)
+        if selected is None:
+            return 0
+    else:
+        selected, problems = [], []
+        for wanted in requested:
+            if wanted == _PURGE_MODEL_PICKER:
+                continue
+            row, why = match_deployed(rows, wanted)
+            if row is None:
+                problems.append(why)
+            elif row not in selected:
+                selected.append(row)
+        if problems:
+            console.print()
+            console.print(notice_panel("Model not found", problems + [
+                "", "Deployed now: " + ", ".join(r["name"] for r in rows),
+            ], border_style="error"))
+            return 1
+
+    # Attempt every selection even if one fails, then report the worst outcome.
+    results = [stop_one(base, row, stream=stream) for row in selected]
+    console.print()
+    return 0 if all(results) else 1

--- a/tt_setup/env_config/__init__.py
+++ b/tt_setup/env_config/__init__.py
@@ -29,6 +29,9 @@ from tt_setup.env_config._preferences import (
 from tt_setup.env_config._hf_access import _hf_check_repo, check_hf_access, render_hf_access
 from tt_setup.env_config._version import save_setup_config, set_app_version_env
 from tt_setup.env_config._configure import (
+    adopt_hf_token_from_environment,
+    hf_login_token_path,
+    read_hf_login_token,
     FORCE_OVERWRITE,
     ask_overwrite_preference,
     configure_environment_sequentially,
@@ -44,7 +47,7 @@ __all__ = [
     "clear_preferences", "is_first_time_setup",
     "_hf_check_repo", "check_hf_access", "render_hf_access",
     "save_setup_config", "set_app_version_env",
-    "FORCE_OVERWRITE", "should_configure_var", "display_first_time_welcome",
+    "FORCE_OVERWRITE", "adopt_hf_token_from_environment", "hf_login_token_path", "read_hf_login_token", "should_configure_var", "display_first_time_welcome",
     "ask_overwrite_preference", "configure_environment_sequentially",
     "configure_inference_server_artifact",
 ]

--- a/tt_setup/env_config/_configure.py
+++ b/tt_setup/env_config/_configure.py
@@ -177,6 +177,68 @@ def ask_overwrite_preference(existing_vars, force_prompt=False):
     return False
 
 
+def hf_login_token_path():
+    """Where huggingface_hub keeps the token saved by `huggingface-cli login` /
+    `tt-model login`, following the library's own resolution order."""
+    explicit = os.environ.get("HF_TOKEN_PATH")
+    if explicit:
+        return explicit
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return os.path.join(hf_home, "token")
+    return os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "token")
+
+
+def read_hf_login_token():
+    """The token from the Hugging Face login store, or None. A plain file read —
+    it is all huggingface_hub does — so the launcher venv needs no extra dependency."""
+    path = hf_login_token_path()
+    try:
+        if not os.path.isfile(path):
+            return None
+        with open(path, "r") as f:
+            token = f.read().strip()
+    except OSError:
+        return None
+    return token or None
+
+
+def adopt_hf_token_from_environment(quiet=False):
+    """Persist an already-available HF token into the repo-root .env.
+
+    Sources, first wins: the shell's exported `HF_TOKEN`, then the Hugging Face
+    login store (`HF_TOKEN_PATH`, `$HF_HOME/token`, `~/.cache/huggingface/token`)
+    written by `huggingface-cli login` or `tt-model login`.
+
+    `python run.py` itself could read either, but the services it starts cannot:
+    the backend container and the inference-api read the repo .env, and the
+    inference server mirrors that file into its artifact for the model
+    container's `--env-file`. Writing the token into .env once makes both
+    sources first-class. A found value wins over a differing .env value,
+    matching get_env_var()'s precedence for the shell export.
+
+    Returns True when .env was updated.
+    """
+    env_token = (os.environ.get("HF_TOKEN") or "").strip()
+    if env_token and not is_placeholder(env_token):
+        token, origin = env_token, "your shell environment"
+    else:
+        token = read_hf_login_token()
+        if not token or is_placeholder(token):
+            return False
+        origin = f"your Hugging Face login ({hf_login_token_path()})"
+    existing = (get_existing_env_vars().get("HF_TOKEN") or "").strip()
+    if existing == token:
+        return False
+    write_env_var("HF_TOKEN", token)
+    if not quiet:
+        verb = "updated from" if existing and not is_placeholder(existing) else "picked up from"
+        console.print(f"[success]✅ HF_TOKEN {verb} {escape_markup(origin)} and saved to .env.[/success]")
+    else:
+        console.print(f"[muted]🤗 HF_TOKEN picked up from {escape_markup(origin)}.[/muted]")
+    return True
+
+
 def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, quick_setup=True, reconfigure_inference=False, accept_terms=False):
     """
     Handles all environment configuration in a sequential, top-to-bottom flow.
@@ -377,6 +439,10 @@ def configure_environment_sequentially(dev_mode=False, force_reconfigure=False, 
     # TAVILY_API_KEY and HF_TOKEN are UI-managed. The Welcome screen in the
     # web app captures them on first run; they're editable later in Settings.
     # HF access is verified in the UI (app/backend/api/hf_access.py), not the CLI.
+    # One exception: a token already exported in the shell is adopted into .env
+    # so every service (backend container, inference-api, model containers)
+    # sees the same token without a trip through the UI.
+    adopt_hf_token_from_environment(quiet=quick_setup)
 
     if not quick_setup:
         console.print("\n[bold accent]--- ⚙️  Application Configuration  ---[/bold accent]")

--- a/tt_setup/services/_health.py
+++ b/tt_setup/services/_health.py
@@ -264,7 +264,7 @@ def wait_for_all_services(skip_fastapi=False, is_deployed_mode=False, skip_docke
     return all_healthy
 
 
-def wait_for_frontend_and_open_browser(host="localhost", port=3000, timeout=60, auto_deploy_model=None, device_id=0):
+def wait_for_frontend_and_open_browser(host="localhost", port=3000, timeout=60, auto_deploy_model=None, device_id=None, path=""):
     """
     Wait for frontend service to be healthy before opening browser.
 
@@ -272,22 +272,25 @@ def wait_for_frontend_and_open_browser(host="localhost", port=3000, timeout=60, 
         host: Frontend host
         port: Frontend port
         timeout: Timeout in seconds
-        auto_deploy_model: Model name to auto-deploy (optional)
-        device_id: Chip slot index for auto-deploy (default 0)
+        auto_deploy_model: Model name to auto-deploy via the web UI (optional)
+        device_id: Chip slot index for auto-deploy; None lets the backend allocate
+        path: Path to open under the frontend root (e.g. "models-deployed")
 
     Returns:
         bool: True if browser opened successfully, False otherwise
     """
     base_url = f"http://{host}:{port}/"
+    frontend_url = base_url + path.lstrip("/")
 
-    # Add auto-deploy parameter if specified
+    # Add auto-deploy parameter if specified (UI-driven deploy path)
     if auto_deploy_model:
         from urllib.parse import urlencode
-        params = urlencode({"auto-deploy": auto_deploy_model, "device-id": device_id})
-        frontend_url = f"{base_url}?{params}"
-        console.print(f"\n[info]🤖 Auto-deploying model: {auto_deploy_model} on chip {device_id}[/info]")
-    else:
-        frontend_url = base_url
+        query = {"auto-deploy": auto_deploy_model}
+        if device_id is not None:
+            query["device-id"] = device_id
+        frontend_url = f"{frontend_url}?{urlencode(query)}"
+        where = f" on chip {device_id}" if device_id is not None else ""
+        console.print(f"\n[info]🤖 Auto-deploying model: {auto_deploy_model}{where}[/info]")
 
     if wait_for_service_health("Frontend", base_url, timeout=timeout, interval=2):
         try:


### PR DESCRIPTION
## Rc v2.10.2

Cut from `main`; validated changes cherry-picked from `dev` (see CONTRIBUTING → Release Process).

### Test plan

- [ ] Fresh `python run.py` completes (setup → ready panel)
- [ ] Backend healthy: `curl localhost:8000/up/` and `curl localhost:8000/models/health/`
- [ ] Frontend loads at `localhost:3000`
- [ ] Deploy a model end-to-end; inference server healthy: `curl localhost:8001/health`
- [ ] `python run.py --stop`, then a restart works
- [ ] `IS_QB2` is off in `.env.default` (rc-* branches never ship it on)
- [ ] Release notes drafted and applied to this description
