### PR TITLE
feat: embedding models on fewer chips and dedicated interface to use them

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cut-release
+description: Orchestrate a TT-Studio release end-to-end with the maintainer release flags — cut an rc-vX.Y.Z branch from main (`python run.py --make-rc-branch`), cherry-pick dev hotfixes into it (`--update-rc-branch`), and ship it (`--merge-rc-branch` merges to main, pushes the vX.Y.Z tag that publishes the GHCR images, and creates the GitHub release) — delegating note-writing to the draft-release-notes skill. Use when someone asks to "cut a release", "make an RC", "update the RC", "ship vX.Y.Z", or "merge the RC branch".
+---
+
+# Cut a TT-Studio release
+
+The release model (CONTRIBUTING → Release Process): an `rc-vX.Y.Z` branch is cut
+from `main`, validated changes are cherry-picked from `dev`, the `Rc vX.Y.Z` PR is
+squash-merged back into `main` after ≥2 approvals, and the merge commit is tagged
+`vX.Y.Z` — the tag push is what builds and publishes the GHCR images. Git tags are
+the only version source of truth.
+
+The three `python run.py` flags automate the mechanical parts. All of them are
+interactive, verify state before acting, and stop with a fix-it panel when
+something is off — prefer them over hand-rolled git/gh sequences.
+
+## 0. Preflight
+
+- These flags need the GitHub CLI: `gh auth status` must pass with push access.
+- The flags never switch your checkout (the RC is created with plumbing and
+  cherry-picked in a scratch worktree), so run them from any branch — including
+  a dirty one. Stay on a branch that has the flags; `main` doesn't until this
+  tooling ships.
+- Figure out which stage the user is at and jump to it:
+  - no RC branch yet → **Cut**
+  - RC exists, fixes landed on dev → **Stabilize**
+  - RC approved and green → **Ship**
+
+## 1. Cut
+
+```bash
+python run.py --make-rc-branch          # asks: bump major / minor / patch
+python run.py --make-rc-branch minor    # or say it up front (also accepts vX.Y.Z)
+```
+
+Detects the latest release across tags, `rc-v*` branches, and `Rc vX.Y.Z (#N)`
+merge commits on main (they have drifted historically), cuts `rc-vX.Y.Z` from
+`origin/main`, pushes it, and opens the `Rc vX.Y.Z` PR against `main` with the
+release test-plan checklist. Relay the PR URL to the user. One release at a
+time: while an untagged `rc-v*` branch exists on origin, the cut refuses and
+points at `--update-rc-branch` / `--merge-rc-branch` (or closing the stray RC).
+
+## 2. Notes
+
+Draft the release notes with the **draft-release-notes** skill (it owns the house
+style — do not restate its rules here). After the user approves the draft, put it
+at the top of the RC PR description, keeping the test-plan checklist below:
+
+```bash
+gh pr edit rc-vX.Y.Z --body-file <notes+testplan.md>
+```
+
+## 3. Stabilize
+
+As hotfixes land on `dev` during RC testing:
+
+```bash
+python run.py --update-rc-branch
+```
+
+Lists dev commits newer than the main commit the RC was cut from (releases are
+squashed into main, so that date is the cutoff — older dev commits need a manual
+`git cherry-pick`), minus ones already picked onto the RC, lets the user pick, cherry-picks oldest-first,
+and pushes. A conflict rolls back the failing pick and prints manual-resolution
+steps. Re-run draft-release-notes if the changeset moved meaningfully.
+
+## 4. Ship
+
+Once the PR has **≥2 approvals** and green checks:
+
+```bash
+python run.py --merge-rc-branch
+```
+
+It verifies approvals/checks via `gh`, asks one explicit confirmation, then:
+squash-merges as `Rc vX.Y.Z`, tags the merge commit `vX.Y.Z`, pushes the tag
+(→ Publish images workflow → `ghcr.io/tenstorrent/tt-studio/*`), and creates the
+GitHub release seeded with GitHub's generated notes (categorized via
+`.github/release.yml`). Afterwards, upgrade the release body to the curated notes:
+
+```bash
+gh release edit vX.Y.Z --notes-file <curated-notes.md>
+```
+
+Watch the Publish images run:
+https://github.com/tenstorrent/tt-studio/actions/workflows/publish-images.yml
+
+## Gotchas
+
+- **Duplicate image build**: the tag push and the release-published event each
+  trigger Publish images; the runs are serialized and idempotent. Expected — don't
+  cancel or "fix" it.
+- **Tags must be pushed from a maintainer machine** (the flag does this). A tag
+  pushed by a workflow with the default `GITHUB_TOKEN` would NOT trigger
+  publishing.
+- **`rc-*` branches keep `IS_QB2` off** in `.env.default`; only the QB2 launch
+  branch ships it on. `--make-rc-branch` warns if it's set.
+- If main's tip moved between merge and tag (something else landed), the flag
+  refuses to tag and prints the manual `git tag` command for the actual merge
+  commit — follow that rather than re-running.

--- a/.claude/skills/tt-studio-cli/SKILL.md
+++ b/.claude/skills/tt-studio-cli/SKILL.md
@@ -63,7 +63,8 @@ test_no_undefined_names.py` is the backstop; run it.
 1. **Declare it** in `tt_setup/cli/_args.py` as a `typer.Option`, with a
    `rich_help_panel=` so it lands in the right `--help` group: *Setup &
    Configuration · Model Deployment · Lifecycle · Reset (--purge-all) · Advanced ·
-   Developer Tools · Troubleshooting & Info*. Deprecated flags use `hidden=True`
+   Developer Tools · Release (maintainers) · Troubleshooting & Info*. Deprecated
+   flags use `hidden=True`
    and warn + normalize onto the current flag.
 2. **Thread it** into the `args = SimpleNamespace(...)` passed to `_run(args)`.
 3. **Dispatch it.** *Utility/lifecycle* flags (`--stop`, `--status`, `--logs`,

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# Category mapping for GitHub's auto-generated release notes
+# (used by `gh api .../releases/generate-notes` in `python run.py --merge-rc-branch`
+# and by the "Generate release notes" button in the UI).
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Fixes"
+      labels:
+        - bug
+    - title: "📖 Documentation"
+      labels:
+        - documentation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🔧 Other changes"
+      labels:
+        - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ python run.py --switch REF    # fetch + check out a tt-studio branch/tag (e.g. a
 python run.py --uninstall     # --purge-all teardown + remove the `tt-studio` shell shortcut
 python run.py --check-headers # report files missing SPDX headers
 python run.py --build-images  # build images locally instead of pulling prebuilt ones from GHCR
+python run.py --make-rc-branch   # maintainers: cut rc-vX.Y.Z from main + open the RC PR
+python run.py --update-rc-branch # maintainers: cherry-pick new dev commits into the RC
+python run.py --merge-rc-branch  # maintainers: merge the approved RC, tag, publish the release
 ```
 
 Frontend (in `app/frontend/`): `npm run dev`, `npm run build`,

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -465,11 +465,22 @@ def deploys_whole_board(impl, board_type=None):
     return infer_inference_server_device(impl, board_type) not in _SINGLE_CHIP_DEVICE_NAMES
 
 
-def run_container(impl, weights_id, device_id=0, host_port=None, use_image_override=True):
+def run_container(impl, weights_id, device_id=0, host_port=None, use_image_override=True, force_full_board=False):
     """Run a docker container.
 
     For FACE_RECOGNITION model type, uses docker-control-service directly.
     For all other model types, uses TT Inference Server API.
+
+    force_full_board: opt-in whole-board mesh deploy for a model whose default is
+    single-chip via a runtime_model_spec_overrides entry (see
+    shared_config.model_config.ModelImpl and
+    sync_models_from_inference_server.STUDIO_CHIP_TIER_MODELS), but which
+    also has a genuine, already-working whole-board spec upstream (e.g.
+    Qwen3-Embedding-0.6B/4B and bge-m3 on P300x2, at 4x throughput). Set by
+    docker_control.views.DeployView from the request's force_full_board flag,
+    gated to models it actually applies to. Bypasses the single-chip override
+    entirely: device resolves to the board mesh name, so runtime_model_spec_json
+    is never set below and normal (already-working) spec resolution runs instead.
     """
     # Face recognition bypasses TT Inference Server — deploy via docker-control-service
     if impl.model_type == ModelTypes.FACE_RECOGNITION:
@@ -485,11 +496,30 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         # ("t3k"). We use chips_required + board_type to pick the right name.
         from shared_config.model_config import infer_chips_required
         board_type = detect_board_type()
-        chips_required = infer_chips_required(impl.device_configurations)
-        device = infer_inference_server_device(impl, board_type)
+        if force_full_board:
+            chips_required = 4
+            device = map_board_type_to_device_name(board_type)
+        else:
+            chips_required = infer_chips_required(impl.device_configurations)
+            device = infer_inference_server_device(impl, board_type)
+            # Card-pair promotion: a model with a P300 (2-chip) override spec that's
+            # asked for an explicit 2-slot device_id forming one physical P300 card
+            # ((0,1) or (2,3)) runs as that one card, not two independent p150 chips.
+            # Gated on the override existing so this never touches ordinary
+            # single-chip models -- see STUDIO_CHIP_TIER_MODELS.
+            requested_ids = [x.strip() for x in str(device_id).split(",") if x.strip() != ""]
+            if (
+                device == "p150"
+                and board_type == "P300x2"
+                and len(requested_ids) == 2
+                and sorted(int(x) for x in requested_ids) in ([0, 1], [2, 3])
+                and "p300" in {k.lower() for k in (impl.runtime_model_spec_overrides or {})}
+            ):
+                device = "p300"
+                chips_required = 2
         logger.info(
             f"Device name '{device}' for {impl.model_name} "
-            f"(board={board_type}, chips_required={chips_required})"
+            f"(board={board_type}, chips_required={chips_required}, force_full_board={force_full_board})"
         )
 
         BASE_SERVICE_PORT = 7000
@@ -523,12 +553,29 @@ def run_container(impl, weights_id, device_id=0, host_port=None, use_image_overr
         if device in _SINGLE_CHIP_DEVICE_NAMES:
             payload["device_id"] = str(device_id)
 
-        # The inference server merges override_tt_config over the spec's, key by key.
-        trace_region_size = trace_region_override(impl.model_name, device)
-        if trace_region_size:
-            payload["override_tt_config"] = json.dumps(
-                {"trace_region_size": trace_region_size}
+        # A model with no upstream ModelConfigs entry for this device (e.g. it only
+        # ships a multi-chip mesh spec, but genuinely runs on one chip -- see
+        # sync_models_from_inference_server.STUDIO_CHIP_TIER_MODELS) needs a
+        # hand-authored spec file: run.py's own spec resolution hard-rejects an
+        # undeclared (model, device) pair before any override flag ever runs, and
+        # --runtime-model-spec-json is the documented bypass -- it's used as-is, so
+        # override_tt_config below would be silently ignored and is skipped.
+        spec_overrides = {
+            k.lower(): v for k, v in (impl.runtime_model_spec_overrides or {}).items()
+        }
+        spec_path = spec_overrides.get(device)
+        if spec_path:
+            payload["runtime_model_spec_json"] = str(
+                Path(backend_config.host_tt_studio_root) / spec_path
             )
+            logger.info(f"Using hand-authored runtime model spec for {impl.model_name} on {device}: {spec_path}")
+        else:
+            # The inference server merges override_tt_config over the spec's, key by key.
+            trace_region_size = trace_region_override(impl.model_name, device)
+            if trace_region_size:
+                payload["override_tt_config"] = json.dumps(
+                    {"trace_region_size": trace_region_size}
+                )
 
         # media/forge models require skipping hw validation; vLLM models do not
         if impl.model_type != ModelTypes.CHAT:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -22,6 +22,11 @@ from shared_config.device_config import DeviceConfigurations
 from shared_config.external_model_config import build_external_model_impl
 from shared_config.logger_config import get_logger
 from shared_config.model_config import _impl_selector, model_implmentations
+from shared_config.model_overrides import (
+    MEDIA_IMAGE_OVERRIDES as _MEDIA_IMAGE_OVERRIDES,
+    TRACE_REGION_OVERRIDES as _TRACE_REGION_OVERRIDES,
+    VLLM_MESH_SPEC_FALLBACK as _VLLM_MESH_SPEC_FALLBACK,
+)
 from shared_config.model_type_config import ModelTypes
 from docker_control.artifact_resolution import (
     resolve_artifact_ref,
@@ -143,44 +148,6 @@ WHOLE_BOARD_DEFAULT_BOARDS = {"T3K", "T3000", "N300x4", "N150X4", "GALAXY", "GAL
 # mesh deployments let the inference server claim the full board itself.
 _SINGLE_CHIP_DEVICE_NAMES = {"n150", "n300", "e150", "p100", "p150", "p300"}
 
-# vLLM spec-name fallback between four-chip Blackhole meshes. The vLLM plugin
-# maps both labels to a (1, 4) mesh, so a chat model that only publishes a
-# p300x2 spec can still be asked for on p150x4 hardware (and vice versa) by
-# sending the other name.
-_VLLM_MESH_SPEC_FALLBACK = {
-    "p150x4": ("p300x2",),
-    "p300x2": ("p150x4",),
-}
-
-# Trace region size (bytes) to force where a model_spec under-allocates it, which
-# stops the deploy during traced warmup with a TT_FATAL error.
-_TRACE_REGION_OVERRIDES = {
-    # p150x4 spec is stale at 0.10.x with 30000000; traced decode needs 56557568.
-    # Value matches the maintained p300x2 spec for the same four-chip mesh.
-    ("Llama-3.3-70B-Instruct", "p150x4"): 402653184,
-    # Both P150X4 FLUX configs omit this setting and inherit 34.5 MB. Traced
-    # warmup needs 50,724,864 bytes; 51 MB matches their maintained P300X2 specs.
-    ("FLUX.1-dev", "p150x4"): 51_000_000,
-    ("FLUX.1-schnell", "p150x4"): 51_000_000,
-}
-
-# Docker images to force where the per-device model_spec resolves to one whose API
-# this backend can no longer drive. Keyed by (model_name, device); a device of "*"
-# applies to every device for that model.
-_MEDIA_IMAGE_OVERRIDES = {
-    # Wan T2V on every board: 0.17.0 carries the MODEL_WEIGHTS_DIR fix (#4107), so
-    # it reads the mounted host HF cache instead of re-downloading ~118GB.
-    ("Wan2.2-T2V-A14B-Diffusers", "*"): (
-        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
-    ),
-    # FLUX on p150x4: that spec resolves to 0.10.0-555f240, so override to the newer image.
-    ("FLUX.1-dev", "p150x4"): (
-        "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
-    ),
-    ("FLUX.1-schnell", "p150x4"): (
-        "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76"
-    ),
-}
 
 def map_board_type_to_device_name(board_type):
     """Map our internal board type names to TT Inference Server device names"""

--- a/app/backend/docker_control/test_hf_detection.py
+++ b/app/backend/docker_control/test_hf_detection.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for _hf_from_container's env-var identity heuristic and _detect_model_info's
+guard against tt-media-server's non-LLM /v1/models path-as-id quirk.
+"""
+
+from unittest.mock import Mock, patch
+
+from docker_control.views import _hf_from_container, _detect_model_info
+
+
+def _container(env: dict) -> dict:
+    return {"Config": {"Env": [f"{k}={v}" for k, v in env.items()]}}
+
+
+class TestHfFromContainer:
+    def test_prefers_slash_shaped_org_repo_id(self):
+        info = _container({"HF_MODEL_ID": "Qwen/Qwen3-Embedding-4B", "MODEL": "Qwen3-Embedding-4B"})
+        assert _hf_from_container(info) == "Qwen/Qwen3-Embedding-4B"
+
+    def test_falls_back_to_bare_model_env_when_nothing_slash_shaped(self):
+        """tt-media-server forge/media launches set MODEL=<short catalog name>
+        (e.g. "bge-m3", "Qwen3-Embedding-4B") with no org prefix; this used to be
+        silently dropped, leaving hf_model_id unset."""
+        info = _container({"MODEL": "Qwen3-Embedding-4B"})
+        assert _hf_from_container(info) == "Qwen3-Embedding-4B"
+
+    def test_bare_model_id_env_also_accepted(self):
+        info = _container({"MODEL_ID": "bge-m3"})
+        assert _hf_from_container(info) == "bge-m3"
+
+    def test_no_identity_anywhere_returns_none(self):
+        info = _container({"SOME_OTHER_VAR": "x"})
+        assert _hf_from_container(info) is None
+
+
+class TestDetectModelInfoIgnoresPathLikeApiId:
+    @patch("docker_control.views.requests.get")
+    def test_live_v1_models_path_does_not_clobber_container_identity(self, mock_get):
+        """tt-media-server's /v1/models reports settings.model_weights_path (an
+        absolute cache path) for non-LLM services when SERVED_MODEL_NAME isn't set
+        at launch -- that must never override a real env-derived identity."""
+        info = {
+            "Config": {"Env": ["MODEL=Qwen3-Embedding-4B"]},
+            "NetworkSettings": {"Ports": {"8000/tcp": [{"HostPort": "8100"}]}},
+        }
+        mock_resp = Mock()
+        mock_resp.json.return_value = {
+            "data": [{"id": "/home/container_app_user/.cache/huggingface/models--Qwen--Qwen3-Embedding-4B/snapshots/abc123"}]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _detect_model_info(Mock(), "container_id", container_info=info)
+
+        assert result["hf_model_id"] == "Qwen3-Embedding-4B"
+        assert result["source"] == "container"
+
+    @patch("docker_control.views.requests.get")
+    def test_live_v1_models_still_wins_when_it_looks_like_a_real_id(self, mock_get):
+        info = {
+            "Config": {"Env": []},
+            "NetworkSettings": {"Ports": {"8000/tcp": [{"HostPort": "8100"}]}},
+        }
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"data": [{"id": "meta-llama/Llama-3.1-8B-Instruct"}]}
+        mock_get.return_value = mock_resp
+
+        result = _detect_model_info(Mock(), "container_id", container_info=info)
+
+        assert result["hf_model_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert result["source"] == "api"

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -3732,6 +3732,7 @@ def _detect_served_api(host_port) -> dict:
         ("/v1/audio/speech", "tts"),
         ("/v1/videos/generations", "video_generation"),
         ("/objdetection_v2", "object_detection"),
+        ("/v1/embeddings", "embedding"),
     ):
         if route in paths:
             result["service_route"] = route

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -1002,6 +1002,15 @@ class DeployView(APIView):
                             pass
                         return job_id, None
 
+                    # Only Whisper/SpeechT5 (TTS, SPEECH_RECOGNITION) forcefully download their weights
+                    # inside the media server container -- the pull is the whole deploy for
+                    # those. Every other non-CHAT model on this path (embedding, image/
+                    # video generation, ...) fetches its weights from HF after the pull,
+                    # same as CHAT models.
+                    expects_weights = impl.model_type not in (
+                        ModelTypes.TTS,
+                        ModelTypes.SPEECH_RECOGNITION,
+                    )
                     start_prepull_and_deploy(
                         pull_id=pull_id,
                         image_name=image_name,
@@ -1009,9 +1018,7 @@ class DeployView(APIView):
                         image_ref=deploy_image,
                         deploy_fn=deploy_fn,
                         heartbeat_fn=_refresh_media_placeholder,
-                        # The media server image ships Whisper/SpeechT5 weights, so
-                        # nothing downloads after the pull — the pull is the deploy.
-                        expects_weights=False,
+                        expects_weights=expects_weights,
                     )
                     return Response(
                         {"status": "success", "job_id": pull_id, "message": "Pulling Docker Image…", "allocated_device_id": device_id},

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -159,6 +159,29 @@ def _is_llama31_8b_model(model_name: str) -> bool:
     token = (model_name or "").lower().replace("_", "").replace(" ", "")
     return "llama-3.1-8b" in token or "llama3.18b" in token
 
+def _is_qwen3_embedding_06b_model(model_name: str) -> bool:
+    token = (model_name or "").lower().replace("_", "").replace(" ", "")
+    return "qwen3-embedding-0.6b" in token or "qwen3embedding0.6b" in token
+
+def _is_qwen3_embedding_4b_model(model_name: str) -> bool:
+    token = (model_name or "").lower().replace("_", "").replace(" ", "")
+    return "qwen3-embedding-4b" in token or "qwen3embedding4b" in token
+
+def _is_bge_m3_model(model_name: str) -> bool:
+    token = (model_name or "").lower().replace("_", "").replace(" ", "")
+    return "bge-m3" in token or "bgem3" in token
+
+def _has_chip_tier_overrides(model_name: str) -> bool:
+    """True for models with a hand-authored P150/P300 override (see
+    shared_config.sync_models_from_inference_server.STUDIO_CHIP_TIER_MODELS)
+    alongside a genuine whole-board P300x2 spec -- these can opt into 4x
+    throughput via force_full_board, unlike single-chip-only models."""
+    return (
+        _is_qwen3_embedding_06b_model(model_name)
+        or _is_qwen3_embedding_4b_model(model_name)
+        or _is_bge_m3_model(model_name)
+    )
+
 def _lookup_deployment_device_ids(container_id):
     """Return the list of device slot ids associated with a deployment, or []."""
     try:
@@ -429,7 +452,20 @@ class DeployView(APIView):
                 and board_type == "P300x2"
                 and _is_llama31_8b_model(impl.model_name)
             )
-            if force_full_board_requested and not should_force_full_board_llama:
+            # Qwen3-Embedding-0.6B and bge-m3 have chip-tier overrides (see
+            # shared_config.model_config.ModelImpl.runtime_model_spec_overrides) that
+            # make chips_required=1 their default, but both also have a genuine,
+            # already-working whole-board P300x2 mesh spec for 4x throughput. Opt-in
+            # only -- the default stays single-chip.
+            should_force_full_board_embedding = (
+                impl.model_type != ModelTypes.CHAT
+                and force_full_board_requested
+                and board_type == "P300x2"
+                and _has_chip_tier_overrides(impl.model_name)
+            )
+            if force_full_board_requested and not (
+                should_force_full_board_llama or should_force_full_board_embedding
+            ):
                 logger.info(
                     "Ignoring force_full_board for model=%s board=%s",
                     impl.model_name,
@@ -520,7 +556,7 @@ class DeployView(APIView):
             # are always set correctly (port = 7000 + device_id).
             try:
                 allocator = ChipSlotAllocator()
-                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+                if should_force_full_board_llama or should_force_full_board_embedding or use_whole_board_deploy or mesh_whole_board:
                     # Whole-board deploy (forced QB2 Llama, a single-chip model on a
                     # Wormhole mesh board, or a media model like FLUX with no single-chip
                     # spec) takes over the entire board — reserve all slots.
@@ -580,7 +616,7 @@ class DeployView(APIView):
                         device_ids = [device_id]
                 device_ids_str = ",".join(str(d) for d in device_ids)
                 # Full set of chip slots this model actually occupies, even though only the primary slot is passed to the inference server via device_ids_str
-                if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+                if should_force_full_board_llama or should_force_full_board_embedding or use_whole_board_deploy or mesh_whole_board:
                     # Whole-board deploy takes over every slot on the board.
                     occupied_device_ids = list(range(allocator.total_slots))
                 elif chips_required > 1:
@@ -614,7 +650,7 @@ class DeployView(APIView):
                 }, status=status.HTTP_409_CONFLICT)
 
             BASE_SERVICE_PORT = 7000
-            if should_force_full_board_llama or use_whole_board_deploy or mesh_whole_board:
+            if should_force_full_board_llama or should_force_full_board_embedding or use_whole_board_deploy or mesh_whole_board:
                 service_port = BASE_SERVICE_PORT
             else:
                 service_port = BASE_SERVICE_PORT + device_id
@@ -950,7 +986,7 @@ class DeployView(APIView):
                             logger.warning(f"Could not retire placeholder {_pull_id}: {e}")
 
                     def deploy_fn(_pull_id=pull_id, _host_port=host_port):
-                        resp = run_container(impl, weights_id, device_id=device_ids_str, host_port=_host_port, use_image_override=use_image_override)
+                        resp = run_container(impl, weights_id, device_id=device_ids_str, host_port=_host_port, use_image_override=use_image_override, force_full_board=should_force_full_board_embedding)
                         job_id = resp.get("job_id") or resp.get("container_id") or resp.get("container_name")
                         if resp.get("status") == "error" or not job_id:
                             # Free the slot: the deploy never started.
@@ -983,7 +1019,7 @@ class DeployView(APIView):
                     )
 
                 # Image already cached → deploy inline (existing path, unchanged).
-                response = run_container(impl, weights_id, device_id=device_ids_str, host_port=host_port, use_image_override=use_image_override)
+                response = run_container(impl, weights_id, device_id=device_ids_str, host_port=host_port, use_image_override=use_image_override, force_full_board=should_force_full_board_embedding)
 
                 # Add allocated_device_id to response
                 response["allocated_device_id"] = device_id

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2807,29 +2807,49 @@ class RegisterExternalModelView(APIView):
                 try:
                     catalog_data = json.loads(_CATALOG_PATH.read_text())
                     for catalog_model in catalog_data.get("models", []):
-                        if catalog_model.get("hf_model_id", "").lower() == hf_model_id.lower():
-                            # Found a catalog match — adopt its authoritative type
-                            # and name (routing is derived from the catalog
-                            # model_impl at enrichment time, not stored here).
-                            catalog_type = catalog_model.get("model_type", "").lower()
+                        catalog_hf_id = catalog_model.get("hf_model_id") or ""
+                        catalog_model_name = catalog_model.get("model_name") or ""
+                        hf_id_match = catalog_hf_id.lower() == hf_model_id.lower()
+                        # A container that only ever advertises its bare catalog
+                        # name (tt-media-server's MODEL=<name> convention, e.g.
+                        # "Qwen3-Embedding-0.6B" rather than an org/repo id) won't
+                        # match above; matching on model_name recovers the same
+                        # entry so we can adopt its real HF id, which some
+                        # embedding runners require verbatim (see
+                        # model_control.model_utils.embed_text).
+                        name_match = (
+                            not hf_id_match
+                            and catalog_model_name.lower() == hf_model_id.lower()
+                        )
+                        if not (hf_id_match or name_match):
+                            continue
+                        if name_match and catalog_hf_id:
+                            corrections.append(
+                                f"Model id resolved to catalog's '{catalog_hf_id}' "
+                                f"(matched by short name '{hf_model_id}')"
+                            )
+                            hf_model_id = catalog_hf_id
 
-                            if catalog_type and catalog_type != model_type:
-                                if model_type:
-                                    corrections.append(
-                                        f"Model type corrected from '{model_type}' to '{catalog_type}' based on catalog entry"
-                                    )
-                                model_type = catalog_type
+                        # Found a catalog match — adopt its authoritative type and
+                        # name (routing is derived from the catalog model_impl at
+                        # enrichment time, not stored here).
+                        catalog_type = catalog_model.get("model_type", "").lower()
+                        if catalog_type and catalog_type != model_type:
+                            if model_type:
+                                corrections.append(
+                                    f"Model type corrected from '{model_type}' to '{catalog_type}' based on catalog entry"
+                                )
+                            model_type = catalog_type
 
-                            # Adopt the catalog's model name
-                            catalog_name = catalog_model.get("model_name")
-                            if catalog_name and catalog_name != model_name:
-                                if model_name:
-                                    corrections.append(
-                                        f"Model name set to catalog name '{catalog_name}'"
-                                    )
-                                model_name = catalog_name
+                        # Adopt the catalog's model name
+                        if catalog_model_name and catalog_model_name != model_name:
+                            if model_name:
+                                corrections.append(
+                                    f"Model name set to catalog name '{catalog_model_name}'"
+                                )
+                            model_name = catalog_model_name
 
-                            break
+                        break
                 except Exception as e:
                     logger.warning(f"Could not check HF model ID against catalog: {e}")
 
@@ -3683,6 +3703,14 @@ def _hf_from_container(container_info: dict):
         val = env.get(key)
         if val and "/" in val:  # looks like an org/name HF id, not a bare label
             return val
+    # No org/repo-shaped value anywhere -- fall back to a bare MODEL/MODEL_ID, the
+    # tt-media-server launch convention for forge/media models (e.g. MODEL=bge-m3,
+    # MODEL=Qwen3-Embedding-4B). Lower confidence than the slash-shaped pass above,
+    # but still a real identity from the container itself, not a guess.
+    for key in ("MODEL_ID", "MODEL"):
+        val = env.get(key)
+        if val:
+            return val
     return None
 
 
@@ -3766,13 +3794,17 @@ def _detect_model_info(docker_client, container_id, container_info=None) -> dict
         result["source"] = "container"
 
     # Live /v1/models is authoritative when reachable (unauth'd); fills/overrides.
+    # Exception: tt-media-server's non-LLM services (embedding, CNN, etc.) report
+    # settings.model_weights_path here instead of a clean id when SERVED_MODEL_NAME
+    # isn't set at launch -- an absolute path, never a real "org/repo" HF id. Don't
+    # let that clobber a real identity already found from the container itself.
     if host_port:
         try:
             api_resp = requests.get(
                 f"http://host.docker.internal:{host_port}/v1/models", timeout=2
             )
             model_id = api_resp.json().get("data", [{}])[0].get("id")
-            if model_id:
+            if model_id and not model_id.startswith("/"):
                 result["hf_model_id"] = model_id
                 result["source"] = "api"
         except Exception:

--- a/app/backend/model_control/model_utils.py
+++ b/app/backend/model_control/model_utils.py
@@ -7,6 +7,7 @@ import os
 import pickle
 import time
 import traceback
+from typing import Optional
 
 import httpx
 import requests
@@ -17,6 +18,8 @@ from django.core.cache import caches
 
 from shared_config.backend_config import backend_config
 from shared_config.logger_config import get_logger
+from shared_config.model_type_config import ModelTypes
+from shared_config.user_config import get_tts_api_key
 from docker_control.docker_utils import update_deploy_cache
 from model_control.metrics_tracker import InferenceMetricsTracker
 
@@ -50,6 +53,54 @@ def auth_headers(deploy: dict = None) -> dict:
     default token (normal deploys share the backend secret)."""
     secret = deploy.get("jwt_secret") if isinstance(deploy, dict) else None
     return {"Authorization": f"Bearer {token_for(secret)}"}
+
+
+def find_deployed_embedding_model(model_identifier: str) -> Optional[dict]:
+    """Return the deploy-cache entry for a currently-running EMBEDDING model whose
+    hf_model_id or model_name matches `model_identifier`, or None if it isn't deployed.
+
+    Deploy/container ids are ephemeral across redeploys, so anything that needs to
+    keep working across them (a Chroma collection's stored embedding function) has
+    to key on the model's own identity instead and re-resolve the live deploy here
+    on every call.
+    """
+    for deploy in get_deploy_cache().values():
+        impl = deploy.get("model_impl")
+        if not impl or getattr(impl, "model_type", None) != ModelTypes.EMBEDDING:
+            continue
+        if model_identifier in (getattr(impl, "hf_model_id", None), getattr(impl, "model_name", None)):
+            return deploy
+    return None
+
+
+def embed_text(deploy: dict, text: str, dimensions: int = None) -> dict:
+    """POST one text to a deployed embedding model's /v1/embeddings route and
+    return the raw OpenAI-shaped response ({"data": [{"embedding": [...]}], ...}).
+    Shared by EmbeddingInferenceView and the Chroma-backed embedding function
+    (vector_db_control.tt_embedding_function) so both build the identical
+    request/auth -- see EmbeddingInferenceView for why hf_model_id (not
+    model_name) is required in the payload, and why media/forge use a static key.
+    Raises requests.exceptions.RequestException on failure; caller decides how to
+    surface it.
+    """
+    internal_url = "http://" + deploy["internal_url"]
+    model_impl = deploy.get("model_impl")
+    hf_model_id = getattr(model_impl, "hf_model_id", None) if model_impl else None
+    model_name = hf_model_id or (getattr(model_impl, "model_name", None) if model_impl else None)
+    inference_engine = getattr(model_impl, "inference_engine", None)
+
+    if inference_engine in ("media", "forge"):
+        headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
+    else:
+        headers = auth_headers(deploy)
+
+    payload = {"model": model_name, "input": text}
+    if dimensions:
+        payload["dimensions"] = dimensions
+
+    resp = requests.post(internal_url, json=payload, headers=headers, timeout=60)
+    resp.raise_for_status()
+    return resp.json()
 
 # Shared async HTTP clients with connection pooling (one pool per target)
 _vllm_client = httpx.AsyncClient(

--- a/app/backend/model_control/test_embed_helpers.py
+++ b/app/backend/model_control/test_embed_helpers.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for model_control.model_utils.find_deployed_embedding_model and embed_text.
+"""
+
+from unittest.mock import Mock, patch
+
+from shared_config.model_type_config import ModelTypes
+from model_control.model_utils import find_deployed_embedding_model, embed_text
+
+
+def _embedding_impl(model_name=None, hf_model_id=None, inference_engine="forge"):
+    impl = Mock()
+    impl.model_type = ModelTypes.EMBEDDING
+    impl.model_name = model_name
+    impl.hf_model_id = hf_model_id
+    impl.inference_engine = inference_engine
+    return impl
+
+
+class TestFindDeployedEmbeddingModel:
+    @patch("model_control.model_utils.get_deploy_cache")
+    def test_matches_by_hf_model_id(self, mock_cache):
+        deploy = {"model_impl": _embedding_impl(model_name="Qwen3-Embedding-4B", hf_model_id="Qwen/Qwen3-Embedding-4B")}
+        mock_cache.return_value = {"d1": deploy}
+        assert find_deployed_embedding_model("Qwen/Qwen3-Embedding-4B") is deploy
+
+    @patch("model_control.model_utils.get_deploy_cache")
+    def test_matches_by_model_name(self, mock_cache):
+        deploy = {"model_impl": _embedding_impl(model_name="bge-m3", hf_model_id="BAAI/bge-m3")}
+        mock_cache.return_value = {"d1": deploy}
+        assert find_deployed_embedding_model("bge-m3") is deploy
+
+    @patch("model_control.model_utils.get_deploy_cache")
+    def test_ignores_non_embedding_models(self, mock_cache):
+        chat_impl = Mock()
+        chat_impl.model_type = ModelTypes.CHAT
+        chat_impl.model_name = "Qwen3-Embedding-4B"  # same name, wrong type
+        chat_impl.hf_model_id = "Qwen/Qwen3-Embedding-4B"
+        mock_cache.return_value = {"d1": {"model_impl": chat_impl}}
+        assert find_deployed_embedding_model("Qwen/Qwen3-Embedding-4B") is None
+
+    @patch("model_control.model_utils.get_deploy_cache")
+    def test_not_deployed_returns_none(self, mock_cache):
+        mock_cache.return_value = {}
+        assert find_deployed_embedding_model("Qwen/Qwen3-Embedding-4B") is None
+
+
+class TestEmbedText:
+    @patch("model_control.model_utils.requests.post")
+    def test_media_engine_uses_static_api_key(self, mock_post):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"embedding": [0.1]}]}
+        mock_post.return_value = mock_resp
+
+        deploy = {
+            "internal_url": "x:8000/v1/embeddings",
+            "model_impl": _embedding_impl(model_name="bge-large-en-v1.5", hf_model_id="BAAI/bge-large-en-v1.5", inference_engine="media"),
+        }
+        result = embed_text(deploy, "hello")
+
+        assert result == {"data": [{"embedding": [0.1]}]}
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"].startswith("Bearer ")
+        assert mock_post.call_args.kwargs["json"]["model"] == "BAAI/bge-large-en-v1.5"

--- a/app/backend/model_control/test_embedding_inference.py
+++ b/app/backend/model_control/test_embedding_inference.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for EmbeddingInferenceView.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from rest_framework.test import APIRequestFactory
+
+from model_control.views import EmbeddingInferenceView
+
+
+class TestEmbeddingInferenceView:
+    @patch('model_control.serializers.get_deploy_cache')
+    @patch('model_control.views.get_deploy_cache')
+    @patch('model_control.views.requests.post')
+    def test_payload_uses_hf_model_id_not_short_model_name(self, mock_post, mock_cache, mock_serializer_cache):
+        """tt-media-server's embedding runners validate "model" against the HF
+        org/repo id (e.g. "Qwen/Qwen3-Embedding-4B"), not the catalog's short
+        model_name (e.g. "Qwen3-Embedding-4B") -- sending the short name gets a
+        500 "Model ... is not supported" from the runner. Verified live against
+        a running Qwen3-Embedding-4B container."""
+        mock_impl = Mock()
+        mock_impl.model_name = "Qwen3-Embedding-4B"
+        mock_impl.hf_model_id = "Qwen/Qwen3-Embedding-4B"
+        mock_impl.inference_engine = "forge"
+
+        deploy_cache = {
+            "test_deploy_id": {
+                "internal_url": "qwen-embed:8000/v1/embeddings",
+                "model_impl": mock_impl,
+            }
+        }
+        mock_cache.return_value = deploy_cache
+        mock_serializer_cache.return_value = deploy_cache
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": [0.1, 0.2], "index": 0}],
+            "model": "Qwen/Qwen3-Embedding-4B",
+        }
+        mock_post.return_value = mock_resp
+
+        factory = APIRequestFactory()
+        request = factory.post(
+            "/models-api/embedding/",
+            {"deploy_id": "test_deploy_id", "input": "Hello world"},
+            format="json",
+        )
+        response = EmbeddingInferenceView.as_view()(request)
+
+        assert response.status_code == 200
+        sent_payload = mock_post.call_args.kwargs["json"]
+        assert sent_payload["model"] == "Qwen/Qwen3-Embedding-4B"
+
+    @patch('model_control.serializers.get_deploy_cache')
+    @patch('model_control.views.get_deploy_cache')
+    @patch('model_control.views.requests.post')
+    def test_falls_back_to_model_name_when_hf_model_id_missing(self, mock_post, mock_cache, mock_serializer_cache):
+        mock_impl = Mock()
+        mock_impl.model_name = "some-embedder"
+        mock_impl.hf_model_id = None
+        mock_impl.inference_engine = "media"
+
+        deploy_cache = {
+            "test_deploy_id": {
+                "internal_url": "some-embedder:8000/v1/embeddings",
+                "model_impl": mock_impl,
+            }
+        }
+        mock_cache.return_value = deploy_cache
+        mock_serializer_cache.return_value = deploy_cache
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"object": "list", "data": []}
+        mock_post.return_value = mock_resp
+
+        factory = APIRequestFactory()
+        request = factory.post(
+            "/models-api/embedding/",
+            {"deploy_id": "test_deploy_id", "input": "Hello world"},
+            format="json",
+        )
+        response = EmbeddingInferenceView.as_view()(request)
+
+        assert response.status_code == 200
+        sent_payload = mock_post.call_args.kwargs["json"]
+        assert sent_payload["model"] == "some-embedder"
+
+    @patch('model_control.serializers.get_deploy_cache')
+    @patch('model_control.views.get_deploy_cache')
+    def test_missing_input_is_rejected(self, mock_cache, mock_serializer_cache):
+        deploy_cache = {
+            "test_deploy_id": {"internal_url": "x:8000/v1/embeddings", "model_impl": Mock()}
+        }
+        mock_cache.return_value = deploy_cache
+        mock_serializer_cache.return_value = deploy_cache
+
+        factory = APIRequestFactory()
+        request = factory.post(
+            "/models-api/embedding/", {"deploy_id": "test_deploy_id"}, format="json"
+        )
+        response = EmbeddingInferenceView.as_view()(request)
+        assert response.status_code == 400
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/app/backend/model_control/test_embedding_inference.py
+++ b/app/backend/model_control/test_embedding_inference.py
@@ -15,7 +15,7 @@ from model_control.views import EmbeddingInferenceView
 class TestEmbeddingInferenceView:
     @patch('model_control.serializers.get_deploy_cache')
     @patch('model_control.views.get_deploy_cache')
-    @patch('model_control.views.requests.post')
+    @patch('model_control.model_utils.requests.post')
     def test_payload_uses_hf_model_id_not_short_model_name(self, mock_post, mock_cache, mock_serializer_cache):
         """tt-media-server's embedding runners validate "model" against the HF
         org/repo id (e.g. "Qwen/Qwen3-Embedding-4B"), not the catalog's short
@@ -59,7 +59,7 @@ class TestEmbeddingInferenceView:
 
     @patch('model_control.serializers.get_deploy_cache')
     @patch('model_control.views.get_deploy_cache')
-    @patch('model_control.views.requests.post')
+    @patch('model_control.model_utils.requests.post')
     def test_falls_back_to_model_name_when_hf_model_id_missing(self, mock_post, mock_cache, mock_serializer_cache):
         mock_impl = Mock()
         mock_impl.model_name = "some-embedder"

--- a/app/backend/model_control/urls.py
+++ b/app/backend/model_control/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("face-recognition/faces/", views.FaceRecognitionListView.as_view()),
     path("face-recognition/faces/<str:name>/", views.FaceRecognitionDeleteView.as_view()),
     path("tts/", views.TtsInferenceView.as_view()),
+    path("embedding/", views.EmbeddingInferenceView.as_view()),
     path("pipeline/voice/", VoicePipelineView.as_view()),
     path("health/", views.ModelHealthView.as_view()),
     path("inference_cloud/", views.InferenceCloudView.as_view()),

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -137,6 +137,7 @@ from model_control.model_utils import (
     stream_response_from_agent_api,
     health_check,
     stream_to_cloud_model,
+    embed_text,
 )
 from shared_config.model_config import model_implmentations
 from shared_config.model_type_config import ModelTypes
@@ -1401,34 +1402,12 @@ class EmbeddingInferenceView(APIView):
             return Response({"error": "input is required"}, status=status.HTTP_400_BAD_REQUEST)
 
         deploy = get_deploy_cache()[deploy_id]
-        internal_url = "http://" + deploy["internal_url"]
-        model_impl = deploy.get("model_impl")
-        # tt-media-server's embedding runners validate the request's "model" against
-        # their configured HF org/repo id (e.g. "Qwen/Qwen3-Embedding-4B"), not the
-        # catalog's short model_name (e.g. "Qwen3-Embedding-4B") -- unlike TTS/chat,
-        # which accept the short name. hf_model_id is that HF id for every embedding
-        # catalog entry; model_name is only a fallback for a record missing one.
-        hf_model_id = getattr(model_impl, "hf_model_id", None) if model_impl else None
-        model_name = hf_model_id or (getattr(model_impl, "model_name", None) if model_impl else None)
-        inference_engine = getattr(model_impl, "inference_engine", None)
-
-        # Embedding models only ship on tt-media-server (media or forge runner), which
-        # authenticates with a static API key rather than the per-deploy JWT chat models use.
-        if inference_engine in ("media", "forge"):
-            headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
-        else:
-            headers = auth_headers(deploy)
-
-        payload = {"model": model_name, "input": text}
         dimensions = data.get("dimensions")
-        if dimensions:
-            payload["dimensions"] = dimensions
 
         try:
-            embed_resp = requests.post(internal_url, json=payload, headers=headers, timeout=60)
-            embed_resp.raise_for_status()
-        except requests.exceptions.HTTPError:
-            logger.error(f"Embedding HTTP error: {embed_resp.status_code} {embed_resp.text}")
+            result = embed_text(deploy, text, dimensions=dimensions)
+        except requests.exceptions.HTTPError as http_err:
+            logger.error(f"Embedding HTTP error: {http_err}")
             return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except requests.exceptions.RequestException as exc:
             logger.error(f"Could not reach the embedding model: {exc}")
@@ -1437,7 +1416,7 @@ class EmbeddingInferenceView(APIView):
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
-        return Response(embed_resp.json(), status=status.HTTP_200_OK)
+        return Response(result, status=status.HTTP_200_OK)
 
 
 class OpenAIAudioSpeechView(APIView):

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -1386,6 +1386,60 @@ class TtsInferenceView(APIView):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+class EmbeddingInferenceView(APIView):
+    """Text embedding inference: proxies to tt-media-server's OpenAI-compatible /v1/embeddings."""
+    def post(self, request, *args, **kwargs):
+        data = request.data
+        logger.info(f"{self.__class__.__name__} data:={data}")
+        serializer = InferenceSerializer(data=data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        deploy_id = data.get("deploy_id")
+        text = data.get("input") or data.get("text")
+        if not text:
+            return Response({"error": "input is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        deploy = get_deploy_cache()[deploy_id]
+        internal_url = "http://" + deploy["internal_url"]
+        model_impl = deploy.get("model_impl")
+        # tt-media-server's embedding runners validate the request's "model" against
+        # their configured HF org/repo id (e.g. "Qwen/Qwen3-Embedding-4B"), not the
+        # catalog's short model_name (e.g. "Qwen3-Embedding-4B") -- unlike TTS/chat,
+        # which accept the short name. hf_model_id is that HF id for every embedding
+        # catalog entry; model_name is only a fallback for a record missing one.
+        hf_model_id = getattr(model_impl, "hf_model_id", None) if model_impl else None
+        model_name = hf_model_id or (getattr(model_impl, "model_name", None) if model_impl else None)
+        inference_engine = getattr(model_impl, "inference_engine", None)
+
+        # Embedding models only ship on tt-media-server (media or forge runner), which
+        # authenticates with a static API key rather than the per-deploy JWT chat models use.
+        if inference_engine in ("media", "forge"):
+            headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
+        else:
+            headers = auth_headers(deploy)
+
+        payload = {"model": model_name, "input": text}
+        dimensions = data.get("dimensions")
+        if dimensions:
+            payload["dimensions"] = dimensions
+
+        try:
+            embed_resp = requests.post(internal_url, json=payload, headers=headers, timeout=60)
+            embed_resp.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error(f"Embedding HTTP error: {embed_resp.status_code} {embed_resp.text}")
+            return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except requests.exceptions.RequestException as exc:
+            logger.error(f"Could not reach the embedding model: {exc}")
+            return Response(
+                {"error": f"Could not reach the embedding model: {exc}"},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(embed_resp.json(), status=status.HTTP_200_OK)
+
+
 class OpenAIAudioSpeechView(APIView):
     """OpenAI-compatible POST /v1/audio/speech — looks up deployed TTS model by name."""
     def post(self, request, *args, **kwargs):
@@ -1742,6 +1796,7 @@ class ModelAPIInfoView(APIView):
             "object_detection": "/object-detection/",
             "speech_recognition": "/speech-recognition/",
             "tts": "/tts/",
+            "embedding": "/embedding/",
         }
         return endpoint_map.get(model_type)
 

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -27,9 +27,9 @@ _TYPE_ROUTING = {
     ModelTypes.MOCK: ("/v1/chat/completions", "vllm"),
     ModelTypes.VLM: ("/v1/chat/completions", "vllm"),
     ModelTypes.CNN: ("/v1/chat/completions", "forge"),
-    # Embedding models on the media server take /enqueue, not a chat route.
-    # TT Studio has no embedding UI, so this is for identification/parity only.
-    ModelTypes.EMBEDDING: ("/enqueue", "media"),
+    # tt-media-server mounts embedding.router at /v1 for both the media and forge
+    # runners (see tt-media-server/open_ai_api/__init__.py), so this is engine-independent.
+    ModelTypes.EMBEDDING: ("/v1/embeddings", "media"),
     ModelTypes.TTS: ("/v1/audio/speech", "media"),
     ModelTypes.SPEECH_RECOGNITION: ("/v1/audio/transcriptions", "media"),
     ModelTypes.IMAGE_GENERATION: ("/v1/images/generations", "media"),

--- a/app/backend/shared_config/model_config.py
+++ b/app/backend/shared_config/model_config.py
@@ -104,6 +104,15 @@ class ModelImpl:
     # Only honoured for requires_dev_catalog models (see
     # docker_control.views._resolve_artifact_ref).
     inference_artifact_ref: Optional[Dict[str, str]] = None
+    # Hand-derived tt-inference-server ModelSpec JSON to pass as
+    # --runtime-model-spec-json when deploying on the given device, for a
+    # (model, device) pair the source artifact never declares -- e.g. a model
+    # that only ships a multi-chip mesh spec but genuinely runs on one chip or
+    # one card. Keyed by the tt-studio device name (e.g. "P150"); paths are
+    # relative to TT_STUDIO_ROOT. See sync_models_from_inference_server's
+    # STUDIO_CHIP_TIER_MODELS/apply_chip_tier_overrides, which generate the spec
+    # files and populate this, and docker_utils.run_container, which consumes it.
+    runtime_model_spec_overrides: Optional[Dict[str, str]] = None
 
     def __post_init__(self):
         # _init methods compute values that are dependent on other values
@@ -394,6 +403,7 @@ def load_model_implementations_from_json(json_path: Path) -> list:
             param_count=entry.get("param_count"),
             requires_dev_catalog=entry.get("requires_dev_catalog", False),
             inference_artifact_ref=entry.get("inference_artifact_ref"),
+            runtime_model_spec_overrides=entry.get("runtime_model_spec_overrides"),
         )
         impls.append(impl)
     return impls

--- a/app/backend/shared_config/model_overrides.py
+++ b/app/backend/shared_config/model_overrides.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Load and validate model_overrides.toml (co-located with this file).
+
+Stdlib-only, deliberately: sync_models_from_inference_server.py runs standalone
+on the host interpreter (outside Django), and docker_control.docker_utils runs
+inside it -- this module is the one place both can import overrides data from
+without either pulling in the other's dependencies.
+
+Exposes the exact shapes each caller already consumed as Python literals
+before this file existed, so callers (and their tests, which monkeypatch these
+dicts directly) need no changes beyond where the data now comes from:
+
+    STUDIO_UNAVAILABLE_REASONS  tuple[str, ...]
+    STUDIO_UNAVAILABLE_MODELS   {model_name: (reason, details)}
+    STUDIO_UNAVAILABLE_DEVICES  {model_name: {device: (reason, details)}}
+    VLLM_MESH_SPEC_FALLBACK     {device: (alt_device, ...)}
+    MEDIA_IMAGE_OVERRIDES       {(model_name, device_or_"*"): docker_image}
+    TRACE_REGION_OVERRIDES      {(model_name, device): trace_region_size}
+    CHIP_TIER_MODELS            {model_name: base_device}
+    CHIP_TIERS                  {model_name: {device: device_ids}}
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from difflib import get_close_matches
+from pathlib import Path
+
+OVERRIDES_PATH = Path(__file__).parent / "model_overrides.toml"
+OVERRIDES_SCHEMA_VERSION = 1
+VALID_REASONS = ("known_broken", "unsupported_in_studio")
+
+
+class OverridesError(Exception):
+    """A model_overrides.toml entry the loader refuses to guess its way past."""
+
+
+def _require(entry: dict, fields: tuple[str, ...], where: str) -> None:
+    missing = [f for f in fields if not entry.get(f)]
+    if missing:
+        raise OverridesError(f"{where}: entry {entry!r} is missing {', '.join(missing)}.")
+
+
+def _check_lowercase(value: str, field: str, where: str) -> None:
+    if value != value.lower():
+        raise OverridesError(
+            f"{where}: {field} {value!r} must be lowercase (the runtime "
+            f"inference-server device name) -- use {value.lower()!r}."
+        )
+
+
+def _parse_unavailable(entries: list[dict], where: str) -> tuple[dict, dict]:
+    models: dict[str, tuple[str, str]] = {}
+    devices: dict[str, dict[str, tuple[str, str]]] = {}
+    seen: set[tuple[str, str | None]] = set()
+    for entry in entries:
+        _require(entry, ("model", "reason", "details"), where)
+        if entry["reason"] not in VALID_REASONS:
+            raise OverridesError(
+                f"{where}: {entry['model']} has unknown reason {entry['reason']!r}; "
+                f"expected one of {VALID_REASONS}."
+            )
+        key = (entry["model"], entry.get("device"))
+        if key in seen:
+            raise OverridesError(
+                f"{where}: duplicate [[unavailable]] entry for "
+                f"{key[0]} / {key[1] or '(model-wide)'}."
+            )
+        seen.add(key)
+
+        mark = (entry["reason"], " ".join(entry["details"].split()))
+        device = entry.get("device")
+        if device is None:
+            models[entry["model"]] = mark
+        else:
+            devices.setdefault(entry["model"], {})[device] = mark
+    return models, devices
+
+
+def _parse_device_fallback(entries: list[dict], where: str) -> dict[str, tuple[str, ...]]:
+    fallback: dict[str, list[str]] = {}
+    for entry in entries:
+        _require(entry, ("device", "serve_as"), where)
+        _check_lowercase(entry["device"], "device", where)
+        _check_lowercase(entry["serve_as"], "serve_as", where)
+        if entry["device"] == entry["serve_as"]:
+            raise OverridesError(f"{where}: device_fallback for {entry['device']!r} points at itself.")
+        fallback.setdefault(entry["device"], []).append(entry["serve_as"])
+    return {device: tuple(alts) for device, alts in fallback.items()}
+
+
+def _parse_serve_override(
+    entries: list[dict], where: str
+) -> tuple[dict[tuple[str, str], str], dict[tuple[str, str], int]]:
+    images: dict[tuple[str, str], str] = {}
+    trace_regions: dict[tuple[str, str], int] = {}
+    seen: set[tuple[str, str]] = set()
+    for entry in entries:
+        _require(entry, ("model",), where)
+        if not (entry.get("docker_image") or entry.get("trace_region_size")):
+            raise OverridesError(
+                f"{where}: serve_override for {entry['model']} sets nothing; "
+                "give it a docker_image or a trace_region_size."
+            )
+        device = entry.get("device", "*")
+        if device != "*":
+            _check_lowercase(device, "device", where)
+        key = (entry["model"], device)
+        if key in seen:
+            raise OverridesError(
+                f"{where}: duplicate serve_override for {key[0]} / {key[1]}."
+            )
+        seen.add(key)
+        if entry.get("docker_image"):
+            images[key] = entry["docker_image"]
+        if entry.get("trace_region_size"):
+            trace_regions[key] = int(entry["trace_region_size"])
+    return images, trace_regions
+
+
+def _parse_chip_tier(
+    entries: list[dict], where: str
+) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    base_devices: dict[str, str] = {}
+    tiers: dict[str, dict[str, str]] = {}
+    for entry in entries:
+        _require(entry, ("model", "base_device", "tiers"), where)
+        if entry["model"] in base_devices:
+            raise OverridesError(f"{where}: duplicate chip_tier entry for {entry['model']}.")
+        base_devices[entry["model"]] = entry["base_device"]
+        tiers[entry["model"]] = dict(entry["tiers"])
+    return base_devices, tiers
+
+
+def known_devices_hint(device: str, known: list[str]) -> str:
+    """" Did you mean 'X'?" for an unavailable/serve_override device typo, or ""."""
+    near = get_close_matches(device, known, n=1)
+    return f" Did you mean {near[0]!r}?" if near else ""
+
+
+class ModelOverrides:
+    """Parsed, validated contents of model_overrides.toml."""
+
+    def __init__(self, path: Path = OVERRIDES_PATH) -> None:
+        where = str(path)
+        try:
+            doc = tomllib.loads(path.read_text())
+        except FileNotFoundError:
+            raise OverridesError(f"{where}: not found.") from None
+        except tomllib.TOMLDecodeError as exc:
+            raise OverridesError(f"{where}: invalid TOML ({exc}).") from exc
+
+        if doc.get("schema_version") != OVERRIDES_SCHEMA_VERSION:
+            raise OverridesError(
+                f"{where}: schema_version {doc.get('schema_version')!r}, "
+                f"expected {OVERRIDES_SCHEMA_VERSION}."
+            )
+
+        self.unavailable_models, self.unavailable_devices = _parse_unavailable(
+            doc.get("unavailable") or [], where
+        )
+        self.vllm_mesh_spec_fallback = _parse_device_fallback(
+            doc.get("device_fallback") or [], where
+        )
+        self.media_image_overrides, self.trace_region_overrides = _parse_serve_override(
+            doc.get("serve_override") or [], where
+        )
+        self.chip_tier_models, self.chip_tiers = _parse_chip_tier(
+            doc.get("chip_tier") or [], where
+        )
+
+
+def _load() -> ModelOverrides:
+    try:
+        return ModelOverrides()
+    except OverridesError as e:
+        print(f"model_overrides.toml: {e}", file=sys.stderr)
+        raise
+
+
+_overrides = _load()
+
+STUDIO_UNAVAILABLE_REASONS: tuple[str, ...] = VALID_REASONS
+STUDIO_UNAVAILABLE_MODELS: dict[str, tuple[str, str]] = _overrides.unavailable_models
+STUDIO_UNAVAILABLE_DEVICES: dict[str, dict[str, tuple[str, str]]] = _overrides.unavailable_devices
+VLLM_MESH_SPEC_FALLBACK: dict[str, tuple[str, ...]] = _overrides.vllm_mesh_spec_fallback
+MEDIA_IMAGE_OVERRIDES: dict[tuple[str, str], str] = _overrides.media_image_overrides
+TRACE_REGION_OVERRIDES: dict[tuple[str, str], int] = _overrides.trace_region_overrides
+CHIP_TIER_MODELS: dict[str, str] = _overrides.chip_tier_models
+CHIP_TIERS: dict[str, dict[str, str]] = _overrides.chip_tiers

--- a/app/backend/shared_config/model_overrides.py
+++ b/app/backend/shared_config/model_overrides.py
@@ -136,7 +136,7 @@ def _parse_chip_tier(
 
 
 def known_devices_hint(device: str, known: list[str]) -> str:
-    """" Did you mean 'X'?" for an unavailable/serve_override device typo, or ""."""
+    """A " Did you mean 'X'?" hint for an unavailable/serve_override device typo, or ""."""
     near = get_close_matches(device, known, n=1)
     return f" Did you mean {near[0]!r}?" if near else ""
 

--- a/app/backend/shared_config/model_overrides.toml
+++ b/app/backend/shared_config/model_overrides.toml
@@ -1,0 +1,286 @@
+# Declarative overrides applied on top of the tt-inference-server release spec
+# by sync_models_from_inference_server.py (unavailable/device_fallback/
+# serve_override) and docker_control/docker_utils.py (device_fallback/
+# serve_override, at deploy time). Mirrors tt-cli's
+# modelhub/model_support_overrides.toml -- same idea, and mostly the same
+# shape: a fix belongs in DATA here, not in code. `chip_tier` is the one
+# addition TT-Studio alone needs (see its own section below).
+#
+# INPUT, never generated: sync_models_from_inference_server.py reads and
+# validates this file but never writes it. Deleting an [[unavailable]] entry
+# genuinely un-hides the model/device on the next sync -- so every entry has to
+# say what breaks, or a stale mark outlives its bug. `verified_on`/`source` are
+# optional today (this file was migrated from pre-existing Python tables with
+# no recorded verification history) but should be filled in on new entries.
+#
+# device values are lowercase (the runtime inference-server device name, e.g.
+# "p300x2") for `device_fallback` and `serve_override` -- matching what
+# docker_utils.py resolves at deploy time. For `unavailable`, device is the
+# tt-studio "device_configurations" spelling instead (e.g. "P300x2") -- that
+# table acts on the catalog after normalization, which already uses that
+# casing everywhere (the frontend's compatibility badge, infer_chips_required).
+
+schema_version = 1
+
+# ===========================================================================
+# Unavailable model/device marks
+# ===========================================================================
+# The source artifact advertises models/devices TT-Studio must not offer.
+# Deleting those rows from the catalog was the old approach and it does not
+# survive: normalize() rebuilds from the source JSON on every sync, so every
+# removal had to be redone by hand, and the catalog lost the record of *why*.
+# These marks are script-owned, NOT hand-owned: this file is the single source
+# of truth, so deleting an entry genuinely unhides the model/device.
+#
+# reason:
+#   known_broken          - does not deploy, or deploys and does not run. A bug.
+#   unsupported_in_studio - runs fine on the inference server, but TT-Studio
+#                           has no UI for its modality. Nothing is broken;
+#                           there is just nowhere to put it.
+#
+# Omit `device` for a defect that is not board-specific -- prefer naming a
+# device where possible, since a model-wide mark hides the model from boards
+# nobody ever tested. A device the model's spec does not claim is an error,
+# not a silent no-op: a casing slip ("P150x4" vs the catalog's "P150X4") once
+# left a model on offer on a board it was meant to be pulled from.
+
+[[unavailable]]
+model = "yolox_nano"
+reason = "known_broken"
+details = """
+Not deployable today, and not because of any board: the forge image runs as \
+USER=container_app_user (uid 1000) while CACHE_ROOT's named Docker volume is \
+created root-owned, so warmup dies in ~0.3s with a PermissionError on \
+cache_root/huggingface before the device is ever opened. Verified on P300x2; \
+the same volume ownership applies on every board. Drop this entry once the \
+forge image ships a uid-1000-owned cache_root. Will be available in \
+tt-inference-server release after merging raahem/yolox_nano_qb2 into main, or \
+once the object detection UI is fixed in TT-Studio and the model is added to \
+the catalog with a custom branch."""
+
+[[unavailable]]
+model = "Falcon3-7B-Instruct"
+reason = "known_broken"
+details = """
+Not deployable today, and not because of any board: the forge image runs as \
+USER=container_app_user (uid 1000) while CACHE_ROOT's named Docker volume is \
+created root-owned, so warmup dies in ~0.3s with a PermissionError on \
+cache_root/huggingface before the device is ever opened. Verified on P300x2; \
+the same volume ownership applies on every board. Drop this entry once the \
+forge image ships a uid-1000-owned cache_root."""
+
+[[unavailable]]
+model = "Z-Image-Turbo"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Wedges Blackhole P300 devices during warmup (eth-core init timeout or a hard \
+device hang mid kernel-compile) badly enough that the host needs a board \
+reset. Re-enable once the media image ships a tt-metal/firmware combo \
+validated on fw 19.7.0."""
+
+[[unavailable]]
+model = "Motif-Image-6B-Preview"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Media container never reaches a healthy state. Verified broken on a P300x2 \
+(4x p300c Blackhole) box. Untested on this model's other boards, so it stays \
+available there."""
+
+[[unavailable]]
+model = "gpt-oss-120b"
+device = "P300x2"
+reason = "known_broken"
+details = """
+vLLM container never reaches a healthy state. Verified broken on a P300x2 \
+(4x p300c Blackhole) box. Untested on this model's other boards, so it stays \
+available there."""
+
+[[unavailable]]
+model = "mochi-1-preview"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Deploy fails with the catalog-pinned image; needs a newer media image plus a \
+spec-level env override the artifact does not carry. Verified broken on a \
+P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it \
+stays available there."""
+
+[[unavailable]]
+model = "DeepSeek-R1-Distill-Llama-70B"
+device = "P150X4"
+reason = "known_broken"
+details = """
+Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry \
+below: both four-chip Blackhole meshes are known bad for it, so neither is \
+offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay \
+available."""
+
+[[unavailable]]
+model = "DeepSeek-R1-Distill-Llama-70B"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Non-functional deploy (#869). Verified broken on a P300x2 (4x p300c \
+Blackhole) box. Untested on this model's other boards, so it stays available \
+there."""
+
+[[unavailable]]
+model = "Llama-3.1-70B"
+device = "P150X4"
+reason = "known_broken"
+details = """
+Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry \
+below: both four-chip Blackhole meshes are known bad for it, so neither is \
+offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay \
+available."""
+
+[[unavailable]]
+model = "Llama-3.1-70B"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Base (non-instruct) 70B pulled alongside the Instruct variant in #904; deploy \
+does not resolve a usable image. Verified broken on a P300x2 (4x p300c \
+Blackhole) box. Untested on this model's other boards, so it stays available \
+there."""
+
+[[unavailable]]
+model = "Llama-3.1-70B-Instruct"
+device = "P150X4"
+reason = "known_broken"
+details = """
+Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry \
+below: both four-chip Blackhole meshes are known bad for it, so neither is \
+offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay \
+available."""
+
+[[unavailable]]
+model = "Llama-3.1-70B-Instruct"
+device = "P300x2"
+reason = "known_broken"
+details = """
+Removed from the deploy UI in #904 - deploy needs a docker image override the \
+catalog cannot express. Use Llama-3.3-70B-Instruct. Verified broken on a \
+P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it \
+stays available there."""
+
+[[unavailable]]
+model = "Qwen3-8B"
+device = "P300"
+reason = "known_broken"
+details = """
+Removed from the deploy UI in #878 after failing on our Blackhole box. Scoped \
+to P300 rather than P300x2 because this model only ever claims the \
+single-chip Blackhole device; its Wormhole boards (N150/N300/T3K/Galaxy) are \
+untested and stay available."""
+
+[[unavailable]]
+model = "Llama-3.3-70B-Instruct"
+device = "P150X4"
+reason = "known_broken"
+details = "Trace region size currently set to 30MB, it needs to be increased to minimum 57MB."
+
+# ===========================================================================
+# vLLM mesh device fallback
+# ===========================================================================
+# The vLLM plugin maps both four-chip Blackhole mesh labels to the same (1, 4)
+# topology, so a chat model that only publishes a spec for one can still be
+# asked for on the other's hardware by sending the other name. Consumed both
+# at deploy time (docker_utils.equivalent_mesh_device/claims_whole_board) and
+# by the catalog's compatibility check (vllm_mesh_fallback_fits).
+
+[[device_fallback]]
+device = "p150x4"
+serve_as = "p300x2"
+
+[[device_fallback]]
+device = "p300x2"
+serve_as = "p150x4"
+
+# ===========================================================================
+# Serve-time overrides
+# ===========================================================================
+# Flags docker_utils.run_container must force because the resolved spec's own
+# value is wrong or missing. Omit `device` to apply to every device for that
+# model (see Wan2.2-T2V-A14B-Diffusers below).
+#
+#   docker_image       -> override_docker_image
+#   trace_region_size  -> override_tt_config's trace_region_size (bytes)
+
+[[serve_override]]
+model = "Wan2.2-T2V-A14B-Diffusers"
+docker_image = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+details = """
+0.17.0 carries the MODEL_WEIGHTS_DIR fix (tt-inference-server#4107), so the \
+container reads the mounted host HF cache instead of re-downloading ~118GB. \
+Applies on every board."""
+
+[[serve_override]]
+model = "FLUX.1-dev"
+device = "p150x4"
+docker_image = "ghcr.io/tenstorrent/tt-media-inference-server:0.17.0-8c48a10"
+trace_region_size = 51_000_000
+details = """
+That spec resolves to image 0.10.0-555f240, whose API this backend can no \
+longer drive -- pin the newer image instead. The p150x4 spec also omits \
+trace_region_size and inherits 34.5MB; traced warmup needs 50,724,864 bytes, \
+matching this model's maintained P300X2 spec."""
+
+[[serve_override]]
+model = "FLUX.1-schnell"
+device = "p150x4"
+docker_image = "ghcr.io/tenstorrent/tt-media-inference-server:0.18.0-c49bb76"
+trace_region_size = 51_000_000
+details = """
+That spec resolves to image 0.10.0-555f240, whose API this backend can no \
+longer drive -- pin the newer image instead. The p150x4 spec also omits \
+trace_region_size and inherits 34.5MB; traced warmup needs 50,724,864 bytes, \
+matching this model's maintained P300X2 spec."""
+
+[[serve_override]]
+model = "Llama-3.3-70B-Instruct"
+device = "p150x4"
+trace_region_size = 402_653_184
+details = """
+p150x4 spec is stale at 0.10.x with 30000000; traced decode needs 56557568. \
+Value matches the maintained p300x2 spec for the same four-chip mesh."""
+
+# ===========================================================================
+# Chip tiers (TT-Studio-specific -- no tt-cli equivalent)
+# ===========================================================================
+# Models the source artifact only ever declares on a whole-board mesh (e.g.
+# P300x2), but which genuinely run on a single constituent chip or one card --
+# confirmed by hand-launching them with a custom runtime model spec. There is
+# no upstream ModelConfigs entry for (this model, single-chip/card device), so
+# run.py's own spec resolution hard-rejects the combination outright; the only
+# sanctioned bypass is --runtime-model-spec-json, which takes a spec file as-is
+# with no resolution/validation. Rather than hand-maintain a full duplicate
+# spec file per tier (drifts from the real upstream spec the moment
+# tt-inference-server bumps an image/commit/vllm arg),
+# apply_chip_tier_overrides() derives each tier from the real, current
+# upstream `base_device` spec at every sync. `tiers` maps a
+# device_configurations name to the DEVICE_IDS env var value (tt-media-server's
+# scheduler splits on "),(" and spawns one independent data-parallel worker per
+# group -- see tt-media-server/config/constants.py's DeviceIds; DEVICE_IDS_1/_2
+# there are the exact upstream values already used for single-card P150/P300
+# deploys). See issue: Qwen3-Embedding-0.6B/4B and bge-m3
+# single-chip/card-pair-on-P300x2 (run.py --tt-device p150/p300 works;
+# --tt-device p300x2 with --device-id N does not -- it wrongly pins the 4-chip
+# mesh init to fewer chips).
+
+[[chip_tier]]
+model = "Qwen3-Embedding-0.6B"
+base_device = "p300x2"
+tiers = { P150 = "(0)", P300 = "(0),(1)" }
+
+[[chip_tier]]
+model = "Qwen3-Embedding-4B"
+base_device = "p300x2"
+tiers = { P150 = "(0)", P300 = "(0),(1)" }
+
+[[chip_tier]]
+model = "bge-m3"
+base_device = "p300x2"
+tiers = { P150 = "(0)", P300 = "(0),(1)" }

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "artifact_version": "0.21.0",
-    "generated_at": "2026-09-10T15:44:22.421575+00:00"
+    "generated_at": "2026-09-10T17:35:17.098729+00:00"
   },
   "total_models": 72,
   "models": [
@@ -33,7 +33,7 @@
       "unavailable_devices": {
         "P150X4": {
           "reason": "known_broken",
-          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry above: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
+          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry below: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
         },
         "P300x2": {
           "reason": "known_broken",
@@ -138,7 +138,7 @@
       "unavailable_devices": {
         "P150X4": {
           "reason": "known_broken",
-          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry above: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
+          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry below: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
         },
         "P300x2": {
           "reason": "known_broken",
@@ -174,7 +174,7 @@
       "unavailable_devices": {
         "P150X4": {
           "reason": "known_broken",
-          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry above: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
+          "details": "Does not deploy on P150X4 either. Blocked alongside this model's P300x2 entry below: both four-chip Blackhole meshes are known bad for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K specs are untested and stay available."
         },
         "P300x2": {
           "reason": "known_broken",
@@ -584,7 +584,7 @@
       },
       "available_in_studio": false,
       "unavailable_reason": "known_broken",
-      "unavailable_details": "Not deployable today, and not because of any board: the forge image runs as USER=container_app_user (uid 1000) while CACHE_ROOT's named Docker volume is created root-owned, so warmup dies in ~0.3s with a PermissionError on cache_root/huggingface before the device is ever opened. Verified on P300x2; the same volume ownership applies on every board. Drop this entry once the forge image ships a uid-1000-owned cache_root."
+      "unavailable_details": "Not deployable today, and not because of any board: the forge image runs as USER=container_app_user (uid 1000) while CACHE_ROOT's named Docker volume is created root-owned, so warmup dies in ~0.3s with a PermissionError on cache_root/huggingface before the device is ever opened. Verified on P300x2; the same volume ownership applies on every board. Drop this entry once the forge image ships a uid-1000-owned cache_root. Will be available in tt-inference-server release after merging raahem/yolox_nano_qb2 into main, or once the object detection UI is fixed in TT-Studio and the model is added to the catalog with a custom branch."
     },
     {
       "model_name": "Llama-3.2-11B-Vision",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "artifact_version": "0.21.0",
-    "generated_at": "2026-09-02T22:33:48.536105+00:00"
+    "generated_at": "2026-09-10T00:59:10.791227+00:00"
   },
   "total_models": 72,
   "models": [
@@ -1090,7 +1090,7 @@
       "status": "EXPERIMENTAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-      "service_route": "/enqueue",
+      "service_route": "/v1/embeddings",
       "health_route": "/health",
       "env_vars": {
         "VLLM__MAX_NUM_BATCHED_TOKENS": "3072",
@@ -1100,10 +1100,7 @@
         "MAX_BATCH_SIZE": "8",
         "DEFAULT_THROTTLE_LEVEL": "0"
       },
-      "param_count": null,
-      "available_in_studio": false,
-      "unavailable_reason": "unsupported_in_studio",
-      "unavailable_details": "No embeddings UI in TT-Studio yet; the model itself deploys and serves correctly on the inference server."
+      "param_count": null
     },
     {
       "model_name": "bge-m3",
@@ -1116,7 +1113,7 @@
       "status": "EXPERIMENTAL",
       "version": "0.20.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
+      "service_route": "/v1/embeddings",
       "health_route": "/health",
       "env_vars": {
         "MODEL_RUNNER": "vllmforge_bge_m3",
@@ -1132,15 +1129,15 @@
         "TT_METAL_INSPECTOR_RPC": "0"
       },
       "param_count": null,
-      "available_in_studio": false,
-      "unavailable_reason": "known_broken",
-      "unavailable_details": "No supported device left: P300x2: Non-functional deploy (#869). Separate from the embedding modality gap: this model does not run. Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it stays available there.",
       "unavailable_devices": {
         "P300x2": {
           "reason": "known_broken",
           "details": "Non-functional deploy (#869). Separate from the embedding modality gap: this model does not run. Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it stays available there."
         }
-      }
+      },
+      "available_in_studio": false,
+      "unavailable_reason": "known_broken",
+      "unavailable_details": "No supported device left: P300x2: Non-functional deploy (#869). Separate from the embedding modality gap: this model does not run. Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it stays available there."
     },
     {
       "model_name": "DeepSeek-R1-0528",
@@ -1678,7 +1675,7 @@
       "status": "EXPERIMENTAL",
       "version": "0.20.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
+      "service_route": "/v1/embeddings",
       "health_route": "/health",
       "env_vars": {
         "MODEL_RUNNER": "vllmforge_qwen_embedding_0_6b",
@@ -1693,10 +1690,7 @@
         "DEFAULT_THROTTLE_LEVEL": "0",
         "TT_METAL_INSPECTOR_RPC": "0"
       },
-      "param_count": 0,
-      "available_in_studio": false,
-      "unavailable_reason": "unsupported_in_studio",
-      "unavailable_details": "No embeddings UI in TT-Studio yet; the model itself deploys and serves correctly on the inference server."
+      "param_count": 0
     },
     {
       "model_name": "Qwen3-Embedding-4B",
@@ -1715,7 +1709,7 @@
       "status": "EXPERIMENTAL",
       "version": "0.20.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server-forge:0.20.0-de59f8a",
-      "service_route": "/v1/chat/completions",
+      "service_route": "/v1/embeddings",
       "health_route": "/health",
       "env_vars": {
         "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
@@ -1725,10 +1719,7 @@
         "MAX_BATCH_SIZE": "1",
         "DEFAULT_THROTTLE_LEVEL": "0"
       },
-      "param_count": 4,
-      "available_in_studio": false,
-      "unavailable_reason": "unsupported_in_studio",
-      "unavailable_details": "No embeddings UI in TT-Studio yet; the model itself deploys and serves correctly on the inference server."
+      "param_count": 4
     },
     {
       "model_name": "Qwen3-Embedding-8B",
@@ -1746,7 +1737,7 @@
       "status": "EXPERIMENTAL",
       "version": "0.12.0",
       "docker_image": "ghcr.io/tenstorrent/tt-media-inference-server:0.2.0-2496be4518bca0a7a5b497a4cda3cfe7e2f59756",
-      "service_route": "/enqueue",
+      "service_route": "/v1/embeddings",
       "health_route": "/health",
       "env_vars": {
         "VLLM__MAX_NUM_BATCHED_TOKENS": "1024",
@@ -1754,10 +1745,7 @@
         "VLLM__MIN_CONTEXT_LENGTH": "32",
         "VLLM__MAX_NUM_SEQS": "1"
       },
-      "param_count": 8,
-      "available_in_studio": false,
-      "unavailable_reason": "unsupported_in_studio",
-      "unavailable_details": "No embeddings UI in TT-Studio yet; the model itself deploys and serves correctly on the inference server."
+      "param_count": 8
     },
     {
       "model_name": "Qwen3.5-9B",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -1,7 +1,7 @@
 {
   "source": {
     "artifact_version": "0.21.0",
-    "generated_at": "2026-09-10T00:59:10.791227+00:00"
+    "generated_at": "2026-09-10T15:44:22.421575+00:00"
   },
   "total_models": 72,
   "models": [
@@ -1106,7 +1106,11 @@
       "model_name": "bge-m3",
       "model_type": "EMBEDDING",
       "display_model_type": "EMBEDDING",
-      "device_configurations": [],
+      "device_configurations": [
+        "P150",
+        "P300",
+        "P300x2"
+      ],
       "hf_model_id": "BAAI/bge-m3",
       "inference_engine": "forge",
       "impl": null,
@@ -1129,15 +1133,10 @@
         "TT_METAL_INSPECTOR_RPC": "0"
       },
       "param_count": null,
-      "unavailable_devices": {
-        "P300x2": {
-          "reason": "known_broken",
-          "details": "Non-functional deploy (#869). Separate from the embedding modality gap: this model does not run. Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it stays available there."
-        }
-      },
-      "available_in_studio": false,
-      "unavailable_reason": "known_broken",
-      "unavailable_details": "No supported device left: P300x2: Non-functional deploy (#869). Separate from the embedding modality gap: this model does not run. Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on this model's other boards, so it stays available there."
+      "runtime_model_spec_overrides": {
+        "P150": "app/backend/shared_config/runtime_model_specs/bge-m3-p150.json",
+        "P300": "app/backend/shared_config/runtime_model_specs/bge-m3-p300.json"
+      }
     },
     {
       "model_name": "DeepSeek-R1-0528",
@@ -1667,6 +1666,8 @@
       "model_type": "EMBEDDING",
       "display_model_type": "EMBEDDING",
       "device_configurations": [
+        "P150",
+        "P300",
         "P300x2"
       ],
       "hf_model_id": "Qwen/Qwen3-Embedding-0.6B",
@@ -1690,7 +1691,11 @@
         "DEFAULT_THROTTLE_LEVEL": "0",
         "TT_METAL_INSPECTOR_RPC": "0"
       },
-      "param_count": 0
+      "param_count": 0,
+      "runtime_model_spec_overrides": {
+        "P150": "app/backend/shared_config/runtime_model_specs/qwen3-embedding-0.6b-p150.json",
+        "P300": "app/backend/shared_config/runtime_model_specs/qwen3-embedding-0.6b-p300.json"
+      }
     },
     {
       "model_name": "Qwen3-Embedding-4B",
@@ -1700,6 +1705,8 @@
         "GALAXY",
         "N150",
         "N300",
+        "P150",
+        "P300",
         "P300x2",
         "T3K"
       ],
@@ -1719,7 +1726,11 @@
         "MAX_BATCH_SIZE": "1",
         "DEFAULT_THROTTLE_LEVEL": "0"
       },
-      "param_count": 4
+      "param_count": 4,
+      "runtime_model_spec_overrides": {
+        "P150": "app/backend/shared_config/runtime_model_specs/qwen3-embedding-4b-p150.json",
+        "P300": "app/backend/shared_config/runtime_model_specs/qwen3-embedding-4b-p300.json"
+      }
     },
     {
       "model_name": "Qwen3-Embedding-8B",

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -66,8 +66,9 @@ HAND_OWNED_MARKER = "hand_owned"
 # had to be re-done by hand after each resync (see the string of "remove
 # non-working models" commits), and the catalog lost the record of *why* a model
 # was pulled. Instead the rows stay and carry a mark, applied on every sync from
-# the two tables below, so hiding a model is a one-line, reproducible edit here
-# rather than a JSON deletion someone has to remember to repeat.
+# model_overrides.toml's [[unavailable]] entries, so hiding a model is a
+# one-line, reproducible edit there rather than a JSON deletion someone has to
+# remember to repeat.
 #
 # Two distinct reasons, deliberately not conflated:
 #   known_broken          - the model does not deploy or does not run correctly
@@ -77,211 +78,33 @@ HAND_OWNED_MARKER = "hand_owned"
 #                           TT-Studio has no UI for its modality yet. Nothing is
 #                           broken; there is just nowhere to put it.
 #
-# These marks are script-owned, NOT hand-owned: the tables here are the single
-# source of truth, so deleting an entry below genuinely unhides the model on the
-# next sync instead of a stale flag in the JSON resurrecting it.
-STUDIO_UNAVAILABLE_REASONS = ("known_broken", "unsupported_in_studio")
+# These marks are script-owned, NOT hand-owned: model_overrides.toml is the
+# single source of truth, so deleting an entry there genuinely unhides the
+# model on the next sync instead of a stale flag in the JSON resurrecting it.
+from model_overrides import (
+    CHIP_TIER_MODELS as STUDIO_CHIP_TIER_MODELS,
+    CHIP_TIERS as STUDIO_CHIP_TIERS,
+    STUDIO_UNAVAILABLE_DEVICES,
+    STUDIO_UNAVAILABLE_MODELS,
+    STUDIO_UNAVAILABLE_REASONS,
+)
 
 # Model types TT-Studio can deploy but has no interface for. These work.
 # For models of types that TT-Studio can deploy but has no interface for, add them here.
 UNSUPPORTED_STUDIO_MODEL_TYPES: dict[str, str] = {}
 
-# Model-wide overrides, keyed by catalog model_name, for breakage that is
-# genuinely independent of hardware (a bad chat template, a missing weight file,
-# a broken container image). Each value is (reason, details).
-#
-# Prefer STUDIO_UNAVAILABLE_DEVICES: most failures we see are one board's, and a
-# model-wide mark hides the model from boards nobody ever tested. Only add here
-# when the failure is known not to be board-specific -- and say how you know.
-_FORGE_CACHE_ROOT_BUG = (
-    "Not deployable today, and not because of any board: the forge image runs as "
-    "USER=container_app_user (uid 1000) while CACHE_ROOT's named Docker volume is "
-    "created root-owned, so warmup dies in ~0.3s with a PermissionError on "
-    "cache_root/huggingface before the device is ever opened. Verified on P300x2; "
-    "the same volume ownership applies on every board. Drop this entry once the "
-    "forge image ships a uid-1000-owned cache_root."
-)
-
-STUDIO_UNAVAILABLE_MODELS: dict[str, tuple[str, str]] = {
-    # yolox_nano will be available in tt-inference-server release after merging of raahem/yolox_nano_qb2 into main branch
-    # or once the object detection UI is fixed in TT-Studio and the model is added to the catalog with a custom branch.
-    "yolox_nano": ("known_broken", _FORGE_CACHE_ROOT_BUG),
-    "Falcon3-7B-Instruct": ("known_broken", _FORGE_CACHE_ROOT_BUG),
-}
 
 
-
-# Per-device unavailability: the artifact advertises a model on several boards
-# and it genuinely works on some of them. Marking the whole model hidden would
-# throw away the boards where it runs, so these are keyed by
-# model_name -> {device_configuration: (reason, details)}. Device keys use the
-# tt-studio spelling that lands in "device_configurations" (e.g. "P300x2").
-#
-# The sync REMOVES the named device from device_configurations and records why in
-# an "unavailable_devices" object. That is deliberate: every consumer already
-# gates on device_configurations (docker_control's compatibility check, the
+# Per-device unavailability and the chip-tier table (STUDIO_UNAVAILABLE_DEVICES,
+# STUDIO_CHIP_TIER_MODELS, STUDIO_CHIP_TIERS) are imported above from
+# model_overrides -- see model_overrides.toml's [[unavailable]] and
+# [[chip_tier]] entries for the data and model_overrides.py's docstring for the
+# exact shapes. Sync REMOVES a marked device from device_configurations and
+# records why in an "unavailable_devices" object: every consumer already gates
+# on device_configurations (docker_control's compatibility check, the
 # frontend's is_compatible badge, infer_chips_required), so per-device hiding
-# needs no new logic anywhere -- the model simply stops claiming a board it
-# cannot run on, and the reason stays in the file for whoever asks later.
-#
-# If every device is removed this way, the model falls back to being hidden
-# outright rather than being left with an empty device list.
-STUDIO_UNAVAILABLE_DEVICES: dict[str, dict[str, tuple[str, str]]] = {
-    "Z-Image-Turbo": {
-        "P300x2": (
-            "known_broken",
-            (
-                "Wedges Blackhole P300 devices during warmup (eth-core init timeout "
-                "or a hard device hang mid kernel-compile) badly enough that the host "
-                "needs a board reset. Re-enable once the media image ships a "
-                "tt-metal/firmware combo validated on fw 19.7.0."
-            ),
-        ),
-    },
-    "Motif-Image-6B-Preview": {
-        "P300x2": (
-            "known_broken",
-            (
-                "Media container never reaches a healthy state. Verified broken on a "
-                "P300x2 (4x p300c Blackhole) box. Untested on this model's other "
-                "boards, so it stays available there."
-            ),
-        ),
-    },
-    "gpt-oss-120b": {
-        "P300x2": (
-            "known_broken",
-            (
-                "vLLM container never reaches a healthy state. Verified broken on a "
-                "P300x2 (4x p300c Blackhole) box. Untested on this model's other "
-                "boards, so it stays available there."
-            ),
-        ),
-    },
-    "mochi-1-preview": {
-        "P300x2": (
-            "known_broken",
-            (
-                "Deploy fails with the catalog-pinned image; needs a newer media "
-                "image plus a spec-level env override the artifact does not carry. "
-                "Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on "
-                "this model's other boards, so it stays available there."
-            ),
-        ),
-    },
-    "DeepSeek-R1-Distill-Llama-70B": {
-        "P150X4": (
-            "known_broken",
-            (
-                "Does not deploy on P150X4 either. Blocked alongside this model's "
-                "P300x2 entry above: both four-chip Blackhole meshes are known bad "
-                "for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K "
-                "specs are untested and stay available."
-            ),
-        ),
-        "P300x2": (
-            "known_broken",
-            (
-                "Non-functional deploy (#869). Verified broken on a P300x2 (4x p300c "
-                "Blackhole) box. Untested on this model's other boards, so it stays "
-                "available there."
-            ),
-        ),
-    },
-    "Llama-3.1-70B": {
-        "P150X4": (
-            "known_broken",
-            (
-                "Does not deploy on P150X4 either. Blocked alongside this model's "
-                "P300x2 entry above: both four-chip Blackhole meshes are known bad "
-                "for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K "
-                "specs are untested and stay available."
-            ),
-        ),
-        "P300x2": (
-            "known_broken",
-            (
-                "Base (non-instruct) 70B pulled alongside the Instruct variant in "
-                "#904; deploy does not resolve a usable image. Verified broken on a "
-                "P300x2 (4x p300c Blackhole) box. Untested on this model's other "
-                "boards, so it stays available there."
-            ),
-        ),
-    },
-    "Llama-3.1-70B-Instruct": {
-        "P150X4": (
-            "known_broken",
-            (
-                "Does not deploy on P150X4 either. Blocked alongside this model's "
-                "P300x2 entry above: both four-chip Blackhole meshes are known bad "
-                "for it, so neither is offered. Its GALAXY/GALAXY_T3K/P150X8/T3K "
-                "specs are untested and stay available."
-            ),
-        ),
-        "P300x2": (
-            "known_broken",
-            (
-                "Removed from the deploy UI in #904 - deploy needs a docker image "
-                "override the catalog cannot express. Use Llama-3.3-70B-Instruct. "
-                "Verified broken on a P300x2 (4x p300c Blackhole) box. Untested on "
-                "this model's other boards, so it stays available there."
-            ),
-        ),
-    },
-    "Qwen3-8B": {
-        "P300": (
-            "known_broken",
-            (
-                "Removed from the deploy UI in #878 after failing on our Blackhole "
-                "box. Scoped to P300 rather than P300x2 because this model only ever "
-                "claims the single-chip Blackhole device; its Wormhole boards "
-                "(N150/N300/T3K/Galaxy) are untested and stay available."
-            ),
-        ),
-    },
-    "Llama-3.3-70B-Instruct": {
-        "P150X4": (
-            "known_broken",
-            (
-                "Trace region size currently set to 30MB, it needs to be increased to minimum 57MB."
-            ),
-        ),
-    }
-}
-
-
-# Models the source artifact only ever declares on a multi-chip mesh (e.g.
-# P300x2), but which genuinely run on a single constituent chip or one P300
-# card -- confirmed by hand-launching them with a custom runtime model spec.
-# There is no upstream ModelConfigs entry for (this model, single-chip/card
-# device), so run.py's own spec resolution hard-rejects the combination
-# outright (raises "No model spec matches..."); the only sanctioned bypass is
-# --runtime-model-spec-json, which takes a spec file as-is with no
-# resolution/validation. Rather than hand-maintain a full duplicate spec file
-# per tier (drifts from the real upstream spec the moment tt-inference-server
-# bumps an image/commit/vllm arg), generate_chip_tier_specs() derives each
-# tier from the real, current upstream board_device spec below -- mirrors the
-# existing small-override pattern used for image pins (_MEDIA_IMAGE_OVERRIDES)
-# and dev branches (inference_artifact_ref) instead of shipping static JSON.
-# Value is the board device the real base spec is fetched from and derived
-# from -- always the whole-board mesh today. See issue: Qwen3-Embedding-0.6B/4B
-# and bge-m3 single-chip/card-pair-on-P300x2 (run.py --tt-device p150/p300
-# works; --tt-device p300x2 with --device-id N does not -- it wrongly pins the
-# 4-chip mesh init to fewer chips).
-STUDIO_CHIP_TIER_MODELS: dict[str, str] = {
-    "Qwen3-Embedding-0.6B": "p300x2",
-    "Qwen3-Embedding-4B": "p300x2",
-    "bge-m3": "p300x2",
-}
-
-# device_type -> DEVICE_IDS env var value (tt-media-server's scheduler splits
-# on "),(" and spawns one independent data-parallel worker per group -- see
-# tt-media-server/config/constants.py's DeviceIds; DEVICE_IDS_1/_2 there are
-# the exact upstream values already used for single-card P150/P300 deploys).
-STUDIO_CHIP_TIERS: dict[str, str] = {
-    "P150": "(0)",
-    "P300": "(0),(1)",
-}
+# needs no new logic anywhere. If every device is removed this way, the model
+# falls back to being hidden outright rather than left with an empty list.
 
 RUNTIME_MODEL_SPECS_DIR = SCRIPT_DIR / "runtime_model_specs"
 
@@ -370,7 +193,7 @@ def apply_chip_tier_overrides(models: list) -> list:
         base = _load_upstream_model_spec(model["hf_model_id"], board_device)
         devices = list(model.get("device_configurations") or [])
         specs = dict(model.get("runtime_model_spec_overrides") or {})
-        for device_type, device_ids in STUDIO_CHIP_TIERS.items():
+        for device_type, device_ids in STUDIO_CHIP_TIERS[model_name].items():
             spec_path = RUNTIME_MODEL_SPECS_DIR / f"{model_name.lower()}-{device_type.lower()}.json"
             if base is not None:
                 derived = _derive_chip_tier_spec(base, device_type, device_ids)

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -81,12 +81,8 @@ HAND_OWNED_MARKER = "hand_owned"
 STUDIO_UNAVAILABLE_REASONS = ("known_broken", "unsupported_in_studio")
 
 # Model types TT-Studio can deploy but has no interface for. These work.
-UNSUPPORTED_STUDIO_MODEL_TYPES = {
-    "EMBEDDING": (
-        "No embeddings UI in TT-Studio yet; the model itself deploys and serves "
-        "correctly on the inference server."
-    ),
-}
+# For models of types that TT-Studio can deploy but has no interface for, add them here.
+UNSUPPORTED_STUDIO_MODEL_TYPES: dict[str, str] = {}
 
 # Model-wide overrides, keyed by catalog model_name, for breakage that is
 # genuinely independent of hardware (a bad chat template, a missing weight file,
@@ -552,6 +548,12 @@ def map_service_route(inference_engine: str, hf_model_id: str = "", raw_model_ty
         hf_model_id: HuggingFace model ID (for vLLM chat detection)
         raw_model_type: Raw model type from inference server (TEXT_TO_SPEECH, TTS, etc.)
     """
+    # Embedding models register tt-media-server's embedding.router at "/v1" regardless of
+    # which runner backs them (media or forge) -- see tt-media-server/open_ai_api/__init__.py
+    # SERVICE_ROUTER_MAP[EMBEDDING]. Check this before the per-engine branches below, which
+    # would otherwise route forge-backed embedding models (e.g. bge-m3) to /v1/chat/completions.
+    if raw_model_type == "EMBEDDING":
+        return "/v1/embeddings"
     if inference_engine == "vLLM":
         return "/v1/chat/completions" if is_chat_capable(hf_model_id) else "/v1/completions"
     if inference_engine == "media":
@@ -569,7 +571,7 @@ def map_service_route(inference_engine: str, hf_model_id: str = "", raw_model_ty
             if "i2v" in hf_model_id.lower():
                 return "/v1/videos/generations/i2v"
             return "/v1/videos/generations"
-        # Other media models (embedding, etc.) use enqueue
+        # Other media models use enqueue
         return "/enqueue"
     if inference_engine == "forge":
         if raw_model_type == "TRAINING":

--- a/app/backend/shared_config/sync_models_from_inference_server.py
+++ b/app/backend/shared_config/sync_models_from_inference_server.py
@@ -11,8 +11,10 @@ Run from any directory:
     python app/backend/shared_config/sync_models_from_inference_server.py
 """
 
+import copy
 import json
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -167,17 +169,6 @@ STUDIO_UNAVAILABLE_DEVICES: dict[str, dict[str, tuple[str, str]]] = {
             ),
         ),
     },
-    "bge-m3": {
-        "P300x2": (
-            "known_broken",
-            (
-                "Non-functional deploy (#869). Separate from the embedding modality "
-                "gap: this model does not run. Verified broken on a P300x2 (4x p300c "
-                "Blackhole) box. Untested on this model's other boards, so it stays "
-                "available there."
-            ),
-        ),
-    },
     "DeepSeek-R1-Distill-Llama-70B": {
         "P150X4": (
             "known_broken",
@@ -257,6 +248,145 @@ STUDIO_UNAVAILABLE_DEVICES: dict[str, dict[str, tuple[str, str]]] = {
         ),
     }
 }
+
+
+# Models the source artifact only ever declares on a multi-chip mesh (e.g.
+# P300x2), but which genuinely run on a single constituent chip or one P300
+# card -- confirmed by hand-launching them with a custom runtime model spec.
+# There is no upstream ModelConfigs entry for (this model, single-chip/card
+# device), so run.py's own spec resolution hard-rejects the combination
+# outright (raises "No model spec matches..."); the only sanctioned bypass is
+# --runtime-model-spec-json, which takes a spec file as-is with no
+# resolution/validation. Rather than hand-maintain a full duplicate spec file
+# per tier (drifts from the real upstream spec the moment tt-inference-server
+# bumps an image/commit/vllm arg), generate_chip_tier_specs() derives each
+# tier from the real, current upstream board_device spec below -- mirrors the
+# existing small-override pattern used for image pins (_MEDIA_IMAGE_OVERRIDES)
+# and dev branches (inference_artifact_ref) instead of shipping static JSON.
+# Value is the board device the real base spec is fetched from and derived
+# from -- always the whole-board mesh today. See issue: Qwen3-Embedding-0.6B/4B
+# and bge-m3 single-chip/card-pair-on-P300x2 (run.py --tt-device p150/p300
+# works; --tt-device p300x2 with --device-id N does not -- it wrongly pins the
+# 4-chip mesh init to fewer chips).
+STUDIO_CHIP_TIER_MODELS: dict[str, str] = {
+    "Qwen3-Embedding-0.6B": "p300x2",
+    "Qwen3-Embedding-4B": "p300x2",
+    "bge-m3": "p300x2",
+}
+
+# device_type -> DEVICE_IDS env var value (tt-media-server's scheduler splits
+# on "),(" and spawns one independent data-parallel worker per group -- see
+# tt-media-server/config/constants.py's DeviceIds; DEVICE_IDS_1/_2 there are
+# the exact upstream values already used for single-card P150/P300 deploys).
+STUDIO_CHIP_TIERS: dict[str, str] = {
+    "P150": "(0)",
+    "P300": "(0),(1)",
+}
+
+RUNTIME_MODEL_SPECS_DIR = SCRIPT_DIR / "runtime_model_specs"
+
+
+def _load_upstream_model_spec(hf_model_repo: str, board_device: str) -> dict | None:
+    """The real, current upstream ModelSpec for hf_model_repo on board_device,
+    as a plain dict, fetched straight from the tt-inference-server artifact's
+    own workflows.model_spec (the same resolution run.py itself uses).
+
+    Never raises -- returns None if the artifact isn't fetched yet or the pair
+    can't be resolved, so callers can fall back to leaving an already-generated
+    file in place instead of breaking the whole catalog sync.
+    """
+    try:
+        artifact_root = resolve_source_json().parent
+    except FileNotFoundError:
+        return None
+    artifact_root_str = str(artifact_root)
+    if artifact_root_str not in sys.path:
+        sys.path.insert(0, artifact_root_str)
+    os.environ.setdefault(
+        "OVERRIDE_BENCHMARK_TARGETS",
+        str(artifact_root / "reference_config/benchmarking/benchmark_targets/model_performance_reference.json"),
+    )
+    try:
+        import workflows.utils as _wf_utils
+
+        _wf_utils.get_repo_root_path = lambda marker=".git", _root=artifact_root: _root
+        from workflows.model_spec import get_runtime_model_spec
+
+        spec, _impl, _engine = get_runtime_model_spec(hf_model_repo, board_device)
+        return spec.get_serialized_dict()
+    except Exception as e:
+        print(
+            f"chip-tier override: could not load upstream spec for "
+            f"{hf_model_repo} on {board_device}: {e}"
+        )
+        return None
+
+
+def _derive_chip_tier_spec(base: dict, device_type: str, device_ids: str) -> dict:
+    """One P150/P300 variant of `base` (a real whole-board spec dict): same
+    model/image/engine, with only the device identity and worker split
+    overridden. VLLMForge on P300 already uses this exact DEVICE_IDS_2 pattern
+    upstream (tt-media-server/config/constants.py) -- this just derives the
+    equivalent spec for a model that has no native P150/P300 entry."""
+    spec = copy.deepcopy(base)
+    spec["device_type"] = device_type
+    spec["device_model_spec"]["device"] = device_type
+    spec["model_id"] = spec["model_id"].rsplit("_", 1)[0] + "_" + device_type.lower()
+    vllm_overrides = json.dumps(
+        {
+            "model": spec["hf_model_repo"],
+            "max_model_length": 2048,
+            "max_num_batched_tokens": 16384,
+            "min_context_length": 32,
+            "max_num_seqs": 8,
+        }
+    )
+    for env in (spec["device_model_spec"]["env_vars"], spec["env_vars"]):
+        env["MESH_DEVICE"] = device_type
+        env["DEVICE_IDS"] = device_ids
+        env["IS_GALAXY"] = "false"
+        env["VLLM"] = vllm_overrides
+    return spec
+
+
+def apply_chip_tier_overrides(models: list) -> list:
+    """Regenerate the P150/P300 runtime_model_specs/*.json for each model in
+    STUDIO_CHIP_TIER_MODELS from its real, current upstream board spec, and
+    point device_configurations + runtime_model_spec_overrides at them.
+    Returns the list of model_names touched.
+
+    Idempotent, and safe to re-run even offline: each tier's file is
+    regenerated from the live artifact every run (so it can never drift from
+    the real spec), but a model whose upstream spec can't be fetched this run
+    keeps whatever file already exists on disk instead of losing the override.
+    """
+    RUNTIME_MODEL_SPECS_DIR.mkdir(parents=True, exist_ok=True)
+    by_name = {m["model_name"]: m for m in models}
+    touched = []
+    for model_name, board_device in STUDIO_CHIP_TIER_MODELS.items():
+        model = by_name.get(model_name)
+        if not model:
+            continue
+        base = _load_upstream_model_spec(model["hf_model_id"], board_device)
+        devices = list(model.get("device_configurations") or [])
+        specs = dict(model.get("runtime_model_spec_overrides") or {})
+        for device_type, device_ids in STUDIO_CHIP_TIERS.items():
+            spec_path = RUNTIME_MODEL_SPECS_DIR / f"{model_name.lower()}-{device_type.lower()}.json"
+            if base is not None:
+                derived = _derive_chip_tier_spec(base, device_type, device_ids)
+                with open(spec_path, "w") as f:
+                    json.dump(derived, f, indent=2)
+                    f.write("\n")
+            elif not spec_path.exists():
+                continue  # No fresh base and no existing file -- can't offer this tier.
+            if device_type not in devices:
+                devices.append(device_type)
+            specs[device_type] = str(spec_path.relative_to(_REPO_ROOT.resolve()))
+        devices.sort()
+        model["device_configurations"] = devices
+        model["runtime_model_spec_overrides"] = specs
+        touched.append(model_name)
+    return touched
 
 
 def apply_device_availability(models: list) -> list:
@@ -775,6 +905,12 @@ def main():
     for _m in models:
         if "impl" in _m:
             _m["impl"] = _impl_selector(_m.get("impl"))
+
+    # Add chip-tier device + spec overrides before the availability passes, so
+    # a model's device_configurations already reflects them going in.
+    chip_tiers = apply_chip_tier_overrides(models)
+    if chip_tiers:
+        print(f"Applied chip-tier overrides: {', '.join(sorted(chip_tiers))}")
 
     # Mark (don't delete) the models TT-Studio won't offer. Keeping the rows means
     # the next resync doesn't silently reintroduce them and the reason travels

--- a/app/backend/shared_config/test_external_model_config.py
+++ b/app/backend/shared_config/test_external_model_config.py
@@ -42,11 +42,11 @@ class TestBuildExternalModelImpl:
         assert impl.service_port == 8000
         assert impl.hf_model_id == "org/my-tts"
 
-    def test_embedding_uses_the_media_enqueue_contract(self):
-        # Not a chat route: media embedding models serve /enqueue, and TT Studio
-        # has no embedding UI to drive a chat endpoint anyway.
+    def test_embedding_uses_the_openai_embeddings_route(self):
+        # tt-media-server mounts embedding.router at /v1 for both the media and
+        # forge runners, so this is the route regardless of engine.
         impl = build_external_model_impl("some-embedder", "embedding")
-        assert impl.service_route == "/enqueue"
+        assert impl.service_route == "/v1/embeddings"
         assert impl.inference_engine == "media"
 
     def test_chat_model_routes_like_a_catalog_chat_model(self):

--- a/app/backend/shared_config/test_sync_models.py
+++ b/app/backend/shared_config/test_sync_models.py
@@ -50,9 +50,14 @@ class TestServiceRouteMapping:
         assert map_service_route("media", "", "IMAGE_GENERATION") == "/v1/images/generations"
 
     def test_non_image_media_models_use_enqueue(self):
-        """Non-image/non-audio/non-video media models should use /enqueue."""
+        """Non-image/non-audio/non-video/non-embedding media models should use /enqueue."""
         assert map_service_route("media", "", "CNN") == "/enqueue"
-        assert map_service_route("media", "", "EMBEDDING") == "/enqueue"
+
+    def test_embedding_models_use_v1_embeddings_regardless_of_engine(self):
+        """Embedding models mount tt-media-server's embedding.router at /v1 on both
+        the media and forge runners, so the route must not depend on inference_engine."""
+        assert map_service_route("media", "", "EMBEDDING") == "/v1/embeddings"
+        assert map_service_route("forge", "", "EMBEDDING") == "/v1/embeddings"
 
     def test_video_gen_media_models_use_v1_videos_generations(self):
         """T2V video generation media models should use /v1/videos/generations."""
@@ -415,12 +420,12 @@ class TestStudioAvailability:
         assert models[0]["available_in_studio"] is False
         assert models[0]["unavailable_details"]
 
-    def test_embeddings_are_unsupported_not_broken(self):
-        """The distinction matters: these deploy fine, Studio just has no UI."""
+    def test_embeddings_are_no_longer_type_level_unsupported(self):
+        """Studio has an Embeddings UI now, so EMBEDDING carries no type-level mark;
+        only a specific STUDIO_UNAVAILABLE_MODELS/_DEVICES entry can hide one."""
         models = [{"model_name": "some-embedder", "model_type": "EMBEDDING"}]
-        apply_studio_availability(models)
-        assert models[0]["unavailable_reason"] == "unsupported_in_studio"
-        assert models[0]["unavailable_reason"] != "known_broken"
+        assert apply_studio_availability(models) == []
+        assert "unavailable_reason" not in models[0]
 
     def test_per_model_override_beats_the_type_rule(self):
         """An EMBEDDING model that is also genuinely broken reads as broken."""

--- a/app/backend/vector_db_control/chroma.py
+++ b/app/backend/vector_db_control/chroma.py
@@ -23,6 +23,21 @@ def list_collections(filter_func=None):
     return chroma_collections
 
 
+def embedding_func_name_for(collection_name: str, default: str) -> str:
+    """The embedding_func_name a collection was actually created with, from its
+    stored metadata -- not necessarily the caller's own default. Collections can
+    now be created with different embedding functions (e.g. a TT-hardware model
+    instead of the local ONNX default), so every subsequent get/query/insert on
+    an existing collection must reuse whatever it was created with, or it lands
+    in the wrong vector space. Falls back to `default` if the collection can't be
+    found or predates this field.
+    """
+    for collection in list_collections():
+        if collection.name == collection_name:
+            return (collection.metadata or {}).get("embedding_func_name") or default
+    return default
+
+
 def get_collection(collection_name: str, embedding_func_name: str):
     embedding_func = get_embedding_function(model_name=embedding_func_name)
     return ChromaClient().get_collection(

--- a/app/backend/vector_db_control/singletons.py
+++ b/app/backend/vector_db_control/singletons.py
@@ -9,6 +9,7 @@ from chromadb import HttpClient, Settings, ClientAPI
 from chromadb.utils import embedding_functions
 
 from shared_config.logger_config import get_logger
+from vector_db_control.tt_embedding_function import TT_EMBED_PREFIX, TTDeployedEmbeddingFunction
 
 logger = get_logger(__name__)
 
@@ -23,17 +24,28 @@ ONNX_EMBED_MODEL = embedding_functions.ONNXMiniLM_L6_V2.MODEL_NAME
 
 def get_embedding_function(model_name: str):
     """
-    Returns the singleton instance of the all-MiniLM-L6-v2 embedding model.
-    Ensures that the model is loaded only once in a thread-safe manner.
+    Returns the singleton embedding function for `model_name`, thread-safely
+    creating it on first use.
 
-    Uses ChromaDB's ONNX embedding function rather than sentence-transformers,
-    which requires torch and pulls in ~4.5 GB of CUDA wheels the backend never
-    uses. Both run the same all-MiniLM-L6-v2 weights and produce interchangeable
-    384-dimension vectors, so collections embedded either way stay queryable.
-
-    `model_name` is retained because callers store it as collection metadata,
-    but the ONNX function supports only all-MiniLM-L6-v2.
+    Two families:
+    - "tt-embed:<model_identifier>" -- a TT-hardware-deployed embedding model
+      (see vector_db_control.tt_embedding_function). The live deploy is
+      re-resolved by identity on every call, so nothing is cached beyond the
+      wrapper object itself.
+    - anything else -- ChromaDB's built-in ONNX all-MiniLM-L6-v2, the default
+      for every collection that doesn't opt into a TT-hardware model. Used
+      instead of sentence-transformers, which requires torch and pulls in
+      ~4.5 GB of CUDA wheels the backend never uses; both run the same weights
+      and produce interchangeable 384-dimension vectors.
     """
+    if model_name.startswith(TT_EMBED_PREFIX):
+        if model_name not in _instances:
+            with _lock:
+                if model_name not in _instances:
+                    _instances[model_name] = TTDeployedEmbeddingFunction(
+                        model_name[len(TT_EMBED_PREFIX):]
+                    )
+        return _instances[model_name]
 
     # Check if the model instance already exists
     if model_name not in _instances:

--- a/app/backend/vector_db_control/test_tt_embedding_function.py
+++ b/app/backend/vector_db_control/test_tt_embedding_function.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Tests for TTDeployedEmbeddingFunction and its dispatch through get_embedding_function.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from vector_db_control.singletons import get_embedding_function
+from vector_db_control.tt_embedding_function import TT_EMBED_PREFIX, TTDeployedEmbeddingFunction
+
+
+class TestTTDeployedEmbeddingFunction:
+    @patch("model_control.model_utils.embed_text")
+    @patch("model_control.model_utils.find_deployed_embedding_model")
+    def test_embeds_each_input_via_the_deployed_model(self, mock_find, mock_embed):
+        mock_find.return_value = {"internal_url": "x:8000/v1/embeddings"}
+        mock_embed.side_effect = [
+            {"data": [{"embedding": [0.1, 0.2]}]},
+            {"data": [{"embedding": [0.3, 0.4]}]},
+        ]
+
+        fn = TTDeployedEmbeddingFunction("Qwen/Qwen3-Embedding-4B")
+        result = fn(["a", "b"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        mock_find.assert_called_with("Qwen/Qwen3-Embedding-4B")
+
+    @patch("model_control.model_utils.find_deployed_embedding_model")
+    def test_raises_clearly_when_model_not_deployed(self, mock_find):
+        mock_find.return_value = None
+        fn = TTDeployedEmbeddingFunction("Qwen/Qwen3-Embedding-4B")
+        with pytest.raises(RuntimeError, match="not currently deployed"):
+            fn(["a"])
+
+
+class TestGetEmbeddingFunctionDispatch:
+    def test_tt_embed_prefix_returns_tt_deployed_function(self):
+        fn = get_embedding_function(f"{TT_EMBED_PREFIX}Qwen/Qwen3-Embedding-4B")
+        assert isinstance(fn, TTDeployedEmbeddingFunction)
+        assert fn.model_identifier == "Qwen/Qwen3-Embedding-4B"
+
+    def test_repeated_calls_return_the_same_instance(self):
+        first = get_embedding_function(f"{TT_EMBED_PREFIX}bge-m3")
+        second = get_embedding_function(f"{TT_EMBED_PREFIX}bge-m3")
+        assert first is second

--- a/app/backend/vector_db_control/tt_embedding_function.py
+++ b/app/backend/vector_db_control/tt_embedding_function.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""
+Chroma-compatible embedding function backed by a TT-hardware-deployed embedding
+model, via the same /v1/embeddings proxy path model_control.EmbeddingInferenceView
+uses. Lets a collection be embedded with e.g. Qwen3-Embedding-4B instead of the
+default local ONNX MiniLM (see vector_db_control.singletons.get_embedding_function).
+"""
+
+from shared_config.logger_config import get_logger
+
+logger = get_logger(__name__)
+
+# Prefix that marks a collection's embedding_func_name as TT-hardware-backed
+# rather than the local ONNX MiniLM default. The rest of the string is the
+# model's stable identity (hf_model_id or model_name) -- never a deploy_id,
+# which is a container id that doesn't survive a redeploy.
+TT_EMBED_PREFIX = "tt-embed:"
+
+
+class TTDeployedEmbeddingFunction:
+    """A Chroma collection created with embedding_func_name="tt-embed:<model_identifier>"
+    resolves back to an instance of this on every get_embedding_function() call.
+    The live deploy is re-resolved by model identity on every embed call rather
+    than captured once, since deploy/container ids churn across redeploys.
+    """
+
+    def __init__(self, model_identifier: str):
+        self.model_identifier = model_identifier
+
+    def __call__(self, input):
+        # Imported lazily: vector_db_control has no other dependency on
+        # model_control, and importing it at module load time would run
+        # model_control's own app-loading side effects during vector_db_control's.
+        from model_control.model_utils import embed_text, find_deployed_embedding_model
+
+        deploy = find_deployed_embedding_model(self.model_identifier)
+        if deploy is None:
+            raise RuntimeError(
+                f"Embedding model '{self.model_identifier}' is not currently "
+                "deployed. Redeploy it to use this collection."
+            )
+        return [embed_text(deploy, text)["data"][0]["embedding"] for text in input]

--- a/app/backend/vector_db_control/tt_embedding_function.py
+++ b/app/backend/vector_db_control/tt_embedding_function.py
@@ -41,4 +41,7 @@ class TTDeployedEmbeddingFunction:
                 f"Embedding model '{self.model_identifier}' is not currently "
                 "deployed. Redeploy it to use this collection."
             )
-        return [embed_text(deploy, text)["data"][0]["embedding"] for text in input]
+        # A bare string is iterable character-by-character; coerce it to the
+        # single-element list a caller almost certainly meant.
+        texts = [input] if isinstance(input, str) else input
+        return [embed_text(deploy, text)["data"][0]["embedding"] for text in texts]

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -24,11 +24,13 @@ from vector_db_control.chroma import (
     insert_to_chroma_collection,
     serialize_collection,
     delete_collection,
+    embedding_func_name_for,
 )
 from vector_db_control.singletons import ChromaClient
 from vector_db_control.documents import chunk_document, deterministic_chunk_id
 from vector_db_control.retrieval import approx_token_count, retrieve
 from vector_db_control.rewrite import maybe_rewrite_query
+from vector_db_control.tt_embedding_function import TT_EMBED_PREFIX
 
 logger = get_logger(__name__)
 logger.info(f"importing {__name__}")
@@ -135,7 +137,13 @@ class VectorCollectionsAPIView(ViewSet):
         super().__init__(**kwargs)
         if hasattr(settings, "CHROMA_DB_EMBED_MODEL"):
             self.EMBED_MODEL = settings.CHROMA_DB_EMBED_MODEL
-            
+
+    def _resolve_embed_func(self, collection_name: str) -> str:
+        """The embedding_func_name an existing collection actually carries, e.g. a
+        TT-hardware model chosen at creation -- never assume self.EMBED_MODEL, or a
+        non-default collection gets queried/inserted into the wrong vector space."""
+        return embedding_func_name_for(collection_name, default=self.EMBED_MODEL)
+
     def get_user_identifier(self, request):
         """Get a unique identifier for the current user/session"""
         # Check if user is authenticated (with proper None check)
@@ -236,16 +244,31 @@ class VectorCollectionsAPIView(ViewSet):
                     )
             
             metadata.update({"user_id": user_id})
-            
+
+            # A collection can opt into a TT-hardware-deployed embedding model
+            # instead of the default local ONNX one, keyed by the model's stable
+            # identity (hf_model_id or model_name) rather than a deploy_id, which
+            # doesn't survive a redeploy.
+            tt_model_identifier = (request.data.get("tt_embedding_model") or "").strip()
+            if tt_model_identifier:
+                from model_control.model_utils import find_deployed_embedding_model
+
+                if find_deployed_embedding_model(tt_model_identifier) is None:
+                    return Response(
+                        status=status.HTTP_400_BAD_REQUEST,
+                        data={"error": f"Embedding model '{tt_model_identifier}' is not currently deployed."}
+                    )
+                embedding_func_name = f"{TT_EMBED_PREFIX}{tt_model_identifier}"
+            else:
+                embedding_func_name = self.EMBED_MODEL
+
             logger.info(f"Final metadata for creation: {metadata}")
-            
-            # Debug the EMBED_MODEL
-            logger.info(f"Using EMBED_MODEL: {self.EMBED_MODEL}")
-            
+            logger.info(f"Using embedding_func_name: {embedding_func_name}")
+
             collection = create_collection(
                 collection_name=name,
                 metadata=metadata,
-                embedding_func_name=self.EMBED_MODEL,
+                embedding_func_name=embedding_func_name,
             )
 
             # Internal knowledge lives once in the shared INTERNAL_KNOWLEDGE_COLLECTION
@@ -269,7 +292,7 @@ class VectorCollectionsAPIView(ViewSet):
             return self.list(request)
             
         collection = get_collection(
-            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
         )
         
         # Check if user has access to this collection
@@ -322,7 +345,7 @@ class VectorCollectionsAPIView(ViewSet):
             
         # Check if user has access to this collection
         collection = get_collection(
-            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
         )
         user_id = self.get_user_identifier(request)
         if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
@@ -341,7 +364,7 @@ class VectorCollectionsAPIView(ViewSet):
         logger.info(f"Insert document request for collection: {pk}")
         # Check if user has access to this collection
         collection = get_collection(
-            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
         )
         user_id = self.get_user_identifier(request)
         if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
@@ -437,7 +460,7 @@ class VectorCollectionsAPIView(ViewSet):
                 documents=documents,
                 ids=ids,
                 metadatas=metadatas,
-                embedding_func_name=self.EMBED_MODEL,
+                embedding_func_name=self._resolve_embed_func(pk),
                 upsert=True,
             )
 
@@ -446,7 +469,7 @@ class VectorCollectionsAPIView(ViewSet):
             # keeps the collection valid even if the request dies mid-way.
             try:
                 collection = get_collection(
-                    collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                    collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
                 )
                 existing = collection.get(where={"source": filename}, include=[])
                 ids_set = set(ids)
@@ -464,7 +487,7 @@ class VectorCollectionsAPIView(ViewSet):
             try:
                 # Get the collection and update its metadata
                 collection = get_collection(
-                    collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                    collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
                 )
                 
                 # Update the collection metadata to include the last uploaded document
@@ -482,7 +505,7 @@ class VectorCollectionsAPIView(ViewSet):
                 
                 # Verify the metadata was updated by re-fetching the collection
                 updated_collection = get_collection(
-                    collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                    collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
                 )
                 
                 if updated_collection.metadata and updated_collection.metadata.get('last_uploaded_document') == filename:
@@ -499,7 +522,7 @@ class VectorCollectionsAPIView(ViewSet):
                         
                         # Try one more verification
                         final_collection = get_collection(
-                            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
                         )
                         if final_collection.metadata and final_collection.metadata.get('last_uploaded_document') == filename:
                             metadata_update_success = True
@@ -531,7 +554,7 @@ class VectorCollectionsAPIView(ViewSet):
             # Add current collection metadata to response for debugging
             try:
                 current_collection = get_collection(
-                    collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                    collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
                 )
                 upload_info["collection_metadata"] = current_collection.metadata
             except Exception as meta_e:
@@ -570,7 +593,7 @@ class VectorCollectionsAPIView(ViewSet):
 
         # Check if user has access to this collection
         collection = get_collection(
-            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
         )
         user_id = self.get_user_identifier(request)
         if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:
@@ -597,11 +620,12 @@ class VectorCollectionsAPIView(ViewSet):
                 data={"error": f"Invalid query filter: {str(e)}"},
             )
 
+        embed_func_name = self._resolve_embed_func(pk)
         results = query_collection(
             collection_name=pk,
             query_texts=[query_text],
             n_results=self.query_results_limit,
-            embedding_func_name=self.EMBED_MODEL,
+            embedding_func_name=embed_func_name,
             where=where,
         )
 
@@ -609,8 +633,15 @@ class VectorCollectionsAPIView(ViewSet):
         # single-collection queries can still surface documentation, without copying the
         # corpus into every collection. The queried collection's own matches always take
         # priority (see _merge_query_results). Skip the merge when a metadata filter is
-        # set — the caller is scoping to their own chunks.
-        if pk != INTERNAL_KNOWLEDGE_COLLECTION and not where:
+        # set — the caller is scoping to their own chunks. Also skip it for a
+        # collection embedded with a different function (e.g. a TT-hardware model):
+        # the internal-knowledge collection is always MiniLM-embedded, and merging
+        # distances computed in two different vector spaces is meaningless.
+        if (
+            pk != INTERNAL_KNOWLEDGE_COLLECTION
+            and not where
+            and embed_func_name == self.EMBED_MODEL
+        ):
             try:
                 internal_results = query_collection(
                     collection_name=INTERNAL_KNOWLEDGE_COLLECTION,
@@ -665,11 +696,16 @@ class VectorCollectionsAPIView(ViewSet):
         for collection in user_collections:
             logger.info(f"Querying collection: {collection.name}")
             try:
+                # Already have the collection object from list_collections() above,
+                # so read its embedding_func_name straight off it rather than
+                # re-fetching (see _resolve_embed_func for why this can't be a flat
+                # self.EMBED_MODEL: a collection may be TT-hardware-embedded).
+                collection_embed_func = (collection.metadata or {}).get("embedding_func_name") or self.EMBED_MODEL
                 results = query_collection(
                     collection_name=collection.name,
                     query_texts=[query_text],
                     n_results=self.query_results_limit,
-                    embedding_func_name=self.EMBED_MODEL,
+                    embedding_func_name=collection_embed_func,
                     where=where,
                 )
                 if results and results.get("documents"):
@@ -709,7 +745,15 @@ class VectorCollectionsAPIView(ViewSet):
     @action(methods=["POST"], detail=False, url_path="retrieve", url_name="retrieve-documents")
     def retrieve_documents(self, request):
         """Server-side RAG pipeline: rewrite -> dense + BM25 -> RRF -> rerank ->
-        parent expansion -> relevance threshold -> token budget."""
+        parent expansion -> relevance threshold -> token budget.
+
+        Still assumes every target collection shares self.EMBED_MODEL (unlike
+        query()/query_all_collections(), which resolve each collection's own
+        embedding_func_name). A collection embedded with a different function --
+        e.g. a TT-hardware model -- fails dense retrieval for that collection with
+        a clear per-collection error in collection_errors rather than silently
+        returning wrong results; it just isn't reachable via this endpoint yet.
+        """
         import time as _time
 
         started = _time.monotonic()
@@ -890,19 +934,20 @@ class VectorCollectionsAPIView(ViewSet):
             )
 
         try:
+            embed_func_name = self._resolve_embed_func(pk)
             collection = get_collection(
-                collection_name=pk, embedding_func_name=self.EMBED_MODEL
+                collection_name=pk, embedding_func_name=embed_func_name
             )
-            
+
             # Get all documents from the collection
             results = collection.get(
                 include=["metadatas", "documents", "embeddings"]
             )
-            
+
             debug_info = {
                 "collection_name": pk,
                 "total_documents": len(results.get("documents", [])) if results else 0,
-                "embedding_model": self.EMBED_MODEL,
+                "embedding_model": embed_func_name,
                 "sample_documents": results.get("documents", [])[:3] if results else [],  # First 3 docs
                 "sample_metadatas": results.get("metadatas", [])[:3] if results else [],  # First 3 metadatas
                 "has_embeddings": bool(results.get("embeddings")) if results else False,
@@ -929,7 +974,7 @@ class VectorCollectionsAPIView(ViewSet):
 
         # Check if user has access to this collection
         collection = get_collection(
-            collection_name=pk, embedding_func_name=self.EMBED_MODEL
+            collection_name=pk, embedding_func_name=self._resolve_embed_func(pk)
         )
         user_id = self.get_user_identifier(request)
         if collection.metadata and collection.metadata.get('user_id') and collection.metadata.get('user_id') != user_id:

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -514,6 +514,38 @@ export interface EmbeddingResult {
   model: string;
 }
 
+export interface DeployedEmbeddingModel {
+  id: string;
+  modelName: string;
+  /** The HF org/repo id, when known -- the stable identity a Chroma collection
+   * locks itself to (see EmbeddingDemo / RagManagement's embedding picker). */
+  hfModelId?: string;
+}
+
+/** Currently deployed embedding models, for any UI that lets the user pick one
+ * to back a Chroma collection with (EmbeddingDemo's Documents tab, RAG upload). */
+export const fetchEmbeddingModels = async (): Promise<DeployedEmbeddingModel[]> => {
+  try {
+    const res = await fetch("/models-api/deployed/");
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Object.entries(data)
+      .map(([id, info]: [string, any]) => ({
+        id,
+        modelName:
+          info.model_impl?.model_name ||
+          info.model_impl?.hf_model_id ||
+          "Unknown",
+        hfModelId: info.model_impl?.hf_model_id,
+        model_type: info.model_impl?.model_type,
+      }))
+      .filter((m) => m.model_type === "embedding")
+      .map(({ id, modelName, hfModelId }) => ({ id, modelName, hfModelId }));
+  } catch {
+    return [];
+  }
+};
+
 export const runEmbeddingInference = async (
   deployId: string,
   input: string,

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -71,13 +71,12 @@ export const ModelType = {
 };
 
 /**
- * Model types TT Studio has no interaction page for. Embedding models have no UI
- * at all (they are consumed by RAG, not driven directly), and an unidentified
- * container has no known request shape — offering either a Chat page or the
- * chat-shaped API page for them would only lead somewhere that cannot work.
- * Such models still show their status and keep Logs/Delete.
+ * Model types TT Studio has no interaction page for. An unidentified container
+ * has no known request shape — offering a Chat page or the chat-shaped API
+ * page for it would only lead somewhere that cannot work. Such models still
+ * show their status and keep Logs/Delete.
  */
-const MODEL_TYPES_WITHOUT_UI: string[] = [ModelType.Embedding, ModelType.Unknown];
+const MODEL_TYPES_WITHOUT_UI: string[] = [ModelType.Unknown];
 
 export const hasInteractionPage = (frontendModelType: string): boolean =>
   !MODEL_TYPES_WITHOUT_UI.includes(frontendModelType);
@@ -452,7 +451,7 @@ export const getDestinationFromModelType = (modelType: string): string => {
     case ModelType.TTS:
       return "/tts";
     case ModelType.Embedding:
-      return "/chat"; // placeholder
+      return "/embedding";
     case ModelType.CNN:
       return "/object-detection"; // CNN reuses object detection UI
     case ModelType.Training:
@@ -507,6 +506,29 @@ export const runTTSInference = async (
     throw new Error(`TTS request failed: HTTP ${response.status}`);
   }
   return response.blob();
+};
+
+// ----- Embedding Inference -----
+export interface EmbeddingResult {
+  embedding: number[];
+  model: string;
+}
+
+export const runEmbeddingInference = async (
+  deployId: string,
+  input: string,
+): Promise<EmbeddingResult> => {
+  const response = await fetch("/models-api/embedding/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ deploy_id: deployId, input }),
+  });
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Embedding request failed: HTTP ${response.status} ${errorText}`);
+  }
+  const data = await response.json();
+  return { embedding: data.data?.[0]?.embedding ?? [], model: data.model };
 };
 
 // ----- Voice Pipeline -----
@@ -611,6 +633,9 @@ export const getModelTypeFromName = (
   }
   if (combined.includes("tts")) {
     return ModelType.TTS;
+  }
+  if (combined.includes("embed") || combined.includes("bge")) {
+    return ModelType.Embedding;
   }
   if (combined.includes("training") || combined.includes("finetune") || combined.includes("fine-tune")) {
     return ModelType.Training;

--- a/app/frontend/src/api/modelsDeployedApis.ts
+++ b/app/frontend/src/api/modelsDeployedApis.ts
@@ -522,14 +522,28 @@ export interface DeployedEmbeddingModel {
   hfModelId?: string;
 }
 
-/** Currently deployed embedding models, for any UI that lets the user pick one
- * to back a Chroma collection with (EmbeddingDemo's Documents tab, RAG upload). */
-export const fetchEmbeddingModels = async (): Promise<DeployedEmbeddingModel[]> => {
+/** Shared shape for every "pick which deployed model to use" dropdown
+ * (EmbeddingDemo, TTSDemo, Chat's model selector, Speech to Text). */
+export type DeployedModelSummary = DeployedEmbeddingModel;
+
+/** Deployed models of the given backend model_type(s), filtered to only ones
+ * that have actually finished warming up. A model still deploying/starting is
+ * a running container that fetchModelHealth (the same live probe the navbar
+ * uses to gate its own nav entries) has not yet reported "healthy" for --
+ * listing it here would let a user pick a model that can't serve a request
+ * yet. Type matching is case-insensitive: backend endpoints don't agree on
+ * casing for model_type ("embedding" vs "EMBEDDING"). */
+export const fetchHealthyModelsByType = async (
+  modelType: string | string[]
+): Promise<DeployedModelSummary[]> => {
+  const wanted = (Array.isArray(modelType) ? modelType : [modelType]).map((t) =>
+    t.toLowerCase()
+  );
   try {
     const res = await fetch("/models-api/deployed/");
     if (!res.ok) return [];
     const data = await res.json();
-    return Object.entries(data)
+    const candidates = Object.entries(data)
       .map(([id, info]: [string, any]) => ({
         id,
         modelName:
@@ -537,14 +551,25 @@ export const fetchEmbeddingModels = async (): Promise<DeployedEmbeddingModel[]> 
           info.model_impl?.hf_model_id ||
           "Unknown",
         hfModelId: info.model_impl?.hf_model_id,
-        model_type: info.model_impl?.model_type,
+        model_type: String(info.model_impl?.model_type ?? "").toLowerCase(),
       }))
-      .filter((m) => m.model_type === "embedding")
+      .filter((m) => wanted.includes(m.model_type));
+    const healthResults = await Promise.all(
+      candidates.map((m) => fetchModelHealth(m.id))
+    );
+    return candidates
+      .filter((_, i) => healthResults[i] === "healthy")
       .map(({ id, modelName, hfModelId }) => ({ id, modelName, hfModelId }));
   } catch {
     return [];
   }
 };
+
+/** Currently deployed, healthy embedding models, for any UI that lets the
+ * user pick one to back a Chroma collection with (EmbeddingDemo's Documents
+ * tab, RAG upload). */
+export const fetchEmbeddingModels = async (): Promise<DeployedEmbeddingModel[]> =>
+  fetchHealthyModelsByType("embedding");
 
 export const runEmbeddingInference = async (
   deployId: string,

--- a/app/frontend/src/components/ChipConfigStep.tsx
+++ b/app/frontend/src/components/ChipConfigStep.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 import { useState, useEffect, useMemo } from "react";
-import { Cpu, Layers } from "lucide-react";
+import { Cpu, Layers, LayoutGrid } from "lucide-react";
 import { ChipStatusDisplay } from "./ChipStatusDisplay";
 import {
   ModelPlacement,
@@ -20,13 +20,14 @@ interface ChipConfigStepProps {
 }
 
 export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigStepProps) {
-  const [selectedMode, setSelectedMode] = useState<"single" | "multi" | null>(
+  const [selectedMode, setSelectedMode] = useState<"single" | "pair" | "multi" | null>(
     null
   );
   const [selectedSlots, setSelectedSlots] = useState<number[]>([]);
 
-  const { allowsSingle, allowsFullBoard, cardGroups } = placement;
+  const { allowsSingle, allowsFullBoard, cardGroups, pairGroups = [] } = placement;
   const isGrouped = cardGroups.length > 0;
+  const hasPairTier = pairGroups.length > 0;
   // The "pick devices" card is offered for single-device and flexible (card-pair) models.
   const pickEnabled = allowsSingle || isGrouped;
 
@@ -38,11 +39,14 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
         : false,
     [chipStatus]
   );
-  // Slots the "All Devices" choice sends: the full board for flexible models,
-  // or just the base slot for standard multi-chip models (backend allocates the rest).
+  // Slots the "All Devices" choice sends: the full board for flexible models
+  // (card-pair grouped) and for a model that also allows a single-device default
+  // (e.g. Qwen3-Embedding-0.6B -- picking "All Devices" must actually select all
+  // slots so the parent's allSlotsSelected/force_full_board logic fires), or just
+  // the base slot for standard multi-chip-only models (backend allocates the rest).
   const multiSlots = useMemo(
-    () => (isGrouped ? fullBoardSlots(chipStatus?.total_slots ?? 4) : [0]),
-    [isGrouped, chipStatus]
+    () => (isGrouped || allowsSingle ? fullBoardSlots(chipStatus?.total_slots ?? 4) : [0]),
+    [isGrouped, allowsSingle, chipStatus]
   );
 
   // Pre-select the only valid mode for this model.
@@ -56,7 +60,7 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
   useEffect(() => {
     if (selectedMode === "multi") {
       onConfirm(multiBoardFree ? multiSlots : []);
-    } else if (selectedMode === "single") {
+    } else if (selectedMode === "single" || selectedMode === "pair") {
       onConfirm(selectedSlots);
     }
   }, [selectedMode, selectedSlots, multiBoardFree, multiSlots, onConfirm]);
@@ -90,7 +94,15 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
     chipStatus !== null &&
     chipStatus.total_slots > 1;
 
+  const pairGroupAvailable = (group: number[]) =>
+    !!chipStatus &&
+    group.every(
+      (g) => chipStatus.slots.find((s) => s.slot_id === g)?.status === "available"
+    );
+  const needsPairPicker = selectedMode === "pair" && chipStatus !== null;
+
   const singleDisabled = !pickEnabled;
+  const pairDisabled = !hasPairTier || !pairGroups.some(pairGroupAvailable);
   const multiDisabled = !allowsFullBoard || !multiBoardFree;
   const multiReason = !allowsFullBoard
     ? "This model uses a single device"
@@ -118,12 +130,12 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
       </div>
 
       {/* Mode selection cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className={`grid grid-cols-1 gap-4 ${hasPairTier ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
         {/* Single / card-pick card */}
         <button
           type="button"
           disabled={singleDisabled}
-          onClick={() => !singleDisabled && setSelectedMode("single")}
+          onClick={() => { if (!singleDisabled) { setSelectedMode("single"); setSelectedSlots([]); } }}
           className={`
             relative text-left p-6 rounded-xl border-2 transition-all duration-200
             ${singleDisabled
@@ -156,11 +168,55 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
           <p className="text-sm text-gray-400 leading-relaxed">{singleDescription}</p>
         </button>
 
+        {/* 2 Devices card — a middle tier alongside single/full-board (Qwen3-Embedding-0.6B, bge-m3) */}
+        {hasPairTier && (
+          <button
+            type="button"
+            disabled={pairDisabled}
+            onClick={() => { if (!pairDisabled) { setSelectedMode("pair"); setSelectedSlots([]); } }}
+            className={`
+              relative text-left p-6 rounded-xl border-2 transition-all duration-200
+              ${pairDisabled
+                ? "border-gray-800 bg-[#0a0e14] opacity-40 cursor-not-allowed"
+                : selectedMode === "pair"
+                  ? "border-TT-purple-accent bg-TT-purple-shade/30 shadow-[0_0_20px_rgba(124,104,250,0.25)] cursor-pointer"
+                  : "border-gray-700 bg-[#0d1117] hover:border-TT-purple-accent/60 hover:bg-TT-purple-shade/10 cursor-pointer"
+              }
+            `}
+          >
+            {selectedMode === "pair" && !pairDisabled && (
+              <div className="absolute top-3 right-3 w-3 h-3 rounded-full bg-TT-purple-accent shadow-[0_0_8px_rgba(124,104,250,0.8)]" />
+            )}
+            <div className="flex items-center gap-3 mb-3">
+              <div
+                className={`p-2 rounded-lg ${selectedMode === "pair" && !pairDisabled ? "bg-TT-purple-shade/60" : "bg-gray-800"}`}
+              >
+                <Layers
+                  className={`w-6 h-6 ${selectedMode === "pair" && !pairDisabled ? "text-TT-purple-accent" : "text-gray-400"}`}
+                />
+              </div>
+              <div>
+                <div
+                  className={`font-mono font-bold text-base ${selectedMode === "pair" && !pairDisabled ? "text-TT-purple" : "text-gray-200"}`}
+                >
+                  2 Devices
+                </div>
+                <div className="text-xs text-gray-500 font-mono">1 card, 2× devices</div>
+              </div>
+            </div>
+            <p className="text-sm text-gray-400 leading-relaxed">
+              {pairDisabled
+                ? "Needs a free card (2 devices)"
+                : "Deploy on one P300 card for roughly 2× throughput."}
+            </p>
+          </button>
+        )}
+
         {/* All Devices card */}
         <button
           type="button"
           disabled={multiDisabled}
-          onClick={() => !multiDisabled && setSelectedMode("multi")}
+          onClick={() => { if (!multiDisabled) { setSelectedMode("multi"); setSelectedSlots([]); } }}
           className={`
             relative text-left p-6 rounded-xl border-2 transition-all duration-200
             ${multiDisabled
@@ -178,7 +234,7 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
             <div
               className={`p-2 rounded-lg ${selectedMode === "multi" && !multiDisabled ? "bg-TT-purple-shade/60" : "bg-gray-800"}`}
             >
-              <Layers
+              <LayoutGrid
                 className={`w-6 h-6 ${selectedMode === "multi" && !multiDisabled ? "text-TT-purple-accent" : "text-gray-400"}`}
               />
             </div>
@@ -254,6 +310,75 @@ export function ChipConfigStep({ onConfirm, placement, chipStatus }: ChipConfigS
           {selectedSlots.length > 0 && (
             <p className="mt-2 text-xs font-mono text-TT-purple-accent">
               ✓ {selectedSlots.length > 1 ? `Devices ${selectedSlots.slice().sort((a, b) => a - b).join(", ")} selected` : `Device ${selectedSlots[0]} selected`}
+              {" — "}
+              {selectedSlots.slice().sort((a, b) => a - b).map((s) => (
+                <code key={s} className="bg-gray-800 px-1 rounded mr-1">
+                  /dev/tenstorrent/{s}
+                </code>
+              ))}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Pair picker — shown when the "2 Devices" tier is selected */}
+      {needsPairPicker && chipStatus && (
+        <div>
+          <h3 className="text-sm font-mono font-semibold text-gray-400 uppercase tracking-widest mb-1">
+            Select a Card
+          </h3>
+          <p className="text-xs text-gray-500 font-mono mb-3">
+            Each card is 2 devices; pick whichever card is free.
+          </p>
+          <div className="flex flex-row justify-center gap-3 flex-wrap">
+            {pairGroups.map((group) => {
+              const isAvailable = pairGroupAvailable(group);
+              const sorted = group.slice().sort((a, b) => a - b);
+              const isSelected =
+                sorted.length === selectedSlots.length &&
+                sorted.every((s) => selectedSlots.includes(s));
+              return (
+                <button
+                  key={sorted.join(",")}
+                  type="button"
+                  disabled={!isAvailable}
+                  onClick={() => setSelectedSlots(sorted)}
+                  className={`
+                    flex flex-col items-center px-5 py-4 rounded-lg border-2 transition-all duration-200 min-w-[120px]
+                    ${isSelected
+                      ? "border-TT-purple-accent bg-TT-purple-shade/40 shadow-[0_0_14px_rgba(124,104,250,0.3)]"
+                      : isAvailable
+                        ? "border-gray-700 bg-[#0d1117] hover:border-TT-purple-accent/50 hover:bg-TT-purple-shade/10 cursor-pointer"
+                        : "border-gray-800 bg-[#0a0e14] opacity-40 cursor-not-allowed"
+                    }
+                  `}
+                >
+                  <Layers
+                    className={`w-6 h-6 mb-1 ${isSelected ? "text-TT-purple-accent" : isAvailable ? "text-gray-400" : "text-gray-700"}`}
+                    strokeWidth={1.4}
+                  />
+                  <span
+                    className={`text-xs font-mono font-bold tracking-wider ${isSelected ? "text-TT-purple" : "text-gray-400"}`}
+                  >
+                    DEVICES {sorted.join("-")}
+                  </span>
+                  <span
+                    className={`text-[10px] font-mono mt-0.5 ${isSelected
+                        ? "text-TT-purple-accent"
+                        : isAvailable
+                          ? "text-gray-500"
+                          : "text-gray-700"
+                      }`}
+                  >
+                    {isAvailable ? "IDLE" : "IN USE"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {selectedSlots.length > 0 && (
+            <p className="mt-2 text-xs font-mono text-TT-purple-accent">
+              ✓ Devices {selectedSlots.slice().sort((a, b) => a - b).join(", ")} selected
               {" — "}
               {selectedSlots.slice().sort((a, b) => a - b).map((s) => (
                 <code key={s} className="bg-gray-800 px-1 rounded mr-1">

--- a/app/frontend/src/components/ModelAPIInfo/tabs/ExamplesTab.tsx
+++ b/app/frontend/src/components/ModelAPIInfo/tabs/ExamplesTab.tsx
@@ -193,6 +193,19 @@ const buildNonLlmExamples = (
   -F "image=@/path/to/image.jpg"`,
         },
       ];
+    case "embedding":
+      return [
+        {
+          name: "cURL - Embedding",
+          language: "bash",
+          code: `curl -X POST "${url}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "deploy_id": "${deployId}",
+    "input": "Hello from Tenstorrent"
+  }'`,
+        },
+      ];
     default:
       return [
         {

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -399,9 +399,9 @@ export default function NavBar() {
   }, [modelIdsKey]);
 
   // Only models that are actually healthy/usable should surface in the navbar.
-  // Model types with no interaction page (embeddings, and containers whose model
-  // could not be identified) are managed from the Models page only — a nav entry
-  // for them would route to a page that cannot drive them.
+  // Model types with no interaction page (containers whose model could not be
+  // identified) are managed from the Models page only — a nav entry for them
+  // would route to a page that cannot drive them.
   const healthyModels = useMemo(
     () =>
       models.filter((m) => {
@@ -413,6 +413,29 @@ export default function NavBar() {
       }),
     [models, healthById]
   );
+
+  // One nav button per destination ROUTE, not per deployed instance -- keyed
+  // by route rather than model type because several types share one page
+  // (ChatModel/VLM both open Chat UI, ObjectDetectionModel/CNN both open
+  // Object Detection), so type alone would still duplicate those. Deploying a
+  // second model of the same type (e.g. two embedding models) must not
+  // duplicate its nav entry either way. The page each button opens has its
+  // own picker to switch between multiple healthy models it can drive, so
+  // only the first one found is passed along as the initial selection.
+  const uniqueHealthyModelsByType = useMemo(() => {
+    const seen = new Set<string>();
+    const unique: typeof healthyModels = [];
+    for (const model of healthyModels) {
+      const t = model.model_type
+        ? getModelTypeFromBackendType(model.model_type)
+        : getModelTypeFromName(model.name, model.image);
+      const route = getDestinationFromModelType(t);
+      if (seen.has(route)) continue;
+      seen.add(route);
+      unique.push(model);
+    }
+    return unique;
+  }, [healthyModels]);
 
   // Voice agent requires all three model types: LLM/VLM, speech recognition (Whisper), and TTS
   const isVoiceAgentReady = useMemo(() => {
@@ -718,7 +741,7 @@ export default function NavBar() {
       // ready to use. Models still deploying/warming up are intentionally hidden.
       if (healthyModels.length > 0) {
         // Show navigation items for each healthy model
-        return healthyModels.map((model) => {
+        return uniqueHealthyModelsByType.map((model) => {
           const modelType = model.model_type
             ? getModelTypeFromBackendType(model.model_type)
             : getModelTypeFromName(model.name, model.image);
@@ -783,7 +806,7 @@ export default function NavBar() {
     } else {
       // In TT-Studio mode, show only models that are healthy and ready to use.
       console.log("TT-Studio mode - creating navigation for healthy models");
-      return healthyModels.map((model) => {
+      return uniqueHealthyModelsByType.map((model) => {
         const modelType = model.model_type
           ? getModelTypeFromBackendType(model.model_type)
           : getModelTypeFromName(model.name, model.image);

--- a/app/frontend/src/components/NavBar.tsx
+++ b/app/frontend/src/components/NavBar.tsx
@@ -20,6 +20,7 @@ import {
   ChevronLeft,
   BrainCog,
   Video,
+  Binary,
   type LucideIcon,
   History,
   Settings as SettingsIcon,
@@ -576,8 +577,9 @@ export default function NavBar() {
     switch (model_type) {
       case ModelType.ChatModel:
       case ModelType.VLM:
-      case ModelType.Embedding:
         return BotMessageSquare;
+      case ModelType.Embedding:
+        return Binary;
       case ModelType.ImageGeneration:
         return Image;
       case ModelType.VideoGeneration:
@@ -619,7 +621,7 @@ export default function NavBar() {
       case ModelType.TTS:
         return "Text to Speech";
       case ModelType.Embedding:
-        return "Chat UI";
+        return "Embeddings";
       case ModelType.Training:
         return "Training";
       default:

--- a/app/frontend/src/components/SelectionSteps.tsx
+++ b/app/frontend/src/components/SelectionSteps.tsx
@@ -205,6 +205,10 @@ export default function StepperDemo() {
   );
   // Flexible models (e.g. Llama 3.1 8B on P300x2) can run as a card pair or full-board.
   const isFlexible = placement.cardGroups.length > 0;
+  // A model with no card groups but that allows *both* a single device and the
+  // full board (e.g. Qwen3-Embedding-0.6B) also needs an explicit opt-in to go
+  // full-board -- it just doesn't group into pairs the way Llama does.
+  const hasFullBoardOptIn = placement.allowsSingle && placement.allowsFullBoard;
   const allSlotsSelected =
     selectedDeviceIds.length > 0 && selectedDeviceIds.length === (totalSlots ?? 0);
   // In auto mode, the best currently-available placement (accounting for in-flight
@@ -213,17 +217,21 @@ export default function StepperDemo() {
   const autoPlace = advancedActive
     ? null
     : autoPlacement(placement, selectedModelChips, effectiveChipStatus?.slots ?? [], totalSlots ?? 4);
-  // The full-board (force_full_board) flow applies only to flexible models.
+  // The full-board (force_full_board) flow applies to flexible (card-pair) models
+  // and to single-vs-full-board opt-in models; both need every slot selected in
+  // advanced mode, or a full-board auto-placement, to actually mean "full board".
   const fullBoardSelected =
-    isFlexible && (advancedActive ? allSlotsSelected : !!autoPlace?.fullBoard);
+    (isFlexible || hasFullBoardOptIn) &&
+    (advancedActive ? allSlotsSelected : !!autoPlace?.fullBoard);
   // Chips the deployment actually occupies (full-board takes every slot).
   const effectiveChips = fullBoardSelected ? 4 : selectedModelChips;
   // Devices shown in the deploy preview; undefined means the backend auto-allocates.
   const previewDeviceIds: number[] | undefined = (() => {
     if (!advancedActive) return autoPlace?.deviceIds;
     const board = fullBoardSlots(totalSlots ?? 4);
-    if (placement.allowsFullBoard && !isFlexible) return board; // true multi-chip
-    if (isFlexible) {
+    // True multi-chip: no single-device option at all, so always the whole board.
+    if (placement.allowsFullBoard && !isFlexible && !placement.allowsSingle) return board;
+    if (isFlexible || hasFullBoardOptIn) {
       return fullBoardSelected ? board : selectedDeviceIds.length ? selectedDeviceIds : undefined;
     }
     return selectedDeviceIds.length ? selectedDeviceIds : undefined;
@@ -270,7 +278,7 @@ export default function StepperDemo() {
       // Find the model by name — exact match first, then a unique substring
       // match, mirroring the CLI's resolve_model_id so both paths behave alike.
       const response = await axios.get("/docker-api/get_containers/");
-      const models: { id: string; name: string }[] = response.data;
+      const models: { id: string; name: string; chips_required?: number }[] = response.data;
       const needle = modelName.toLowerCase();
       let model = models.find((m) => m.name.toLowerCase() === needle);
       if (!model) {
@@ -319,8 +327,18 @@ export default function StepperDemo() {
       } else {
         // Same whole-card hint the manual flow sends for an unpinned deploy. The
         // backend honours it only where it matters (Llama-3.1-8B on P300x2 dies
-        // on a lone chip) and ignores it everywhere else.
-        deployPayload.force_full_board = true;
+        // on a lone chip) and ignores it everywhere else -- except a model that
+        // also allows a single-device default (e.g. Qwen3-Embedding-0.6B), where
+        // sending it unconditionally would override that default. Use the same
+        // placement rules the manual flow uses to decide.
+        const resolvedPlacement = getModelPlacement(
+          model.name,
+          model.chips_required ?? 1,
+          effectiveChipStatus?.board_type
+        );
+        if (!resolvedPlacement.allowsSingle) {
+          deployPayload.force_full_board = true;
+        }
       }
 
       console.log("Auto-deploy payload:", deployPayload);

--- a/app/frontend/src/components/chatui/ChatComponent.tsx
+++ b/app/frontend/src/components/chatui/ChatComponent.tsx
@@ -9,6 +9,7 @@ import { useLogo } from "../../utils/logo";
 import {
   fetchModels,
   fetchDeployedModelsInfo,
+  fetchModelHealth,
   getModelTypeFromBackendType,
   ModelType,
 } from "../../api/modelsDeployedApis";
@@ -101,6 +102,7 @@ export default function ChatComponent() {
   const [modelName, setModelName] = useState<string | null>(null);
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [modelsDeployed, setModelsDeployed] = useState<Model[]>([]);
+  const [modelHealthById, setModelHealthById] = useState<Record<string, string>>({});
   const [reRenderingMessageId, setReRenderingMessageId] = useState<
     string | null
   >(null);
@@ -240,17 +242,49 @@ export default function ChatComponent() {
     loadModels();
   }, [location.state]);
 
+  // Probe each deployed model's actual readiness -- the same live /health
+  // check the navbar uses to gate its own entries. A container can be
+  // "deployed" (running) well before it's warmed up enough to serve a
+  // request, so the model switcher and voice-input lookup below must not
+  // offer one that isn't there yet.
+  useEffect(() => {
+    if (modelsDeployed.length === 0) {
+      setModelHealthById({});
+      return;
+    }
+    let cancelled = false;
+    const ids = modelsDeployed
+      .map((model) => model.id)
+      .filter((id): id is string => !!id);
+    Promise.all(
+      ids.map(async (id) => [id, await fetchModelHealth(id)] as const)
+    ).then((entries) => {
+      if (!cancelled) setModelHealthById(Object.fromEntries(entries));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [modelsDeployed]);
+
+  const healthyModelsDeployed = useMemo(
+    () =>
+      modelsDeployed.filter(
+        (model) => !!model.id && modelHealthById[model.id] === "healthy"
+      ),
+    [modelsDeployed, modelHealthById]
+  );
+
   // Voice input transcribes through a deployed speech recognition model, or the
   // cloud endpoint in deployed mode. Without either, the mic button is hidden.
   const sttDeployId = useMemo(() => {
-    const sttModel = modelsDeployed.find(
+    const sttModel = healthyModelsDeployed.find(
       (model) =>
         model.model_type &&
         getModelTypeFromBackendType(model.model_type) ===
           ModelType.SpeechRecognitionModel
     );
     return sttModel?.id ?? null;
-  }, [modelsDeployed]);
+  }, [healthyModelsDeployed]);
   const voiceInputAvailable =
     sttDeployId !== null || import.meta.env.VITE_ENABLE_DEPLOYED === "true";
 
@@ -1024,11 +1058,17 @@ export default function ChatComponent() {
     }
   }, [chatThreads, currentThreadIndex, getCurrentThread]);
 
-  // Transform Model[] to the format expected by Header component
-  const headerModelsDeployed = modelsDeployed.map((model) => ({
-    id: model.containerID || model.id || "", // Use containerID from Model type or fall back to id
-    name: model.modelName || model.name || "", // Use modelName from Model type or fall back to name
-  }));
+  // The model switcher only makes sense for models this page can actually
+  // drive (chat + VLM), and only ones that have finished warming up.
+  const headerModelsDeployed = healthyModelsDeployed
+    .filter((model) => {
+      const t = model.model_type && getModelTypeFromBackendType(model.model_type);
+      return t === ModelType.ChatModel || t === ModelType.VLM;
+    })
+    .map((model) => ({
+      id: model.containerID || model.id || "", // Use containerID from Model type or fall back to id
+      name: model.modelName || model.name || "", // Use modelName from Model type or fall back to name
+    }));
   const currentThreadMessages = (() => {
     const currentThread = getCurrentThread();
     return Array.isArray(currentThread?.messages) ? currentThread.messages : [];

--- a/app/frontend/src/components/embedding/DocumentsPanel.tsx
+++ b/app/frontend/src/components/embedding/DocumentsPanel.tsx
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useCallback, useEffect, useState } from "react";
+import { Search, Loader2, FileText, Trash2 } from "lucide-react";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import {
+  GentleFileUpload,
+  type UploadFileItem,
+} from "../ui/gentle-file-upload";
+import { customToast } from "../CustomToaster";
+import {
+  fetchCollections,
+  createCollection,
+  deleteCollection,
+  uploadDocument,
+  fetchDocuments,
+  queryCollection,
+  type CollectionQueryResult,
+} from "../rag";
+import { type RagDataSource } from "../chatui/types";
+
+interface DocumentsPanelProps {
+  /** hf_model_id (preferred) or model_name of the currently-selected embedding
+   * model -- the stable identity a collection is locked to (see EmbeddingDemo). */
+  modelIdentifier: string;
+}
+
+interface DocEntry {
+  filename: string;
+  chunks_count: number;
+  upload_date?: string;
+}
+
+const generateCollectionName = (fileName: string): string =>
+  fileName
+    .replace(/\.[^/.]+$/, "")
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_{2,}/g, "_")
+    .replace(/^_|_$/g, "")
+    .toLowerCase();
+
+export default function DocumentsPanel({
+  modelIdentifier,
+}: DocumentsPanelProps) {
+  const embedFuncName = `tt-embed:${modelIdentifier}`;
+
+  const [collections, setCollections] = useState<RagDataSource[]>([]);
+  const [selectedCollection, setSelectedCollection] = useState("");
+  const [loadingCollections, setLoadingCollections] = useState(true);
+  const [documents, setDocuments] = useState<DocEntry[]>([]);
+  const [uploadFiles, setUploadFiles] = useState<UploadFileItem[]>([]);
+  const [queryText, setQueryText] = useState("");
+  const [queryResults, setQueryResults] = useState<CollectionQueryResult | null>(null);
+  const [isQuerying, setIsQuerying] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const loadCollections = useCallback(async () => {
+    try {
+      const all: RagDataSource[] = await fetchCollections();
+      const matching = all.filter(
+        (c) => c.metadata?.embedding_func_name === embedFuncName
+      );
+      setCollections(matching);
+      return matching;
+    } catch {
+      customToast.error("Failed to load collections for this model");
+      return [];
+    } finally {
+      setLoadingCollections(false);
+    }
+  }, [embedFuncName]);
+
+  // Model switched: this panel's collection list is model-scoped, so reset.
+  useEffect(() => {
+    setSelectedCollection("");
+    setDocuments([]);
+    setQueryResults(null);
+    setLoadingCollections(true);
+    loadCollections();
+  }, [loadCollections]);
+
+  useEffect(() => {
+    if (!selectedCollection) {
+      setDocuments([]);
+      return;
+    }
+    fetchDocuments(selectedCollection)
+      .then((d) => setDocuments(d.documents || []))
+      .catch(() => setDocuments([]));
+  }, [selectedCollection]);
+
+  const handleFilesSelected = async (files: File[]) => {
+    for (const file of files) {
+      const uploadId = `${file.name}-${Date.now()}-${Math.random()}`;
+      setUploadFiles((prev) => [
+        ...prev,
+        { id: uploadId, file, status: "loading", progress: 20, statusText: "Uploading…" },
+      ]);
+
+      try {
+        let targetCollection = selectedCollection;
+        if (!targetCollection) {
+          targetCollection = generateCollectionName(file.name);
+          setUploadFiles((prev) =>
+            prev.map((u) =>
+              u.id === uploadId
+                ? { ...u, statusText: `Creating collection "${targetCollection}"…` }
+                : u
+            )
+          );
+          await createCollection({
+            collectionName: targetCollection,
+            ttEmbeddingModel: modelIdentifier,
+          });
+          setSelectedCollection(targetCollection);
+        }
+
+        setUploadFiles((prev) =>
+          prev.map((u) =>
+            u.id === uploadId
+              ? { ...u, progress: 60, statusText: "Chunking & generating embeddings…" }
+              : u
+          )
+        );
+        await uploadDocument({ file, collectionName: targetCollection });
+
+        setUploadFiles((prev) =>
+          prev.map((u) =>
+            u.id === uploadId
+              ? { ...u, status: "success", progress: 100, statusText: "Embedded" }
+              : u
+          )
+        );
+
+        await loadCollections();
+        const docs = await fetchDocuments(targetCollection);
+        setDocuments(docs.documents || []);
+      } catch (err) {
+        setUploadFiles((prev) =>
+          prev.map((u) =>
+            u.id === uploadId
+              ? {
+                  ...u,
+                  status: "error",
+                  errorMessage:
+                    err instanceof Error ? err.message : "Upload failed",
+                }
+              : u
+          )
+        );
+      }
+    }
+  };
+
+  const handleQuery = async () => {
+    if (!selectedCollection || !queryText.trim()) return;
+    setIsQuerying(true);
+    setQueryResults(null);
+    try {
+      const result = await queryCollection(selectedCollection, queryText.trim());
+      setQueryResults(result);
+    } catch (err) {
+      customToast.error(
+        `Search failed: ${err instanceof Error ? err.message : "Unknown error"}`
+      );
+    } finally {
+      setIsQuerying(false);
+    }
+  };
+
+  const handleDeleteCollection = async () => {
+    if (!selectedCollection) return;
+    setIsDeleting(true);
+    try {
+      await deleteCollection({ collectionName: selectedCollection });
+      customToast.success(`Deleted collection "${selectedCollection}"`);
+      setSelectedCollection("");
+      setQueryResults(null);
+      await loadCollections();
+    } catch (err) {
+      customToast.error(
+        `Failed to delete collection: ${err instanceof Error ? err.message : "Unknown error"}`
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const resultRows = queryResults?.documents?.[0] ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Collection selector */}
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          Collection
+        </label>
+        <div className="flex gap-2">
+          <Select
+            value={selectedCollection || "__new__"}
+            onValueChange={(v) => setSelectedCollection(v === "__new__" ? "" : v)}
+            disabled={loadingCollections}
+          >
+            <SelectTrigger className="h-11 text-base border-2 flex-1">
+              <SelectValue placeholder="Select a collection" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__new__">
+                + New collection (named from first upload)
+              </SelectItem>
+              {collections.map((c) => (
+                <SelectItem key={c.name} value={c.name}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selectedCollection && (
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-11 w-11 shrink-0 text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950"
+              onClick={handleDeleteCollection}
+              disabled={isDeleting}
+              title="Delete this collection"
+            >
+              {isDeleting ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Trash2 className="w-4 h-4" />
+              )}
+            </Button>
+          )}
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Locked to this model's vector space -- only collections created with it
+          appear here.
+        </p>
+      </div>
+
+      {/* Upload */}
+      <GentleFileUpload files={uploadFiles} onChange={handleFilesSelected} />
+
+      {/* Document list */}
+      {selectedCollection && documents.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Documents in "{selectedCollection}"
+          </label>
+          <div className="flex flex-col gap-1.5 max-h-40 overflow-auto">
+            {documents.map((doc) => (
+              <div
+                key={doc.filename}
+                className="flex items-center gap-2 text-sm px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800"
+              >
+                <FileText className="w-3.5 h-3.5 shrink-0 text-gray-400" />
+                <span className="truncate flex-1">{doc.filename}</span>
+                <span className="text-xs text-gray-500 shrink-0">
+                  {doc.chunks_count} chunk{doc.chunks_count === 1 ? "" : "s"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Search */}
+      {selectedCollection && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Search this collection
+          </label>
+          <div className="flex gap-2">
+            <Input
+              value={queryText}
+              onChange={(e) => setQueryText(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleQuery()}
+              placeholder="Ask something about the uploaded documents…"
+              className="h-11 text-base border-2"
+              disabled={isQuerying}
+            />
+            <Button
+              className="h-11 px-5 bg-TT-purple-accent hover:bg-TT-purple text-white shrink-0"
+              onClick={handleQuery}
+              disabled={isQuerying || !queryText.trim()}
+            >
+              {isQuerying ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Search className="w-4 h-4" />
+              )}
+            </Button>
+          </div>
+
+          {queryResults && (
+            <div className="flex flex-col gap-2 mt-1">
+              {resultRows.length === 0 ? (
+                <p className="text-sm text-gray-500">No matches found.</p>
+              ) : (
+                resultRows.map((doc, i) => (
+                  <div
+                    key={queryResults.ids[0][i]}
+                    className="rounded-lg border border-[#7C68FA]/30 p-3"
+                    style={{ background: "#0D0D14" }}
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-xs font-mono text-[#2EE8C4]">
+                        {(queryResults.metadatas[0][i]?.source as string) ||
+                          "chunk"}
+                      </span>
+                      <span className="text-xs font-mono text-gray-500">
+                        distance {queryResults.distances[0][i].toFixed(4)}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-300 line-clamp-3">{doc}</p>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/embedding/DocumentsPanel.tsx
+++ b/app/frontend/src/components/embedding/DocumentsPanel.tsx
@@ -302,7 +302,7 @@ export default function DocumentsPanel({
           </div>
 
           {queryResults && (
-            <div className="flex flex-col gap-2 mt-1">
+            <div className="flex flex-col gap-2 mt-1 max-h-72 overflow-auto">
               {resultRows.length === 0 ? (
                 <p className="text-sm text-gray-500">No matches found.</p>
               ) : (

--- a/app/frontend/src/components/embedding/EmbeddingDemo.tsx
+++ b/app/frontend/src/components/embedding/EmbeddingDemo.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Binary, Copy, Loader2, GitCompareArrows } from "lucide-react";
 import { motion } from "framer-motion";
 import { Button } from "../ui/button";
@@ -17,10 +17,12 @@ import {
 } from "../ui/select";
 import { runEmbeddingInference } from "../../api/modelsDeployedApis";
 import { customToast } from "../CustomToaster";
+import DocumentsPanel from "./DocumentsPanel";
 
 interface DeployedModelInfo {
   id: string;
   modelName: string;
+  hfModelId?: string;
   model_type?: string;
 }
 
@@ -36,6 +38,7 @@ async function fetchEmbeddingModels(): Promise<DeployedModelInfo[]> {
           info.model_impl?.model_name ||
           info.model_impl?.hf_model_id ||
           "Unknown",
+        hfModelId: info.model_impl?.hf_model_id,
         model_type: info.model_impl?.model_type,
       }))
       .filter((m) => m.model_type === "embedding");
@@ -59,7 +62,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return dot / (Math.sqrt(magA) * Math.sqrt(magB));
 }
 
-type Mode = "single" | "compare";
+type Mode = "single" | "compare" | "documents";
 
 export default function EmbeddingDemo() {
   const [models, setModels] = useState<DeployedModelInfo[]>([]);
@@ -70,6 +73,14 @@ export default function EmbeddingDemo() {
   const [isLoading, setIsLoading] = useState(false);
   const [vectorA, setVectorA] = useState<number[] | null>(null);
   const [vectorB, setVectorB] = useState<number[] | null>(null);
+
+  const selectedModel = useMemo(
+    () => models.find((m) => m.id === selectedDeployId),
+    [models, selectedDeployId]
+  );
+  // A Chroma collection is locked to one embedding function for life, so it has
+  // to key on the model's stable identity, not this ephemeral deploy/container id.
+  const modelIdentifier = selectedModel?.hfModelId || selectedModel?.modelName;
 
   useEffect(() => {
     fetchEmbeddingModels().then((found) => {
@@ -208,10 +219,34 @@ export default function EmbeddingDemo() {
               >
                 Compare Similarity
               </button>
+              <button
+                className={`px-3 py-1.5 text-sm transition-colors ${
+                  mode === "documents"
+                    ? "bg-TT-purple-accent text-white"
+                    : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                onClick={() => switchMode("documents")}
+                disabled={isLoading}
+              >
+                Documents
+              </button>
             </div>
           </motion.div>
 
+          {/* Documents mode: upload, browse, and search a collection instead of
+              the single/compare text workflow below. */}
+          {mode === "documents" && modelIdentifier && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.2 }}
+            >
+              <DocumentsPanel modelIdentifier={modelIdentifier} />
+            </motion.div>
+          )}
+
           {/* Text input(s) */}
+          {mode !== "documents" && (
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -247,8 +282,10 @@ export default function EmbeddingDemo() {
               </div>
             )}
           </motion.div>
+          )}
 
           {/* Generate button */}
+          {mode !== "documents" && (
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -284,6 +321,7 @@ export default function EmbeddingDemo() {
               )}
             </Button>
           </motion.div>
+          )}
 
           {/* Results */}
           {vectorA && mode === "single" && (

--- a/app/frontend/src/components/embedding/EmbeddingDemo.tsx
+++ b/app/frontend/src/components/embedding/EmbeddingDemo.tsx
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import { useEffect, useState } from "react";
+import { Binary, Copy, Loader2, GitCompareArrows } from "lucide-react";
+import { motion } from "framer-motion";
+import { Button } from "../ui/button";
+import { Textarea } from "../ui/textarea";
+import { Card } from "../ui/card";
+import { Progress } from "../ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { runEmbeddingInference } from "../../api/modelsDeployedApis";
+import { customToast } from "../CustomToaster";
+
+interface DeployedModelInfo {
+  id: string;
+  modelName: string;
+  model_type?: string;
+}
+
+async function fetchEmbeddingModels(): Promise<DeployedModelInfo[]> {
+  try {
+    const res = await fetch("/models-api/deployed/");
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Object.entries(data)
+      .map(([id, info]: [string, any]) => ({
+        id,
+        modelName:
+          info.model_impl?.model_name ||
+          info.model_impl?.hf_model_id ||
+          "Unknown",
+        model_type: info.model_impl?.model_type,
+      }))
+      .filter((m) => m.model_type === "embedding");
+  } catch {
+    return [];
+  }
+}
+
+// Standard cosine similarity between two equal-length embedding vectors.
+function cosineSimilarity(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+type Mode = "single" | "compare";
+
+export default function EmbeddingDemo() {
+  const [models, setModels] = useState<DeployedModelInfo[]>([]);
+  const [selectedDeployId, setSelectedDeployId] = useState("");
+  const [mode, setMode] = useState<Mode>("single");
+  const [textA, setTextA] = useState("");
+  const [textB, setTextB] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [vectorA, setVectorA] = useState<number[] | null>(null);
+  const [vectorB, setVectorB] = useState<number[] | null>(null);
+
+  useEffect(() => {
+    fetchEmbeddingModels().then((found) => {
+      setModels(found);
+      if (found.length > 0) setSelectedDeployId(found[0].id);
+    });
+  }, []);
+
+  const switchMode = (next: Mode) => {
+    setMode(next);
+    setVectorA(null);
+    setVectorB(null);
+  };
+
+  const handleGenerate = async () => {
+    if (!selectedDeployId) {
+      customToast.error("Please select an embedding model");
+      return;
+    }
+    if (!textA.trim() || (mode === "compare" && !textB.trim())) {
+      customToast.error("Please enter text to embed");
+      return;
+    }
+
+    setIsLoading(true);
+    setVectorA(null);
+    setVectorB(null);
+    try {
+      if (mode === "single") {
+        const result = await runEmbeddingInference(selectedDeployId, textA.trim());
+        setVectorA(result.embedding);
+      } else {
+        const [resultA, resultB] = await Promise.all([
+          runEmbeddingInference(selectedDeployId, textA.trim()),
+          runEmbeddingInference(selectedDeployId, textB.trim()),
+        ]);
+        setVectorA(resultA.embedding);
+        setVectorB(resultB.embedding);
+      }
+    } catch (err) {
+      customToast.error(
+        `Embedding generation failed: ${err instanceof Error ? err.message : "Unknown error"}`
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCopyVector = (vector: number[]) => {
+    navigator.clipboard.writeText(JSON.stringify(vector));
+    customToast.success("Vector copied to clipboard!");
+  };
+
+  const similarity = vectorA && vectorB ? cosineSimilarity(vectorA, vectorB) : null;
+
+  return (
+    <Card className="flex flex-col w-full max-w-3xl max-h-[85vh] overflow-hidden shadow-xl bg-white dark:bg-black border-gray-200 dark:border-[#7C68FA]/20 rounded-2xl">
+      <div className="flex-1 overflow-auto flex items-center justify-center">
+        <div className="w-full max-w-3xl px-6 py-8 flex flex-col gap-6">
+          {/* Header */}
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            className="text-center"
+          >
+            <h1 className="text-4xl font-bold text-gray-900 dark:text-white">
+              Embeddings Demo
+            </h1>
+            <p className="mt-2 text-base text-gray-600 dark:text-gray-300">
+              Generate vector embeddings from text using a deployed embedding model.
+            </p>
+          </motion.div>
+
+          {/* Model selector */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+            className="flex flex-col gap-2"
+          >
+            <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+              Embedding Model
+            </label>
+            {models.length === 0 ? (
+              <div className="text-sm text-amber-600 dark:text-amber-400 border-2 border-amber-400 dark:border-amber-600 rounded-lg px-4 py-3 bg-amber-50 dark:bg-amber-950">
+                No embedding models are currently deployed. Deploy an embedding
+                model to get started.
+              </div>
+            ) : (
+              <Select value={selectedDeployId} onValueChange={setSelectedDeployId}>
+                <SelectTrigger className="h-12 text-base border-2">
+                  <SelectValue placeholder="Select embedding model" />
+                </SelectTrigger>
+                <SelectContent>
+                  {models.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.modelName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </motion.div>
+
+          {/* Mode toggle */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.15 }}
+            className="flex items-center gap-2"
+          >
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Mode:
+            </span>
+            <div className="flex border-2 rounded-md overflow-hidden">
+              <button
+                className={`px-3 py-1.5 text-sm transition-colors ${
+                  mode === "single"
+                    ? "bg-TT-purple-accent text-white"
+                    : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                onClick={() => switchMode("single")}
+                disabled={isLoading}
+              >
+                Single Text
+              </button>
+              <button
+                className={`px-3 py-1.5 text-sm transition-colors ${
+                  mode === "compare"
+                    ? "bg-TT-purple-accent text-white"
+                    : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                onClick={() => switchMode("compare")}
+                disabled={isLoading}
+              >
+                Compare Similarity
+              </button>
+            </div>
+          </motion.div>
+
+          {/* Text input(s) */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.2 }}
+            className="flex flex-col gap-4"
+          >
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+                {mode === "compare" ? "Text A" : "Text to embed"}
+              </label>
+              <Textarea
+                rows={4}
+                placeholder="Enter text here…"
+                value={textA}
+                onChange={(e) => setTextA(e.target.value)}
+                className="resize-none focus-visible:ring-2 focus-visible:ring-TT-purple-accent text-base border-2"
+                disabled={isLoading}
+              />
+            </div>
+            {mode === "compare" && (
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+                  Text B
+                </label>
+                <Textarea
+                  rows={4}
+                  placeholder="Enter text here…"
+                  value={textB}
+                  onChange={(e) => setTextB(e.target.value)}
+                  className="resize-none focus-visible:ring-2 focus-visible:ring-TT-purple-accent text-base border-2"
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+          </motion.div>
+
+          {/* Generate button */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.3 }}
+            className="flex justify-center"
+          >
+            <Button
+              size="lg"
+              className="flex items-center gap-2 px-12 h-14 text-lg bg-TT-purple-accent hover:bg-TT-purple text-white font-semibold transition-all duration-200 hover:shadow-xl hover:scale-105 disabled:hover:scale-100 disabled:hover:shadow-none"
+              onClick={handleGenerate}
+              disabled={
+                isLoading ||
+                models.length === 0 ||
+                !textA.trim() ||
+                (mode === "compare" && !textB.trim())
+              }
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-6 h-6 animate-spin" />
+                  Generating…
+                </>
+              ) : mode === "compare" ? (
+                <>
+                  <GitCompareArrows className="w-6 h-6" />
+                  Compare
+                </>
+              ) : (
+                <>
+                  <Binary className="w-6 h-6" />
+                  Generate Embedding
+                </>
+              )}
+            </Button>
+          </motion.div>
+
+          {/* Results */}
+          {vectorA && mode === "single" && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.3 }}
+              className="rounded-xl overflow-hidden border border-[#7C68FA]/30 shadow-2xl p-4 flex flex-col gap-3"
+              style={{ background: "#0D0D14" }}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-mono uppercase tracking-widest text-[#2EE8C4]">
+                  {vectorA.length}-dimensional vector
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs h-7 text-gray-300 hover:text-white hover:bg-white/10"
+                  onClick={() => handleCopyVector(vectorA)}
+                >
+                  <Copy className="w-3.5 h-3.5 mr-1" />
+                  Copy Full Vector
+                </Button>
+              </div>
+              <code className="text-xs font-mono text-gray-400 break-all">
+                [{vectorA.slice(0, 8).map((v) => v.toFixed(4)).join(", ")}
+                {vectorA.length > 8 ? ", …" : ""}]
+              </code>
+            </motion.div>
+          )}
+
+          {vectorA && vectorB && mode === "compare" && similarity !== null && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.3 }}
+              className="rounded-xl overflow-hidden border border-[#7C68FA]/30 shadow-2xl p-4 flex flex-col gap-3"
+              style={{ background: "#0D0D14" }}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-mono uppercase tracking-widest text-[#2EE8C4]">
+                  Cosine Similarity
+                </span>
+                <span className="text-lg font-mono font-bold text-white">
+                  {similarity.toFixed(4)}
+                </span>
+              </div>
+              <Progress
+                value={((similarity + 1) / 2) * 100}
+                className="bg-white/10"
+                indicatorClassName="bg-gradient-to-r from-[#7C68FA] to-[#2EE8C4]"
+              />
+              <span className="text-xs text-gray-500">
+                −1 (opposite) · 0 (unrelated) · 1 (identical meaning)
+              </span>
+            </motion.div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/app/frontend/src/components/embedding/EmbeddingDemo.tsx
+++ b/app/frontend/src/components/embedding/EmbeddingDemo.tsx
@@ -15,37 +15,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { runEmbeddingInference } from "../../api/modelsDeployedApis";
+import {
+  runEmbeddingInference,
+  fetchEmbeddingModels,
+  type DeployedEmbeddingModel,
+} from "../../api/modelsDeployedApis";
 import { customToast } from "../CustomToaster";
 import DocumentsPanel from "./DocumentsPanel";
-
-interface DeployedModelInfo {
-  id: string;
-  modelName: string;
-  hfModelId?: string;
-  model_type?: string;
-}
-
-async function fetchEmbeddingModels(): Promise<DeployedModelInfo[]> {
-  try {
-    const res = await fetch("/models-api/deployed/");
-    if (!res.ok) return [];
-    const data = await res.json();
-    return Object.entries(data)
-      .map(([id, info]: [string, any]) => ({
-        id,
-        modelName:
-          info.model_impl?.model_name ||
-          info.model_impl?.hf_model_id ||
-          "Unknown",
-        hfModelId: info.model_impl?.hf_model_id,
-        model_type: info.model_impl?.model_type,
-      }))
-      .filter((m) => m.model_type === "embedding");
-  } catch {
-    return [];
-  }
-}
 
 // Standard cosine similarity between two equal-length embedding vectors.
 function cosineSimilarity(a: number[], b: number[]): number {
@@ -65,7 +41,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
 type Mode = "single" | "compare" | "documents";
 
 export default function EmbeddingDemo() {
-  const [models, setModels] = useState<DeployedModelInfo[]>([]);
+  const [models, setModels] = useState<DeployedEmbeddingModel[]>([]);
   const [selectedDeployId, setSelectedDeployId] = useState("");
   const [mode, setMode] = useState<Mode>("documents");
   const [textA, setTextA] = useState("");

--- a/app/frontend/src/components/embedding/EmbeddingDemo.tsx
+++ b/app/frontend/src/components/embedding/EmbeddingDemo.tsx
@@ -67,7 +67,7 @@ type Mode = "single" | "compare" | "documents";
 export default function EmbeddingDemo() {
   const [models, setModels] = useState<DeployedModelInfo[]>([]);
   const [selectedDeployId, setSelectedDeployId] = useState("");
-  const [mode, setMode] = useState<Mode>("single");
+  const [mode, setMode] = useState<Mode>("documents");
   const [textA, setTextA] = useState("");
   const [textB, setTextB] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -137,8 +137,19 @@ export default function EmbeddingDemo() {
   const similarity = vectorA && vectorB ? cosineSimilarity(vectorA, vectorB) : null;
 
   return (
-    <Card className="flex flex-col w-full max-w-3xl max-h-[85vh] overflow-hidden shadow-xl bg-white dark:bg-black border-gray-200 dark:border-[#7C68FA]/20 rounded-2xl">
-      <div className="flex-1 overflow-auto flex items-center justify-center">
+    // Fixed height, not max-height: the outer page wrapper vertically centers
+    // this card (items-center in a h-screen flex). A card that grows with its
+    // content -- switching modes, search results appearing -- would grow
+    // symmetrically around that centered point, pushing its top edge upward
+    // until it goes behind the navbar. A constant footprint keeps the card's
+    // position stable; content beyond it scrolls internally instead.
+    <Card className="flex flex-col w-full max-w-3xl h-[85vh] overflow-hidden shadow-xl bg-white dark:bg-black border-gray-200 dark:border-[#7C68FA]/20 rounded-2xl">
+      {/* items-start (not center): centering a flex item taller than its
+          container defaults the scroll position to the middle, hiding the
+          header above the visible area once content (e.g. search results)
+          grows past the viewport. Top-anchoring keeps it reachable by
+          scrolling down instead. */}
+      <div className="flex-1 overflow-auto flex items-start justify-center">
         <div className="w-full max-w-3xl px-6 py-8 flex flex-col gap-6">
           {/* Header */}
           <motion.div
@@ -199,6 +210,17 @@ export default function EmbeddingDemo() {
             <div className="flex border-2 rounded-md overflow-hidden">
               <button
                 className={`px-3 py-1.5 text-sm transition-colors ${
+                  mode === "documents"
+                    ? "bg-TT-purple-accent text-white"
+                    : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                onClick={() => switchMode("documents")}
+                disabled={isLoading}
+              >
+                Documents
+              </button>
+              <button
+                className={`px-3 py-1.5 text-sm transition-colors ${
                   mode === "single"
                     ? "bg-TT-purple-accent text-white"
                     : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
@@ -218,17 +240,6 @@ export default function EmbeddingDemo() {
                 disabled={isLoading}
               >
                 Compare Similarity
-              </button>
-              <button
-                className={`px-3 py-1.5 text-sm transition-colors ${
-                  mode === "documents"
-                    ? "bg-TT-purple-accent text-white"
-                    : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
-                }`}
-                onClick={() => switchMode("documents")}
-                disabled={isLoading}
-              >
-                Documents
               </button>
             </div>
           </motion.div>

--- a/app/frontend/src/components/models/row-cells/ManageCell.tsx
+++ b/app/frontend/src/components/models/row-cells/ManageCell.tsx
@@ -15,6 +15,7 @@ import {
   Volume2,
   ScanFace,
   BrainCog,
+  Binary,
 } from "lucide-react";
 import type { HealthStatus } from "../../../types/models";
 import {
@@ -94,8 +95,8 @@ export default React.memo(function ManageCell({
   const modelType = model_type
     ? getModelTypeFromBackendType(model_type)
     : getModelTypeFromName(name ?? "");
-  // Embedding models have no UI, and an unidentified container has no known API
-  // shape — neither gets an interaction or API button, only management actions.
+  // An unidentified container has no known API shape — it gets no interaction
+  // or API button, only management actions.
   const noInteraction = !hasInteractionPage(modelType);
   const openLabel =
     modelType === ModelType.ImageGeneration
@@ -108,9 +109,11 @@ export default React.memo(function ManageCell({
             ? "Face Rec"
             : modelType === ModelType.TTS
               ? "TTS"
-              : modelType === ModelType.Training
-                ? "Training Dashboard"
-                : "Chat";
+              : modelType === ModelType.Embedding
+                ? "Embed"
+                : modelType === ModelType.Training
+                  ? "Training Dashboard"
+                  : "Chat";
   const OpenIcon =
     modelType === ModelType.ImageGeneration
       ? ImageIcon
@@ -122,9 +125,11 @@ export default React.memo(function ManageCell({
             ? ScanFace
             : modelType === ModelType.TTS
               ? Volume2
-              : modelType === ModelType.Training
-                ? BrainCog
-                : MessageSquareText;
+              : modelType === ModelType.Embedding
+                ? Binary
+                : modelType === ModelType.Training
+                  ? BrainCog
+                  : MessageSquareText;
 
   if (isFailed) {
     return (

--- a/app/frontend/src/components/rag/RagManagement.tsx
+++ b/app/frontend/src/components/rag/RagManagement.tsx
@@ -23,6 +23,10 @@ import {
   isSystemKnowledgeCollection,
 } from "@/src/components/rag";
 import {
+  fetchEmbeddingModels,
+  type DeployedEmbeddingModel,
+} from "@/src/api/modelsDeployedApis";
+import {
   FileType,
   Trash2,
   Upload,
@@ -37,6 +41,13 @@ import {
   GentleFileUpload,
   type UploadFileItem,
 } from "@/src/components/ui/gentle-file-upload";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
 import { RagManagementSkeleton } from "@/src/components/rag/RagSkeletons";
 import { v4 as uuidv4 } from "uuid";
 import type { JSX } from "react";
@@ -153,6 +164,12 @@ export default function RagManagement() {
   const [isDragging, setIsDragging] = useState(false);
   const [uploadBoxKey, setUploadBoxKey] = useState(0);
 
+  // Embedding model for newly-created datasources: "" is the default local
+  // model, otherwise a deployed embedding model's stable identity (see
+  // EmbeddingDemo, which introduced TT-hardware-backed collections).
+  const [embeddingModels, setEmbeddingModels] = useState<DeployedEmbeddingModel[]>([]);
+  const [embeddingModel, setEmbeddingModel] = useState("");
+
   // State to track expanded rows
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
 
@@ -242,6 +259,33 @@ export default function RagManagement() {
     getBrowserId();
   }, []);
 
+  // Offer any deployed embedding model as an alternative to the default local
+  // one for datasources created from here on. Polls like the health checks
+  // elsewhere on this page do, so deploying/removing a model is reflected
+  // without a refresh.
+  useEffect(() => {
+    let cancelled = false;
+    const loadEmbeddingModels = async () => {
+      const models = await fetchEmbeddingModels();
+      if (cancelled) return;
+      setEmbeddingModels(models);
+      // A model the picker was set to got undeployed -- fall back to default
+      // rather than silently keep sending a now-invalid identity. Reads the
+      // latest selection via the updater fn since this effect never re-runs.
+      setEmbeddingModel((current) =>
+        current && !models.some((m) => (m.hfModelId || m.modelName) === current)
+          ? ""
+          : current
+      );
+    };
+    loadEmbeddingModels();
+    const id = setInterval(loadEmbeddingModels, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
   // Load data effect similar to ModelsDeployedTable approach
   useEffect(() => {
     const loadCollections = async () => {
@@ -324,13 +368,15 @@ export default function RagManagement() {
       file,
       collectionName,
       uploadId,
+      ttEmbeddingModel,
     }: {
       file: File;
       collectionName: string;
       uploadId?: string;
+      ttEmbeddingModel?: string;
     }) => {
       // First create the collection
-      await createCollection({ collectionName });
+      await createCollection({ collectionName, ttEmbeddingModel });
 
       // Then upload the document; if that fails, roll back the collection so
       // we don't leave behind an empty datasource that can't be retried.
@@ -777,11 +823,19 @@ export default function RagManagement() {
         (rds) => rds.name === collectionName
       );
       if (existingCollection) {
-        // Upload to existing collection
+        // Upload to existing collection -- its embedding function is already
+        // fixed from when it was created, so there's nothing to pass here.
         uploadDocumentMutation.mutate({ file, collectionName, uploadId });
       } else {
-        // Create new collection and upload
-        autoCreateAndUploadMutation.mutate({ file, collectionName, uploadId });
+        // Create new collection and upload. embeddingModel is "" for the
+        // default local model, or a deployed model's identity to back this
+        // new datasource with it instead (see the picker above the dropzone).
+        autoCreateAndUploadMutation.mutate({
+          file,
+          collectionName,
+          uploadId,
+          ttEmbeddingModel: embeddingModel || undefined,
+        });
       }
     });
   };
@@ -1143,6 +1197,32 @@ export default function RagManagement() {
           ref={inputFile}
           style={{ display: "none" }}
         />
+
+        {/* Embedding model picker: only shown once something is deployed to
+            offer as an alternative to the default local model. Applies to
+            datasources created from here on -- an existing one keeps whatever
+            it was created with, since a collection can't change embedding
+            functions after the fact. */}
+        {embeddingModels.length > 0 && (
+          <div className="flex items-center gap-2 mb-3 text-sm">
+            <span className="font-medium text-gray-600 dark:text-gray-400 shrink-0">
+              Embed new datasources with:
+            </span>
+            <Select value={embeddingModel || "__default__"} onValueChange={(v) => setEmbeddingModel(v === "__default__" ? "" : v)}>
+              <SelectTrigger className="h-9 w-auto min-w-[220px] text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">Default (local model)</SelectItem>
+                {embeddingModels.map((m) => (
+                  <SelectItem key={m.id} value={m.hfModelId || m.modelName}>
+                    {m.modelName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         {/* File Upload Area */}
         <Card

--- a/app/frontend/src/components/rag/index.ts
+++ b/app/frontend/src/components/rag/index.ts
@@ -51,19 +51,28 @@ export const fetchCollections = async () => {
 
 export const createCollection = async ({
   collectionName,
+  ttEmbeddingModel,
 }: {
   collectionName: string;
+  /** HF id (or model_name) of a deployed embedding model to back this collection
+   * with, instead of the default local ONNX MiniLM. Locked in for the
+   * collection's lifetime -- see EmbeddingDemo's Documents tab. */
+  ttEmbeddingModel?: string;
 }) => {
   try {
     const response = await axios.post(`${collectionsAPIURL}/`, {
       name: collectionName,
+      ...(ttEmbeddingModel ? { tt_embedding_model: ttEmbeddingModel } : {}),
     });
     return response.data;
   } catch (error) {
     console.error("Error creating collection:", error);
     // Extract error message from the response if available
+    // Surface the backend's actual reason (name collision, or -- new -- the
+    // chosen TT embedding model isn't currently deployed) instead of a fixed
+    // "already exists" message that would be wrong for the latter.
     if (axios.isAxiosError(error) && error.response?.data?.error) {
-      customToast.error("Collection name already exists");
+      customToast.error(error.response.data.error);
       throw new Error(error.response.data.error);
     }
     throw error;
@@ -107,6 +116,33 @@ export const uploadDocument = async ({
   } catch (error) {
     console.error("Error uploading document:", error);
     // Surface the backend's reason (e.g. "Unsupported file type") to callers
+    if (axios.isAxiosError(error) && error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+    throw error;
+  }
+};
+
+export interface CollectionQueryResult {
+  ids: string[][];
+  documents: string[][];
+  metadatas: (Record<string, unknown> | null)[][];
+  distances: number[][];
+}
+
+export const queryCollection = async (
+  collectionName: string,
+  queryText: string
+): Promise<CollectionQueryResult> => {
+  try {
+    // n_results isn't caller-configurable server-side (fixed at query_results_limit).
+    const response = await axios.get(
+      `${collectionsAPIURL}/${collectionName}/query`,
+      { params: { query_text: queryText } }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error querying collection:", error);
     if (axios.isAxiosError(error) && error.response?.data?.error) {
       throw new Error(error.response.data.error);
     }

--- a/app/frontend/src/components/speechToText/speechToTextApp.tsx
+++ b/app/frontend/src/components/speechToText/speechToTextApp.tsx
@@ -6,12 +6,23 @@ import { AppSidebar } from "@/src/components/speechToText/appSidebar";
 import { MainContent } from "@/src/components/speechToText/mainContent";
 import { SidebarProvider, SidebarTrigger } from "@/src/components/ui/sidebar";
 import { Card } from "../ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Mic, MessageSquare } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "../../lib/utils";
 import { useTheme } from "../../hooks/useTheme";
 import { useLocation } from "react-router-dom";
 import { customToast } from "../CustomToaster";
+import {
+  fetchHealthyModelsByType,
+  type DeployedModelSummary,
+} from "../../api/modelsDeployedApis";
 import type { TranscriptSegment } from "./lib/apiClient";
 
 interface Transcription {
@@ -46,19 +57,28 @@ export default function SpeechToTextApp() {
 
   const location = useLocation();
   const [modelID, setModelID] = useState<string | null>(null);
+  const [sttModels, setSttModels] = useState<DeployedModelSummary[]>([]);
 
+  // List every healthy (fully warmed up) speech recognition model, so a
+  // second deployment stays reachable even though the navbar only links here
+  // once. Prefer the model the nav button was opened for, when it's actually
+  // one of the healthy ones; otherwise fall back to the first healthy model.
   useEffect(() => {
-    if (location.state) {
-      if (!location.state.containerID) {
+    fetchHealthyModelsByType("speech_recognition").then((models) => {
+      setSttModels(models);
+      const fromNav = location.state?.containerID;
+      if (fromNav && models.some((m) => m.id === fromNav)) {
+        setModelID(fromNav);
+      } else if (models.length > 0) {
+        setModelID(models[0].id);
+      } else {
+        setModelID(null);
         customToast.error(
-          "modelID is unavailable. Try navigating here from the Models Deployed tab"
+          "No speech recognition model is ready yet. Deploy or wait for one to finish warming up."
         );
-        return;
       }
-      setModelID(location.state.containerID);
-      console.log(location.state.containerID);
-    }
-  }, [location.state, modelID]);
+    });
+  }, [location.state]);
 
   // Function to create a new conversation
   const handleNewConversation = () => {
@@ -228,8 +248,26 @@ export default function SpeechToTextApp() {
                     </div>
                   )}
                 </div>
-                {selectedConversation && (
-                  <div className="flex items-center">
+                <div className="flex items-center gap-2 md:gap-3">
+                  {/* Model picker: keeps every healthy STT deployment reachable
+                      even though the navbar links here with just one button. */}
+                  <Select
+                    value={modelID ?? ""}
+                    onValueChange={setModelID}
+                    disabled={sttModels.length === 0}
+                  >
+                    <SelectTrigger className="h-8 md:h-9 text-xs md:text-sm w-[120px] md:w-[200px]">
+                      <SelectValue placeholder="No model ready" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sttModels.map((m) => (
+                        <SelectItem key={m.id} value={m.id}>
+                          {m.modelName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {selectedConversation && (
                     <Button
                       variant="outline"
                       size="sm"
@@ -254,8 +292,8 @@ export default function SpeechToTextApp() {
                         </>
                       )}
                     </Button>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
 
               <div className="flex-1 overflow-hidden">

--- a/app/frontend/src/components/tts/TTSDemo.tsx
+++ b/app/frontend/src/components/tts/TTSDemo.tsx
@@ -374,7 +374,12 @@ export default function TTSDemo() {
   };
 
   return (
-    <Card className="flex flex-col w-full max-w-3xl max-h-[85vh] overflow-hidden shadow-xl bg-white dark:bg-black border-gray-200 dark:border-[#7C68FA]/20 rounded-2xl">
+    // Fixed height, not max-height: the outer page wrapper vertically centers
+    // this card (items-center in a h-screen flex). A card that grows with its
+    // content would grow symmetrically around that centered point, pushing its
+    // top edge upward until it goes behind the navbar. A constant footprint
+    // keeps the card's position stable; content beyond it scrolls internally.
+    <Card className="flex flex-col w-full max-w-3xl h-[85vh] overflow-hidden shadow-xl bg-white dark:bg-black border-gray-200 dark:border-[#7C68FA]/20 rounded-2xl">
       {/* Always-mounted audio element (no native controls) */}
       <audio
         ref={audioRef}
@@ -387,7 +392,11 @@ export default function TTSDemo() {
         className="hidden"
       />
 
-      <div className="flex-1 overflow-auto flex items-center justify-center">
+      {/* items-start (not center): centering a flex item taller than its
+          container defaults the scroll position to the middle, hiding the
+          header above the visible area once content grows past the
+          viewport. Top-anchoring keeps it reachable by scrolling down. */}
+      <div className="flex-1 overflow-auto flex items-start justify-center">
         <div className="w-full max-w-3xl px-6 py-8 flex flex-col gap-6">
           {/* Header */}
           <motion.div

--- a/app/frontend/src/components/tts/TTSDemo.tsx
+++ b/app/frontend/src/components/tts/TTSDemo.tsx
@@ -14,37 +14,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { runTTSInference } from "../../api/modelsDeployedApis";
+import {
+  runTTSInference,
+  fetchHealthyModelsByType,
+  type DeployedModelSummary,
+} from "../../api/modelsDeployedApis";
 import { customToast } from "../CustomToaster";
 
-interface DeployedModelInfo {
-  id: string;
-  modelName: string;
-  model_type?: string;
-}
-
-async function fetchTTSModels(): Promise<DeployedModelInfo[]> {
-  try {
-    const res = await fetch("/models-api/deployed/");
-    if (!res.ok) return [];
-    const data = await res.json();
-    return Object.entries(data)
-      .map(([id, info]: [string, any]) => ({
-        id,
-        modelName:
-          info.model_impl?.model_name ||
-          info.model_impl?.hf_model_id ||
-          "Unknown",
-        model_type: info.model_impl?.model_type,
-      }))
-      .filter((m) => m.model_type === "tts");
-  } catch {
-    return [];
-  }
-}
-
 export default function TTSDemo() {
-  const [ttsModels, setTtsModels] = useState<DeployedModelInfo[]>([]);
+  const [ttsModels, setTtsModels] = useState<DeployedModelSummary[]>([]);
   const [selectedDeployId, setSelectedDeployId] = useState("");
   const [text, setText] = useState("");
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
@@ -64,7 +42,7 @@ export default function TTSDemo() {
   const sourceNodeRef = useRef<MediaElementAudioSourceNode | null>(null);
 
   useEffect(() => {
-    fetchTTSModels().then((models) => {
+    fetchHealthyModelsByType("tts").then((models) => {
       setTtsModels(models);
       if (models.length > 0) setSelectedDeployId(models[0].id);
     });

--- a/app/frontend/src/components/ui/DeploymentProgress.tsx
+++ b/app/frontend/src/components/ui/DeploymentProgress.tsx
@@ -3,7 +3,8 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Progress } from './progress';
-import { formatBytes, formatEtaRemaining } from '../../lib/deployProgress';
+import { compactPercent, formatBytes, formatEtaRemaining } from '../../lib/deployProgress';
+import type { DeploymentProgressData } from '../../hooks/useActiveDeployments';
 
 /** Log / TT_PROGRESS lines when host setup finished or weights were already present (no long download). */
 function isCacheReadyOrSetupCompleteMessage(msg: string): boolean {
@@ -21,19 +22,9 @@ function isCacheReadyOrSetupCompleteMessage(msg: string): boolean {
 }
 
 interface DeploymentProgressProps {
-  progress: {
-    status: string;
-    stage: string;
-    progress: number;
-    message: string;
-    last_updated?: number;
-    weights_repo?: string;
-    downloaded_bytes?: number;
-    total_bytes?: number | null;
-    eta_seconds?: number | null;
-    speed_bps?: number | null;
-    weights_cached?: boolean;
-  } | null;
+  // Shared with DeploymentTray/VoiceAgentSolutionStep so this component can
+  // never drift onto its own hand-duplicated shape again (see compactPercent).
+  progress: DeploymentProgressData | null;
   className?: string;
   onRetry?: () => void;
   onCancel?: () => void;
@@ -137,7 +128,7 @@ export const DeploymentProgress: React.FC<DeploymentProgressProps> = ({
 
   if (!progress) return null;
 
-  const { status, stage, progress: progressPercent, message } = progress;
+  const { status, stage, message } = progress;
   const isError = status === 'error' || status === 'failed';
   const showProminentSetupMessage =
     !isError && isCacheReadyOrSetupCompleteMessage(message);
@@ -187,45 +178,15 @@ export const DeploymentProgress: React.FC<DeploymentProgressProps> = ({
       ? Math.min(100, Math.max(0, (downloadedBytes / totalBytes) * 100))
       : null;
 
-  // Byte-level download fraction (0–1), used to advance the download segment.
-  const downloadFraction =
-    totalBytes !== null && downloadedBytes !== null && totalBytes > 0
-      ? Math.min(1, Math.max(0, downloadedBytes / totalBytes))
-      : null;
-
   const isContainerStarting =
     !isError && !isComplete && !isStalled && !isCancelled && !isImagePull;
 
-  // Adaptive three-segment bar: image pull → weight download → container start, in
-  // the order they occur before the Models Deployed page.
-  //   with pull:    pull 0–25, download 25–95, start 95–99
-  //   image cached: download 0–95, start 95–99   (pull segment collapses)
-  // A weights cache-hit fast-forwards the download segment. Pull and download advance
-  // on real byte fractions; container start uses the backend's coarse per-stage progress.
-  const hasPull = isImagePull || imagePulled;
-  const cacheReady = isCacheReadyOrSetupCompleteMessage(message);
-  const [pullLo, pullHi] = hasPull ? [0, 25] : [0, 0];
-  const [dlLo, dlHi] = hasPull ? [25, 95] : [0, 95];
-  const [startLo, startHi] = [95, 99];
-  const lerp = (lo: number, hi: number, f: number) =>
-    lo + (hi - lo) * Math.min(1, Math.max(0, f));
-
-  // Only genuine post-download container-start stages map into the tail band. Early
-  // stages (starting/initialization/setup, or a transient not_found) precede the
-  // download and stay at the start, so the monotonic clamp can't lock the bar high
-  // before the download has even begun.
-  const containerStartStages = new Set([
-    'image_ready', 'container_setup', 'container_started', 'network_setup', 'finalizing', 'complete',
-  ]);
-  const rawPercent = (() => {
-    if (isError || isComplete) return 100;
-    if (isImagePull) return lerp(pullLo, pullHi, downloadFraction ?? 0);
-    if (stage === 'model_preparation')
-      return lerp(dlLo, dlHi, downloadFraction ?? (cacheReady ? 1 : 0));
-    if (containerStartStages.has(stage))
-      return lerp(startLo, startHi, (progressPercent ?? 0) / 100);
-    return hasPull ? pullLo : dlLo;
-  })();
+  // The exact same adaptive three-segment bar (image pull → weight download →
+  // container start) DeploymentTray/VoiceAgentSolutionStep use, so this card's
+  // percentage and the compact tray's can never drift apart again — see
+  // compactPercent's expects_weights handling (models like bge-m3 whose
+  // weights ship in the image skip the download band entirely).
+  const rawPercent = isError ? 100 : compactPercent(progress, isComplete, imagePulled);
 
   // Clamp monotonic so a noisy/coarse backend value can never make the bar jump
   // backwards. The ref resets naturally — the panel unmounts at completion and

--- a/app/frontend/src/pages/EmbeddingPage.tsx
+++ b/app/frontend/src/pages/EmbeddingPage.tsx
@@ -14,7 +14,10 @@ export default function EmbeddingPage() {
               "radial-gradient(ellipse at center, transparent 95%, black 100%)",
           }}
         ></div>
-        <div className="w-full h-screen flex items-center justify-center pl-[4.5rem] lg:pl-32 pb-20 p-4">
+        {/* pt-28 > pb-20: centering within padding pulls the card toward
+            whichever side has more of it, so the extra top padding settles it
+            a bit below true-center -- clear of the navbar, like AppsPage. */}
+        <div className="w-full h-screen flex items-center justify-center pl-[4.5rem] lg:pl-32 pt-28 pb-20 p-4">
           <EmbeddingDemo />
         </div>
       </div>

--- a/app/frontend/src/pages/EmbeddingPage.tsx
+++ b/app/frontend/src/pages/EmbeddingPage.tsx
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+import EmbeddingDemo from "../components/embedding/EmbeddingDemo";
+
+export default function EmbeddingPage() {
+  return (
+    <>
+      <div className="fixed inset-0 w-full dark:bg-black bg-white dark:bg-grid-white/[0.2] bg-grid-black/[0.2]">
+        <div
+          className="absolute pointer-events-none inset-0 flex items-center justify-center dark:bg-black bg-white"
+          style={{
+            maskImage:
+              "radial-gradient(ellipse at center, transparent 95%, black 100%)",
+          }}
+        ></div>
+        <div className="w-full h-screen flex items-center justify-center pl-[4.5rem] lg:pl-32 pb-20 p-4">
+          <EmbeddingDemo />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/src/routes/route-config.tsx
+++ b/app/frontend/src/routes/route-config.tsx
@@ -57,6 +57,7 @@ import SpeechToTextPage from "../pages/SpeechToTextPage";
 import ApiInfoPage from "../pages/ApiInfoPage";
 import DeploymentHistoryPage from "../pages/DeploymentHistoryPage";
 import TTSPage from "../pages/TTSPage";
+import EmbeddingPage from "../pages/EmbeddingPage";
 import WelcomePage from "../pages/WelcomePage";
 import WorkflowsPage from "../pages/WorkflowsPage";
 import CanvasPage from "../pages/CanvasPage";
@@ -155,6 +156,11 @@ export const getRoutes = (): RouteConfig[] => {
     {
       path: "/tts",
       element: <TTSPage />,
+      condition: true,
+    },
+    {
+      path: "/embedding",
+      element: <EmbeddingPage />,
       condition: true,
     },
     {

--- a/app/frontend/src/utils/deviceFit.ts
+++ b/app/frontend/src/utils/deviceFit.ts
@@ -8,7 +8,14 @@
 // To support a new model or change which device configurations a model allows,
 // edit getModelPlacement() below — nothing else in the frontend needs to change.
 
-import { isFluxModel, isLlama31_8BModel, isP300x2Board } from "./p300x2Placement";
+import {
+  isBgeM3Model,
+  isFluxModel,
+  isLlama31_8BModel,
+  isP300x2Board,
+  isQwen3Embedding06BModel,
+  isQwen3Embedding4BModel,
+} from "./p300x2Placement";
 import type { ChipStatusSlot } from "../types/chipStatus";
 
 export type DeviceSlotLike = Pick<ChipStatusSlot, "slot_id" | "status" | "model_name">;
@@ -100,6 +107,11 @@ export interface ModelPlacement {
   // True when a single-device model deploys board-wide by default (Wormhole mesh
   // boards); auto mode previews and uses the whole board, advanced can pin a slot.
   defaultsFullBoard?: boolean;
+  // Optional 2-device card-pair tier alongside allowsSingle/allowsFullBoard, e.g.
+  // Qwen3-Embedding-0.6B/bge-m3 on P300x2 (1/2/4 chips all valid, 1 by default).
+  // Unlike cardGroups (which means pairs are the ONLY multi-device option), this
+  // is a middle tier a model can offer in addition to a true single-device mode.
+  pairGroups?: number[][];
 }
 
 // SINGLE SOURCE OF TRUTH for per-model device configurations.
@@ -112,6 +124,25 @@ export function getModelPlacement(
   // Llama 3.1 8B on P300x2 runs on either P300 card (2 devices) or the full board.
   if (isP300x2Board(boardType) && isLlama31_8BModel(modelName)) {
     return { allowsSingle: false, allowsFullBoard: true, cardGroups: [[0, 1], [2, 3]] };
+  }
+  // Qwen3-Embedding-0.6B, Qwen3-Embedding-4B, and bge-m3 have P150/P300 chip-tier
+  // override specs (see runtime_model_spec_overrides in shared_config/model_config.py)
+  // AND a real, already-working whole-board P300x2 mesh spec -- unlike Llama's
+  // card-pair-only choice or FLUX's mesh-only fallback, these models offer all of
+  // 1/2/4 devices (each roughly N x throughput via independent data-parallel
+  // workers) and default to the cheapest, single chip.
+  if (
+    isP300x2Board(boardType) &&
+    (isQwen3Embedding06BModel(modelName) ||
+      isQwen3Embedding4BModel(modelName) ||
+      isBgeM3Model(modelName))
+  ) {
+    return {
+      allowsSingle: true,
+      allowsFullBoard: true,
+      cardGroups: [],
+      pairGroups: [[0, 1], [2, 3]],
+    };
   }
   // Multi-chip models always take the full board.
   if (isMultiChipModel(chipsRequired)) {

--- a/app/frontend/src/utils/p300x2Placement.ts
+++ b/app/frontend/src/utils/p300x2Placement.ts
@@ -36,6 +36,24 @@ export function isFluxModel(modelNameOrId?: string | null): boolean {
   return normalizeToken(modelNameOrId).includes("flux");
 }
 
+export function isQwen3Embedding06BModel(modelNameOrId?: string | null): boolean {
+  if (!modelNameOrId) return false;
+  const token = normalizeToken(modelNameOrId);
+  return token.includes("qwen3-embedding-0.6b") || token.includes("qwen3embedding0.6b");
+}
+
+export function isQwen3Embedding4BModel(modelNameOrId?: string | null): boolean {
+  if (!modelNameOrId) return false;
+  const token = normalizeToken(modelNameOrId);
+  return token.includes("qwen3-embedding-4b") || token.includes("qwen3embedding4b");
+}
+
+export function isBgeM3Model(modelNameOrId?: string | null): boolean {
+  if (!modelNameOrId) return false;
+  const token = normalizeToken(modelNameOrId);
+  return token.includes("bge-m3") || token.includes("bgem3");
+}
+
 export function parseDeviceIds(deviceId?: string | number): number[] {
   if (deviceId === undefined || deviceId === null) {
     return [];

--- a/dev-docs/run-py-guide.md
+++ b/dev-docs/run-py-guide.md
@@ -105,6 +105,16 @@ comma-separated list (e.g. `--device-id 0,1`).
 | `--add-headers` | Add missing SPDX license headers (excludes frontend). |
 | `--check-headers` | Report files missing SPDX license headers (no changes). |
 
+### Release (maintainers)
+
+These automate the release process in CONTRIBUTING.md (RC branch cut from `main`, cherry-picks from `dev`, squash-merge back, tag). They need the GitHub CLI (`gh`) installed and logged in with push access. They never switch your checkout (the RC branch is created with git plumbing and cherry-picked inside a scratch worktree), so run them from whatever branch you're on.
+
+| Option | Description |
+| --- | --- |
+| `--make-rc-branch [major\|minor\|patch\|vX.Y.Z]` | Cut a new `rc-vX.Y.Z` branch from `origin/main` (plus one empty marker commit so GitHub allows the PR before the first cherry-pick) and open the `Rc vX.Y.Z` PR against `main` with the release test plan. The bare flag asks which part of the version to bump; the last release is detected across tags, `rc-v*` branches, and RC merge commits. Refuses while an unshipped (untagged) `rc-v*` branch is on origin — one release at a time. |
+| `--update-rc-branch` | Cherry-pick new `dev` commits into the current `rc-vX.Y.Z` branch via an interactive picker. Lists dev commits newer than the `main` commit the RC was cut from (releases squash into `main`, so that date is the only reliable cutoff), minus picks already on the RC. Older dev commits can still be cherry-picked by hand. A conflict rolls the failing pick back and prints manual-resolution steps. |
+| `--merge-rc-branch` | Ship the RC: verifies the PR is approved (≥2 approvals) with green checks, asks for one confirmation, then squash-merges into `main`, pushes the `vX.Y.Z` tag (which triggers the Publish images workflow → GHCR), and creates the GitHub release with auto-generated notes. |
+
 ### Troubleshooting & Info
 
 | Option | Description |

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -2631,7 +2631,19 @@ async def run_inference(request: RunRequest):
         if request.vllm_override_args:
             base_argv.extend(["--vllm-override-args", request.vllm_override_args])
         if request.runtime_model_spec_json:
-            base_argv.extend(["--runtime-model-spec-json", request.runtime_model_spec_json])
+            # This path comes straight from the request body, so it must be
+            # constrained to TT_STUDIO_ROOT and checked to actually exist
+            # before being handed to run.py -- otherwise a caller could point
+            # this host process at an arbitrary file.
+            spec_path = Path(request.runtime_model_spec_json).resolve()
+            if _tt_studio_root not in spec_path.parents:
+                raise ValueError(
+                    f"runtime_model_spec_json must be under {_tt_studio_root}, "
+                    f"got {spec_path}"
+                )
+            if not spec_path.is_file():
+                raise ValueError(f"runtime_model_spec_json does not exist: {spec_path}")
+            base_argv.extend(["--runtime-model-spec-json", str(spec_path)])
         if request.disable_metal_timeout:
             base_argv.append("--disable-metal-timeout")
 

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -2093,6 +2093,13 @@ class RunRequest(BaseModel):
     device_id: Optional[str] = None
     override_tt_config: Optional[str] = None
     vllm_override_args: Optional[str] = None
+    # Hand-authored ModelSpec JSON path for a (model, device) pair the artifact
+    # doesn't declare a spec for -- taken as-is by run.py, bypassing its normal
+    # spec resolution/matching entirely (see run.py's own resolve_runtime()).
+    # Set by TT-Studio for catalog entries with a runtime_model_spec_overrides
+    # entry (shared_config/model_config.py); mutually exclusive with
+    # --custom-weights (enforced by run.py itself).
+    runtime_model_spec_json: Optional[str] = None
     # Optional secrets - can be passed through API if not set in environment
     jwt_secret: Optional[str] = None
     hf_token: Optional[str] = None
@@ -2623,6 +2630,8 @@ async def run_inference(request: RunRequest):
             base_argv.extend(["--override-tt-config", request.override_tt_config])
         if request.vllm_override_args:
             base_argv.extend(["--vllm-override-args", request.vllm_override_args])
+        if request.runtime_model_spec_json:
+            base_argv.extend(["--runtime-model-spec-json", request.runtime_model_spec_json])
         if request.disable_metal_timeout:
             base_argv.append("--disable-metal-timeout")
 

--- a/run.py
+++ b/run.py
@@ -21,6 +21,9 @@ Options:
     --build-images     Build container images locally instead of pulling prebuilt ones
     --check-headers       Check for missing SPDX license headers
     --add-headers         Add missing SPDX license headers (excludes frontend)
+    --make-rc-branch   Cut a new rc-vX.Y.Z branch from main + open the RC PR (maintainers)
+    --update-rc-branch Cherry-pick new dev commits into the current RC branch (maintainers)
+    --merge-rc-branch  Merge the approved RC PR, tag, and publish the release (maintainers)
     --help-env         Show environment variables help"""
 
 # Thin entrypoint. Implementation lives in the tt_setup/ package.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,6 +348,56 @@ class TestCli(unittest.TestCase):
         for argv, expected in cases:
             self.assertEqual(_normalize_purge_model_argv(argv), expected, argv)
 
+    def test_release_flags_listed_in_their_own_help_panel(self):
+        result = runner.invoke(M.app, ["--help"])
+        self.assertEqual(result.exit_code, 0)
+        output_without_ansi = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        self.assertIn("Release (maintainers)", output_without_ansi)
+        for flag in ("--make-rc-branch", "--update-rc-branch", "--merge-rc-branch"):
+            self.assertIn(flag, output_without_ansi)
+
+    def test_make_rc_branch_dispatches_with_value(self):
+        with patch.object(_cli_run, "make_rc_branch", return_value=0) as make:
+            result = runner.invoke(M.app, ["--make-rc-branch", "minor"])
+        self.assertEqual(result.exit_code, 0)
+        make.assert_called_once_with("minor")
+
+    def test_make_rc_branch_picker_sentinel_reaches_dispatch(self):
+        # main() (not click) supplies the sentinel for a bare --make-rc-branch;
+        # here we inject it the way _normalize_argv would.
+        from tt_setup.constants import _RC_BUMP_PICKER
+        with patch.object(_cli_run, "make_rc_branch", return_value=0) as make:
+            result = runner.invoke(M.app, ["--make-rc-branch", _RC_BUMP_PICKER])
+        self.assertEqual(result.exit_code, 0)
+        make.assert_called_once_with(_RC_BUMP_PICKER)
+
+    def test_update_rc_branch_dispatches(self):
+        with patch.object(_cli_run, "update_rc_branch", return_value=0) as update:
+            result = runner.invoke(M.app, ["--update-rc-branch"])
+        self.assertEqual(result.exit_code, 0)
+        update.assert_called_once_with()
+
+    def test_merge_rc_branch_nonzero_exit_propagates(self):
+        with patch.object(_cli_run, "merge_rc_branch", return_value=1) as merge:
+            result = runner.invoke(M.app, ["--merge-rc-branch"])
+        self.assertEqual(result.exit_code, 1)
+        merge.assert_called_once_with()
+
+    def test_normalize_argv_handles_bare_optional_value_flags(self):
+        from tt_setup.cli._args import _normalize_argv
+        from tt_setup.constants import _PURGE_MODEL_PICKER as P, _RC_BUMP_PICKER as R
+        cases = [
+            (["--make-rc-branch"], ["--make-rc-branch", R]),
+            (["--make-rc-branch", "-v"], ["--make-rc-branch", R, "-v"]),
+            (["--make-rc-branch", "minor"], ["--make-rc-branch", "minor"]),
+            (["--make-rc-branch=minor"], ["--make-rc-branch=minor"]),
+            # Both optional-value flags normalize independently.
+            (["--purge-model", "--make-rc-branch"],
+             ["--purge-model", P, "--make-rc-branch", R]),
+        ]
+        for argv, expected in cases:
+            self.assertEqual(_normalize_argv(argv), expected, argv)
+
     def test_no_clear_flag_sets_globals_and_implies_verbose(self):
         # --no-clear preserves the terminal's contents AND streams full detail, so
         # it flips both the no_clear and verbose rendering globals. _run is patched

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for the release flags: version planning and the git/gh command
+sequences (all subprocess use mocked — no real git, gh, or network)."""
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from tt_setup import release as M
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["git"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+class _Recorder:
+    """Fake _git/_gh: records argv tuples and answers from a script of
+    responses keyed by argv prefix (first match in insertion order wins)."""
+
+    def __init__(self, responses=None):
+        self.calls = []
+        self._responses = responses or {}
+
+    def __call__(self, *argv, **kwargs):
+        self.calls.append(argv)
+        for key, proc in self._responses.items():
+            if argv[:len(key)] == key:
+                return proc
+        return _proc()
+
+    def prefixes(self, *key):
+        return [c for c in self.calls if c[:len(key)] == key]
+
+
+# --- pure planners ------------------------------------------------------------
+
+class TestVersionPlanning(unittest.TestCase):
+    def test_parse_version_strict(self):
+        self.assertEqual(M.parse_version("v2.9.1"), (2, 9, 1))
+        self.assertIsNone(M.parse_version("v0.0.0-ghcr-test"))  # suffixes rejected
+        self.assertIsNone(M.parse_version("rc-v2.9.1"))
+        self.assertIsNone(M.parse_version("2.9.1"))
+        self.assertIsNone(M.parse_version(""))
+
+    def test_bump_version(self):
+        self.assertEqual(M.bump_version("v2.9.1", "major"), "v3.0.0")
+        self.assertEqual(M.bump_version("v2.9.1", "minor"), "v2.10.0")
+        self.assertEqual(M.bump_version("v2.9.1", "patch"), "v2.9.2")
+
+    def test_bump_version_rejects_junk(self):
+        with self.assertRaises(ValueError):
+            M.bump_version("banana", "minor")
+        with self.assertRaises(ValueError):
+            M.bump_version("v2.9.1", "huge")
+
+    def test_find_last_rc_version_each_source(self):
+        self.assertEqual(M.find_last_rc_version(["v2.8.0", "v1.0.0"], [], []), "v2.8.0")
+        self.assertEqual(M.find_last_rc_version([], ["  origin/rc-v2.9.0"], []), "v2.9.0")
+        self.assertEqual(M.find_last_rc_version([], [], ["Rc v2.9.1 (#1196)"]), "v2.9.1")
+
+    def test_find_last_rc_version_takes_max_across_sources(self):
+        # The real drift: tags stop at v2.8.0 while RC merges reached v2.9.1.
+        self.assertEqual(
+            M.find_last_rc_version(
+                ["v2.8.0", "v0.0.0-ghcr-test"],
+                ["origin/rc-v2.9.0", "origin/jashan/release-automation"],
+                ["Rc v2.9.1 (#1196)", "Rc v2.9.0 (#1157)",
+                 "Release Candidate v2.5.1 (#726)", "rc-2.3.1 (#579)"],
+            ),
+            "v2.9.1",
+        )
+
+    def test_find_last_rc_version_empty(self):
+        self.assertIsNone(M.find_last_rc_version([], [], ["unrelated subject"]))
+
+    def test_parse_oneline(self):
+        self.assertEqual(
+            M.parse_oneline(["abc123 fix: one thing", "", "def456 feat: another"]),
+            [("abc123", "fix: one thing"), ("def456", "feat: another")],
+        )
+
+    def test_render_test_plan_mentions_version_and_health_checks(self):
+        body = M.render_test_plan("v2.10.0")
+        self.assertIn("Rc v2.10.0", body)
+        for probe in ("localhost:8000/up/", "localhost:8001/health", "localhost:3000"):
+            self.assertIn(probe, body)
+
+
+# --- shared fixtures ----------------------------------------------------------
+
+_LAST_RC_STATE = {
+    ("tag", "-l"): _proc(stdout="v2.8.0\nv0.0.0-ghcr-test\n"),
+    ("branch", "-r"): _proc(stdout="  origin/dev\n  origin/rc-v2.9.0\n"),
+    ("log", "origin/main"): _proc(stdout="Rc v2.9.1 (#1196)\nRc v2.9.0 (#1157)\n"),
+    ("rev-parse", "--verify"): _proc(returncode=1),  # no local/remote rc for the new version
+    # rc-v2.9.0 shipped (its tag is on origin), so it is not an in-flight RC.
+    ("ls-remote", "--tags", "origin", "refs/tags/v2.9.0"): _proc(stdout="f00\trefs/tags/v2.9.0\n"),
+    ("rev-parse", "origin/main"): _proc(stdout="feedc0de\n"),
+    ("commit-tree",): _proc(stdout="cafe1234\n"),  # the empty marker commit
+}
+
+
+def _with_gh(test):
+    """Patch gh presence + auth so preflight passes."""
+    return patch.object(M.shutil, "which", return_value="/usr/bin/gh")(test)
+
+
+# --- make_rc_branch -----------------------------------------------------------
+
+class TestMakeRcBranch(unittest.TestCase):
+    def test_never_switches_the_users_checkout(self):
+        # The RC is cut from main, which doesn't carry these flags until the
+        # tooling itself ships — so a dirty tree is fine and no checkout happens.
+        responses = dict(_LAST_RC_STATE)
+        responses[("status",)] = _proc(stdout=" M run.py\n")
+        git = _Recorder(responses)
+        gh = _Recorder({("pr", "create"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 0)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+        self.assertNotIn("switch", [c[0] for c in git.calls])
+
+    def test_missing_gh_is_a_clean_failure(self):
+        git = _Recorder()
+        with patch.object(M, "_git", git), \
+             patch.object(M.shutil, "which", return_value=None):
+            self.assertEqual(M.make_rc_branch("minor"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_logged_out_gh_is_a_clean_failure(self):
+        git = _Recorder()
+        gh = _Recorder({("auth", "status"): _proc(returncode=1, stderr="not logged in")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_existing_branch_refused(self):
+        responses = dict(_LAST_RC_STATE)
+        responses[("rev-parse", "--verify")] = _proc(returncode=0)  # branch exists
+        git = _Recorder(responses)
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_in_flight_rc_refused_instead_of_bumping_past_it(self):
+        # First real run: a second `--make-rc-branch patch` cut rc-v2.10.3 on
+        # top of an unshipped rc-v2.10.2. An untagged rc-v* branch on origin is
+        # a release in progress — refuse, whatever bump was asked for.
+        responses = dict(_LAST_RC_STATE)
+        responses[("branch", "-r")] = _proc(stdout="  origin/dev\n  origin/rc-v2.10.2\n")
+        git = _Recorder(responses)  # no ls-remote hit for v2.10.2 → not tagged
+        gh = _Recorder()
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("patch"), 1)
+            self.assertEqual(M.make_rc_branch("v3.0.0"), 1)
+        self.assertEqual(git.prefixes("commit-tree"), [])
+        self.assertEqual(git.prefixes("push"), [])
+        self.assertEqual(gh.prefixes("pr", "create"), [])
+
+    def test_shipped_rc_branch_does_not_block_the_next_cut(self):
+        # rc-v2.9.0 is still on origin but tagged → a normal minor bump proceeds.
+        git = _Recorder(_LAST_RC_STATE)
+        gh = _Recorder({("pr", "create"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 0)
+        self.assertIn(("push", "origin", "cafe1234:refs/heads/rc-v2.10.0"), git.calls)
+
+    def test_existing_tag_refused(self):
+        responses = dict(_LAST_RC_STATE)
+        responses[("ls-remote",)] = _proc(stdout="deadbeef\trefs/tags/v2.10.0\n")
+        git = _Recorder(responses)
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_bare_flag_without_tty_fails_with_hint(self):
+        git = _Recorder(_LAST_RC_STATE)
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=False):
+            from tt_setup.constants import _RC_BUMP_PICKER
+            self.assertEqual(M.make_rc_branch(_RC_BUMP_PICKER), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_explicit_minor_bumps_last_rc_and_opens_pr(self):
+        # Last known version is v2.9.1 (from a merge subject, not a tag) →
+        # minor bump cuts rc-v2.10.0.
+        git = _Recorder(_LAST_RC_STATE)
+        gh = _Recorder({("pr", "create"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 0)
+        self.assertIn(("push", "origin", "cafe1234:refs/heads/rc-v2.10.0"), git.calls)
+        pr_create = gh.prefixes("pr", "create")
+        self.assertEqual(len(pr_create), 1)
+        self.assertIn("Rc v2.10.0", pr_create[0])
+        self.assertIn("main", pr_create[0])
+
+    def test_branch_starts_with_an_empty_marker_commit_so_the_pr_can_open(self):
+        # GitHub rejects a PR between identical branches ("No commits between
+        # main and rc-vX.Y.Z"), so the cut must push one commit ahead of main.
+        git = _Recorder(_LAST_RC_STATE)
+        gh = _Recorder({("pr", "create"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("minor"), 0)
+        tree = git.prefixes("commit-tree")
+        self.assertEqual(len(tree), 1)
+        self.assertEqual(tree[0][:4], ("commit-tree", "feedc0de^{tree}", "-p", "feedc0de"))
+        self.assertIn("Rc v2.10.0", tree[0][5])
+        push = ("push", "origin", "cafe1234:refs/heads/rc-v2.10.0")
+        self.assertLess(git.calls.index(tree[0]), git.calls.index(push))
+        # The marker is pushed before the PR is requested.
+        self.assertIn(push, git.calls)
+        self.assertEqual(len(gh.prefixes("pr", "create")), 1)
+
+    def test_bare_flag_prompts_for_part(self):
+        git = _Recorder(_LAST_RC_STATE)
+        gh = _Recorder({("pr", "create"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=True), \
+             patch.object(M, "ask", return_value="patch") as asked:
+            from tt_setup.constants import _RC_BUMP_PICKER
+            self.assertEqual(M.make_rc_branch(_RC_BUMP_PICKER), 0)
+        asked.assert_called_once()
+        self.assertIn(("push", "origin", "cafe1234:refs/heads/rc-v2.9.2"), git.calls)
+
+    def test_garbage_value_is_rejected(self):
+        git = _Recorder(_LAST_RC_STATE)
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.make_rc_branch("hueg"), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+
+# --- update_rc_branch ---------------------------------------------------------
+
+class TestUpdateRcBranch(unittest.TestCase):
+    def _base(self, extra=None):
+        responses = {
+            ("branch", "-r"): _proc(stdout="  origin/dev\n  origin/rc-v2.10.0\n"),
+            ("merge-base",): _proc(stdout="ba5e0000\n"),  # main commit the RC was cut from
+            ("rev-parse", "origin/rc-v2.10.0"): _proc(stdout="0ddba11\n"),  # RC tip at start
+            ("log", "-1", "--format=%cI"): _proc(stdout="2026-08-28T16:40:34-04:00\n"),
+        }
+        responses.update(extra or {})
+        return responses
+
+    def test_candidates_are_cut_off_at_the_rcs_base_on_main(self):
+        # Releases land on main as one squash commit, so patch-id matching alone
+        # lists dev's whole history (328 commits on the first real run). The log
+        # must be bounded by the date of the main commit the RC was cut from.
+        git = _Recorder(self._base({("log", "--cherry-pick"): _proc(stdout="")}))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.update_rc_branch(), 0)
+        self.assertIn(("merge-base", "origin/rc-v2.10.0", "origin/main"), git.calls)
+        log = git.prefixes("log", "--cherry-pick")
+        self.assertEqual(len(log), 1)
+        self.assertIn("--since=2026-08-28T16:40:34-04:00", log[0])
+        self.assertEqual(log[0][-1], "origin/rc-v2.10.0...origin/dev")
+
+    def test_unknown_base_falls_back_to_no_cutoff(self):
+        git = _Recorder(self._base({
+            ("merge-base",): _proc(returncode=1, stderr="fatal: no merge base"),
+            ("log", "--cherry-pick"): _proc(stdout=""),
+        }))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.update_rc_branch(), 0)
+        log = git.prefixes("log", "--cherry-pick")[0]
+        self.assertFalse(any(a.startswith("--since") for a in log))
+
+    def test_fetch_prunes_deleted_remote_branches(self):
+        # Without --prune a deleted rc-v* lingers as origin/rc-v* and gets "found".
+        git = _Recorder({("branch", "-r"): _proc(stdout="  origin/dev\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            M.update_rc_branch()
+        self.assertIn(("fetch", "origin", "--tags", "--prune"), git.calls)
+
+    def test_no_rc_branch_is_a_clean_failure(self):
+        git = _Recorder({("branch", "-r"): _proc(stdout="  origin/dev\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.update_rc_branch(), 1)
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+
+    def test_up_to_date_rc_exits_zero_without_picks(self):
+        git = _Recorder(self._base({("log", "--cherry-pick"): _proc(stdout="")}))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.update_rc_branch(), 0)
+        self.assertNotIn("cherry-pick", [c[0] for c in git.calls])
+
+    def test_happy_path_picks_all_and_pushes(self):
+        git = _Recorder(self._base({
+            ("log", "--cherry-pick"): _proc(stdout="abc123 fix: one\ndef456 fix: two\n"),
+        }))
+        gh = _Recorder({("pr", "view"): _proc(stdout="https://github.com/x/pull/1\n")})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=True), \
+             patch.object(M, "ask", return_value="all"):
+            self.assertEqual(M.update_rc_branch(), 0)
+        # Work happens in a scratch worktree of origin/<rc>, never in the checkout.
+        self.assertNotIn("checkout", [c[0] for c in git.calls])
+        adds = git.prefixes("worktree", "add")
+        self.assertEqual(len(adds), 1)
+        self.assertEqual(adds[0][2], "--detach")
+        self.assertEqual(adds[0][4], "origin/rc-v2.10.0")
+        # Applied oldest-first, in the order git listed them.
+        picks = git.prefixes("cherry-pick")
+        self.assertEqual(picks, [("cherry-pick", "abc123"), ("cherry-pick", "def456")])
+        # Leased on the RC tip seen at the start: a branch that moved or was
+        # deleted meanwhile (first real run resurrected a deleted RC) is rejected.
+        self.assertIn(("push", "--force-with-lease=refs/heads/rc-v2.10.0:0ddba11",
+                       "origin", "HEAD:refs/heads/rc-v2.10.0"), git.calls)
+        removes = git.prefixes("worktree", "remove")
+        self.assertEqual(len(removes), 1)
+        self.assertEqual(removes[0][3], adds[0][3])  # same scratch path
+
+    def test_subset_selection_only_picks_chosen(self):
+        git = _Recorder(self._base({
+            ("log", "--cherry-pick"): _proc(stdout="abc123 fix: one\ndef456 fix: two\n"),
+        }))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=True), \
+             patch.object(M, "ask", return_value="2"):
+            self.assertEqual(M.update_rc_branch(), 0)
+        self.assertEqual(git.prefixes("cherry-pick"), [("cherry-pick", "def456")])
+
+    def test_conflict_aborts_the_pick_and_fails(self):
+        git = _Recorder(self._base({
+            ("log", "--cherry-pick"): _proc(stdout="abc123 fix: one\n"),
+            ("cherry-pick", "--abort"): _proc(),
+            ("cherry-pick",): _proc(returncode=1, stderr="CONFLICT (content)"),
+        }))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=True), \
+             patch.object(M, "ask", return_value="all"):
+            self.assertEqual(M.update_rc_branch(), 1)
+        self.assertIn(("cherry-pick", "--abort"), git.calls)
+        self.assertNotIn("push", [c[0] for c in git.calls])
+        self.assertEqual(len(git.prefixes("worktree", "remove")), 1)  # scratch cleaned up
+
+    def test_worktree_cleanup_also_runs_when_the_worktree_cannot_be_created(self):
+        git = _Recorder(self._base({
+            ("log", "--cherry-pick"): _proc(stdout="abc123 fix: one\n"),
+            ("worktree", "add"): _proc(returncode=1, stderr="fatal: nope"),
+        }))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=True), \
+             patch.object(M, "ask", return_value="all"):
+            self.assertEqual(M.update_rc_branch(), 1)
+        self.assertNotIn("cherry-pick", [c[0] for c in git.calls])
+        self.assertEqual(len(git.prefixes("worktree", "remove")), 1)
+
+    def test_non_tty_with_candidates_fails_cleanly(self):
+        git = _Recorder(self._base({
+            ("log", "--cherry-pick"): _proc(stdout="abc123 fix: one\n"),
+        }))
+        with patch.object(M, "_git", git), patch.object(M, "_gh", _Recorder()), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch("sys.stdin.isatty", return_value=False):
+            self.assertEqual(M.update_rc_branch(), 1)
+        self.assertNotIn("cherry-pick", [c[0] for c in git.calls])
+
+
+# --- merge_rc_branch ----------------------------------------------------------
+
+_APPROVED_PR = (
+    '{"number": 123, "url": "https://github.com/x/pull/123", "state": "OPEN",'
+    ' "reviewDecision": "APPROVED",'
+    ' "statusCheckRollup": [{"name": "ci", "conclusion": "SUCCESS"}]}'
+)
+
+
+class TestMergeRcBranch(unittest.TestCase):
+    def _git_base(self, extra=None):
+        responses = {
+            ("branch", "-r"): _proc(stdout="  origin/rc-v2.10.0\n"),
+            ("rev-parse", "--verify"): _proc(returncode=1),  # no stale local v2.10.0 tag
+            ("rev-parse", "origin/main"): _proc(stdout="feedc0de\n"),
+            ("log", "-1"): _proc(stdout="Rc v2.10.0 (#123)\n"),
+        }
+        responses.update(extra or {})
+        return responses
+
+    def test_stale_local_tag_refused_before_merging(self):
+        git = _Recorder(self._git_base({("rev-parse", "--verify"): _proc(returncode=0)}))
+        gh = _Recorder({("pr", "view"): _proc(stdout=_APPROVED_PR)})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.merge_rc_branch(), 1)
+        self.assertEqual(gh.prefixes("pr", "merge"), [])
+
+    def test_already_tagged_version_refused(self):
+        git = _Recorder(self._git_base({
+            ("ls-remote",): _proc(stdout="deadbeef\trefs/tags/v2.10.0\n"),
+        }))
+        gh = _Recorder()
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.merge_rc_branch(), 1)
+        self.assertEqual(gh.prefixes("pr", "merge"), [])
+
+    def test_unapproved_pr_refused_without_merge(self):
+        git = _Recorder(self._git_base())
+        gh = _Recorder({("pr", "view"): _proc(stdout=_APPROVED_PR.replace(
+            "APPROVED", "REVIEW_REQUIRED"))})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.merge_rc_branch(), 1)
+        self.assertEqual(gh.prefixes("pr", "merge"), [])
+
+    def test_failing_checks_refused_without_merge(self):
+        git = _Recorder(self._git_base())
+        gh = _Recorder({("pr", "view"): _proc(stdout=_APPROVED_PR.replace(
+            "SUCCESS", "FAILURE"))})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"):
+            self.assertEqual(M.merge_rc_branch(), 1)
+        self.assertEqual(gh.prefixes("pr", "merge"), [])
+
+    def test_declined_confirmation_merges_nothing(self):
+        git = _Recorder(self._git_base())
+        gh = _Recorder({("pr", "view"): _proc(stdout=_APPROVED_PR)})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch.object(M, "confirm", return_value=False):
+            self.assertEqual(M.merge_rc_branch(), 0)
+        self.assertEqual(gh.prefixes("pr", "merge"), [])
+        self.assertNotIn("tag", [c[0] for c in git.calls])
+
+    def test_happy_path_merges_tags_and_releases_in_order(self):
+        git = _Recorder(self._git_base())
+        gh = _Recorder({
+            ("pr", "view"): _proc(stdout=_APPROVED_PR),
+            ("api",): _proc(stdout="## What's Changed\n- stuff\n"),
+            ("release", "create"): _proc(stdout="https://github.com/x/releases/v2.10.0\n"),
+        })
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch.object(M, "confirm", return_value=True):
+            self.assertEqual(M.merge_rc_branch(), 0)
+        merge = gh.prefixes("pr", "merge")
+        self.assertEqual(len(merge), 1)
+        self.assertIn("--squash", merge[0])
+        self.assertIn("Rc v2.10.0", merge[0])
+        self.assertIn(("tag", "v2.10.0", "feedc0de"), git.calls)
+        self.assertIn(("push", "origin", "v2.10.0"), git.calls)
+        self.assertEqual(len(gh.prefixes("release", "create")), 1)
+        # Tag is only pushed after the PR merge, release only after the tag.
+        self.assertLess(gh.calls.index(merge[0]),
+                        len(gh.calls))  # merge happened
+        self.assertLess(git.calls.index(("tag", "v2.10.0", "feedc0de")),
+                        git.calls.index(("push", "origin", "v2.10.0")))
+
+    def test_moved_main_tip_refuses_to_tag(self):
+        git = _Recorder(self._git_base({
+            ("log", "-1"): _proc(stdout="Add unrelated workflow (#1205)\n"),
+        }))
+        gh = _Recorder({("pr", "view"): _proc(stdout=_APPROVED_PR)})
+        with patch.object(M, "_git", git), patch.object(M, "_gh", gh), \
+             patch.object(M.shutil, "which", return_value="/usr/bin/gh"), \
+             patch.object(M, "confirm", return_value=True):
+            self.assertEqual(M.merge_rc_branch(), 1)
+        self.assertNotIn("tag", [c[0] for c in git.calls])
+        self.assertEqual(gh.prefixes("release", "create"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tt_setup/cli/_args.py
+++ b/tt_setup/cli/_args.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from typing import List, Optional
 from tt_setup.console import console, ensure_region_reset, set_no_clear, set_verbose
 from tt_setup.constants import *
-from tt_setup.constants import _PURGE_MODEL_PICKER
+from tt_setup.constants import _PURGE_MODEL_PICKER, _RC_BUMP_PICKER
 from tt_setup.cli._run import _run
 
 
@@ -226,6 +226,10 @@ def _entry(
     # ── Developer Tools ──────────────────────────────────────────────────────
     add_headers: bool = typer.Option(False, "--add-headers", help="Add missing SPDX license headers (excludes frontend).", rich_help_panel="Developer Tools"),
     check_headers: bool = typer.Option(False, "--check-headers", help="Check for missing SPDX license headers.", rich_help_panel="Developer Tools"),
+    # ── Release (maintainers) ────────────────────────────────────────────────
+    make_rc_branch: str = typer.Option(None, "--make-rc-branch", metavar="[major|minor|patch|vX.Y.Z]", help="Cut a new rc-vX.Y.Z branch from main and open the RC PR (bare flag asks which part to bump).", rich_help_panel="Release (maintainers)"),
+    update_rc_branch: bool = typer.Option(False, "--update-rc-branch", help="Cherry-pick new dev commits into the current rc-vX.Y.Z branch (interactive picker).", rich_help_panel="Release (maintainers)"),
+    merge_rc_branch: bool = typer.Option(False, "--merge-rc-branch", help="Merge the approved RC PR into main, push the vX.Y.Z tag (publishes GHCR images), and create the GitHub release.", rich_help_panel="Release (maintainers)"),
     # ── Troubleshooting & Info ───────────────────────────────────────────────
     help_env: bool = typer.Option(False, "--help-env", help="Show detailed environment-variables help.", rich_help_panel="Troubleshooting & Info"),
     report_bug: bool = typer.Option(False, "--report-bug", help="Collect a diagnostics bundle and open a pre-filled GitHub issue.", rich_help_panel="Troubleshooting & Info"),
@@ -271,6 +275,8 @@ def _entry(
         report_bug=report_bug, install_shortcut=install_shortcut,
         accept_terms=accept_terms, switch=switch, uninstall=uninstall,
         purge_model=list(purge_model or []), stop_model=list(stop_model or []),
+        make_rc_branch=make_rc_branch, update_rc_branch=update_rc_branch,
+        merge_rc_branch=merge_rc_branch,
     )
     _run(args)
 
@@ -304,24 +310,32 @@ def run_model_command(
     _run(args)
 
 
-# Flags that take an optional model name: bare means "open the picker".
-_OPTIONAL_MODEL_FLAGS = ("--purge-model", "--stop-model")
+# Flags that accept an optional value: bare usage injects a sentinel meaning
+# "open the interactive picker/prompt" (the vendored click in this typer
+# version can't express an option with an optional value).
+_BARE_FLAG_SENTINELS = {
+    "--purge-model": _PURGE_MODEL_PICKER,
+    "--stop-model": _PURGE_MODEL_PICKER,
+    "--make-rc-branch": _RC_BUMP_PICKER,
+}
 
 
-def _normalize_purge_model_argv(argv):
-    """Support a bare `--purge-model` / `--stop-model` (no model name) meaning
-    "open the picker". The vendored click in this typer version can't express an
-    option with an optional value, so inject the picker sentinel whenever such a
-    flag is the last token or is followed by another flag. `--flag NAME` and
-    `--flag=NAME` pass through untouched."""
+def _normalize_argv(argv):
+    """Inject a flag's sentinel whenever it is the last token or is followed by
+    another flag. `--flag VALUE` and `--flag=VALUE` pass through untouched."""
     out = []
     for i, token in enumerate(argv):
         out.append(token)
-        if token in _OPTIONAL_MODEL_FLAGS and (
+        if token in _BARE_FLAG_SENTINELS and (
             i + 1 == len(argv) or argv[i + 1].startswith("-")
         ):
-            out.append(_PURGE_MODEL_PICKER)
+            out.append(_BARE_FLAG_SENTINELS[token])
     return out
+
+
+def _normalize_purge_model_argv(argv):
+    """Back-compat alias for _normalize_argv (kept for existing callers/tests)."""
+    return _normalize_argv(argv)
 
 
 def main():
@@ -331,7 +345,7 @@ def main():
     import atexit
     atexit.register(ensure_region_reset)
     try:
-        app(_normalize_purge_model_argv(sys.argv[1:]))
+        app(_normalize_argv(sys.argv[1:]))
     finally:
         ensure_region_reset()
 

--- a/tt_setup/cli/_run.py
+++ b/tt_setup/cli/_run.py
@@ -21,6 +21,7 @@ from tt_setup.image_source import BUILD_REASON_FRONTEND, DEFAULT_IMAGE_REGISTRY,
 from tt_setup.bug_report import report_bug
 from tt_setup.shortcut import install_shortcut, maybe_offer_shortcut, maybe_repair_shortcut, uninstall_shortcut
 from tt_setup.switch import switch_checkout
+from tt_setup.release import make_rc_branch, merge_rc_branch, update_rc_branch
 from tt_setup.cleanup import cleanup_resources, purge_models
 from tt_setup.services import check_and_free_ports, ensure_frontend_dependencies, get_frontend_config, report_service_failure, setup_fastapi_environment, snapshot_health, start_docker_control_service, start_fastapi_server, wait_for_all_services, wait_for_frontend_and_open_browser
 from tt_setup.inference_server import _sync_model_catalog, setup_tt_inference_server
@@ -306,6 +307,9 @@ def _run(args):
   {C_CYAN}python run.py --no-sudo{C_RESET}              Skip sudo usage (may limit functionality)
   {C_CYAN}python run.py --check-headers{C_RESET}        Check for missing SPDX license headers
   {C_CYAN}python run.py --add-headers{C_RESET}          Add missing SPDX license headers
+  {C_CYAN}python run.py --make-rc-branch{C_RESET}       Cut a new rc-vX.Y.Z branch from main + open the RC PR (maintainers)
+  {C_CYAN}python run.py --update-rc-branch{C_RESET}     Cherry-pick new dev commits into the current RC branch (maintainers)
+  {C_CYAN}python run.py --merge-rc-branch{C_RESET}      Merge the approved RC PR, tag, and publish the release (maintainers)
 
 {'=' * 80}
 {C_WHITE}For more information, visit: {C_CYAN}https://github.com/tenstorrent/tt-studio{C_RESET}
@@ -343,6 +347,15 @@ def _run(args):
 
         if getattr(args, "switch", None):
             sys.exit(switch_checkout(args.switch))
+
+        if getattr(args, "make_rc_branch", None):
+            sys.exit(make_rc_branch(args.make_rc_branch))
+
+        if getattr(args, "update_rc_branch", False):
+            sys.exit(update_rc_branch())
+
+        if getattr(args, "merge_rc_branch", False):
+            sys.exit(merge_rc_branch())
 
         # Stopping one model (and resetting its chips) must never fall through
         # to the full-stack teardown either.

--- a/tt_setup/constants.py
+++ b/tt_setup/constants.py
@@ -97,6 +97,8 @@ _CLEANUP_VOLUME_PREFIX = "volume_id_"
 # Sentinel injected by the CLI when --purge-model is passed with no model name,
 # meaning "open the interactive picker" (typer can't express optional values).
 _PURGE_MODEL_PICKER = "__picker__"
+# Same trick for a bare --make-rc-branch: "ask which version part to bump".
+_RC_BUMP_PICKER = "__bump-picker__"
 # Marketplace apps (Open WebUI, AnythingLLM, Vane, …) keep their state in named
 # volumes declared in shared_config/marketplace_config.py. Matched by shape
 # rather than an app list so volumes left by apps since removed from the

--- a/tt_setup/release.py
+++ b/tt_setup/release.py
@@ -1,0 +1,735 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Maintainer release flags: --make-rc-branch / --update-rc-branch / --merge-rc-branch.
+
+TT Studio's release model (CONTRIBUTING.md → Release Process): a release
+candidate branch `rc-vX.Y.Z` is cut from `main`, validated changes are
+cherry-picked from `dev`, the "Rc vX.Y.Z" PR is squash-merged back into `main`
+with at least two approvals, and the merge commit is tagged `vX.Y.Z`. Git tags
+are the only version source of truth — nothing bumps package.json.
+
+Pushing the tag triggers the Publish images workflow (GHCR); publishing the
+GitHub release fires it a second time. That duplicate is known and accepted:
+the workflow's concurrency group serializes the runs and the rebuild produces
+identical image tags.
+
+These flags require the GitHub CLI (`gh`), authenticated with push access —
+the only part of the launcher that does. Everything degrades to a clear
+"install / log in" panel when it's missing.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from tt_setup.cleanup import _parse_picker_selection
+from tt_setup.console import ask, confirm, console, notice_panel, step
+from tt_setup.constants import TT_STUDIO_ROOT, _RC_BUMP_PICKER
+
+_BUMP_PARTS = ("major", "minor", "patch")
+# Strict vX.Y.Z (no suffixes) — deliberately rejects junk like v0.0.0-ghcr-test.
+_VERSION_RE = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
+_ACTIONS_URL = "https://github.com/tenstorrent/tt-studio/actions/workflows/publish-images.yml"
+
+# None of the release flags ever switch the user's checkout: the RC branch is
+# created from plumbing commands and cherry-picked inside a throwaway worktree.
+# That matters because the RC is cut from main, which (until this tooling has
+# itself shipped) doesn't carry these flags — switching in place would make
+# the next `--update-rc-branch` an unknown option.
+
+
+def _git(*argv, cwd=None):
+    """Run git (in the repo root, or `cwd`) with output captured — surfaced
+    only on failure."""
+    return subprocess.run(
+        ["git", "-C", cwd or TT_STUDIO_ROOT, *argv],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _gh(*argv, stdin_text=None):
+    """Run the GitHub CLI in the repo root with output captured."""
+    return subprocess.run(
+        ["gh", *argv],
+        cwd=TT_STUDIO_ROOT, input=stdin_text,
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _proc_output(proc):
+    return (proc.stderr or proc.stdout).strip() or "(no output)"
+
+
+def _ref_exists(full_ref):
+    return _git("rev-parse", "--verify", "--quiet", full_ref).returncode == 0
+
+
+def _fail_panel(title, lines):
+    console.print(notice_panel(f"[bold]{title}[/bold]", lines, border_style="error"))
+    return 1
+
+
+# --- pure planners (no subprocess — unit-tested directly) ---------------------
+
+def parse_version(text):
+    """Strict `vX.Y.Z` → (X, Y, Z) int tuple, or None. The whole string must be
+    the version (so `v0.0.0-ghcr-test` and branch names don't parse here)."""
+    m = re.fullmatch(_VERSION_RE, (text or "").strip())
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def bump_version(last, part):
+    """`("v2.9.1", "minor")` → `"v2.10.0"`. Raises ValueError on junk input."""
+    v = parse_version(last)
+    if v is None:
+        raise ValueError(f"not a vX.Y.Z version: {last!r}")
+    if part not in _BUMP_PARTS:
+        raise ValueError(f"bump part must be one of {_BUMP_PARTS}, got {part!r}")
+    major, minor, patch = v
+    if part == "major":
+        return f"v{major + 1}.0.0"
+    if part == "minor":
+        return f"v{major}.{minor + 1}.0"
+    return f"v{major}.{minor}.{patch + 1}"
+
+
+def find_last_rc_version(tags, branches, merge_subjects):
+    """Latest release version seen anywhere — release tags, `rc-vX.Y.Z`
+    branches, or `Rc vX.Y.Z (#N)`-style merge subjects on main. Sources are
+    combined because they have drifted: v2.9.x RCs merged without tags ever
+    being pushed. Returns `"vX.Y.Z"` or None."""
+    versions = []
+    for tag in tags:
+        v = parse_version(tag)
+        if v:
+            versions.append(v)
+    for branch in branches:
+        name = branch.strip().split("/")[-1]
+        if name.startswith("rc-"):
+            v = parse_version(name[len("rc-"):])
+            if v:
+                versions.append(v)
+    for subject in merge_subjects:
+        m = re.search(r"\b(?:rc[- ]v?|release candidate v)(\d+)\.(\d+)\.(\d+)\b",
+                      subject, re.IGNORECASE)
+        if m:
+            versions.append(tuple(int(g) for g in m.groups()))
+    if not versions:
+        return None
+    return "v{}.{}.{}".format(*max(versions))
+
+
+def parse_oneline(lines):
+    """`git log --oneline` lines → [(sha, subject)], skipping blanks."""
+    out = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        sha, _, subject = line.partition(" ")
+        out.append((sha, subject))
+    return out
+
+
+def render_test_plan(version):
+    """RC PR body: what this PR is, plus the release test checklist."""
+    return f"""## Rc {version}
+
+Cut from `main`; validated changes cherry-picked from `dev` (see CONTRIBUTING → Release Process).
+
+### Test plan
+
+- [ ] Fresh `python run.py` completes (setup → ready panel)
+- [ ] Backend healthy: `curl localhost:8000/up/` and `curl localhost:8000/models/health/`
+- [ ] Frontend loads at `localhost:3000`
+- [ ] Deploy a model end-to-end; inference server healthy: `curl localhost:8001/health`
+- [ ] `python run.py --stop`, then a restart works
+- [ ] `IS_QB2` is off in `.env.default` (rc-* branches never ship it on)
+- [ ] Release notes drafted and applied to this description
+"""
+
+
+def render_release_body(version, generated_notes):
+    """GitHub release body: auto-generated notes plus the changelog link."""
+    notes = (generated_notes or "").strip()
+    compare = f"https://github.com/tenstorrent/tt-studio/releases/tag/{version}"
+    return f"{notes}\n\n---\n\nRelease page: {compare}\n" if notes else f"TT Studio {version}\n"
+
+
+# --- shared guards ------------------------------------------------------------
+
+def _preflight_gh():
+    """None when `gh` is present and logged in; an exit code after a panel
+    otherwise. Release flags are the only launcher feature that needs it."""
+    if not shutil.which("gh"):
+        return _fail_panel(
+            "⛔ The GitHub CLI (gh) isn't installed",
+            [
+                "The release flags open and merge PRs and publish releases through gh.",
+                "",
+                "[bold]Fix →[/bold]  install it from [info]https://cli.github.com[/info], "
+                "run [info]gh auth login[/info], then retry.",
+            ],
+        )
+    auth = _gh("auth", "status")
+    if auth.returncode != 0:
+        return _fail_panel(
+            "⛔ The GitHub CLI isn't logged in",
+            [
+                "[bold]Fix →[/bold]  run [info]gh auth login[/info] (needs repo push access), then retry.",
+                "",
+                _proc_output(auth),
+            ],
+        )
+    return None
+
+
+def _fetch_origin():
+    """None on success; an exit code after a panel when origin is unreachable."""
+    fetch_error = ""
+    with step("Fetching origin (branches and tags)") as s:
+        # --prune: a deleted rc-v* branch must not linger as a stale origin/ ref,
+        # or the next command would "find" it and a push would resurrect it.
+        fetched = _git("fetch", "origin", "--tags", "--prune")
+        if fetched.returncode != 0:
+            fetch_error = _proc_output(fetched)
+            s.fail()
+    if fetch_error:
+        return _fail_panel(
+            "⛔ Couldn't reach origin",
+            ["[muted]Check your network connection / git remote, then retry.[/muted]",
+             "", fetch_error],
+        )
+    return None
+
+
+def _last_rc_version(branches_only=False):
+    """Probe git for the latest known release version (see find_last_rc_version)."""
+    branches = _git("branch", "-r").stdout.splitlines()
+    if branches_only:
+        return find_last_rc_version([], branches, [])
+    tags = _git("tag", "-l", "v[0-9]*").stdout.splitlines()
+    subjects = _git("log", "origin/main", "--format=%s", "-50").stdout.splitlines()
+    return find_last_rc_version(tags, branches, subjects)
+
+
+def _tag_on_origin(version):
+    out = _git("ls-remote", "--tags", "origin", f"refs/tags/{version}")
+    return bool(out.stdout.strip())
+
+
+# --- --make-rc-branch ---------------------------------------------------------
+
+def _resolve_new_version(part_or_version, last):
+    """Turn the flag value (bump part, explicit vX.Y.Z, or the picker sentinel)
+    into the new version string. Returns (version, None) or (None, exit_code)."""
+    value = (part_or_version or "").strip()
+    if value == _RC_BUMP_PICKER:
+        if not sys.stdin.isatty():
+            console.print()
+            console.print(notice_panel(
+                "[bold]--make-rc-branch needs a terminal to ask which part to bump[/bold]",
+                ["stdin is not interactive.",
+                 "Pass the bump directly:  [accent]python run.py --make-rc-branch minor[/accent]"
+                 "  [muted](or major / patch / an explicit vX.Y.Z)[/muted]"],
+                border_style="error",
+            ))
+            return None, 1
+        current = last or "v0.0.0"
+        console.print(f"\n[bold]Current version:[/bold] {current}"
+                      + ("" if last else " [muted](no previous release found)[/muted]"))
+        console.print(
+            "[muted]  major — breaking changes (APIs, networking, incompatible redesigns)\n"
+            "  minor — new backwards-compatible features (e.g. new model support)\n"
+            "  patch — backwards-compatible bug fixes[/muted]")
+        try:
+            part = ask("Bump which part?", choices=list(_BUMP_PARTS), default="minor")
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[info]🛑 Aborted — nothing was created.[/info]")
+            return None, 0
+        return bump_version(current, part), None
+    if value.lower() in _BUMP_PARTS:
+        return bump_version(last or "v0.0.0", value.lower()), None
+    explicit = value if value.startswith("v") else f"v{value}"
+    if parse_version(explicit):
+        return explicit, None
+    return None, _fail_panel(
+        f"⛔ '{part_or_version}' isn't a bump part or a version",
+        ["Use [info]major[/info], [info]minor[/info], [info]patch[/info], "
+         "or an explicit version like [info]v2.10.0[/info]."],
+    )
+
+
+def _warn_if_qb2_enabled():
+    """rc-* branches must not ship IS_QB2=true (CONTRIBUTING → QB2 launch branch)."""
+    env_default = os.path.join(TT_STUDIO_ROOT, ".env.default")
+    try:
+        with open(env_default) as f:
+            content = f.read()
+    except OSError:
+        return
+    if re.search(r"^\s*IS_QB2\s*=\s*true\s*$", content, re.IGNORECASE | re.MULTILINE):
+        console.print("[warning]⚠  .env.default has IS_QB2=true — rc-* branches must keep "
+                      "it off (that flag belongs to the QB2 launch branch only). "
+                      "Remove it on this RC before merging.[/warning]")
+
+
+def make_rc_branch(part_or_version):
+    """Cut `rc-vX.Y.Z` from origin/main and open the "Rc vX.Y.Z" PR against
+    main with the release test plan. Returns a process exit code.
+
+    The branch starts with one empty marker commit on top of main: GitHub
+    refuses to open a PR between identical branches, and the first cherry-pick
+    only lands later via --update-rc-branch. The squash-merge folds it away."""
+    code = _preflight_gh()
+    if code is not None:
+        return code
+    code = _fetch_origin()
+    if code is not None:
+        return code
+
+    # One release at a time: an rc-v* branch on origin that hasn't shipped (no
+    # tag) is a release in progress. Refuse rather than bump past it — that was
+    # the first-run surprise where a repeated cut produced rc-v2.10.3.
+    in_flight, in_flight_branch = _current_rc_branch()
+    if in_flight and not _tag_on_origin(in_flight):
+        return _fail_panel(
+            f"⛔ Release candidate {in_flight} is already in progress",
+            [
+                f"[muted]'{in_flight_branch}' is on origin and {in_flight} isn't tagged yet — "
+                "one release at a time.[/muted]",
+                "Finish it first: cherry-pick with [info]python run.py --update-rc-branch[/info], "
+                "ship with [info]python run.py --merge-rc-branch[/info].",
+                f"If it was cut by mistake, close its PR and delete the branch: "
+                f"[info]gh pr close {in_flight_branch} --delete-branch[/info]",
+            ],
+        )
+
+    version, code = _resolve_new_version(part_or_version, _last_rc_version())
+    if version is None:
+        return code
+    branch = f"rc-{version}"
+
+    if _ref_exists(f"refs/heads/{branch}") or _ref_exists(f"refs/remotes/origin/{branch}"):
+        return _fail_panel(
+            f"⛔ Branch '{branch}' already exists",
+            ["Cherry-pick into it with [info]python run.py --update-rc-branch[/info], "
+             "or pick a different bump."],
+        )
+    if _ref_exists(f"refs/tags/{version}") or _tag_on_origin(version):
+        return _fail_panel(
+            f"⛔ Tag '{version}' already exists — that version has shipped",
+            ["Pick a different bump."],
+        )
+
+    branch_error = ""
+    with step(f"Cutting {branch} from origin/main") as s:
+        result = _git("rev-parse", "origin/main")
+        base = result.stdout.strip()
+        if result.returncode == 0:
+            # Plumbing only — the user's checkout stays on whatever branch it was.
+            result = _git("commit-tree", f"{base}^{{tree}}", "-p", base, "-m",
+                          f"Rc {version}: open release candidate\n\n"
+                          "Empty marker commit so the RC pull request can be opened "
+                          "before the first cherry-pick from dev lands.")
+        marker = result.stdout.strip()
+        if result.returncode == 0:
+            result = _git("push", "origin", f"{marker}:refs/heads/{branch}")
+        if result.returncode != 0:
+            branch_error = _proc_output(result)
+            s.fail()
+    if branch_error:
+        return _fail_panel(f"⛔ Couldn't create and push '{branch}'", ["", branch_error])
+
+    _warn_if_qb2_enabled()
+
+    pr_url, pr_error = "", ""
+    with step(f"Opening the 'Rc {version}' PR against main") as s:
+        result = _gh("pr", "create", "--base", "main", "--head", branch,
+                     "--title", f"Rc {version}", "--body-file", "-",
+                     stdin_text=render_test_plan(version))
+        if result.returncode != 0:
+            pr_error = _proc_output(result)
+            s.fail()
+        else:
+            pr_url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+    if pr_error:
+        return _fail_panel(
+            f"⛔ Branch '{branch}' was pushed, but the PR couldn't be opened",
+            ["[muted]Open it manually:[/muted] "
+             f"[info]gh pr create --base main --head {branch} --title 'Rc {version}'[/info]",
+             "", pr_error],
+        )
+
+    console.print(notice_panel(
+        f"[bold]✅ Release candidate {version} is cut[/bold]",
+        [
+            f"Branch [info]{branch}[/info] is on origin · PR: [info]{pr_url}[/info]",
+            "[muted]Your checkout wasn't switched — keep running the release flags from here.[/muted]",
+            "",
+            "[bold]Next →[/bold]  cherry-pick validated fixes from dev with "
+            "[info]python run.py --update-rc-branch[/info],",
+            "then, once the PR has ≥2 approvals and green checks, ship it with "
+            "[info]python run.py --merge-rc-branch[/info].",
+        ],
+        border_style="accent",
+    ))
+    return 0
+
+
+# --- --update-rc-branch -------------------------------------------------------
+
+def _current_rc_branch():
+    """(version, branch) for the newest rc-v* branch on origin, or (None, None)."""
+    version = _last_rc_version(branches_only=True)
+    return (version, f"rc-{version}") if version else (None, None)
+
+
+def _rc_base_date(branch):
+    """ISO committer date of the main commit the RC was cut from (the release
+    state it builds on), or "" when git can't tell — then no cutoff is applied."""
+    base = _git("merge-base", f"origin/{branch}", "origin/main")
+    if base.returncode != 0 or not base.stdout.strip():
+        return ""
+    date = _git("log", "-1", "--format=%cI", base.stdout.strip())
+    return date.stdout.strip() if date.returncode == 0 else ""
+
+
+def _pick_commits_interactively(candidates):
+    """Numbered multi-select over the candidate dev commits (oldest first).
+    Returns the chosen (sha, subject) list, or None when the user cancels."""
+    console.print("\n[bold]Commits on dev since this RC's base on main that aren't on the RC yet[/bold] "
+                  "[muted](oldest first; older dev commits can still be cherry-picked by hand)[/muted]")
+    for i, (sha, subject) in enumerate(candidates, start=1):
+        console.print(f"  {i}. [info]{sha}[/info] {subject}")
+    while True:
+        try:
+            raw = ask("Commits to cherry-pick (e.g. '1 3', or 'all'; Enter to cancel)", default="")
+        except (KeyboardInterrupt, EOFError):
+            raw = ""
+        raw = (raw or "").strip()
+        if raw.lower() in ("", "q", "quit", "n", "no"):
+            console.print("\n[info]🛑 Aborted — the RC branch was not changed.[/info]")
+            return None
+        selection = _parse_picker_selection(raw, len(candidates))
+        if selection:
+            return [candidates[i - 1] for i in selection]
+        console.print(f"[muted]Enter numbers between 1 and {len(candidates)} "
+                      f"(space/comma separated), or 'all'.[/muted]")
+
+
+def update_rc_branch():
+    """Cherry-pick new dev commits into the current rc-vX.Y.Z branch.
+    Returns a process exit code.
+
+    The picks happen in a temporary `git worktree` of origin/<rc-branch>, so
+    the user's checkout (and any uncommitted work in it) is never touched."""
+    code = _preflight_gh()
+    if code is not None:
+        return code
+    code = _fetch_origin()
+    if code is not None:
+        return code
+
+    version, branch = _current_rc_branch()
+    if branch is None:
+        return _fail_panel(
+            "⛔ No rc-v* branch found on origin",
+            ["Cut one first with [info]python run.py --make-rc-branch[/info]."],
+        )
+
+    # Releases reach main as ONE squash commit, so by patch identity main never
+    # contains any dev commit — a plain `rc...dev` comparison lists dev's entire
+    # history (328 commits on the first real run). Cut the list off at the main
+    # commit this RC was built from: anything on dev newer than that is a
+    # candidate. --cherry-pick still drops picks already on this RC (cherry-picks
+    # preserve the patch), --reverse lists oldest first — the order they apply.
+    since = _rc_base_date(branch)
+    log = _git("log", "--cherry-pick", "--right-only", "--no-merges", "--reverse",
+               "--oneline", *([f"--since={since}"] if since else []),
+               f"origin/{branch}...origin/dev")
+    if log.returncode != 0:
+        return _fail_panel("⛔ Couldn't compare the RC against dev", ["", _proc_output(log)])
+    candidates = parse_oneline(log.stdout.splitlines())
+    if not candidates:
+        console.print(notice_panel(
+            f"[bold]✅ {branch} is up to date with dev[/bold]",
+            ["No new commits to cherry-pick."],
+            border_style="accent",
+        ))
+        return 0
+
+    if not sys.stdin.isatty():
+        console.print()
+        console.print(notice_panel(
+            "[bold]--update-rc-branch needs a terminal for its commit picker[/bold]",
+            [f"{len(candidates)} candidate commit(s) found, but stdin is not interactive.",
+             "Run this from a terminal to choose which ones to cherry-pick."],
+            border_style="error",
+        ))
+        return 1
+    picked = _pick_commits_interactively(candidates)
+    if picked is None:
+        return 0
+
+    worktree = tempfile.mkdtemp(prefix="tt-studio-rc-")
+    try:
+        return _cherry_pick_in_worktree(worktree, branch, picked)
+    finally:
+        _git("worktree", "remove", "--force", worktree)
+        shutil.rmtree(worktree, ignore_errors=True)
+
+
+def _cherry_pick_in_worktree(worktree, branch, picked):
+    """Apply `picked` (sha, subject) pairs onto origin/<branch> inside the
+    detached worktree at `worktree`, then push. Returns an exit code."""
+    # Remember where origin/<branch> was: the push below is leased on it, so a
+    # branch that moved (someone else pushed) or vanished (deleted) is rejected
+    # instead of being clobbered or resurrected.
+    expected = _git("rev-parse", f"origin/{branch}").stdout.strip()
+
+    wt_error = ""
+    with step(f"Preparing a scratch worktree of {branch}") as s:
+        result = _git("worktree", "add", "--detach", worktree, f"origin/{branch}")
+        if result.returncode != 0:
+            wt_error = _proc_output(result)
+            s.fail()
+    if wt_error:
+        return _fail_panel(f"⛔ Couldn't check out '{branch}' into a scratch worktree",
+                           ["", wt_error])
+
+    for sha, subject in picked:
+        pick_error = ""
+        with step(f"Cherry-picking {sha} {subject}") as s:
+            result = _git("cherry-pick", sha, cwd=worktree)
+            if result.returncode != 0:
+                pick_error = _proc_output(result)
+                _git("cherry-pick", "--abort", cwd=worktree)
+                s.fail()
+        if pick_error:
+            return _fail_panel(
+                f"⛔ Cherry-pick of {sha} hit a conflict — the RC was left unchanged",
+                [
+                    f"[muted]{subject}[/muted]",
+                    "",
+                    "Nothing was pushed (earlier picks in this run were discarded with the scratch worktree).",
+                    f"[bold]Fix →[/bold]  resolve it by hand: [info]git checkout {branch}[/info], "
+                    f"[info]git cherry-pick {sha}[/info], fix the conflicts, then",
+                    f"[info]git cherry-pick --continue[/info] and [info]git push origin {branch}[/info].",
+                    "", pick_error,
+                ],
+            )
+
+    push_error = ""
+    with step(f"Pushing {branch}") as s:
+        lease = [f"--force-with-lease=refs/heads/{branch}:{expected}"] if expected else []
+        result = _git("push", *lease, "origin", f"HEAD:refs/heads/{branch}", cwd=worktree)
+        if result.returncode != 0:
+            push_error = _proc_output(result)
+            s.fail()
+    if push_error:
+        return _fail_panel(
+            f"⛔ Couldn't push '{branch}'",
+            ["[muted]If origin rejected the lease, the RC branch moved or was deleted "
+             "since this run started — re-run to pick against its current state.[/muted]",
+             "", push_error],
+        )
+
+    pr = _gh("pr", "view", branch, "--json", "url", "--jq", ".url")
+    pr_url = pr.stdout.strip() if pr.returncode == 0 else ""
+    console.print(notice_panel(
+        f"[bold]✅ {branch} updated — {len(picked)} commit(s) cherry-picked[/bold]",
+        [f"[muted]·[/muted] {sha} {subject}" for sha, subject in picked]
+        + ([""] if pr_url else [])
+        + ([f"PR: [info]{pr_url}[/info]"] if pr_url else []),
+        border_style="accent",
+    ))
+    return 0
+
+
+# --- --merge-rc-branch --------------------------------------------------------
+
+def _failing_checks(rollup):
+    """Names of failed checks from a gh statusCheckRollup list."""
+    bad = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+    names = []
+    for item in rollup or []:
+        outcome = (item.get("conclusion") or item.get("state") or "").upper()
+        if outcome in bad:
+            names.append(item.get("name") or item.get("context") or "unnamed check")
+    return names
+
+
+def merge_rc_branch():
+    """Merge the approved RC PR into main, push the vX.Y.Z tag (publishes GHCR
+    images), and create the GitHub release. Returns a process exit code."""
+    import json
+
+    code = _preflight_gh()
+    if code is not None:
+        return code
+    code = _fetch_origin()
+    if code is not None:
+        return code
+
+    version, branch = _current_rc_branch()
+    if branch is None:
+        return _fail_panel(
+            "⛔ No rc-v* branch found on origin",
+            ["Cut one first with [info]python run.py --make-rc-branch[/info]."],
+        )
+    if _tag_on_origin(version):
+        return _fail_panel(
+            f"⛔ Tag '{version}' already exists on origin — {version} looks released already",
+            ["If the release itself is missing, create it from the tag: "
+             f"[info]gh release create {version} --verify-tag[/info]"],
+        )
+    if _ref_exists(f"refs/tags/{version}"):
+        return _fail_panel(
+            f"⛔ Tag '{version}' already exists locally — not overwriting it",
+            [f"Delete it and retry:  [info]git tag -d {version}[/info]"],
+        )
+
+    view = _gh("pr", "view", branch, "--json",
+               "number,url,state,reviewDecision,statusCheckRollup")
+    if view.returncode != 0:
+        return _fail_panel(
+            f"⛔ No open PR found for '{branch}'",
+            ["Open it with [info]python run.py --make-rc-branch[/info] "
+             "(or [info]gh pr create --base main[/info]).", "", _proc_output(view)],
+        )
+    try:
+        pr = json.loads(view.stdout)
+    except ValueError:
+        return _fail_panel("⛔ Couldn't read the PR state from gh", ["", _proc_output(view)])
+
+    if pr.get("state") != "OPEN":
+        return _fail_panel(
+            f"⛔ The PR for '{branch}' is {pr.get('state', 'gone').lower()}, not open",
+            [f"PR: [info]{pr.get('url', '')}[/info]"],
+        )
+    if pr.get("reviewDecision") != "APPROVED":
+        return _fail_panel(
+            f"⛔ The PR for '{branch}' isn't approved yet",
+            ["Merging to main needs at least two approvals (CONTRIBUTING → Release Process).",
+             f"Request reviews on [info]{pr.get('url', '')}[/info], then re-run."],
+        )
+    failing = _failing_checks(pr.get("statusCheckRollup"))
+    if failing:
+        return _fail_panel(
+            f"⛔ The PR for '{branch}' has failing checks",
+            [f"[muted]·[/muted] {name}" for name in failing]
+            + ["", f"Fix them on [info]{pr.get('url', '')}[/info], then re-run."],
+        )
+
+    console.print(notice_panel(
+        f"[bold]Ready to ship {version}[/bold]",
+        [
+            f"PR [info]#{pr['number']}[/info] ({pr.get('url', '')}) → squash-merge into main as "
+            f"[info]Rc {version}[/info],",
+            f"then tag [info]{version}[/info] (builds + publishes the GHCR images) "
+            "and create the GitHub release.",
+        ],
+        border_style="accent",
+    ))
+    try:
+        if not confirm(f"Merge Rc {version} into main, tag, and publish the release?", default=False):
+            console.print("\n[info]🛑 Aborted — nothing was merged.[/info]")
+            return 0
+    except (KeyboardInterrupt, EOFError):
+        console.print("\n[info]🛑 Aborted — nothing was merged.[/info]")
+        return 0
+
+    merge_error = ""
+    with step(f"Squash-merging PR #{pr['number']} into main") as s:
+        result = _gh("pr", "merge", str(pr["number"]), "--squash", "--subject", f"Rc {version}")
+        if result.returncode != 0:
+            merge_error = _proc_output(result)
+            s.fail()
+    if merge_error:
+        return _fail_panel(
+            "⛔ The merge was rejected",
+            ["[muted]Branch protection may require something gh can't see "
+             "(e.g. up-to-date branch, merge queue).[/muted]", "", merge_error],
+        )
+
+    fetch_main_error = ""
+    with step("Fetching the merge commit from main") as s:
+        fetched = _git("fetch", "origin", "main")
+        if fetched.returncode != 0:
+            fetch_main_error = _proc_output(fetched)
+            s.fail()
+    if fetch_main_error:
+        return _fail_panel(
+            "⛔ Couldn't fetch main after merging — not tagging",
+            ["[muted]Fix your network / origin remote, then re-run --merge-rc-branch.[/muted]", "", fetch_main_error],
+        )
+
+    merge_sha = _git("rev-parse", "origin/main").stdout.strip()
+    tip_subject = _git("log", "-1", "--format=%s", "origin/main").stdout.strip()
+    if f"Rc {version}" not in tip_subject:
+        return _fail_panel(
+            "⛔ main's tip isn't the RC merge — not tagging",
+            [f"Expected the tip of main to be 'Rc {version} (#N)' but found:",
+             f"[muted]{tip_subject}[/muted]", "",
+             "Something else landed on main in between. Tag the RC merge commit manually:",
+             f"[info]git tag {version} <merge-sha> && git push origin {version}[/info]"],
+        )
+
+    tag_error = ""
+    with step(f"Tagging {version} and pushing (this publishes the GHCR images)") as s:
+        result = _git("tag", version, merge_sha)
+        if result.returncode == 0:
+            result = _git("push", "origin", version)
+        if result.returncode != 0:
+            tag_error = _proc_output(result)
+            s.fail()
+    if tag_error:
+        return _fail_panel(
+            f"⛔ Couldn't tag/push '{version}' (the PR IS merged)",
+            ["Finish manually:",
+             f"[info]git tag {version} {merge_sha} && git push origin {version}[/info]",
+             f"[info]gh release create {version} --verify-tag --title 'TT Studio {version}'[/info]",
+             "", tag_error],
+        )
+
+    notes = _gh("api", "repos/{owner}/{repo}/releases/generate-notes",
+                "-f", f"tag_name={version}", "-f", "target_commitish=main",
+                "--jq", ".body")
+    generated = notes.stdout if notes.returncode == 0 else ""
+
+    release_url, release_error = "", ""
+    with step(f"Creating the GitHub release for {version}") as s:
+        result = _gh("release", "create", version, "--verify-tag",
+                     "--title", f"TT Studio {version}", "--notes-file", "-",
+                     stdin_text=render_release_body(version, generated))
+        if result.returncode != 0:
+            release_error = _proc_output(result)
+            s.fail()
+        else:
+            release_url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+    if release_error:
+        return _fail_panel(
+            f"⛔ Tag '{version}' is pushed, but the release couldn't be created",
+            ["Create it manually: "
+             f"[info]gh release create {version} --verify-tag --title 'TT Studio {version}'[/info]",
+             "", release_error],
+        )
+
+    console.print(notice_panel(
+        f"[bold]✅ TT Studio {version} is shipped[/bold]",
+        [
+            f"Release: [info]{release_url}[/info]",
+            f"Images:  [info]{_ACTIONS_URL}[/info] [muted](watch the Publish images run; "
+            "the release event queues a second, identical run — that's expected)[/muted]",
+            "",
+            "[bold]Next →[/bold]  polish the release notes "
+            "[muted](draft-release-notes skill, then[/muted] [info]gh release edit[/info][muted]).[/muted]",
+        ],
+        border_style="accent",
+    ))
+    return 0


### PR DESCRIPTION
## Summary

Adds a first-class embedding model experience to TT-Studio and cleans up how model availability/deploy exceptions are maintained.

**User-facing:**
- Embedding models (bge-m3, Qwen3-Embedding-0.6B, Qwen3-Embedding-4B) are now deployable from the catalog — previously hidden/no UI.
- New Embedding Demo page: single-text embedding and document-upload/search, matching the design language of the other model demo pages.
- RAG Management can now embed documents using a deployed embedding model instead of only the default local model.
- Advanced deploy config for embedding models offers a real throughput/cost tradeoff: 1 device (default, cheapest), 2 devices (one P300 card, ~2x throughput), or all 4 devices (~4x throughput), instead of only an all-or-nothing board allocation.

**Developer-facing:**
- All model-availability exceptions (known-broken models/devices), mesh device fallbacks, deploy-time image/trace-region overrides, and the new chip-tier definitions now live in one reviewable `model_overrides.toml`, validated with clear errors (unknown reason, typo'd device, duplicate entry) — mirroring tt-cli's `model_support_overrides.toml` pattern instead of several scattered Python dicts across two files.
- The three embedding models' single-chip/dual-chip runtime specs are generated automatically from the live tt-inference-server artifact on every catalog sync, instead of being hand-maintained files that could drift from upstream.

## Test plan

- Run `python run.py` (or `python run.py --dev` for hot reload) and open the TT-Studio UI.
- From the model catalog, deploy `bge-m3` or `Qwen3-Embedding-0.6B` with default (1-device) settings and confirm it reaches Healthy.
- Open the new Embedding Demo page for the deployed model: submit a single text and confirm an embedding vector comes back, then upload a document and confirm search/retrieval works.
- Go to RAG Management, add/select a collection, and confirm the deployed embedding model appears as an option and successfully embeds an uploaded document with it.
- Deploy an embedding model again with Advanced Config open on a P300x2 board: confirm "1 Device", "2 Devices", and "All Devices" are all selectable, each deploys successfully, and 1 Device is pre-selected by default.
- Stop all deployments and confirm chip slots reset cleanly between the three tiers.
- Optionally: edit an entry in `app/backend/shared_config/model_overrides.toml` (e.g. change a `verified_on` or add a bogus device name) and re-run the sync script to confirm validation errors surface clearly instead of failing silently.
- Go to the apps marketplace, ensure OpenWebUI and AnythingLLM display a dropdown to select an embedding model from the one deployed and their native one. Launch one and confirm in settings that it is set up. Upload a document to test end to end.
- Deploy an STT or TTS model and confirm those too show up in the app card drop-downs, confirm that they work end to end.
