### PR TITLE
fix: prevent orphaned supervisor loops on stop or restart

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -69,6 +69,12 @@ try:
 except ImportError:
     _dc_mod = M
 
+# FastAPI lifecycle helpers live in the _fastapi submodule.
+try:
+    from tt_setup.services import _fastapi as _fa_mod
+except ImportError:
+    _fa_mod = M
+
 
 class TestGetFrontendConfig(unittest.TestCase):
     def test_defaults(self):
@@ -333,3 +339,27 @@ class TestDockerControlRestartLoopIsBounded(unittest.TestCase):
         src = self._wrapper_source()
         self.assertIn("8002", src)
         self.assertIn("Giving up", src)
+
+
+class TestSupervisorGhostSelfTermination(unittest.TestCase):
+    """Regression guards for Issue #1307:
+    Supervisor wrappers must exit immediately (code 0) when the PID file is
+    removed (by --stop / --purge-all) or overwritten by another launcher run,
+    preventing orphaned ghost loops from surviving and fighting for ports."""
+
+    def test_docker_control_wrapper_checks_pid_file_and_ownership(self):
+        import inspect
+        src = inspect.getsource(_dc_mod.start_docker_control_service)
+        self.assertIn('[ ! -f "$2" ]', src, "must verify PID file still exists")
+        self.assertIn('"$(cat "$2" 2>/dev/null)" != "$$"', src, "must verify PID still matches wrapper PID")
+        self.assertIn("Exiting ghost loop", src)
+        self.assertIn("exit 0", src)
+
+    def test_fastapi_dev_wrapper_checks_pid_file_and_ownership(self):
+        import inspect
+        src = inspect.getsource(_fa_mod.start_fastapi_server)
+        self.assertIn('[ ! -f "$2" ]', src, "must verify PID file still exists")
+        self.assertIn('"$(cat "$2" 2>/dev/null)" != "$$"', src, "must verify PID still matches wrapper PID")
+        self.assertIn("Exiting ghost loop", src)
+        self.assertIn("exit 0", src)
+

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -419,6 +419,18 @@ class TestSupervisorTreeTraversal(unittest.TestCase):
         self.assertEqual(terminated, [100, 300],
                          "supervisor (100) must be terminated before listener child (300)")
 
+    def test_kill_port_holder_fails_if_supervisor_termination_fails(self):
+        with patch.object(_ports_mod, "shutil") as mock_shutil, \
+             patch.object(_ports_mod, "run_command") as mock_run_cmd, \
+             patch.object(_ports_mod, "_process_is_docker", return_value=False), \
+             patch.object(_ports_mod, "_find_supervisor_wrapper_pid", return_value=100), \
+             patch.object(_ports_mod, "_terminate_pid_graceful_then_force", return_value=False):
+            mock_shutil.which.return_value = "/usr/bin/lsof"
+            mock_run_cmd.return_value = MagicMock(returncode=0, stdout="300\n", stderr="")
+            result = _ports_mod._kill_port_holder(8002, no_sudo=True, quiet=True)
+
+        self.assertFalse(result, "kill_port_holder must return False if supervisor wrapper termination fails")
+
 
 class TestStrictSupervisorReaping(unittest.TestCase):
     """Regression guards for Issue #1307:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,6 +3,7 @@
 
 """Characterization tests for service helpers (ports, git, frontend config)."""
 import os
+import signal
 import tempfile
 import unittest
 from unittest.mock import patch, MagicMock
@@ -363,3 +364,108 @@ class TestSupervisorGhostSelfTermination(unittest.TestCase):
         self.assertIn("Exiting ghost loop", src)
         self.assertIn("exit 0", src)
 
+
+class TestSupervisorTreeTraversal(unittest.TestCase):
+    """Regression guards for Issue #1307:
+    Freeing a port held by a supervisor's child must climb the process tree
+    and terminate the supervisor wrapper first, preventing restart loops."""
+
+    def test_is_supervisor_wrapper_detection(self):
+        # Matches Linux temp wrapper
+        self.assertTrue(_ports_mod._is_supervisor_wrapper(
+            "/bin/bash /tmp/tmpera45p4b.sh /path/to/docker-control-service /path/to/pid .venv log"
+        ))
+        # Matches macOS temp wrapper
+        self.assertTrue(_ports_mod._is_supervisor_wrapper(
+            "/bin/bash /var/folders/zb/tmpcjb01kdb.sh /path/to/docker-control-service"
+        ))
+        # Matches inference-api wrapper
+        self.assertTrue(_ports_mod._is_supervisor_wrapper(
+            "/bin/bash /tmp/tmp12345.sh /path/to/inference-api"
+        ))
+        # Does not match regular processes
+        self.assertFalse(_ports_mod._is_supervisor_wrapper("/usr/bin/python3 app.py"))
+        self.assertFalse(_ports_mod._is_supervisor_wrapper("com.docker.backend"))
+        self.assertFalse(_ports_mod._is_supervisor_wrapper("node server.js"))
+
+    def test_find_supervisor_wrapper_pid_climbs_tree(self):
+        # Simulate worker (300) -> reloader (200) -> supervisor (100) -> init (1)
+        tree = {300: 200, 200: 100, 100: 1}
+        cmds = {
+            300: "python uvicorn api:app",
+            200: "python -m uvicorn --reload",
+            100: "/bin/bash /tmp/tmp_supervisor.sh /path/to/docker-control-service",
+            1: "init",
+        }
+        with patch.object(_ports_mod, "_get_parent_pid", side_effect=lambda p, **kw: tree.get(p)), \
+             patch.object(_ports_mod, "_get_process_command", side_effect=lambda p, **kw: cmds.get(p, "")):
+            supervisor_pid = _ports_mod._find_supervisor_wrapper_pid(300)
+        self.assertEqual(supervisor_pid, 100)
+
+    def test_kill_port_holder_terminates_supervisor_first(self):
+        terminated = []
+        with patch.object(_ports_mod, "shutil") as mock_shutil, \
+             patch.object(_ports_mod, "run_command") as mock_run_cmd, \
+             patch.object(_ports_mod, "_process_is_docker", return_value=False), \
+             patch.object(_ports_mod, "_find_supervisor_wrapper_pid", return_value=100), \
+             patch.object(_ports_mod, "_terminate_pid_graceful_then_force",
+                          side_effect=lambda p, **kw: terminated.append(p) or True):
+            mock_shutil.which.return_value = "/usr/bin/lsof"
+            # Return PID 300 for lsof
+            mock_run_cmd.return_value = MagicMock(returncode=0, stdout="300\n", stderr="")
+            result = _ports_mod._kill_port_holder(8002, no_sudo=True, quiet=True)
+
+        self.assertTrue(result)
+        self.assertEqual(terminated, [100, 300],
+                         "supervisor (100) must be terminated before listener child (300)")
+
+
+class TestStrictSupervisorReaping(unittest.TestCase):
+    """Regression guards for Issue #1307:
+    Reaping the supervisor must strictly wait until the process is dead before
+    proceeding to start a new supervisor or truncating the PID file."""
+
+    def test_terminate_pid_polls_until_dead(self):
+        # Process is alive on first check, then dies
+        alive_states = [True, False]
+
+        def fake_alive(pid, no_sudo=False):
+            if alive_states:
+                return alive_states.pop(0)
+            return False
+
+        with patch.object(_dc_mod, "_process_is_alive", side_effect=fake_alive), \
+             patch.object(_dc_mod.os, "kill") as mock_kill, \
+             patch.object(_dc_mod.time, "sleep"):
+            result = _dc_mod._terminate_pid(1234, grace_period=1.0)
+
+        self.assertTrue(result)
+        mock_kill.assert_called_once_with(1234, signal.SIGTERM)
+
+    def test_terminate_pid_escalates_to_sigkill_when_stubborn(self):
+        # Process stays alive on SIGTERM, dies only after SIGKILL is sent
+        kill_calls = []
+
+        def fake_alive(pid, no_sudo=False):
+            return signal.SIGKILL not in kill_calls
+
+        def record_kill(pid, sig):
+            kill_calls.append(sig)
+
+        with patch.object(_dc_mod, "_process_is_alive", side_effect=fake_alive), \
+             patch.object(_dc_mod.os, "kill", side_effect=record_kill):
+            result = _dc_mod._terminate_pid(1234, grace_period=0.05, kill_timeout=0.05)
+
+        self.assertTrue(result)
+        self.assertEqual(kill_calls, [signal.SIGTERM, signal.SIGKILL])
+
+    def test_start_service_aborts_if_supervisor_still_alive(self):
+        with patch.object(_dc_mod, "check_docker_access", return_value=True), \
+             patch.object(_dc_mod, "_service_is_healthy", return_value=False), \
+             patch.object(_dc_mod, "_stop_previous_supervisor", return_value=False), \
+             patch.object(_dc_mod, "check_port_available", return_value=True), \
+             patch.object(_dc_mod, "_read_supervisor_pid", return_value=4242), \
+             patch.object(_dc_mod, "_process_is_alive", return_value=True):
+            result = _dc_mod.start_docker_control_service()
+
+        self.assertFalse(result, "start_docker_control_service must abort if previous supervisor is alive")

--- a/tt_setup/services/_docker_control.py
+++ b/tt_setup/services/_docker_control.py
@@ -107,31 +107,59 @@ def _process_is_alive(pid, no_sudo=False):
         return False
 
 
-def _terminate_pid(pid, no_sudo=False):
+def _wait_for_process_death(pid, timeout=2.5, interval=0.1, no_sudo=False):
+    """Poll until process is no longer alive, up to `timeout` seconds.
+
+    Returns True if process died, False if still alive.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_is_alive(pid, no_sudo=no_sudo):
+            return True
+        time.sleep(interval)
+    return not _process_is_alive(pid, no_sudo=no_sudo)
+
+
+def _terminate_pid(pid, no_sudo=False, grace_period=2.0, kill_timeout=2.0):
     """SIGTERM a pid, escalating to SIGKILL if it outlives the grace period.
 
+    Polls until the process is confirmed dead. Returns True if dead, False otherwise.
     SIGTERM is what the supervisor wrapper traps to take uvicorn (and, under
     --reload, uvicorn's spawned child) down with it, so terminating the wrapper
     is what actually stops the service.
     """
-    pid_int = int(pid)
+    try:
+        pid_int = int(pid)
+    except (ValueError, TypeError):
+        return True
+
+    if pid_int <= 1:
+        return True
+
+    if not _process_is_alive(pid_int, no_sudo=no_sudo):
+        return True
+
     try:
         os.kill(pid_int, signal.SIGTERM)
-        time.sleep(2)
+        if _wait_for_process_death(pid_int, timeout=grace_period, no_sudo=no_sudo):
+            return True
         if _process_is_alive(pid_int, no_sudo=no_sudo):
             os.kill(pid_int, signal.SIGKILL)
-            time.sleep(1)
+            return _wait_for_process_death(pid_int, timeout=kill_timeout, no_sudo=no_sudo)
+        return True
     except PermissionError:
         if no_sudo:
             console.print(f"[warning]⚠️  Could not stop Docker Control process {pid} (no sudo)[/warning]")
-            return
+            return False
         subprocess.run(["sudo", "kill", "-15", str(pid)], check=False)
-        time.sleep(2)
+        if _wait_for_process_death(pid_int, timeout=grace_period, no_sudo=no_sudo):
+            return True
         if _process_is_alive(pid_int, no_sudo=no_sudo):
             subprocess.run(["sudo", "kill", "-9", str(pid)], check=False)
-            time.sleep(1)
+            return _wait_for_process_death(pid_int, timeout=kill_timeout, no_sudo=no_sudo)
+        return True
     except (ProcessLookupError, Exception):
-        pass
+        return not _process_is_alive(pid_int, no_sudo=no_sudo)
 
 
 def _read_supervisor_pid():
@@ -141,7 +169,7 @@ def _read_supervisor_pid():
             return None
         with open(DOCKER_CONTROL_PID_FILE, 'r') as f:
             pid = f.read().strip()
-        return int(pid) if pid.isdigit() else None
+        return int(pid) if pid.isdigit() and int(pid) > 1 else None
     except Exception:
         return None
 
@@ -156,10 +184,14 @@ def _stop_previous_supervisor(no_sudo=False):
     """
     pid = _read_supervisor_pid()
     if pid is None or not _process_is_alive(pid, no_sudo=no_sudo):
-        return
+        return True
     if show_detail():
         console.print(f"[muted]   Stopping previous Docker Control supervisor (pid {pid})…[/muted]")
-    _terminate_pid(pid, no_sudo=no_sudo)
+    reaped = _terminate_pid(pid, no_sudo=no_sudo)
+    if not reaped and _process_is_alive(pid, no_sudo=no_sudo):
+        console.print(f"[warning]⚠️  Previous Docker Control supervisor (pid {pid}) could not be terminated.[/warning]")
+        return False
+    return True
 
 
 def start_docker_control_service(no_sudo=False, dev_mode=False):
@@ -214,6 +246,14 @@ def start_docker_control_service(no_sudo=False, dev_mode=False):
     # Check if service directory exists
     if not os.path.exists(DOCKER_CONTROL_SERVICE_DIR):
         console.print(f"[error]⛔ Error: Docker Control Service directory not found at {DOCKER_CONTROL_SERVICE_DIR}[/error]")
+        return False
+
+    # Verify that the previous supervisor is strictly dead before truncating the PID file.
+    # If it is still alive (e.g. unkillable or permission-denied), abort to prevent
+    # creating multiple conflicting supervisor processes.
+    prev_pid = _read_supervisor_pid()
+    if prev_pid is not None and _process_is_alive(prev_pid, no_sudo=no_sudo):
+        console.print(f"[error]❌ Previous Docker Control supervisor (pid {prev_pid}) is still alive. Aborting startup to prevent collision.[/error]")
         return False
 
     # Preserve the previous instance's log before truncating it below. A plain

--- a/tt_setup/services/_docker_control.py
+++ b/tt_setup/services/_docker_control.py
@@ -367,8 +367,21 @@ while true; do
         exit 1
     fi
 
+    # Check if this supervisor is still tracked by the PID file. If the PID file
+    # was removed (via --stop or --purge-all) or overwritten by another launcher
+    # run, this process has become an untracked ghost. Exit cleanly immediately.
+    if [ ! -f "$2" ] || [ "$(cat "$2" 2>/dev/null)" != "$$" ]; then
+        echo "[$(date)] Docker Control supervisor PID file removed or belongs to another process ($$ vs $(cat "$2" 2>/dev/null)). Exiting ghost loop." >> "$4"
+        exit 0
+    fi
+
     echo "[$(date)] Docker Control Service exited with code $EXIT_CODE (restart #$RESTART_COUNT) — restarting in 3s..." >> "$4"
     sleep 3
+
+    if [ ! -f "$2" ] || [ "$(cat "$2" 2>/dev/null)" != "$$" ]; then
+        echo "[$(date)] Docker Control supervisor PID file removed or belongs to another process ($$ vs $(cat "$2" 2>/dev/null)). Exiting ghost loop." >> "$4"
+        exit 0
+    fi
 done
 ''')
             temp_script_path = temp_script.name

--- a/tt_setup/services/_fastapi.py
+++ b/tt_setup/services/_fastapi.py
@@ -330,6 +330,14 @@ def cleanup_fastapi_server(no_sudo=False):
                 return result.returncode == 0
             return True
 
+    def wait_for_death(pid, timeout=2.5, interval=0.1):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not is_process_alive(pid):
+                return True
+            time.sleep(interval)
+        return not is_process_alive(pid)
+
     # Kill process if PID file exists
     if os.path.exists(FASTAPI_PID_FILE):
         try:
@@ -337,20 +345,18 @@ def cleanup_fastapi_server(no_sudo=False):
                 pid = f.read().strip()
             if pid and pid.isdigit():
                 pid_int = int(pid)
-                if is_process_alive(pid_int):
+                if pid_int > 1 and is_process_alive(pid_int):
                     try:
                         os.kill(pid_int, signal.SIGTERM)
-                        time.sleep(2)
-                        if is_process_alive(pid_int):
+                        if not wait_for_death(pid_int, timeout=2.0):
                             os.kill(pid_int, signal.SIGKILL)
-                            time.sleep(1)
+                            wait_for_death(pid_int, timeout=1.0)
                     except PermissionError:
                         if not no_sudo:
                             subprocess.run(["sudo", "kill", "-15", pid], check=False)
-                            time.sleep(2)
-                            if is_process_alive(pid_int):
+                            if not wait_for_death(pid_int, timeout=2.0):
                                 subprocess.run(["sudo", "kill", "-9", pid], check=False)
-                                time.sleep(1)
+                                wait_for_death(pid_int, timeout=1.0)
                         else:
                             print(f"{C_YELLOW}⚠️  Could not kill FastAPI process {pid} (no sudo){C_RESET}")
                     except (ProcessLookupError, Exception):

--- a/tt_setup/services/_fastapi.py
+++ b/tt_setup/services/_fastapi.py
@@ -213,8 +213,22 @@ while true; do
     "$3/bin/uvicorn" main:app --host 0.0.0.0 --port 8001 >> "$4" 2>&1
     EXIT_CODE=$?
     RESTART_COUNT=$((RESTART_COUNT + 1))
+
+    # Check if this supervisor is still tracked by the PID file. If the PID file
+    # was removed (via --stop or --purge-all) or overwritten by another launcher
+    # run, this process has become an untracked ghost. Exit cleanly immediately.
+    if [ ! -f "$2" ] || [ "$(cat "$2" 2>/dev/null)" != "$$" ]; then
+        echo "[$(date)] FastAPI supervisor PID file removed or belongs to another process ($$ vs $(cat "$2" 2>/dev/null)). Exiting ghost loop." >> "$4"
+        exit 0
+    fi
+
     echo "[$(date)] FastAPI exited with code $EXIT_CODE (restart #$RESTART_COUNT) — restarting in 3s..." >> "$4"
     sleep 3
+
+    if [ ! -f "$2" ] || [ "$(cat "$2" 2>/dev/null)" != "$$" ]; then
+        echo "[$(date)] FastAPI supervisor PID file removed or belongs to another process ($$ vs $(cat "$2" 2>/dev/null)). Exiting ghost loop." >> "$4"
+        exit 0
+    fi
 done
 '''
             else:

--- a/tt_setup/services/_ports.py
+++ b/tt_setup/services/_ports.py
@@ -330,7 +330,8 @@ def _kill_port_holder(port, no_sudo=False, quiet=False):
     if supervisor_pid and supervisor_pid != pid:
         if not quiet:
             print(f"🛑 Found parent supervisor wrapper with PID {supervisor_pid}. Stopping it first...")
-        _terminate_pid_graceful_then_force(supervisor_pid, use_sudo=use_sudo_for_kill, quiet=quiet)
+        if not _terminate_pid_graceful_then_force(supervisor_pid, use_sudo=use_sudo_for_kill, quiet=quiet):
+            return False
 
     if not quiet:
         print(f"🛑 Found process with PID {pid} using port {port}. Attempting to stop it...")

--- a/tt_setup/services/_ports.py
+++ b/tt_setup/services/_ports.py
@@ -170,6 +170,104 @@ def kill_process_on_port(port, no_sudo=False, quiet=False, attempts=3):
     return check_port_available(port)
 
 
+def _get_parent_pid(pid, use_sudo=False):
+    """Return parent PID of `pid`, or None."""
+    cmd = ["ps", "-o", "ppid=", "-p", str(pid)]
+    if use_sudo:
+        cmd.insert(0, "sudo")
+    result = run_command(cmd, check=False, capture_output=True)
+    if result.returncode == 0 and result.stdout.strip():
+        val = result.stdout.strip()
+        return int(val) if val.isdigit() else None
+    return None
+
+
+def _get_process_command(pid, use_sudo=False):
+    """Return command string of `pid`, or empty string."""
+    cmd = ["ps", "-o", "command=", "-p", str(pid)]
+    if use_sudo:
+        cmd.insert(0, "sudo")
+    result = run_command(cmd, check=False, capture_output=True)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return ""
+
+
+def _is_supervisor_wrapper(cmd_str):
+    """True if `cmd_str` matches a TT Studio bash supervisor wrapper."""
+    cmd = cmd_str.lower()
+    is_bash = "bash" in cmd or "sh" in cmd
+    has_script = ".sh" in cmd
+    targets_service = (
+        "docker-control-service" in cmd
+        or "inference-api" in cmd
+        or "docker_control" in cmd
+    )
+    if is_bash and (targets_service or (has_script and ("tmp" in cmd or "/var/folders" in cmd))):
+        return True
+    return False
+
+
+def _find_supervisor_wrapper_pid(pid, use_sudo=False, max_depth=5):
+    """Walk up the process tree to find any ancestor bash supervisor wrapper.
+
+    Handles dev mode where `uvicorn --reload` spawns intermediate reloader
+    processes between the bash wrapper and the socket listener.
+    """
+    curr = pid
+    for _ in range(max_depth):
+        ppid = _get_parent_pid(curr, use_sudo=use_sudo)
+        if not ppid or ppid <= 1:
+            break
+        cmd = _get_process_command(ppid, use_sudo=use_sudo)
+        if _is_supervisor_wrapper(cmd):
+            return ppid
+        curr = ppid
+    return None
+
+
+def _terminate_pid_graceful_then_force(pid, use_sudo=False, quiet=False):
+    """Send SIGTERM (-15), wait 2s, escalate to SIGKILL (-9) if still alive."""
+    try:
+        pid_int = int(pid)
+    except (ValueError, TypeError):
+        return True
+
+    if pid_int <= 1:
+        return True
+
+    pid_str = str(pid_int)
+    kill_cmd_graceful = ["kill", "-15", pid_str]
+    kill_cmd_force = ["kill", "-9", pid_str]
+    check_alive_cmd = ["kill", "-0", pid_str]
+
+    if use_sudo:
+        kill_cmd_graceful.insert(0, "sudo")
+        kill_cmd_force.insert(0, "sudo")
+        check_alive_cmd.insert(0, "sudo")
+
+    try:
+        run_command(kill_cmd_graceful, check=False, capture_output=True)
+        time.sleep(2)
+
+        result = run_command(check_alive_cmd, check=False, capture_output=True)
+        if result.returncode == 0:
+            if not quiet:
+                print(f"⚠️  Process {pid_str} still alive. Forcing termination...")
+            run_command(kill_cmd_force, check=True, capture_output=True)
+            if not quiet:
+                print(f"{C_GREEN}✅ Process {pid_str} terminated by force.{C_RESET}")
+        else:
+            if not quiet:
+                print(f"{C_GREEN}✅ Process {pid_str} terminated gracefully.{C_RESET}")
+    except Exception as e:
+        if not quiet:
+            print(f"{C_RED}⛔ Failed to kill process {pid_str}: {e}{C_RESET}")
+            print(f"{C_YELLOW}   You may need to stop it manually. Try: {' '.join(kill_cmd_force)}{C_RESET}")
+        return False
+    return True
+
+
 def _kill_port_holder(port, no_sudo=False, quiet=False):
     """One pass: find whoever holds `port` and stop it (see kill_process_on_port)."""
     pid = None
@@ -213,6 +311,9 @@ def _kill_port_holder(port, no_sudo=False, quiet=False):
             print(f"{C_YELLOW}⚠️  Could not find a specific process using port {port}. This is likely okay.{C_RESET}")
         return True
 
+    if str(pid).isdigit():
+        pid = int(pid)
+
     # NEVER kill Docker itself. On macOS/Docker Desktop the port is held by
     # com.docker.backend; killing it crashes the engine and the build then fails
     # with "Cannot connect to the Docker daemon". A TT Studio container holding
@@ -220,42 +321,18 @@ def _kill_port_holder(port, no_sudo=False, quiet=False):
     if _process_is_docker(pid):
         return "docker"
 
+    use_sudo_for_kill = not no_sudo and hasattr(os, "geteuid") and os.geteuid() != 0
+
+    # Stop supervisor wrapper first if one exists in the process tree.
+    # Killing only the socket holder leaves the supervisor loop alive to respawn
+    # its child 3 seconds later and recapture the port (Issue #1307).
+    supervisor_pid = _find_supervisor_wrapper_pid(pid, use_sudo=use_sudo_for_kill)
+    if supervisor_pid and supervisor_pid != pid:
+        if not quiet:
+            print(f"🛑 Found parent supervisor wrapper with PID {supervisor_pid}. Stopping it first...")
+        _terminate_pid_graceful_then_force(supervisor_pid, use_sudo=use_sudo_for_kill, quiet=quiet)
+
     if not quiet:
         print(f"🛑 Found process with PID {pid} using port {port}. Attempting to stop it...")
 
-    # Build kill commands
-    kill_cmd_graceful = ["kill", "-15", pid]
-    kill_cmd_force = ["kill", "-9", pid]
-    check_alive_cmd = ["kill", "-0", pid]
-    # os.geteuid() is POSIX-only; guard it so a non-POSIX host doesn't crash with
-    # AttributeError. (The kill/-15/-9 commands here are POSIX anyway.)
-    use_sudo_for_kill = not no_sudo and hasattr(os, "geteuid") and os.geteuid() != 0
-
-    if use_sudo_for_kill:
-        kill_cmd_graceful.insert(0, "sudo")
-        kill_cmd_force.insert(0, "sudo")
-        check_alive_cmd.insert(0, "sudo")
-
-    try:
-        run_command(kill_cmd_graceful, check=False, capture_output=True)
-        time.sleep(2)
-
-        result = run_command(check_alive_cmd, check=False, capture_output=True)
-        if result.returncode == 0:
-            if not quiet:
-                print(f"⚠️  Process {pid} still alive. Forcing termination...")
-            run_command(kill_cmd_force, check=True, capture_output=True)
-            if not quiet:
-                print(f"{C_GREEN}✅ Process {pid} terminated by force.{C_RESET}")
-        else:
-            if not quiet:
-                print(f"{C_GREEN}✅ Process {pid} terminated gracefully.{C_RESET}")
-
-    except Exception as e:
-        if not quiet:
-            print(f"{C_RED}⛔ Failed to kill process {pid}: {e}{C_RESET}")
-            print(f"{C_YELLOW}   You may need to stop it manually. Try: {' '.join(kill_cmd_force)}{C_RESET}")
-        return False
-
-    return True
-
+    return _terminate_pid_graceful_then_force(pid, use_sudo=use_sudo_for_kill, quiet=quiet)


### PR DESCRIPTION
### Summary

- Resolves #1307 

where `docker-control-service` (:8002) and `inference-api` (:8001) left orphaned supervisor bash loops running in the background on `run.py --stop` or restarts. 

This PR prevents resurrection loops by discovering and terminating parent supervisor wrappers before child listeners, adds an automatic self-termination guard to the supervisor loops if their PID file is removed or overwritten, and ensures previous supervisors are strictly reaped before new ones start.

### Changes
- **Supervisor-first kill order (`tt_setup/services/_ports.py`)**: `kill_process_on_port` now climbs the process tree (`ps -o ppid=`) to find and terminate the parent supervisor wrapper *before* killing the child socket listener, stopping the 3-second respawn loop.
- **Ghost self-termination guard (`_docker_control.py`, `_fastapi.py`)**: The supervisor script checks its PID file before and after `sleep 3`. If the file was unlinked or reassigned to another process, it cleanly exits (`exit 0`).
- **Strict process reaping on start (`_docker_control.py`, `_fastapi.py`)**: Startup actively polls until any previous supervisor is confirmed dead before truncating the PID file or spawning a new instance. Added `pid <= 1` guards across kill helpers.

### Testing
- `python -m unittest discover tests` — all 425 tests pass.
- Added regression tests in `tests/test_services.py` for tree traversal, ghost self-termination, and reaping.
- Verified live on macOS: started detached service, deleted PID file, and called `kill_process_on_port(8002)`. Confirmed port 8002 stayed completely free with no supervisor respawning after 4+ seconds.