### PR TITLE
fix(frontend): handle insecure origins for microphone

### DIFF
--- a/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
+++ b/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
@@ -20,6 +20,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip";
+import { customToast } from "../CustomToaster";
+import {
+  isAudioRecordingSupported,
+  INSECURE_CONTEXT_MIC_MESSAGE,
+  INSECURE_CONTEXT_TOOLTIP_MESSAGE,
+  getMicrophoneErrorMessage,
+} from "../../lib/mediaUtils";
 
 type Props = {
   className?: string;
@@ -50,6 +57,7 @@ export const AudioRecorderWithVisualizer = ({
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
   const [hasRecordedBefore, setHasRecordedBefore] = useState<boolean>(false);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const isMicSupported = useMemo(() => isAudioRecordingSupported(), []);
 
   // Calculate the hours, minutes, and seconds from the timer
   // const hours = Math.floor(timer / 3600);
@@ -128,6 +136,11 @@ export const AudioRecorderWithVisualizer = ({
   }
 
   function startRecording() {
+    if (!isAudioRecordingSupported()) {
+      customToast.warning(INSECURE_CONTEXT_MIC_MESSAGE);
+      return;
+    }
+
     if (mediaRecorderRef.current.stream) {
       mediaRecorderRef.current.stream
         .getTracks()
@@ -194,8 +207,8 @@ export const AudioRecorderWithVisualizer = ({
           };
         })
         .catch((error) => {
-          alert("Microphone access error: " + error.message);
           console.error("Microphone access error:", error);
+          customToast.error(getMicrophoneErrorMessage(error));
         });
     }
   }
@@ -681,28 +694,49 @@ export const AudioRecorderWithVisualizer = ({
                 <TooltipTrigger asChild>
                   <div
                     onClick={startRecording}
-                    className="h-14 w-14 sm:h-16 sm:w-16 rounded-full relative flex items-center justify-center bg-white dark:bg-[#222222] border-2 border-TT-purple-accent cursor-pointer shadow-lg transition-all duration-200 hover:scale-105 active:scale-95 hover:shadow-TT-purple-accent/30 dark:hover:shadow-TT-purple/30 hover:border-TT-purple dark:hover:border-TT-purple-tint1"
+                    role="button"
+                    tabIndex={0}
+                    aria-disabled={!isMicSupported}
+                    className={cn(
+                      "h-14 w-14 sm:h-16 sm:w-16 rounded-full relative flex items-center justify-center border-2 shadow-lg transition-all duration-200",
+                      isMicSupported
+                        ? "bg-white dark:bg-[#222222] border-TT-purple-accent cursor-pointer hover:scale-105 active:scale-95 hover:shadow-TT-purple-accent/30 dark:hover:shadow-TT-purple/30 hover:border-TT-purple dark:hover:border-TT-purple-tint1"
+                        : "bg-gray-100 dark:bg-[#1f1f1f] border-gray-400/40 cursor-not-allowed opacity-60"
+                    )}
                     style={{
-                      boxShadow: "0 0 0 2px rgba(124, 104, 250, 0.3)", // TT-purple-accent with opacity
+                      boxShadow: isMicSupported
+                        ? "0 0 0 2px rgba(124, 104, 250, 0.3)"
+                        : "none",
                       transform: "translateY(0)",
                       transition:
                         "transform 0.2s, box-shadow 0.2s, border-color 0.2s",
                     }}
                   >
-                    <Mic className="h-6 w-6 sm:h-7 sm:w-7 text-TT-purple-accent dark:text-TT-purple-tint1 transition-colors duration-200" />
+                    <Mic
+                      className={cn(
+                        "h-6 w-6 sm:h-7 sm:w-7 transition-colors duration-200",
+                        isMicSupported
+                          ? "text-TT-purple-accent dark:text-TT-purple-tint1"
+                          : "text-gray-400 dark:text-gray-500"
+                      )}
+                    />
                     {hasRecordedBefore && (
                       <span className="absolute -top-1 -right-1 h-3 w-3 bg-TT-red rounded-full"></span>
                     )}
                     <span className="sr-only">Start recording</span>
                   </div>
                 </TooltipTrigger>
-                <TooltipContent side="top">
-                  <div className="flex items-center gap-2">
-                    <Mic className="h-4 w-4 text-TT-purple-accent" />
-                    {hasRecordedBefore
-                      ? "Click to record again"
-                      : "Click to start recording"}
-                  </div>
+                <TooltipContent side="top" className="max-w-xs text-center">
+                  {isMicSupported ? (
+                    <div className="flex items-center gap-2">
+                      <Mic className="h-4 w-4 text-TT-purple-accent" />
+                      {hasRecordedBefore
+                        ? "Click to record again"
+                        : "Click to start recording"}
+                    </div>
+                  ) : (
+                    <span>{INSECURE_CONTEXT_TOOLTIP_MESSAGE}</span>
+                  )}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
+++ b/app/frontend/src/components/speechToText/AudioRecorderWithVisualizer.tsx
@@ -23,7 +23,7 @@ import {
 import { customToast } from "../CustomToaster";
 import {
   isAudioRecordingSupported,
-  INSECURE_CONTEXT_MIC_MESSAGE,
+  INSECURE_CONTEXT_STT_MESSAGE,
   INSECURE_CONTEXT_TOOLTIP_MESSAGE,
   getMicrophoneErrorMessage,
 } from "../../lib/mediaUtils";
@@ -137,7 +137,7 @@ export const AudioRecorderWithVisualizer = ({
 
   function startRecording() {
     if (!isAudioRecordingSupported()) {
-      customToast.warning(INSECURE_CONTEXT_MIC_MESSAGE);
+      customToast.warning(INSECURE_CONTEXT_STT_MESSAGE);
       return;
     }
 
@@ -694,6 +694,12 @@ export const AudioRecorderWithVisualizer = ({
                 <TooltipTrigger asChild>
                   <div
                     onClick={startRecording}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        startRecording();
+                      }
+                    }}
                     role="button"
                     tabIndex={0}
                     aria-disabled={!isMicSupported}

--- a/app/frontend/src/components/speechToText/mainContent.tsx
+++ b/app/frontend/src/components/speechToText/mainContent.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   Loader2,
   Copy,
@@ -19,6 +19,7 @@ import { Button } from "@/src/components/ui/button";
 import { Card } from "@/src/components/ui/card";
 import { AudioRecorderWithVisualizer } from "@/src/components/speechToText/AudioRecorderWithVisualizer";
 import { FileUpload } from "../ui/file-upload";
+import { isAudioRecordingSupported } from "../../lib/mediaUtils";
 import { cn } from "../../lib/utils";
 import {
   Tooltip,
@@ -109,6 +110,7 @@ export function MainContent({
   const [showUpload, setShowUpload] = useState(true);
   const [partialRun, setPartialRun] = useState<PartialRun | null>(null);
   const { theme } = useTheme();
+  const isMicSupported = useMemo(() => isAudioRecordingSupported(), []);
 
   // Anything that blocks starting new work.
   const isProcessing = progress !== null;
@@ -734,9 +736,18 @@ export function MainContent({
                         : "bg-white/80 border-TT-purple-shade/30 hover:border-TT-purple-shade/50"
                     )}
                   >
-                    <h2 className="text-lg sm:text-xl font-semibold text-TT-purple">
-                      Or upload an audio file
-                    </h2>
+                    <div className="flex items-center justify-between mb-2">
+                      <h2 className="text-lg sm:text-xl font-semibold text-TT-purple">
+                        {isMicSupported
+                          ? "Or upload an audio file"
+                          : "Upload an audio file"}
+                      </h2>
+                      {!isMicSupported && (
+                        <span className="text-xs px-2.5 py-0.5 rounded-full bg-TT-purple-shade/20 text-TT-purple-accent dark:text-TT-purple-tint1 font-medium">
+                          Available on HTTP
+                        </span>
+                      )}
+                    </div>
                     <FileUpload
                       onChange={handleFileUpload}
                       accept={ACCEPTED_AUDIO}

--- a/app/frontend/src/components/voiceAgent/AudioRecorderWithVisualizer.tsx
+++ b/app/frontend/src/components/voiceAgent/AudioRecorderWithVisualizer.tsx
@@ -2,12 +2,27 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useTheme } from "../../hooks/useTheme";
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState, useCallback } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
 import { Mic, Square } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import type { PipelineStage } from "./types";
 import { useSilenceDetection } from "./hooks/useSilenceDetection";
+import { customToast } from "../CustomToaster";
+import {
+  isAudioRecordingSupported,
+  INSECURE_CONTEXT_MIC_MESSAGE,
+  INSECURE_CONTEXT_TOOLTIP_MESSAGE,
+  getMicrophoneErrorMessage,
+} from "../../lib/mediaUtils";
 
 type Props = {
   className?: string;
@@ -46,6 +61,7 @@ export const AudioRecorderWithVisualizer = forwardRef<AudioRecorderHandle, Props
 
   const [isRecording, setIsRecording] = useState(false);
   const [levels, setLevels] = useState<number[]>(new Array(LEVEL_BARS).fill(0));
+  const isMicSupported = useMemo(() => isAudioRecordingSupported(), []);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -104,6 +120,10 @@ export const AudioRecorderWithVisualizer = forwardRef<AudioRecorderHandle, Props
 
   const startRecording = async () => {
     if (disabled) return;
+    if (!isAudioRecordingSupported()) {
+      customToast.warning(INSECURE_CONTEXT_MIC_MESSAGE);
+      return;
+    }
     cleanup();
     // Play before opening the mic so the chime isn't captured into the recording.
     playStartChime();
@@ -149,6 +169,7 @@ export const AudioRecorderWithVisualizer = forwardRef<AudioRecorderHandle, Props
       startVisualization(analyser);
     } catch (err) {
       console.error("Microphone access error:", err);
+      customToast.error(getMicrophoneErrorMessage(err));
     }
   };
 
@@ -165,6 +186,10 @@ export const AudioRecorderWithVisualizer = forwardRef<AudioRecorderHandle, Props
   useSilenceDetection({ enabled: isRecording, onSilence: stopRecording });
 
   const toggleRecording = () => {
+    if (!isMicSupported) {
+      customToast.warning(INSECURE_CONTEXT_MIC_MESSAGE);
+      return;
+    }
     if (isRecording) {
       stopRecording();
     } else {
@@ -280,17 +305,21 @@ export const AudioRecorderWithVisualizer = forwardRef<AudioRecorderHandle, Props
         <motion.button
           onClick={toggleRecording}
           disabled={disabled}
-          whileHover={!disabled ? { scale: 1.06 } : undefined}
-          whileTap={!disabled ? { scale: 0.95 } : undefined}
+          aria-disabled={disabled || !isMicSupported}
+          title={!isMicSupported ? INSECURE_CONTEXT_TOOLTIP_MESSAGE : undefined}
+          whileHover={!disabled && isMicSupported ? { scale: 1.06 } : undefined}
+          whileTap={!disabled && isMicSupported ? { scale: 0.95 } : undefined}
           className={cn(
             "relative z-10 w-10 h-10 sm:w-12 sm:h-12 lg:w-14 lg:h-14 rounded-full flex items-center justify-center transition-all duration-200",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-TT-purple-accent focus-visible:ring-offset-2",
-            disabled && "opacity-50 cursor-not-allowed",
+            (disabled || !isMicSupported) && "opacity-50 cursor-not-allowed",
             isRecording
               ? "bg-TT-red-accent hover:bg-TT-red-shade text-white shadow-lg shadow-TT-red-accent/30"
-              : theme === "dark"
-                ? "bg-white/[0.05] border-2 border-TT-purple-accent/50 text-TT-purple-accent hover:border-TT-purple-accent hover:shadow-lg hover:shadow-TT-purple-accent/20"
-                : "bg-white border-2 border-TT-purple-accent/50 text-TT-purple-accent hover:border-TT-purple-accent hover:shadow-lg hover:shadow-TT-purple-accent/20"
+              : !isMicSupported
+                ? "bg-gray-100 dark:bg-[#1a1a1a] border-2 border-gray-400/40 text-gray-400 dark:text-gray-500"
+                : theme === "dark"
+                  ? "bg-white/[0.05] border-2 border-TT-purple-accent/50 text-TT-purple-accent hover:border-TT-purple-accent hover:shadow-lg hover:shadow-TT-purple-accent/20"
+                  : "bg-white border-2 border-TT-purple-accent/50 text-TT-purple-accent hover:border-TT-purple-accent hover:shadow-lg hover:shadow-TT-purple-accent/20"
           )}
         >
           {isRecording ? (

--- a/app/frontend/src/components/voiceAgent/hooks/useWakeWord.ts
+++ b/app/frontend/src/components/voiceAgent/hooks/useWakeWord.ts
@@ -31,17 +31,24 @@ export function useWakeWord({ enabled, onWake }: UseWakeWordOptions) {
       cancelled = true;
       try {
         workletNode?.disconnect();
-      } catch { }
+      } catch {
+        /* ignore */
+      }
       try {
         source?.disconnect();
-      } catch { }
-      if (ctx && ctx.state !== "closed") ctx.close().catch(() => { });
+      } catch {
+        /* ignore */
+      }
+      if (ctx && ctx.state !== "closed") ctx.close().catch(() => {});
       stream?.getTracks().forEach((t) => t.stop());
       if (ws && ws.readyState !== WebSocket.CLOSED) ws.close();
     };
 
     (async () => {
       try {
+        if (!navigator.mediaDevices?.getUserMedia) {
+          return;
+        }
         stream = await navigator.mediaDevices.getUserMedia({ audio: true });
         if (cancelled) return cleanup();
 

--- a/app/frontend/src/lib/mediaUtils.ts
+++ b/app/frontend/src/lib/mediaUtils.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+/**
+ * Checks whether the browser supports audio capture via MediaDevices.
+ * Restricts to secure contexts (HTTPS or localhost) per W3C specifications.
+ */
+export function isAudioRecordingSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    Boolean(window.isSecureContext) &&
+    Boolean(
+      navigator.mediaDevices &&
+        typeof navigator.mediaDevices.getUserMedia === "function"
+    )
+  );
+}
+
+export const INSECURE_CONTEXT_MIC_MESSAGE =
+  "Microphone access requires a secure origin (HTTPS or localhost via SSH tunnel). You can still upload audio files.";
+
+export const INSECURE_CONTEXT_TOOLTIP_MESSAGE =
+  "Microphone requires a secure origin (HTTPS or localhost via SSH tunnel).";
+
+/**
+ * Normalizes browser MediaDevices / getUserMedia errors into user-friendly messages.
+ */
+export function getMicrophoneErrorMessage(error: unknown): string {
+  if (error && typeof error === "object") {
+    const err = error as { name?: string; message?: string };
+    if (
+      err.name === "NotAllowedError" ||
+      err.name === "PermissionDeniedError"
+    ) {
+      return "Microphone permission denied. Please allow microphone access in your browser settings.";
+    }
+    if (
+      err.name === "NotFoundError" ||
+      err.name === "DevicesNotFoundError"
+    ) {
+      return "No microphone found. Please connect an audio input device.";
+    }
+    if (err.name === "NotReadableError" || err.name === "TrackStartError") {
+      return "Microphone is already in use by another application.";
+    }
+    if (err.message) {
+      return `Microphone access error: ${err.message}`;
+    }
+  }
+  return "Unable to access microphone. Please check your system settings.";
+}

--- a/app/frontend/src/lib/mediaUtils.ts
+++ b/app/frontend/src/lib/mediaUtils.ts
@@ -11,13 +11,16 @@ export function isAudioRecordingSupported(): boolean {
     Boolean(window.isSecureContext) &&
     Boolean(
       navigator.mediaDevices &&
-        typeof navigator.mediaDevices.getUserMedia === "function"
+      typeof navigator.mediaDevices.getUserMedia === "function"
     )
   );
 }
 
 export const INSECURE_CONTEXT_MIC_MESSAGE =
-  "Microphone access requires a secure origin (HTTPS or localhost via SSH tunnel). You can still upload audio files.";
+  "Microphone access requires a secure origin. Please access via HTTPS or use an SSH tunnel to localhost (e.g. http://localhost:3000)";
+
+export const INSECURE_CONTEXT_STT_MESSAGE =
+  "Microphone access requires a secure origin (HTTPS or localhost via SSH tunnel). You can still upload audio files below.";
 
 export const INSECURE_CONTEXT_TOOLTIP_MESSAGE =
   "Microphone requires a secure origin (HTTPS or localhost via SSH tunnel).";


### PR DESCRIPTION
## Description
On plain HTTP non-secure origins (e.g. `http://<ip>:3000`), modern browsers do not expose `navigator.mediaDevices`. Previously, clicking the microphone button silently failed with no visual feedback, leaving users to think the button was dead. Additionally, permission denial triggered a disruptive native `window.alert()`.
- Fixes #1313.

## Changes
- **Shared capability check**: Added `isAudioRecordingSupported()` and `getMicrophoneErrorMessage()` in `src/lib/mediaUtils.ts`.
- **Speech to Text**:
  - Pre-checks capability in `startRecording()` and surfaces `customToast.warning` explaining the HTTPS / SSH tunnel requirement.
  - Replaced native `alert()` with `customToast.error()` providing clear browser permission instructions.
  - Visually disables the mic button with a Radix UI tooltip.
  - Keeps the file upload panel prominently visible as the working alternative.
- **Voice Agent**:
  - Eliminated false start chime on insecure origins.
  - Disabled mic button with tooltip title and toast warning on interaction.
  - Guarded `useWakeWord` hook against unhandled `TypeError` exceptions.

## How Has This Been Tested?
- **Manual / Browser Testing**:
  - Simulated insecure origin (`window.isSecureContext = false` / `navigator.mediaDevices = undefined`): verified mic button is disabled with tooltip, warning toast fires on interaction, and file upload card remains visible with "Available on HTTP" badge.
  - Tested on both Speech to Text (`/speech-to-text`) and Voice Agent (`/voice-agent`).
  - Simulated microphone permission denied: verified `customToast.error` displays settings guidance with zero blocking `window.alert()` dialogs.
- **Lint & Headers**: Passed `npx eslint --quiet` and `npm run header:check:changed` with zero errors.
- **Build**: Production bundle compiles cleanly via `npx vite build`.