### PR TITLE
fix(frontend): use react-joyride v3 prop names so the prod build compiles

### DIFF
--- a/app/frontend/src/components/tour/tours/onboarding.ts
+++ b/app/frontend/src/components/tour/tours/onboarding.ts
@@ -10,7 +10,6 @@ export const onboardingSteps: Step[] = [
     content:
       "TT-Studio lets you deploy, run, and interact with AI models optimized for Tenstorrent hardware.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom-start",
   },
   {
@@ -19,7 +18,6 @@ export const onboardingSteps: Step[] = [
     content:
       "Monitor active containers, inspect streaming logs, check device health, and review deployment history.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom",
   },
   {
@@ -28,7 +26,6 @@ export const onboardingSteps: Step[] = [
     content:
       "Access advanced utilities including RAG knowledge bases, visual workflows, interactive canvas, and agent integrations.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom",
   },
   {
@@ -37,7 +34,6 @@ export const onboardingSteps: Step[] = [
     content:
       "Directly test and interact with your deployed models across Chat, Computer Vision, Speech-to-Text, and Media Generation.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom",
   },
   {
@@ -46,7 +42,6 @@ export const onboardingSteps: Step[] = [
     content:
       "Quickly reset board state, adjust application settings, or report issues directly from the navbar.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom-end",
   },
   {
@@ -55,7 +50,6 @@ export const onboardingSteps: Step[] = [
     content:
       "Need a refresher? Click the Help button anytime to restart this tour or choose another guided walkthrough from the menu.",
     skipBeacon: true,
-    disableBeacon: true,
     placement: "bottom-end",
   },
 ];

--- a/app/frontend/src/providers/TourProvider.tsx
+++ b/app/frontend/src/providers/TourProvider.tsx
@@ -198,14 +198,13 @@ export function TourProvider({ children }: TourProviderProps) {
         steps={steps}
         run={run}
         continuous={true}
-        showProgress={true}
-        showSkipButton={true}
         stepIndex={stepIndex}
         onEvent={handleJoyrideEvent}
         styles={joyrideStyles}
         options={{
           buttons: ["back", "primary", "skip"],
           skipBeacon: true,
+          showProgress: true,
           arrowColor: isDark ? "#18181b" : "#ffffff",
           backgroundColor: isDark ? "#18181b" : "#ffffff",
           overlayColor: isDark ? "rgba(0, 0, 0, 0.75)" : "rgba(0, 0, 0, 0.45)",


### PR DESCRIPTION
`tt serve <model>` (tt-cli) runs `python run.py run <model>` from a `dev` checkout, and since #1296 that fails at the Build stage: `tsc` rejects react-joyride v2 prop names against the pinned v3.2.0, so `tt_studio_frontend` never builds.

Fix: drop the removed per-step `disableBeacon` (steps already set `skipBeacon`) and move `showProgress` into `options` (`options.buttons` already includes skip). No behaviour change.

Verified with `npm run build` and a compose build of `tt_studio_frontend`; `tt serve Qwen3.5-9B` gets past Build with this applied.
