### PR TITLE
Rc v2.10.2

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -20,7 +20,7 @@ BACKEND_API_HOSTNAME=tt-studio-backend-api
 # in commit b788278 (tenstorrent/tt-inference-server). The source branch was deleted but
 # the SHA is still valid. Re-pin to a release version once that fix ships in a tag.
 # TT_INFERENCE_ARTIFACT_BRANCH=b788278762b0bcc9332ad453d265050bfa94738d
-TT_INFERENCE_ARTIFACT_VERSION=v0.20.0
+TT_INFERENCE_ARTIFACT_VERSION=v0.21.0
 # TT_INFERENCE_ARTIFACT_BRANCH=tt-studio/202605
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/backend/docker_control/deployment_store.py
+++ b/app/backend/docker_control/deployment_store.py
@@ -207,6 +207,7 @@ class _Manager:
                 "jwt_secret": kwargs.get("jwt_secret", None),
                 "model_type": kwargs.get("model_type", None),
                 "hf_model_id": kwargs.get("hf_model_id", None),
+                "service_route": kwargs.get("service_route", None),
             }
             data["next_id"] += 1
             data["records"].append(record)
@@ -259,6 +260,9 @@ class ModelDeployment:
         # catalog. "unknown" means we could not identify what the container serves.
         self.model_type: Optional[str] = None
         self.hf_model_id: Optional[str] = None
+        # The route the container was observed to serve, when it differs from the
+        # per-type convention (e.g. a tt-dit image server serving /generate).
+        self.service_route: Optional[str] = None
 
     @classmethod
     def _from_dict(cls, d: dict) -> "ModelDeployment":
@@ -283,6 +287,7 @@ class ModelDeployment:
         obj.failure_reason = d.get("failure_reason")
         obj.failure_message = d.get("failure_message")
         obj.tool_calling_enabled = d.get("tool_calling_enabled", False)
+        obj.service_route = d.get("service_route")
         obj.jwt_secret = d.get("jwt_secret")
         obj.model_type = d.get("model_type")
         obj.hf_model_id = d.get("hf_model_id")
@@ -309,6 +314,7 @@ class ModelDeployment:
             "jwt_secret": self.jwt_secret,
             "model_type": self.model_type,
             "hf_model_id": self.hf_model_id,
+            "service_route": self.service_route,
         }
 
     def save(self) -> None:

--- a/app/backend/docker_control/docker_utils.py
+++ b/app/backend/docker_control/docker_utils.py
@@ -903,6 +903,7 @@ def _external_model_impl(con_id, con):
         hf_model_id=dep.hf_model_id,
         service_port=dep.port or 7000,
         tool_calling_enabled=bool(getattr(dep, "tool_calling_enabled", False)),
+        service_route=getattr(dep, "service_route", None),
     )
     logger.debug(
         f"Using external model_impl for '{con['name']}' "

--- a/app/backend/docker_control/tt_inference_client.py
+++ b/app/backend/docker_control/tt_inference_client.py
@@ -48,7 +48,7 @@ def tool_call_parser_for(model_name: str = "", hf_model_id: str = "") -> Optiona
         return "mistral"
     if "deepseek" in s:
         return "deepseek_v3"
-    if "gemma-4-" in s:
+    if "gemma-4-" in s or "diffusiongemma" in s:
         return "gemma4"
     return None
 

--- a/app/backend/docker_control/views.py
+++ b/app/backend/docker_control/views.py
@@ -2704,6 +2704,28 @@ class RegisterExternalModelView(APIView):
                 except Exception as e:
                     logger.warning(f"Could not check HF model ID against catalog: {e}")
 
+            # What the container serves is a physical fact about it, so read the
+            # routes before falling back to guessing from names. This is also the
+            # only way to learn a route that diverges from the per-type convention
+            # (a tt-dit image server serves /generate, not /v1/images/generations),
+            # which is why the route is kept even when the type came from elsewhere.
+            served_api = _detect_served_api(service_port)
+            service_route = served_api.get("service_route") or None
+            served_type = served_api.get("model_type")
+            if served_type and served_type != model_type:
+                if model_type:
+                    corrections.append(
+                        f"Model type corrected from '{model_type}' to '{served_type}' "
+                        f"based on the routes the container actually serves "
+                        f"({service_route})."
+                    )
+                else:
+                    corrections.append(
+                        f"Model type '{served_type}' detected from the container's "
+                        f"own API ({service_route})."
+                    )
+                model_type = served_type
+
             # Derive any remaining identity fields, then settle on a model type
             if not model_type and hf_model_id:
                 model_type = _infer_model_type(hf_model_id)
@@ -2815,6 +2837,7 @@ class RegisterExternalModelView(APIView):
                     rec.jwt_secret = jwt_secret
                     rec.model_type = model_type
                     rec.hf_model_id = hf_model_id
+                    rec.service_route = service_route
                     rec.save()
                     corrections.append("Reused this container's existing deployment record.")
                     logger.info(f"Updated existing deployment record for '{container_name}' to device_ids={device_ids}")
@@ -2833,6 +2856,7 @@ class RegisterExternalModelView(APIView):
                         jwt_secret=jwt_secret,
                         model_type=model_type,
                         hf_model_id=hf_model_id,
+                        service_route=service_route,
                     )
                     logger.info(f"Created deployment record for external container '{container_name}' on device_ids={device_ids}")
             except Exception as e:
@@ -3533,6 +3557,60 @@ def _hf_from_container(container_info: dict):
     return None
 
 
+def _detect_served_api(host_port) -> dict:
+    """Read a container's OpenAPI document and report the API it actually serves.
+
+    Returns {"routes": [...], "service_route": str, "model_type": str} for a
+    container whose served routes identify a contract TT Studio can drive, else
+    whatever subset could be determined ({} when the container has no OpenAPI doc).
+
+    This is the strongest identity signal available and needs no name heuristics:
+    a server that answers on ``/generate`` + ``/jobs/<id>/image`` is an image
+    generator whatever its weights are called, and one that serves no route we
+    recognise is not something we should offer an interaction page for.
+    """
+    if not host_port:
+        return {}
+    try:
+        resp = requests.get(
+            f"http://host.docker.internal:{host_port}/openapi.json", timeout=3
+        )
+        resp.raise_for_status()
+        paths = resp.json().get("paths") or {}
+    except Exception:
+        return {}
+
+    result = {"routes": sorted(paths)}
+
+    # Image dialects are the case where the served route genuinely diverges from
+    # the per-type convention, so consult the dialect table rather than
+    # duplicating its route knowledge here.
+    try:
+        from model_control.image_dialects import dialect_from_openapi
+
+        dialect = dialect_from_openapi(paths)
+    except Exception:
+        dialect = None
+    if dialect is not None:
+        result["service_route"] = dialect.submit_route
+        result["model_type"] = "image_generation"
+        return result
+
+    # Otherwise fall back to the routes that identify the remaining types.
+    for route, model_type in (
+        ("/v1/chat/completions", "chat"),
+        ("/v1/audio/transcriptions", "speech_recognition"),
+        ("/v1/audio/speech", "tts"),
+        ("/v1/videos/generations", "video_generation"),
+        ("/objdetection_v2", "object_detection"),
+    ):
+        if route in paths:
+            result["service_route"] = route
+            result["model_type"] = model_type
+            break
+    return result
+
+
 def _detect_model_info(docker_client, container_id, container_info=None) -> dict:
     """Detect {hf_model_id, model_type, port, source} for a running container.
 
@@ -3582,6 +3660,16 @@ def _detect_model_info(docker_client, container_id, container_info=None) -> dict
             result.setdefault("source", "logs")
         if parsed.get("port") and not result.get("port"):
             result["port"] = parsed["port"]
+
+    # What the container serves beats what its weights are named: a DiT image
+    # server and a vLLM chat server can both be called "<org>/<model>", but they
+    # do not expose the same routes.
+    served = _detect_served_api(host_port)
+    if served.get("model_type"):
+        result["model_type"] = served["model_type"]
+        result["service_route"] = served["service_route"]
+        result.setdefault("source", "openapi")
+        return result
 
     if result.get("hf_model_id"):
         result["model_type"] = _infer_model_type(result["hf_model_id"])

--- a/app/backend/model_control/image_dialects.py
+++ b/app/backend/model_control/image_dialects.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Image-generation API dialects.
+
+TT Studio drives image models over three different HTTP contracts, because the
+serving stacks below it were designed independently:
+
+* ``openai`` — ``POST /v1/images/generations``, synchronous, base64 in the JSON
+  response. What tt-media-server exposes for its OpenAI-compatible image models.
+* ``media``  — ``POST /enqueue`` → poll ``/status/<id>`` → ``GET /fetch_image/<id>``.
+  tt-media-server's older job API.
+* ``tt_dit`` — ``POST /generate`` → poll ``/jobs/<id>`` → ``GET /jobs/<id>/image``.
+  tt-metal's DiT models (``models.tt_dit.server.*``) serving HTTP directly,
+  without tt-media-server in front. Diffusion on accelerators takes minutes per
+  image, so this stack is job-based by design and exposes diffusion-native knobs
+  (steps, guidance scale, seed, height, width) that the OpenAI image contract
+  has no place for.
+
+A dialect is data, not control flow: adding a fourth serving stack should mean
+adding a row here, not another branch in the inference view. Keeping the job
+polling in one place also means a new stack inherits the terminal-state and
+error handling the existing ones already have.
+"""
+
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+# Optional generation parameters we forward when the caller supplies them, keyed
+# by the request field TT Studio accepts. Only the tt_dit contract models these;
+# the others silently ignore anything beyond the prompt.
+_DIT_PARAMS = {
+    "num_inference_steps": "num_inference_steps",
+    "guidance_scale": "guidance_scale",
+    "seed": "seed",
+    "height": "height",
+    "width": "width",
+}
+
+
+@dataclass(frozen=True)
+class ImageDialect:
+    """One image-generation HTTP contract.
+
+    ``mode`` is "sync" (the image comes back on the submit call) or "job" (submit
+    returns an id, then poll for a terminal state and fetch the bytes). Templates
+    are relative to the server root, so they compose with whatever host/port the
+    deployment happens to be on.
+    """
+
+    name: str
+    submit_route: str
+    mode: str
+    job_id_field: str = ""
+    status_template: str = ""
+    image_template: str = ""
+    # Compared case-insensitively: tt-media-server says "Completed", tt_dit "done".
+    done_states: frozenset = frozenset()
+    error_states: frozenset = frozenset()
+    extra_params: Mapping[str, str] = field(default_factory=dict)
+    # Image media type to report when the server does not say (the sync dialect
+    # hands us raw base64 with no content type of its own).
+    default_content_type: str = "image/png"
+    default_filename: str = "image.png"
+
+
+OPENAI = ImageDialect(
+    name="openai",
+    submit_route="/v1/images/generations",
+    mode="sync",
+    # Historic behaviour: the base64 payload is re-served as JPEG.
+    default_content_type="image/jpeg",
+    default_filename="image.jpg",
+)
+
+MEDIA = ImageDialect(
+    name="media",
+    submit_route="/enqueue",
+    mode="job",
+    job_id_field="task_id",
+    status_template="/status/{job_id}",
+    image_template="/fetch_image/{job_id}",
+    done_states=frozenset({"completed"}),
+    error_states=frozenset({"failed", "error", "cancelled"}),
+)
+
+TT_DIT = ImageDialect(
+    name="tt_dit",
+    submit_route="/generate",
+    mode="job",
+    job_id_field="job_id",
+    status_template="/jobs/{job_id}",
+    image_template="/jobs/{job_id}/image",
+    # models/tt_dit/server/flux2/jobs.py: JobStatus = queued|running|done|error|cancelled
+    done_states=frozenset({"done"}),
+    error_states=frozenset({"error", "cancelled"}),
+    extra_params=_DIT_PARAMS,
+)
+
+# Longest submit_route first so "/v1/images/generations" is tested before any
+# shorter route that could also appear as a suffix.
+DIALECTS = tuple(sorted((OPENAI, MEDIA, TT_DIT), key=lambda d: -len(d.submit_route)))
+
+# Routes we can recognise in a container's OpenAPI document, most specific first.
+_ROUTE_TO_DIALECT = {d.submit_route: d for d in DIALECTS}
+
+
+def split_route(internal_url: str) -> tuple[str, str]:
+    """Split a stored internal_url into (server_root, route).
+
+    ``internal_url`` is built as ``<host>:<port><service_route>``, so the route is
+    just its path. Returns ("", url) when the url carries no path to speak of.
+    """
+    parts = urlsplit(internal_url)
+    path = parts.path or ""
+    root = urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+    return root, path
+
+
+def resolve_dialect(internal_url: str) -> ImageDialect:
+    """Pick the dialect for a deployment's stored internal_url.
+
+    Matches on the route the deployment was registered with. Falls back to MEDIA,
+    which is what this code path did unconditionally before other stacks existed —
+    an unrecognised route is more likely an older media server than a new contract
+    we would only guess at.
+    """
+    _, path = split_route(internal_url)
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if path.endswith(route):
+            return dialect
+    return MEDIA
+
+
+def dialect_from_openapi(paths) -> Optional[ImageDialect]:
+    """Identify the dialect a live container serves from its OpenAPI paths.
+
+    ``paths`` is the ``paths`` object of an OpenAPI document (any mapping of route
+    -> operations). Returns None when the container serves no image route we know,
+    which is a positive signal in its own right: there is no point registering it
+    as an image model TT Studio can drive.
+    """
+    served = set(paths or ())
+    for route, dialect in _ROUTE_TO_DIALECT.items():
+        if route in served:
+            return dialect
+    return None

--- a/app/backend/model_control/marketplace_utils.py
+++ b/app/backend/model_control/marketplace_utils.py
@@ -341,6 +341,19 @@ def launch_blocked_reason(app: MarketplaceApp) -> Optional[str]:
     # Short-circuits before default_model(), so only the apps that pin one model
     # pay for the deploy scan.
     if app.requires_model and default_model() is None:
+        # A chat model can be deployed and still not be one this app can drive.
+        # Saying "none is deployed" there contradicts the Models page and sends
+        # the user off to deploy a second model that would be just as unusable.
+        from model_control.views import _running_coding_agent_deploys
+
+        if _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
+            return (
+                f"{app.name} needs a model it can drive with tool calling. The "
+                f"deployed model was launched without it — redeploy it from the "
+                f"Home page, then launch {app.name}."
+            )
         return (
             f"{app.name} needs a chat model to connect to, and none is deployed "
             f"yet. Deploy one from the Home page, then launch {app.name}."

--- a/app/backend/model_control/test_image_dialects.py
+++ b/app/backend/model_control/test_image_dialects.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Tests for image-generation dialect resolution.
+
+The route shapes and job-status values here are taken from real servers:
+tt-media-server's ``/enqueue`` + ``/v1/images/generations`` contracts, and
+tt-metal's DiT server (``models/tt_dit/server/flux2/``), whose OpenAPI document
+and ``JobStatus`` enum were read off a running FLUX.2-dev container.
+"""
+
+from model_control.image_dialects import (
+    MEDIA,
+    OPENAI,
+    TT_DIT,
+    dialect_from_openapi,
+    resolve_dialect,
+    split_route,
+)
+
+# The paths object served by a real FLUX.2-dev tt-dit container.
+FLUX2_PATHS = [
+    "/health",
+    "/generate",
+    "/jobs",
+    "/jobs/{job_id}",
+    "/jobs/{job_id}/image",
+    "/jobs/{job_id}/cancel",
+]
+
+
+class TestResolveDialect:
+    def test_tt_dit_generate_route(self):
+        assert resolve_dialect("http://flux2:7010/generate") is TT_DIT
+
+    def test_openai_images_route(self):
+        assert resolve_dialect("http://sd:7000/v1/images/generations") is OPENAI
+
+    def test_media_enqueue_route(self):
+        assert resolve_dialect("http://media:7000/enqueue") is MEDIA
+
+    def test_unrecognised_route_falls_back_to_media(self):
+        # Back-compat: this code path was unconditionally the media contract
+        # before other stacks existed.
+        assert resolve_dialect("http://thing:7000/something-else") is MEDIA
+
+    def test_resolves_without_a_scheme(self):
+        # internal_url is stored as "<host>:<port><route>".
+        assert resolve_dialect("flux2:7010/generate") is TT_DIT
+
+
+class TestSplitRoute:
+    def test_splits_root_from_route(self):
+        root, path = split_route("http://flux2:7010/generate")
+        assert root == "http://flux2:7010"
+        assert path == "/generate"
+
+    def test_job_templates_compose_onto_the_root(self):
+        root, _ = split_route("http://flux2:7010/generate")
+        assert root + TT_DIT.status_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc"
+        )
+        assert root + TT_DIT.image_template.format(job_id="abc") == (
+            "http://flux2:7010/jobs/abc/image"
+        )
+
+
+class TestDialectFromOpenapi:
+    def test_identifies_tt_dit_from_served_routes(self):
+        assert dialect_from_openapi(FLUX2_PATHS) is TT_DIT
+
+    def test_identifies_openai_image_server(self):
+        assert dialect_from_openapi(["/v1/images/generations", "/health"]) is OPENAI
+
+    def test_chat_server_is_not_an_image_dialect(self):
+        # A vLLM container serves no image route: returning None is what keeps it
+        # from being registered as an image model.
+        assert dialect_from_openapi(["/v1/models", "/v1/chat/completions"]) is None
+
+    def test_no_paths(self):
+        assert dialect_from_openapi([]) is None
+        assert dialect_from_openapi(None) is None
+
+
+class TestJobStateVocabulary:
+    def test_tt_dit_terminal_states_match_the_server_enum(self):
+        # models/tt_dit/server/flux2/jobs.py: queued|running|done|error|cancelled
+        assert "done" in TT_DIT.done_states
+        assert {"error", "cancelled"} <= TT_DIT.error_states
+        assert not ({"queued", "running"} & (TT_DIT.done_states | TT_DIT.error_states))
+
+    def test_media_completed_state_is_matched_lowercased(self):
+        # tt-media-server reports "Completed"; the view lowercases before comparing.
+        assert "Completed".lower() in MEDIA.done_states
+
+    def test_only_tt_dit_forwards_diffusion_params(self):
+        assert "num_inference_steps" in TT_DIT.extra_params
+        assert not MEDIA.extra_params
+        assert not OPENAI.extra_params

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -46,6 +46,7 @@ class IgnoreClientContentNegotiation(DefaultContentNegotiation):
 
 from .serializers import InferenceSerializer, ModelWeightsSerializer
 from .log_classifier import classify_startup_phase
+from .image_dialects import resolve_dialect, split_route
 
 
 # Module-level latch: tracks the highest phase + cached state we've ever seen
@@ -683,6 +684,11 @@ class ObjectDetectionInferenceCloudView(APIView):
         return Response(inference_data.json(), status=status.HTTP_200_OK)
 
 
+# Upper bound on a single image-generation job. FLUX.2 at 1024x1024/50 steps is
+# minutes of work, so this is a stuck-job backstop, not a performance budget.
+IMAGE_JOB_TIMEOUT_SECONDS = 30 * 60
+
+
 class ImageGenerationInferenceView(APIView):
     def post(self, request, *args, **kwargs):
         """special image generation inference view that performs special file handling"""
@@ -697,8 +703,14 @@ class ImageGenerationInferenceView(APIView):
             try:
                 headers = {"Authorization": f"Bearer {get_tts_api_key() or ''}"}
 
-                if "/v1/images/generations" in internal_url:
-                    # Synchronous OpenAI-compatible API — returns base64 JSON immediately
+                dialect = resolve_dialect(internal_url)
+                server_root, _ = split_route(internal_url)
+                logger.info(
+                    f"image generation via '{dialect.name}' dialect at {internal_url}"
+                )
+
+                if dialect.mode == "sync":
+                    # The image comes back on the submit call as base64 JSON.
                     inference_data = requests.post(
                         internal_url,
                         json={"prompt": prompt},
@@ -712,34 +724,81 @@ class ImageGenerationInferenceView(APIView):
                     else:
                         b64_image = resp_json["data"][0]["b64_json"]
                     image_bytes = base64.b64decode(b64_image)
-                    django_response = HttpResponse(image_bytes, content_type="image/jpeg")
-                    django_response["Content-Disposition"] = "attachment; filename=image.jpg"
-                    return django_response
-                else:
-                    # Legacy enqueue/poll/fetch API
-                    inference_data = requests.post(
-                        internal_url, json={"prompt": prompt}, headers=headers, timeout=5
+                    django_response = HttpResponse(
+                        image_bytes, content_type=dialect.default_content_type
                     )
-                    inference_data.raise_for_status()
-
-                    ready_latest = False
-                    task_id = inference_data.json().get("task_id")
-                    get_status_url = internal_url.replace("/enqueue", f"/status/{task_id}")
-                    while not ready_latest:
-                        latest_prompt = requests.get(get_status_url, headers=headers)
-                        if latest_prompt.status_code != status.HTTP_404_NOT_FOUND:
-                            latest_prompt.raise_for_status()
-                            if latest_prompt.json()["status"] == "Completed":
-                                ready_latest = True
-                        time.sleep(1)
-
-                    get_image_url = internal_url.replace("/enqueue", f"/fetch_image/{task_id}")
-                    latest_image = requests.get(get_image_url, headers=headers, stream=True)
-                    latest_image.raise_for_status()
-                    content_type = latest_image.headers.get("Content-Type", "application/octet-stream")
-                    django_response = HttpResponse(latest_image.content, content_type=content_type)
-                    django_response["Content-Disposition"] = "attachment; filename=image.png"
+                    django_response["Content-Disposition"] = (
+                        f"attachment; filename={dialect.default_filename}"
+                    )
                     return django_response
+
+                # Job dialects: submit -> poll for a terminal state -> fetch bytes.
+                payload = {"prompt": prompt}
+                for req_field, server_field in dialect.extra_params.items():
+                    value = data.get(req_field)
+                    if value is not None:
+                        payload[server_field] = value
+
+                inference_data = requests.post(
+                    internal_url, json=payload, headers=headers, timeout=30
+                )
+                inference_data.raise_for_status()
+                job_id = inference_data.json().get(dialect.job_id_field)
+                if not job_id:
+                    logger.error(
+                        f"{dialect.name}: submit response carried no "
+                        f"'{dialect.job_id_field}'; cannot track the job"
+                    )
+                    return Response(status=status.HTTP_502_BAD_GATEWAY)
+
+                status_url = server_root + dialect.status_template.format(job_id=job_id)
+                image_url = server_root + dialect.image_template.format(job_id=job_id)
+
+                # Diffusion on accelerators runs for minutes, so this poll is bounded
+                # generously; it exists to stop a wedged job from hanging the request
+                # forever, not to second-guess a slow-but-healthy generation.
+                deadline = time.time() + IMAGE_JOB_TIMEOUT_SECONDS
+                while True:
+                    if time.time() > deadline:
+                        logger.error(
+                            f"{dialect.name}: job {job_id} did not finish within "
+                            f"{IMAGE_JOB_TIMEOUT_SECONDS}s"
+                        )
+                        return Response(status=status.HTTP_504_GATEWAY_TIMEOUT)
+
+                    poll = requests.get(status_url, headers=headers, timeout=30)
+                    # A job id can briefly 404 before the server registers it.
+                    if poll.status_code != status.HTTP_404_NOT_FOUND:
+                        poll.raise_for_status()
+                        job_state = str(poll.json().get("status", "")).lower()
+                        if job_state in dialect.done_states:
+                            break
+                        if job_state in dialect.error_states:
+                            detail = poll.json().get("error")
+                            logger.error(
+                                f"{dialect.name}: job {job_id} ended as "
+                                f"'{job_state}': {detail}"
+                            )
+                            return Response(
+                                {"error": detail or f"Generation {job_state}."},
+                                status=status.HTTP_502_BAD_GATEWAY,
+                            )
+                    time.sleep(1)
+
+                latest_image = requests.get(
+                    image_url, headers=headers, stream=True, timeout=120
+                )
+                latest_image.raise_for_status()
+                content_type = latest_image.headers.get(
+                    "Content-Type", dialect.default_content_type
+                )
+                django_response = HttpResponse(
+                    latest_image.content, content_type=content_type
+                )
+                django_response["Content-Disposition"] = (
+                    f"attachment; filename={dialect.default_filename}"
+                )
+                return django_response
 
             except requests.exceptions.HTTPError as http_err:
                 if inference_data.status_code == status.HTTP_401_UNAUTHORIZED:

--- a/app/backend/model_control/views.py
+++ b/app/backend/model_control/views.py
@@ -1845,6 +1845,7 @@ class ModelAPIInfoView(APIView):
 # Coding-agent gateway support (LiteLLM). Eligibility (the model allowlist + rule)
 # is the SSOT in shared_config.coding_agent_config.
 from shared_config.coding_agent_config import (  # noqa: E402
+    CODING_AGENT_MODEL_TYPES,
     is_coding_agent_eligible,
     get_gateway_model_names,
     resolve_thinking_variant,
@@ -1860,7 +1861,9 @@ _rr_lock = threading.Lock()
 _rr_counters: dict[str, int] = {}
 
 
-def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tuple[str, dict]]:
+def _running_coding_agent_deploys(
+    require_tool_calling: bool = True, require_vetted: bool = True
+) -> list[tuple[str, dict]]:
     """Return [(deploy_id, entry), ...] for running, coding-agent-eligible deployments.
 
     Eligibility is decided by is_coding_agent_eligible (shared_config SSOT). By
@@ -1868,6 +1871,13 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
     workflow agents send tool_choice:"auto" and a container launched without vLLM
     tool-calling support would silently fail. Pass require_tool_calling=False to
     also get eligible-but-incapable deploys (e.g. to explain why they're unusable).
+
+    require_vetted=False widens it once more, to any running chat/VLM deployment.
+    The allowlist answers "have we verified this against coding agents", which is
+    not the same question as "is a chat model deployed" — a caller that reports
+    deployment state to the user has to ask the second one or it ends up claiming
+    nothing is deployed while a model is serving.
+
     Resilient to deploy-cache failures (e.g. docker-control-service down): logs
     and returns an empty list so callers degrade gracefully instead of 500ing.
     """
@@ -1879,7 +1889,12 @@ def _running_coding_agent_deploys(require_tool_calling: bool = True) -> list[tup
         return out
     for deploy_id, entry in cache.items():
         impl = entry.get("model_impl")
-        if not entry.get("internal_url") or not is_coding_agent_eligible(impl):
+        if not entry.get("internal_url"):
+            continue
+        if require_vetted:
+            if not is_coding_agent_eligible(impl):
+                continue
+        elif getattr(impl, "model_type", None) not in CODING_AGENT_MODEL_TYPES:
             continue
         if require_tool_calling and not entry.get("tool_calling_enabled"):
             continue
@@ -2050,19 +2065,22 @@ class CodingAgentsView(APIView):
             except requests.RequestException:
                 health = "unreachable"
 
-        # Eligible models split into usable (tool-calling capable) and unavailable
-        # (launched without tool-calling support) so the UI can explain the latter
-        # instead of advertising models that would silently fail.
+        # Every deployed chat model, split into usable (vetted and tool-calling
+        # capable) and unavailable, so the UI can explain the latter instead of
+        # either advertising models that would silently fail or -- worse --
+        # reporting nothing deployed while one is serving.
         models = []
         unavailable = []
         seen = set()
-        for _, entry in _running_coding_agent_deploys(require_tool_calling=False):
+        for _, entry in _running_coding_agent_deploys(
+            require_tool_calling=False, require_vetted=False
+        ):
             impl = entry.get("model_impl")
             name = getattr(impl, "model_name", None)
             if not name:
                 continue
             mtype = getattr(getattr(impl, "model_type", None), "value", "chat")
-            capable = bool(entry.get("tool_calling_enabled"))
+            capable = bool(entry.get("tool_calling_enabled")) and is_coding_agent_eligible(impl)
             # Context window + max_tokens ceiling, same policy the gateway and InferenceView enforce
             context_window = entry.get("max_model_len") or get_max_tokens_limit(
                 getattr(impl, "param_count", None)
@@ -2079,7 +2097,7 @@ class CodingAgentsView(APIView):
                         "context_window": context_window,
                         "max_tokens": max_tokens,
                     })
-                else:
+                elif not entry.get("tool_calling_enabled"):
                     unavailable.append({
                         "name": exposed,
                         "type": mtype,
@@ -2087,6 +2105,15 @@ class CodingAgentsView(APIView):
                         "relaunch_with": tool_calling_launch_flags(
                             name, getattr(impl, "hf_model_id", "") or ""
                         ),
+                    })
+                else:
+                    # Can answer tool calls, just not one we have verified against
+                    # coding agents -- so no relaunch flags would help.
+                    unavailable.append({
+                        "name": exposed,
+                        "type": mtype,
+                        "reason": "not_verified",
+                        "relaunch_with": None,
                     })
 
         return Response(

--- a/app/backend/shared_config/coding_agent_config.py
+++ b/app/backend/shared_config/coding_agent_config.py
@@ -17,7 +17,8 @@ CODING_AGENT_ELIGIBLE_MODELS = {
     "Llama-3.3-70B-Instruct",
     "Qwen3.6-27B",
     "Qwen3.8-27B",
-    "gemma-4-31B-it"
+    "gemma-4-31B-it",
+    "diffusiongemma-26B-A4B-it",
 }
 
 # Model types coding agents can talk to.
@@ -31,6 +32,7 @@ REASONING_MODELS = {
     "Qwen3.6-27B": "qwen3",
     "Qwen3.8-27B": "qwen3",
     "gemma-4-31B-it": "gemma4",
+    "diffusiongemma-26B-A4B-it": "gemma4",
 }
 
 # Suffix that selects thinking mode for a reasoning model over the gateway,

--- a/app/backend/shared_config/external_model_config.py
+++ b/app/backend/shared_config/external_model_config.py
@@ -81,17 +81,29 @@ def build_external_model_impl(
     hf_model_id: Optional[str] = None,
     service_port: int = 7000,
     tool_calling_enabled: bool = False,
+    service_route: Optional[str] = None,
 ) -> ExternalModelImpl:
     """Build the stand-in impl for an externally-registered container.
 
     An UNKNOWN type still gets an impl (so the container is tracked) but keeps a
     bare service route: nothing in the UI offers inference against it, and health
     is reported as unknown rather than probing a guessed endpoint.
+
+    ``service_route`` overrides the per-type default when registration observed the
+    route the container actually serves (read from its OpenAPI document). The
+    per-type default is only a convention, and stacks that predate or ignore it --
+    tt-metal's DiT image servers serve ``/generate``, not
+    ``/v1/images/generations`` -- would otherwise be handed a route that 404s.
     """
     resolved_type = normalize_external_model_type(
         getattr(model_type, "value", model_type)
     )
-    service_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    resolved_route, engine = _TYPE_ROUTING.get(resolved_type, ("/", "vllm"))
+    # An observed route only applies to a type we can actually drive; UNKNOWN keeps
+    # its bare route so no UI offers inference against it.
+    if service_route and resolved_type is not ModelTypes.UNKNOWN:
+        resolved_route = service_route
+    service_route = resolved_route
     return ExternalModelImpl(
         model_name=model_name,
         model_id=f"id_external-{model_name}",

--- a/app/backend/shared_config/models_from_inference_server.json
+++ b/app/backend/shared_config/models_from_inference_server.json
@@ -3,7 +3,7 @@
     "artifact_version": "0.20.0",
     "generated_at": "2026-08-17T18:22:32.785689+00:00"
   },
-  "total_models": 59,
+  "total_models": 60,
   "models": [
     {
       "model_name": "distil-large-v3",
@@ -874,6 +874,44 @@
         "TORCHDYNAMO_DISABLE": "1"
       },
       "param_count": null
+    },
+    {
+      "model_name": "diffusiongemma-26B-A4B-it",
+      "model_type": "CHAT",
+      "display_model_type": "LLM",
+      "device_configurations": [
+        "P300x2"
+      ],
+      "hf_model_id": "google/diffusiongemma-26B-A4B-it",
+      "inference_engine": "vLLM",
+      "impl": null,
+      "status": "EXPERIMENTAL",
+      "version": "0.21.0",
+      "docker_image": "ghcr.io/tenstorrent/tt-inference-server/vllm-tt-metal-src-release-ubuntu-22.04-amd64:0.21.0-bc4c4df-be7d805",
+      "service_route": "/v1/chat/completions",
+      "health_route": "/health",
+      "env_vars": {
+        "VLLM_CONFIGURE_LOGGING": "1",
+        "VLLM_RPC_TIMEOUT": "1800000",
+        "VLLM_TARGET_DEVICE": "tt",
+        "TORCHDYNAMO_DISABLE": "1",
+        "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
+        "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+        "DISABLE_METAL_OP_TIMEOUT": "1",
+        "DG_VLLM_GUMBEL_MODE": "device",
+        "DG_UPFRONT_CAPTURE": "1",
+        "DG_MODEL_OWNED_HYBRID_KV": "1",
+        "DG_UPFRONT_COARSE_PREFILL_BUCKETS": "1",
+        "DG_UPFRONT_LAZY_PREFILL_RECAPTURE": "1",
+        "DG_PREFILL_FIXED_CHUNKS": "1",
+        "DG_PREFILL_CHUNK_SIZE": "4096",
+        "DG_PREFILL_RAGGED_CHUNK": "1024",
+        "DG_DENOISE_REVEAL_PMAX": "262144",
+        "DG_DENOISE_SLIDING_WINDOW": "1",
+        "DG_UPFRONT_PREFILL_WARMUP_LENS": "32,64,96",
+        "DG_TRACE_REGION_SIZE": "3758096384"
+      },
+      "param_count": 4
     },
     {
       "model_name": "efficientnet",

--- a/app/backend/vector_db_control/test_chunking.py
+++ b/app/backend/vector_db_control/test_chunking.py
@@ -80,6 +80,16 @@ class TestPdfPages:
         assert docs[0].metadata is not docs[1].metadata
         assert all(d.metadata["source"] == "x.pdf" for d in docs)
 
+    def test_empty_or_whitespace_pages_yield_no_documents(self):
+        docs = DocumentProcessor.pages_to_documents(
+            ["", "   \n\t  ", ""], {"source": "blank_or_image.pdf"}
+        )
+        assert docs == []
+
+    def test_empty_parents_yield_zero_child_chunks(self):
+        children = _build_children([], chunk_size=200, chunk_overlap=0)
+        assert children == []
+
 
 class TestIdsAndHeaders:
     def test_deterministic_chunk_id_stable_and_distinct(self):

--- a/app/backend/vector_db_control/views.py
+++ b/app/backend/vector_db_control/views.py
@@ -414,6 +414,12 @@ class VectorCollectionsAPIView(ViewSet):
             }
             
             chunked_document = chunk_document(file_path=temp_file_path, metadata=base_metadata)
+            if not chunked_document:
+                raise ValueError(
+                    f"No extractable text found in '{filename}'. "
+                    "Scanned documents or image-only files are not supported."
+                )
+
             documents = [d.page_content for d in chunked_document]
             
             # Update each chunk's metadata to include the folder structure

--- a/app/frontend/src/components/chatui/StreamingMessage.tsx
+++ b/app/frontend/src/components/chatui/StreamingMessage.tsx
@@ -102,6 +102,22 @@ const tagProseThinking = (
   return isStreamFinished ? `<think>${content}</think>` : `<think>${content}`;
 };
 
+/** Close a thinking block the stream ended inside, so it stays readable.
+ *
+ * Belt to runInference's braces: any path that leaves an unterminated <think>
+ * (a stopped stream, a reply restored from history, a model whose reasoning
+ * never gave way to an answer) would otherwise fail the closed-tag regex below,
+ * be stripped from the reply text, and vanish along with the live panel. */
+const closeUnterminatedThinking = (
+  content: string,
+  isStreamFinished: boolean
+): string => {
+  if (!isStreamFinished) return content;
+  const openIdx = content.lastIndexOf("<think>");
+  if (openIdx === -1 || content.includes("</think>", openIdx)) return content;
+  return `${content}</think>`;
+};
+
 const processContent = (content: string): ProcessedContent => {
   const thinkingBlocks: string[] = [];
 
@@ -159,7 +175,11 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
   }) {
     // Everything below reasons about thinking in terms of <think> tags, so
     // normalize prose scratchpads into tags once, up front.
-    const taggedContent = tagProseThinking(content, isStreamFinished);
+    const streamOver = isStreamFinished || Boolean(isStopped);
+    const taggedContent = closeUnterminatedThinking(
+      tagProseThinking(content, streamOver),
+      streamOver
+    );
 
     const [renderedContent, setRenderedContent] = useState("");
     const [showThinking, setShowThinking] = useState(Boolean(externalShowThinking));
@@ -204,7 +224,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
 
       // Check if thinking is actively streaming (has <think> but no closing </think>)
       const hasIncompleteThinking =
-        !isStreamFinished && /<think>(?!.*<\/think>)/is.test(taggedContent);
+        !streamOver && /<think>(?!.*<\/think>)/is.test(taggedContent);
       setIsThinkingActive(hasIncompleteThinking);
 
       if (isStreamFinished) {
@@ -237,6 +257,7 @@ const StreamingMessage: React.FC<StreamingMessageProps> = React.memo(
     }, [
       taggedContent,
       isStreamFinished,
+      streamOver,
       renderNextChunk,
       renderedContent,
       onThinkingBlocksChange,

--- a/app/frontend/src/components/chatui/runInference.ts
+++ b/app/frontend/src/components/chatui/runInference.ts
@@ -526,6 +526,18 @@ export const runInference = async (
       reader.releaseLock();
     }
 
+    // The closing </think> is synthesized when the first content delta arrives,
+    // so a reply that ends while still in the reasoning channel never gets one:
+    // a truncated answer (finish_reason "length"), or a block-diffusion model
+    // like diffusiongemma that emits its whole block as reasoning and no
+    // content. Left open, processContent drops the block and the reply renders
+    // empty, losing the reasoning the model did produce.
+    if (thinkingText && !thinkingDone) {
+      thinkingDone = true;
+      accumulatedText = `<think>${thinkingText}</think>${contentText}`;
+      scheduleUiUpdate();
+    }
+
     t.end = performance.now();
     const ms = (key: string) => (t[key] != null ? `${Math.round(t[key] - t.start)}ms` : "—");
     const serverTtftMs = inferenceStats?.user_ttft_s != null

--- a/app/frontend/src/components/rag/RagManagement.tsx
+++ b/app/frontend/src/components/rag/RagManagement.tsx
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// This file incorporates work covered by the following copyright and permission notice:
+//  SPDX-FileCopyrightText: Copyright (c) 2023 shadcn
+//  SPDX-License-Identifier: MIT
+
 import { Button } from "@/src/components/ui/button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "@/src/components/ui/card";
@@ -136,6 +140,7 @@ export default function RagManagement() {
     []
   );
   const [isDragging, setIsDragging] = useState(false);
+  const [uploadBoxKey, setUploadBoxKey] = useState(0);
 
   // State to track expanded rows
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
@@ -269,6 +274,9 @@ export default function RagManagement() {
       customToast.info(
         `Creating datasource "${collectionName}" and uploading document...`
       );
+    },
+    onSettled: () => {
+      setUploadBoxKey((prev) => prev + 1);
     },
     onError: (error: any, { file, collectionName }) => {
       setCollectionsUploading((prev) =>
@@ -417,6 +425,9 @@ export default function RagManagement() {
         prev.includes(collectionName) ? prev : [...prev, collectionName]
       );
       customToast.info("Uploading document...");
+    },
+    onSettled: () => {
+      setUploadBoxKey((prev) => prev + 1);
     },
     onError: (error: Error, { file, collectionName }) => {
       setCollectionsUploading((prev) =>
@@ -584,6 +595,7 @@ export default function RagManagement() {
         customToast.error(
           `Generated collection name "${collectionName}" is too short. Please rename the file.`
         );
+        setUploadBoxKey((prev) => prev + 1);
         return;
       }
 
@@ -953,7 +965,7 @@ export default function RagManagement() {
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
         >
-          <GentleFileUpload onChange={handleFileUpload} />
+          <GentleFileUpload key={uploadBoxKey} onChange={handleFileUpload} />
         </Card>
 
         <Card

--- a/app/frontend/src/pages/AppsPage.tsx
+++ b/app/frontend/src/pages/AppsPage.tsx
@@ -36,6 +36,7 @@ import { customToast } from "../components/CustomToaster";
 import {
   fetchCodingAgentsInfo,
   type CodingAgentsInfo,
+  type UnavailableCodingAgentModel,
 } from "../api/modelsDeployedApis";
 import {
   fetchMarketplaceApps,
@@ -138,6 +139,10 @@ export default function AppsPage() {
 
   const models = useMemo(() => gateway?.models ?? [], [gateway]);
   const modelNames = useMemo(() => models.map((m) => m.name), [models]);
+  // Deployed chat models the apps here cannot drive. They are still deployed, so
+  // they decide between "nothing to talk to" and "something to talk to, once you
+  // relaunch it" -- the two used to be conflated into the first message.
+  const unavailable = useMemo(() => gateway?.unavailable ?? [], [gateway]);
   const activeModel =
     selectedModel && modelNames.includes(selectedModel)
       ? selectedModel
@@ -248,7 +253,11 @@ export default function AppsPage() {
               onSelectModel={setSelectedModel}
             />
 
-            {modelNames.length === 0 && (
+            {modelNames.length === 0 && unavailable.length > 0 && (
+              <UnusableModelsNote unavailable={unavailable} />
+            )}
+
+            {modelNames.length === 0 && unavailable.length === 0 && (
               <div className="flex flex-col gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:gap-4">
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
                   <AlertCircle className="h-5 w-5" />
@@ -354,6 +363,59 @@ export default function AppsPage() {
           )}
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+// Chat models are deployed, but none can be driven from here yet. Says which
+// and why, rather than the old "no chat model is deployed" -- which contradicts
+// the Models page and sends the user off to deploy a second one.
+function UnusableModelsNote({
+  unavailable,
+}: {
+  unavailable: UnavailableCodingAgentModel[];
+}) {
+  // -thinking variants repeat their base model's reason; one row each is enough.
+  const rows = unavailable.filter((m) => !m.name.endsWith("-thinking"));
+  const relaunchFlags = rows.find((m) => m.relaunch_with)?.relaunch_with;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-500">
+          <AlertCircle className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">
+            {rows.length === 1 ? "A deployed model" : "Deployed models"} cannot be
+            used by apps yet
+          </p>
+          <ul className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+            {rows.map((model) => (
+              <li key={model.name}>
+                <code className="font-mono text-xs text-gray-900 dark:text-gray-200">
+                  {model.name}
+                </code>{" "}
+                —{" "}
+                {model.reason === "tool_calling_disabled"
+                  ? "was launched without tool calling; redeploy it from the Home page to turn it on"
+                  : "has not been verified against the apps here yet"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {relaunchFlags && (
+        <div className="pl-12">
+          <div className="mb-1.5 text-[11px] uppercase tracking-wide text-gray-500">
+            Flags a redeploy adds
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white px-3 py-2 font-mono text-xs dark:border-gray-800 dark:bg-black">
+            <CopyableText text={relaunchFlags} />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/inference-api/api.py
+++ b/inference-api/api.py
@@ -1884,6 +1884,11 @@ def _process_run_output_line(
             stage = "container_started"
             progress = 60
             message = "Container is running..."
+        # Defence in depth for the v0.21.0 readiness gate (see TT_SERVER_BOOT_ATTEMPTS in run_inference).
+        elif "waiting for inference server readiness" in message.lower():
+            stage = "container_started"
+            progress = 61
+            message = "Container is running..."
         elif any(keyword in message.lower() for keyword in ["searching for container", "looking for container"]):
             stage = "container_started"
             progress = 64
@@ -2506,6 +2511,19 @@ async def run_inference(request: RunRequest):
         # (e.g., /home/username/.cache/huggingface instead of /root/.cache/huggingface)
         env_vars_to_set = {
             "AUTOMATIC_HOST_SETUP": "True",
+            # tt-inference-server v0.21.0 added a readiness gate to ServerCommand
+            # (workflow_module/commands.py): with TT_SERVER_BOOT_ATTEMPTS > 1 -- its
+            # default of 2 -- bring-up blocks polling /health until the model is fully
+            # warm (up to TT_SERVER_READY_TIMEOUT_SECONDS, default 1h). We call
+            # run_main() in-process and only emit container_started / connect
+            # tt_studio_network / rename *after* it returns, so that gate freezes the
+            # deploy bar at container_setup for the entire warmup and defers the
+            # frontend's redirect to the end of the deploy. Forcing a single attempt
+            # restores v0.20.0's fire-and-forget return (the container is up, the model
+            # is still loading), which is the point we want to hand off from the deploy
+            # bar to the container-log classifier. Warmup progress and hang detection
+            # are already covered on our side by log_classifier + health_monitor.
+            "TT_SERVER_BOOT_ATTEMPTS": "1",
             "TT_PROGRESS_DEBUG": "1",  # Enable structured progress emission
             "TT_PROGRESS_SSE": "1",     # Enable SSE endpoint for real-time progress
             "SERVICE_PORT": request.service_port or "7000",  # Use requested port (per-slot)


### PR DESCRIPTION
## Rc v2.10.2

Cut from `main`; validated changes cherry-picked from `dev` (see CONTRIBUTING → Release Process).

### Test plan

- [ ] Fresh `python run.py` completes (setup → ready panel)
- [ ] Backend healthy: `curl localhost:8000/up/` and `curl localhost:8000/models/health/`
- [ ] Frontend loads at `localhost:3000`
- [ ] Deploy a model end-to-end; inference server healthy: `curl localhost:8001/health`
- [ ] `python run.py --stop`, then a restart works
- [ ] `IS_QB2` is off in `.env.default` (rc-* branches never ship it on)
- [ ] Release notes drafted and applied to this description
