### PR TITLE
ci: fix frontend lint job failing on fork pull requests

### DIFF
--- a/.github/workflows/frontend-lint-license-checker.yml
+++ b/.github/workflows/frontend-lint-license-checker.yml
@@ -38,15 +38,23 @@ jobs:
         working-directory: app/frontend
         run: npm ci
 
-      # Fetch git history for PR comparisons (must happen before header check)
+      # Fetch git history for PR comparisons (must happen before header check).
+      # Only the base branch is fetched: the checkout above already has the
+      # PR merge commit (github.sha), and the head branch lives in the
+      # contributor's fork for cross-repo PRs, so fetching it from origin
+      # would fail. Refs go through env vars so branch names never reach the
+      # shell unquoted.
       - name: Fetch Git History for PR
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          echo "Fetching base branch: ${{ github.event.pull_request.base.ref }}"
-          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} --depth=100
-          git fetch origin ${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }} --depth=100
-          echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
-          echo "Head SHA: ${{ github.sha }}"
+          echo "Fetching base branch: $BASE_REF"
+          git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF" --depth=100
+          echo "Base SHA: $BASE_SHA"
+          echo "Head SHA: $HEAD_SHA"
 
       # Check SPDX headers on changed files (enforces current year)
       - name: Check SPDX Headers on Changed Files (Current Year)


### PR DESCRIPTION
## Summary

The frontend lint / SPDX checker job fails on every pull request opened from a fork. Its "Fetch Git History for PR" step runs `git fetch origin <head branch>`, but a fork's head branch does not exist on `origin`, so git exits 128 before the header or ESLint checks run. Example: #1314 (https://github.com/tenstorrent/tt-studio/actions/runs/34247224347/job/102207676707).

## Change

- Drop the head-branch fetch. The checkout step (`fetch-depth: 0`) already has the PR merge commit (`github.sha`) and the base branch, which is exactly what `scripts/check-headers-changed.js` and the changed-files step diff against.
- Keep the base-branch fetch, and pass refs through `env` instead of interpolating branch names directly into the shell.

## Verification

- YAML parses cleanly.
- Confirmed from the failing run's log that the full-history checkout already fetched `origin/dev` and `refs/remotes/pull/1314/merge`, so both SHAs the diff needs are present without the extra fetch.
- Because `pull_request` runs use the workflow from the merge commit, #1314 will pick this up on its next sync once this lands on `dev`, with no change needed on the contributor's branch.